### PR TITLE
Surface FileMaker code + admin-mode registration picker on affiliation edit

### DIFF
--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -63,10 +63,10 @@ class AffiliationsController < ApplicationController
   end
 
   def affiliation_params
-    params.require(:affiliation).permit(
-      :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact, :organization_address_id,
-      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
-    )
+    keys = [ :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
+             :organization_address_id, :filemaker_code ]
+    keys << :event_registration_id if params[:admin] == "true"
+    params.require(:affiliation).permit(*keys, comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ])
   end
 
   # Return to whichever edit page the gear was clicked from, scrolled to the row
@@ -74,11 +74,11 @@ class AffiliationsController < ApplicationController
   def affiliation_return_path(anchor: helpers.dom_id(@affiliation))
     case params[:return_to]
     when "person"
-      edit_person_path(params[:origin_id], anchor: anchor)
+      edit_person_path(params[:origin_id], anchor: anchor, admin: params[:admin].presence)
     when "organization"
-      edit_organization_path(params[:origin_id], anchor: anchor)
+      edit_organization_path(params[:origin_id], anchor: anchor, admin: params[:admin].presence)
     else
-      edit_affiliation_path(@affiliation)
+      edit_affiliation_path(@affiliation, admin: params[:admin].presence)
     end
   end
 end

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -63,10 +63,11 @@ class AffiliationsController < ApplicationController
   end
 
   def affiliation_params
-    keys = [ :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
-             :organization_address_id, :filemaker_code ]
-    keys << :event_registration_id if params[:admin] == "true"
-    params.require(:affiliation).permit(*keys, comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ])
+    params.require(:affiliation).permit(
+      :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
+      :organization_address_id, :filemaker_code, :event_registration_id,
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
+    )
   end
 
   # Return to whichever edit page the gear was clicked from, scrolled to the row

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -38,7 +38,8 @@
       <%# Escape to the full affiliation editor: comments + reassign person/org. %>
       <%= link_to edit_affiliation_path(f.object,
                     return_to: person_side ? "organization" : "person",
-                    origin_id: person_side ? f.object.organization_id : f.object.person_id),
+                    origin_id: person_side ? f.object.organization_id : f.object.person_id,
+                    admin: params[:admin].presence),
                   target: "_blank", rel: "noopener",
                   class: "absolute top-1/2 right-2 z-10 -translate-y-1/2 text-gray-300 hover:text-gray-500",
                   title: "Edit affiliation, add comments, or reassign (opens in a new tab)" do %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -89,6 +89,12 @@
                 input_html: {
                   data: { controller: "remote-select", remote_select_model_value: "event_registration" }
                 } %>
+          <% if @affiliation.event_registration.present? %>
+            <%= link_to edit_event_registration_path(@affiliation.event_registration),
+                  class: "mt-1 inline-block text-xs underline font-medium text-gray-600", target: "_blank", rel: "noopener" do %>
+              <i class="fa-solid fa-arrow-up-right-from-square mr-1"></i>Open the linked registration
+            <% end %>
+          <% end %>
         </div>
       <% elsif @affiliation.event_registration.present? %>
         <% er = @affiliation.event_registration %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -46,7 +46,7 @@
             <p class="mt-1 text-xs text-gray-500">Main contact for this org</p>
           </div>
           <% if allowed_to?(:manage?, @affiliation) %>
-            <div class="admin-only w-28 rounded-md bg-blue-100 p-2">
+            <div class="admin-only ml-auto w-40 rounded-md bg-blue-100 p-2">
               <%= f.input :filemaker_code,
                     label: "FileMaker code",
                     label_html: { class: "block text-xs font-medium text-gray-700 mb-1" },

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -4,6 +4,26 @@
    when "organization" then edit_organization_path(params[:origin_id], anchor: dom_id(@affiliation), admin: params[:admin].presence)
    end %>
 
