### PR TITLE
Workshop-log quotes: credit the submitter, preference-aware speaker display, confirm log-author meaning

### DIFF
--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -24,8 +24,10 @@ class WorkshopLogsController < ApplicationController
     set_default_values
     @workshop_log = WorkshopLog.find(params[:id])
     authorize! @workshop_log
+    @workshop_log.assign_attributes(workshop_log_params)
+    credit_new_quotes_to_current_user
 
-    if @workshop_log.update(workshop_log_params)
+    if @workshop_log.save
       redirect_to @workshop_log, notice: "Thanks for reporting on a workshop."
     else
       flash.now[:alert] = "Failed to update workshop log."
@@ -38,6 +40,7 @@ class WorkshopLogsController < ApplicationController
     set_default_values
     @workshop_log = WorkshopLog.new(workshop_log_params)
     authorize! @workshop_log
+    credit_new_quotes_to_current_user
 
     if @workshop_log.save
       NotificationServices::CreateNotification.call(
@@ -176,6 +179,16 @@ class WorkshopLogsController < ApplicationController
         .order(:name)
     organization = params[:agency_id].present? ? Organization.where(id: params[:agency_id]).last : @organizations.first
     @organization_id = organization.id if organization
+  end
+
+  # Credit new quotes to the facilitator submitting the log — the speaker (the
+  # quote's `author` Person) is left unset, since it's the participant, not the
+  # submitter. Only new records, so editing a log never re-credits existing quotes.
+  def credit_new_quotes_to_current_user
+    @workshop_log.all_quotable_item_quotes.each do |qiq|
+      quote = qiq.quote
+      quote.created_by = current_user if quote&.new_record?
+    end
   end
 
   def set_default_values

--- a/app/decorators/quote_decorator.rb
+++ b/app/decorators/quote_decorator.rb
@@ -17,7 +17,7 @@ class QuoteDecorator < ApplicationDecorator
   end
 
   def attribution
-    name = author&.name.presence || speaker_name.presence || "anonymous"
+    name = object.author_credit
 
     details = []
     details << "#{age.gsub("years", "").gsub("yrs", "")} yrs" if age.present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -197,7 +197,9 @@ class Person < ApplicationRecord
   scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
   scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
   # WorkshopLog has no author column — it is created_by a User, so "author" here
-  # means the person whose linked user account created the log.
+  # means the person whose linked user account created the log. Confirmed intended
+  # (rubyforgood/awbw#2326): the logger is the author; we deliberately don't add an
+  # author_id column, since created_by.person already carries that meaning.
   scope :workshop_log_authors, -> {
     creator_user_ids = WorkshopLog.where.not(created_by_id: nil).select(:created_by_id)
     where(id: User.where(id: creator_user_ids).where.not(person_id: nil).select(:person_id)) }

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,6 +1,11 @@
 class Quote < ApplicationRecord
   include AuthorCreditable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable
 
+  # A quote's speaker is a workshop participant. When none is named — no linked
+  # author, or the author opted out — credit reads "Participant", not the default
+  # "AWBW Facilitator" (the facilitator entered the quote; they didn't say it).
+  self.unattributed_author_label = "Participant"
+
   belongs_to :workshop, optional: true
   belongs_to :author, class_name: "Person", optional: true
   belongs_to :created_by, class_name: "User", optional: true

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -188,7 +188,7 @@
                   </span>
                 </div>
                 <div class="text-gray-700 mt-3">
-                  -- <%= quote.attribution %>
+                  <span class="font-medium not-italic">Speaker:</span> <%= quote.attribution %>
                   <%= "@ " + quote.created_at.strftime("%m-%d-%-Y") %>
                   <%= ("re " + link_to(quote.workshop.title, workshop_path(quote.workshop),
                                        class: "hover:underline") if quote.workshop).to_s.html_safe %>

--- a/spec/decorators/quote_decorator_spec.rb
+++ b/spec/decorators/quote_decorator_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe QuoteDecorator do
+  describe "#attribution" do
+    it "credits a linked author by their profile-preferred name" do
+      author = create(:person, first_name: "Jane", last_name: "Doe",
+                               display_name_preference: "first_name_last_initial")
+      quote = create(:quote, author: author, speaker_name: nil, age: nil, gender: nil).decorate
+
+      expect(quote.attribution).to eq("Jane D.")
+    end
+
+    it "falls back to the free-text speaker_name when there is no linked author" do
+      quote = create(:quote, author: nil, speaker_name: "Sam Rivera", age: nil, gender: nil).decorate
+
+      expect(quote.attribution).to eq("Sam Rivera")
+    end
+
+    it "reads as Participant when the linked author opted out of being credited" do
+      author = create(:person, :anonymous_contributions, first_name: "Jane", last_name: "Doe")
+      quote = create(:quote, author: author, speaker_name: nil, age: nil, gender: nil).decorate
+
+      expect(quote.attribution).to eq("Participant")
+    end
+
+    it "reads as Participant when there is no author and no speaker name" do
+      quote = create(:quote, author: nil, speaker_name: nil, age: nil, gender: nil).decorate
+
+      expect(quote.attribution).to eq("Participant")
+    end
+
+    it "appends age and gender details when present" do
+      quote = create(:quote, author: nil, speaker_name: "Sam Rivera", age: "34", gender: "F").decorate
+
+      expect(quote.attribution).to eq("Sam Rivera (34 yrs, F)")
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -574,6 +574,23 @@ RSpec.describe Person, type: :model do
         expect(results).to include(person_alice)
         expect(results).not_to include(person_bob)
       end
+
+      it "credits the log's creator, not other people (confirmed meaning, awbw#2326)" do
+        alice_user = create(:user, person: person_alice)
+        create(:workshop_log, created_by: alice_user)
+        create(:user, person: person_bob)
+
+        results = Person.search_by_params(role: "workshop_log_author")
+
+        expect(results).to include(person_alice)
+        expect(results).not_to include(person_bob)
+      end
+
+      it "ignores logs whose creating user has no linked person" do
+        create(:workshop_log, created_by: create(:user, person: nil))
+        results = Person.search_by_params(role: "workshop_log_author")
+        expect(results).not_to include(person_alice, person_bob)
+      end
     end
 
     context "membership_status" do

--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -354,6 +354,23 @@ RSpec.describe "/workshop_logs", type: :request do
         expect(response).to have_http_status(:redirect)
       end
 
+      it "credits nested quotes to the current user without setting the quote author" do
+        post workshop_logs_path, params: {
+          workshop_log: valid_attributes.merge(
+            all_quotable_item_quotes_attributes: {
+              "0" => {
+                quotable_type: "WorkshopLog",
+                quote_attributes: { body: "Coming here makes me feel happy!", age: "child" }
+              }
+            }
+          )
+        }
+
+        quote = WorkshopLog.last.quotes.last
+        expect(quote.created_by).to eq(user)
+        expect(quote.author).to be_nil
+      end
+
       it "creates admin and submitter notifications and enqueues mail" do
         expect {
           post workshop_logs_path, params: {


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 controller + decorator/model credit change (shared across quote surfaces) + scope confirmation, all test-backed

## Quotes: credit to the submitting facilitator
- Quotes entered through a workshop log persisted with `created_by = nil`.
- Set `quote.created_by = current_user` for **newly-built** quotes on create and update; existing quotes are never re-credited.
- `update` now assigns then saves (instead of `update(params)`) so new quotes are credited before save.
- The quote's `author` (the speaker `Person`) is **deliberately left unset** — that's the participant who spoke, not the facilitator.

## Quotes: preference-aware speaker display + "Speaker" label
- `QuoteDecorator#attribution` now routes through `AuthorCreditable#author_credit`, so a linked speaker is credited by their **profile-preferred name** and **suppressed if they opted out of being credited**; otherwise the free-text `speaker_name`.
- When no speaker is named, the credit reads **"Participant"** (not the default "AWBW Facilitator" — the facilitator entered the quote, they didn't say it). Set via `Quote.unattributed_author_label = "Participant"`.
- Labeled **"Speaker:"** on the workshop-log show page (was a bare `--`).
- **Shared surface note:** `attribution` is also used on quotes show/index and the submitted-FYI mailers; those now show the same preference-aware credit and the "Participant" fallback instead of the old literal "anonymous".

## Workshop-log author meaning (closes #2326)
- The people-directory **Role → Workshop log authors** filter resolves authorship through `created_by.person`, since `WorkshopLog` has no author column.
- **Confirmed intended:** the logger is the author. We deliberately don't add an `author_id` column (avoids a denormalized column + backfill).
- Recorded the decision in the scope comment; locked the semantics with tests.

## Tests
- New `QuoteDecorator` spec (preference, anonymity, speaker_name, Participant fallback, age/gender).
- Request spec: workshop-log quotes credited to current user, author left nil.
- `workshop_log_authors` scope tests.

Closes #2326