### PR TITLE
Link affiliation address picker hint to org's addresses editor

### DIFF
--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -68,6 +68,11 @@
           <p class="mt-1 text-xs text-amber-700">
             <i class="fa-solid fa-triangle-exclamation mr-1"></i>
             Reassigning the organization links the new organization's address automatically only if it has exactly one — otherwise set the address after saving.
+            <% if @affiliation.organization %>
+              <%= link_to "Add or edit this organization's addresses",
+                    edit_organization_path(@affiliation.organization, anchor: "addresses"),
+                    class: "underline font-medium", target: "_blank", rel: "noopener" %>.
+            <% end %>
           </p>
         </div>
       </div>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -221,7 +221,7 @@
     </div>
   </div>
 
-  <div class="form-group space-y-4 mb-8">
+  <div id="addresses" class="form-group space-y-4 mb-8 scroll-mt-20">
     <div class="font-semibold text-gray-700 mb-2">
       Addresses
     </div>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only: one anchor id + one hint link, no logic change

## Why
- The affiliation edit form's address picker only lets you pick among an org's **existing** addresses — there was no way to add or fix one from there.

## Changes
- Add `id="addresses"` (`scroll-mt-20`) anchor to the org form's Addresses section, matching the existing `id="affiliations"` anchor pattern.
- Link the address-picker hint to `edit_organization_path(org, anchor: "addresses")`, opening in a new tab like the registration links already in this form.

## Notes
- **"Is everything in the affiliations table shown on the edit form?"** — yes, everything meaningful is: `person_id`, `organization_id`, `organization_address_id`, `primary_contact`, `title`, `start_date`, `end_date` are all editable; `created_at`/`updated_at` show in the audit footer; `event_registration_id` shows as the linked-registration banner. The two omitted are intentional: `inactive` is derived server-side from the dates, and `filemaker_code` is a legacy import field.