+<%# Live field tinting mirrors the inline editor (affiliations/_fields): role is the
+    hue (facilitator = purple, else blue), status the saturation (active = full,
+    past = light). Kept in sync as you type by the inactive-toggle controller. A
+    blank title displays and saves as "Facilitator", so treat it as one here too. %>
+<% expired = @affiliation.inactive? || (@affiliation.end_date.present? && @affiliation.end_date < Date.current) %>
+<% displayed_title = @affiliation.title.presence || Affiliation::FACILITATOR_TITLE %>
+<% facilitator = displayed_title.strip == Affiliation::FACILITATOR_TITLE %>
+<% row_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-blue-50 border-blue-200" %>
+<% fill_color = if facilitator
+     expired ? "bg-purple-50!" : "bg-purple-100!"
+   else
+     expired ? "bg-blue-50!" : "bg-blue-100!"
+   end %>
+<% field_bg = ->(present) { present ? fill_color : "bg-transparent!" } %>
+<% title_class = if facilitator
+     expired ? "bg-purple-50! text-purple-500! border-purple-200!" : "bg-purple-100! text-purple-700! font-semibold border-purple-300!"
+   else
+     expired ? "bg-blue-50! text-blue-500! border-blue-200!" : "bg-blue-100! text-blue-700! font-semibold border-blue-300!"
+   end %>
+
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
     <% if back_path %>
@@ -122,25 +142,44 @@
         </div>
       <% end %>
 
-      <div class="flex flex-wrap items-start gap-4">
-        <div class="flex-1 min-w-[200px]">
-          <%= f.input :title,
-                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                hint: "\"Facilitator\" = AWBW Facilitator." %>
-        </div>
-        <div class="w-40">
-          <%= f.input :start_date,
-                as: :string,
-                label: "Start",
-                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                input_html: { type: "date", value: @affiliation.start_date&.strftime("%Y-%m-%d") } %>
-        </div>
-        <div class="w-40">
-          <%= f.input :end_date,
-                as: :string,
-                label: "End",
-                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                input_html: { type: "date", value: @affiliation.end_date&.strftime("%Y-%m-%d") } %>
+      <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>">
+        <div class="flex flex-wrap items-start gap-4 rounded-lg border p-3 <%= row_bg %> <%= 'aff-ended' if expired %>"
+             data-inactive-toggle-target="row">
+          <div class="flex-1 min-w-[200px]">
+            <%= f.input :title,
+                  as: :string,
+                  label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                  hint: "\"Facilitator\" = AWBW Facilitator.",
+                  input_html: {
+                    value: displayed_title,
+                    class: title_class,
+                    data: { inactive_toggle_target: "title", action: "inactive-toggle#updateBorder" }
+                  } %>
+          </div>
+          <div class="w-40">
+            <%= f.input :start_date,
+                  as: :string,
+                  label: "Start",
+                  label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                  input_html: {
+                    type: "date",
+                    value: @affiliation.start_date&.strftime("%Y-%m-%d"),
+                    class: field_bg.call(@affiliation.start_date.present?),
+                    data: { inactive_toggle_target: "valueField", action: "change->inactive-toggle#paintFields" }
+                  } %>
+          </div>
+          <div class="w-40">
+            <%= f.input :end_date,
+                  as: :string,
+                  label: "End",
+                  label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                  input_html: {
+                    type: "date",
+                    value: @affiliation.end_date&.strftime("%Y-%m-%d"),
+                    class: field_bg.call(@affiliation.end_date.present?),
+                    data: { inactive_toggle_target: "endDate valueField", action: "change->inactive-toggle#toggle" }
+                  } %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -39,9 +39,20 @@
                 data: { controller: "remote-select", remote_select_model_value: "person" }
               } %>
 
-        <div>
-          <span class="block text-sm font-medium text-gray-700 mb-1">Primary organization contact</span>
-          <%= render "affiliations/primary_contact_toggle", f: f %>
+        <div class="flex items-start gap-4">
+          <div>
+            <span class="block text-sm font-medium text-gray-700 mb-1">Primary contact</span>
+            <%= render "affiliations/primary_contact_toggle", f: f %>
+            <p class="mt-1 text-xs text-gray-500">Main contact for this org</p>
+          </div>
+          <% if allowed_to?(:manage?, @affiliation) %>
+            <div class="admin-only w-28 rounded-md bg-blue-100 p-2">
+              <%= f.input :filemaker_code,
+                    label: "FileMaker code",
+                    label_html: { class: "block text-xs font-medium text-gray-700 mb-1" },
+                    input_html: { class: "w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-200 text-sm" } %>
+            </div>
+          <% end %>
         </div>
       </div>
 
@@ -132,16 +143,6 @@
                 input_html: { type: "date", value: @affiliation.end_date&.strftime("%Y-%m-%d") } %>
         </div>
       </div>
-
-      <% if allowed_to?(:manage?, @affiliation) %>
-        <div class="admin-only rounded-md bg-blue-100 p-3">
-          <%= f.input :filemaker_code,
-                label: "FileMaker code",
-                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
-                hint: "Legacy FileMaker import identifier.",
-                input_html: { class: "rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-200" } %>
-        </div>
-      <% end %>
     </div>
 
     <%# ---- Comments (saved with the affiliation, like the other forms) ---- %>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% back_path = case params[:return_to]
