### PR TITLE
Remove dead workshops#summary action

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -28,54 +28,6 @@ class WorkshopsController < ApplicationController
     end
   end
 
-  def summary
-    authorize! :workshop, to: :summary?
-    @year = params[:year] ? params[:year].to_i : Date.current.year.to_i
-    @month = params[:month] ? params[:month].to_i : Date.current.month.to_i
-
-    reports = build_report
-    @report = reports[0]
-
-    types = reports.map do |r|
-      r.windows_type
-    end
-    @workshop_logs = current_user.organization_monthly_workshop_logs(
-      reports.first.date, *types,
-    )
-
-    logs = @workshop_logs.map { |_k, v| v }.flatten
-    @total_ongoing    = logs.reduce(0) { |sum, l| sum += l.num_ongoing }
-    @total_first_time = logs.reduce(0) { |sum, l| sum += l.num_first_time }
-
-    combined_windows_type = WindowsType.where(short_name: "Combined").first
-    @combined_workshop_logs = current_user.organization_workshop_logs(
-      @report.date, combined_windows_type, nil
-    )
-    authorize! @combined_workshop_logs
-  end
-
-  def build_report
-    authorize! :workshop, to: :summary?
-    date = Date.new(@year, @month)
-
-    form_builder = FormBuilder
-                   .monthly
-
-    report = form_builder.map do |f|
-      Report.new(
-        type: f.report_type,
-        windows_type: f.windows_type,
-        date: date
-      )
-    end
-
-    report.each do |r|
-      r.media_files.build
-    end
-
-    report
-  end
-
   def new
     if params[:workshop_idea_id].present?
       @workshop_idea = WorkshopIdea.find(params[:workshop_idea_id])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,17 +193,6 @@ class User < ApplicationRecord
     logs.uniq.group_by { |log| log.workshop_held_on }
   end
 
-  def organization_workshop_logs(date, windows_type, organization_id)
-    if organization_id
-      logs = workshop_logs.where(organization_id: organization_id, windows_type_id: windows_type.id)
-      logs = logs.select do |log|
-        log.workshop_held_on && log.workshop_held_on.month == date.month.to_i &&
-          log.workshop_held_on.year == date.year.to_i
-      end.flatten
-      logs.uniq.group_by { |log| log.workshop_held_on }
-    end
-  end
-
   def deletable?
     !reports.exists? &&
       !workshop_logs.exists? &&


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 pure dead-code removal; verified unreachable before deleting

## Why
Follow-up to #2307. Removing `users.agency_id` left `workshops#summary` as the column's last (vestigial) reader, so I checked whether the action is reachable. It isn't — it's dead three ways over:

- **No route** — `resources :workshops` only nests `comments`; there is no `summary` route.
- **No view** — there's no `workshops/summary.html.erb`, so it couldn't render.
- **No policy rule** — `authorize! :workshop, to: :summary?` targets a `summary?` that no policy defines, so the action would raise `NoMethodError` on its first line if ever reached.
- No tests reference it.

## What
- Removed the `summary` action.
- Removed its private `build_report` helper (local to this controller — only `summary` called it; `ReportsController` has its own).
- Removed `User#organization_workshop_logs` (the 3-arg one) — only `summary` called it. `organization_monthly_workshop_logs` stays; `ReportsController` still uses it.

## Not touched
- `monthly_reports/_form.html.erb` still renders `_combined_workshop_log_summary` with `@combined_workshop_logs`, which is now simply never assigned (it was already always-nil in prod). That's legacy monthly-reports territory — separate cleanup.