-   when "person" then edit_person_path(params[:origin_id], anchor: dom_id(@affiliation))
-   when "organization" then edit_organization_path(params[:origin_id], anchor: dom_id(@affiliation))
+   when "person" then edit_person_path(params[:origin_id], anchor: dom_id(@affiliation), admin: params[:admin].presence)
+   when "organization" then edit_organization_path(params[:origin_id], anchor: dom_id(@affiliation), admin: params[:admin].presence)
    end %>
 
 <div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
@@ -23,7 +23,7 @@
   </p>
 
   <%= simple_form_for @affiliation,
-        url: affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence),
+        url: affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
         method: :patch,
         html: { id: "affiliation_form", data: { turbo: false } } do |f| %>
     <div class="bg-white rounded-lg p-6 space-y-5">
@@ -77,7 +77,20 @@
         </div>
       </div>
 
-      <% if @affiliation.event_registration.present? %>
+      <% if params[:admin] == "true" && allowed_to?(:manage?, @affiliation) %>
+        <div class="admin-only rounded-md bg-blue-100 p-3">
+          <%= f.input :event_registration_id,
+                collection: @affiliation.event_registration ? [ [ @affiliation.event_registration.remote_search_label[:label], @affiliation.event_registration_id ] ] : [],
+                selected: @affiliation.event_registration_id,
+                include_blank: "— None",
+                label: "Linked registration",
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                hint: "Search by registrant or event to link (or clear) the source registration. Reassigning the organization clears this automatically.",
+                input_html: {
+                  data: { controller: "remote-select", remote_select_model_value: "event_registration" }
+                } %>
+        </div>
+      <% elsif @affiliation.event_registration.present? %>
         <% er = @affiliation.event_registration %>
         <div class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
           <p class="font-medium"><i class="fa-solid fa-link mr-1"></i>Linked to a registration</p>
@@ -113,6 +126,16 @@
                 input_html: { type: "date", value: @affiliation.end_date&.strftime("%Y-%m-%d") } %>
         </div>
       </div>
+
+      <% if allowed_to?(:manage?, @affiliation) %>
+        <div class="admin-only rounded-md bg-blue-100 p-3">
+          <%= f.input :filemaker_code,
+                label: "FileMaker code",
+                label_html: { class: "block text-sm font-medium text-gray-700 mb-1" },
+                hint: "Legacy FileMaker import identifier.",
+                input_html: { class: "rounded-md border-gray-300 bg-white shadow-sm focus:border-blue-500 focus:ring-blue-200" } %>
+        </div>
+      <% end %>
     </div>
 
     <%# ---- Comments (saved with the affiliation, like the other forms) ---- %>
@@ -160,7 +183,7 @@
        "Remove this affiliation?" %>
   <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
     <%= button_to "Delete",
-          affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence),
+          affiliation_path(@affiliation, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
           method: :delete,
           form: { data: { turbo_confirm: delete_confirm } },
           class: "btn btn-danger-outline" %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Affiliation editor: FileMaker code and registration relinking"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  pr_number: 2332
+  summary: >-
+    The affiliation editor now shows the FileMaker code, and in admin mode adds a
+    searchable picker to link, change, or clear the registration an affiliation came from.
+  pro_tips:
+    - "Add ?admin=true to the affiliation editor URL to reveal the registration picker."
+
 - name: "Activity log: readable details column"
   area: reporting
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,14 +27,23 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
-- name: "Affiliation editor: FileMaker code and registration relinking"
+- name: "Affiliation editor: FileMaker code"
   area: people
   display_status: admin_facing
   released_on: 2026-08-22
   pr_number: 2332
   summary: >-
-    The affiliation editor now shows the FileMaker code, and in admin mode adds a
-    searchable picker to link, change, or clear the registration an affiliation came from.
+    The affiliation editor now surfaces the FileMaker code so it can be viewed and edited
+    alongside the affiliation's other details.
+
+- name: "Affiliation editor: relink the source registration"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  pr_number: 2332
+  summary: >-
+    In admin mode the affiliation editor adds a searchable picker to link, change, or clear
+    the registration an affiliation came from, with a link straight to that registration.
   pro_tips:
     - "Add ?admin=true to the affiliation editor URL to reveal the registration picker."
 

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe "/affiliations", type: :request do
         expect(response.body).to include("Linked registration")
         expect(response.body).to include("event_registration")
       end
+
+      it "surfaces a link to the linked registration in the admin picker" do
+        registration = create(:event_registration)
+        affiliation.update_column(:event_registration_id, registration.id)
+
+        get edit_affiliation_path(affiliation, admin: "true")
+
+        expect(response.body).to include(edit_event_registration_path(registration))
+      end
     end
 
     context "as a non-admin" do
@@ -103,22 +112,13 @@ RSpec.describe "/affiliations", type: :request do
         expect(affiliation.reload.filemaker_code).to eq("FM-123")
       end
 
-      it "links a registration when in admin mode" do
+      it "links a registration through the picker" do
         registration = create(:event_registration)
 
         patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id, admin: "true"),
               params: { affiliation: { event_registration_id: registration.id } }
 
         expect(affiliation.reload.event_registration_id).to eq(registration.id)
-      end
-
-      it "ignores the registration link outside admin mode" do
-        registration = create(:event_registration)
-
-        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
-              params: { affiliation: { event_registration_id: registration.id } }
-
-        expect(affiliation.reload.event_registration_id).to be_nil
       end
     end
 

--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe "/affiliations", type: :request do
         expect(response.body).to include("Linked to a registration")
         expect(response.body).to include(link_organization_event_registration_path(registration))
       end
+
+      it "surfaces the FileMaker code field" do
+        get edit_affiliation_path(affiliation)
+
+        expect(response.body).to include("affiliation[filemaker_code]")
+      end
+
+      it "shows the registration remote-search picker only in admin mode" do
+        get edit_affiliation_path(affiliation)
+        expect(response.body).not_to include("Linked registration")
+
+        get edit_affiliation_path(affiliation, admin: "true")
+        expect(response.body).to include("Linked registration")
+        expect(response.body).to include("event_registration")
+      end
     end
 
     context "as a non-admin" do
@@ -79,6 +94,31 @@ RSpec.describe "/affiliations", type: :request do
               params: { affiliation: { organization_address_id: address.id } }
 
         expect(affiliation.reload.organization_address_id).to eq(address.id)
+      end
+
+      it "updates the FileMaker code" do
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { filemaker_code: "FM-123" } }
+
+        expect(affiliation.reload.filemaker_code).to eq("FM-123")
+      end
+
+      it "links a registration when in admin mode" do
+        registration = create(:event_registration)
+
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id, admin: "true"),
+              params: { affiliation: { event_registration_id: registration.id } }
+
+        expect(affiliation.reload.event_registration_id).to eq(registration.id)
+      end
+
+      it "ignores the registration link outside admin mode" do
+        registration = create(:event_registration)
+
+        patch affiliation_path(affiliation, return_to: "organization", origin_id: organization.id),
+              params: { affiliation: { event_registration_id: registration.id } }
+
+        expect(affiliation.reload.event_registration_id).to be_nil
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained form + strong-params + JS-wiring changes, admin-gated

## Why
- Two `affiliations` columns had no real editor: `filemaker_code` wasn't on the form, and `event_registration_id` was read-only (a banner) — no way to link, change, or clear the source registration.
- The standalone affiliation editor rendered title/dates as plain gray inputs, unlike the inline editor's live status tinting.

## Changes
### View — `affiliations/edit.html.erb`
- **FileMaker code** — admin-only text input, right-aligned in the top row, width-matched to the End date field.
- **Primary contact** — relabeled from "Primary organization contact" with a "Main contact for this org" hint.
- **Linked registration** — `event_registration_id` remote-search select (TomSelect via `remote-select`), rendered only when `?admin=true`. Falls back to the read-only banner otherwise, and surfaces an "Open the linked registration" link when one is set.
- **Live field tinting** — wired the `inactive-toggle` controller so title/dates tint live by role (facilitator = purple, else blue) and status (active = full, past = light), mirroring the inline editor. Blank titles display/save as "Facilitator" to match.

### Controller — `affiliations_controller.rb`
- Permit `filemaker_code` and `event_registration_id`. The registration picker is gated at the form level (`?admin=true`); the update action is already admin-only.
- Thread `admin` through the post-save redirect.

### Reachability
- Thread `admin` through the gear link (`_fields.html.erb`), form URL, back/cancel, and delete so admin mode survives the round-trip.

## Notes
- Registration search is admin-only at the policy layer (`EventRegistrationPolicy` inherits `manage? → admin?`).
- The model callback that clears `event_registration_id` on org change is intentionally kept — a linked registration is org-scoped, so clearing it keeps the surfaced link honest.