### PR TITLE
Add author (Person) to workshop logs, variations, and monthly reports

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -59,44 +59,40 @@ class PeopleController < ApplicationController
 
       case section
       when "workshops"
-        # Credit the person for workshops they authored — not ones their user
-        # merely created (created_by is a pure audit trail).
-        @workshops = visible_authored_content(@person.workshops_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        # Credit the person for workshops they authored, or — the legacy fallback —
+        # that their user account created (AuthorCreditable#author_person).
+        @workshops = visible_authored_content(Workshop.credited_to_person(@person)).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshops", locals: { person: @person, workshops: @workshops }
       when "workshop_variations"
-        # Credit the person for variations they authored — not ones their user
-        # merely entered (created_by is a pure audit trail).
-        @workshop_variations = visible_authored_content(@person.workshop_variations_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        # Author, or the legacy fallback to their user's creations (author_person).
+        @workshop_variations = visible_authored_content(WorkshopVariation.credited_to_person(@person)).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variations", locals: { person: @person, workshop_variations: @workshop_variations }
       when "stories"
-        # Credit the person for stories they authored or were spotlighted in —
-        # not ones their user merely entered (created_by is a pure audit trail).
-        # The spotlight is a separate credit from authorship, so anonymity doesn't apply.
-        story_ids = visible_authored_content(@person.stories_as_author).pluck(:id) +
+        # Author (or legacy creator) plus stories they were spotlighted in. The
+        # spotlight is a separate credit from authorship, so anonymity doesn't apply.
+        story_ids = visible_authored_content(Story.credited_to_person(@person)).pluck(:id) +
           @person.stories_as_spotlighted_facilitator.pluck(:id)
         @stories = Story.where(id: story_ids).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/stories", locals: { person: @person, stories: @stories }
       when "resources"
-        # Credit the person for resources they authored — not ones their user
-        # merely entered (created_by is a pure audit trail).
-        @resources = visible_authored_content(@person.resources_as_author).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        # Author, or the legacy fallback to their user's creations (author_person).
+        @resources = visible_authored_content(Resource.credited_to_person(@person)).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/resources", locals: { person: @person, resources: @resources }
       when "events"
         @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/events", locals: { person: @person, event_registrations: @event_registrations }
       when "workshop_ideas"
-        # Credit the person for ideas they authored — not ones their user merely
-        # entered (created_by is a pure audit trail).
-        @workshop_ideas = @person.workshop_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        # Author, or the legacy fallback to their user's creations (author_person).
+        @workshop_ideas = WorkshopIdea.credited_to_person(@person).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_ideas", locals: { person: @person, workshop_ideas: @workshop_ideas }
       when "story_ideas"
-        @story_ideas = @person.story_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        @story_ideas = StoryIdea.credited_to_person(@person).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/story_ideas", locals: { person: @person, story_ideas: @story_ideas }
       when "workshop_logs"
-        @workshop_logs = @person.user&.workshop_logs&.includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets)&.order(workshop_held_on: :desc, created_at: :desc) || WorkshopLog.none
+        @workshop_logs = WorkshopLog.credited_to_person(@person).includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets).order(workshop_held_on: :desc, created_at: :desc)
         render partial: "people/sections/workshop_logs", locals: { person: @person, workshop_logs: @workshop_logs }
       when "workshop_variation_ideas"
-        @workshop_variation_ideas = @person.workshop_variation_ideas_as_author.order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
+        @workshop_variation_ideas = WorkshopVariationIdea.credited_to_person(@person).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variation_ideas", locals: { person: @person, workshop_variation_ideas: @workshop_variation_ideas }
       when "affiliations"
         @affiliations = @person.affiliations.active.includes(organization: :logo_attachment).paginate(page: params[:page], per_page: per_page)
@@ -133,7 +129,7 @@ class PeopleController < ApplicationController
   def workshop_logs
     authorize! @person
     @person = @person.decorate
-    all_logs = @person.user&.workshop_logs&.includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets)&.order(workshop_held_on: :desc, created_at: :desc) || WorkshopLog.none
+    all_logs = WorkshopLog.credited_to_person(@person).includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets).order(workshop_held_on: :desc, created_at: :desc)
     @grouped_logs = all_logs.group_by { |log| log.workshop_id || log.external_workshop_title }.sort_by { |_key, logs|
       dates = logs.first(10).map { |l| -(l.workshop_held_on || l.created_at.to_date).to_time.to_i }
       dates.fill(0, dates.size...10)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -4,7 +4,7 @@ class PeopleController < ApplicationController
 
   # The profile's "Submitted content" sections — private to the person and admins,
   # not part of the public profile even after profile viewing opens up.
-  PRIVATE_SECTIONS = %w[ workshop_ideas story_ideas workshop_variation_ideas workshop_logs ].freeze
+  PRIVATE_SECTIONS = %w[ workshop_ideas story_ideas workshop_variation_ideas workshop_logs monthly_reports ].freeze
 
   def index
     authorize!
@@ -91,6 +91,9 @@ class PeopleController < ApplicationController
       when "workshop_logs"
         @workshop_logs = WorkshopLog.credited_to_person(@person).includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets).order(workshop_held_on: :desc, created_at: :desc)
         render partial: "people/sections/workshop_logs", locals: { person: @person, workshop_logs: @workshop_logs }
+      when "monthly_reports"
+        @monthly_reports = MonthlyReport.credited_to_person(@person).order(Arel.sql("COALESCE(reports.date, reports.created_at) DESC")).paginate(page: params[:page], per_page: per_page)
+        render partial: "people/sections/monthly_reports", locals: { person: @person, monthly_reports: @monthly_reports }
       when "workshop_variation_ideas"
         @workshop_variation_ideas = WorkshopVariationIdea.credited_to_person(@person).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variation_ideas", locals: { person: @person, workshop_variation_ideas: @workshop_variation_ideas }
@@ -566,6 +569,7 @@ class PeopleController < ApplicationController
       :profile_show_workshops,
       :profile_show_workshop_ideas,
       :profile_show_workshop_logs,
+      :profile_show_monthly_reports,
       :profile_show_resources,
       :member_since,
       :linked_in_url,

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -40,6 +40,7 @@ class WorkshopLogsController < ApplicationController
     set_default_values
     @workshop_log = WorkshopLog.new(workshop_log_params)
     authorize! @workshop_log
+    @workshop_log.author ||= @workshop_log.created_by&.person
     credit_new_quotes_to_current_user
 
     if @workshop_log.save

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -59,6 +59,19 @@ module AuthorCreditable
     # The idea models' only authorship link. Keyed on person, not user, so it stays
     # empty for a person with no account.
     scope :created_by_person, ->(person_id) { joins(:created_by).where(users: { person_id: person_id }) }
+
+    # Everything a person is credited for under author_person semantics: the
+    # explicit author, or — the legacy fallback, only when nobody else is the
+    # explicit author — anything their user account created. The read-side twin
+    # of #author_person, for profile listings.
+    scope :credited_to_person, ->(person) {
+      if person
+        where(author_id: person.id)
+          .or(where(author_id: nil, created_by_id: User.where(person_id: person.id).select(:id)))
+      else
+        none
+      end
+    }
   end
 
   # The linkable credited person, in precedence order: the explicit/legacy author

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -64,6 +64,11 @@ module AuthorCreditable
     # explicit author, or — the legacy fallback, only when nobody else is the
     # explicit author — anything their user account created. The read-side twin
     # of #author_person, for profile listings.
+    #
+    # The created_by fallback only matters on the select models that carry legacy,
+    # author-less rows (workshop variations, monthly reports, and older workshop
+    # logs from before we set author on create). On models where author is always
+    # populated, the fallback clause matches nothing and this is just authored_by.
     scope :credited_to_person, ->(person) {
       if person
         where(author_id: person.id)

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -1,4 +1,8 @@
 class MonthlyReport < Report
+  include AuthorCreditable
+  # No explicit author → credit the creator's person by name, else "Anonymous".
+  self.unattributed_author_label = "Anonymous"
+
   PARTICIPANT_ONGOING_QUESTION = "Total # On-going Participants"
   PARTICIPANT_FIRST_TIME_QUESTION = "Total # First-Time Participants"
 
@@ -9,6 +13,7 @@ class MonthlyReport < Report
   # Associations (override Report's)
   belongs_to :owner, polymorphic: true, optional: true
   belongs_to :created_by, class_name: "User"
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :organization
   belongs_to :windows_type
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
@@ -101,6 +106,14 @@ class MonthlyReport < Report
 
   def name
     "Monthly Report ##{id}"
+  end
+
+  # The legacy (pre-Person-author) credit for a report: the creator's person by
+  # name, honoring their credit preference — suppressed when the person opted
+  # out. Nil (no creator/person, or opted out) reads "Anonymous".
+  def legacy_author_name_text
+    person = created_by&.person
+    person.name unless person.nil? || person.anonymous_contributions?
   end
 
   def display_date

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -390,6 +390,13 @@ class Person < ApplicationRecord
     professional_licenses.filter_map { |license| license.kind.presence&.strip }.uniq.join(", ").presence
   end
 
+  # Monthly reports are deprecated. Only surface the profile section and its
+  # visibility toggle for people who already have some (explicit author, or the
+  # legacy fallback to their user's creations) — newer users never see it.
+  def any_monthly_reports?
+    MonthlyReport.credited_to_person(self).exists?
+  end
+
   def full_name_with_email
     email = preferred_email
     name = full_name

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -41,6 +41,10 @@ class Person < ApplicationRecord
            dependent: :restrict_with_error
   has_many :workshop_variation_ideas_as_author, inverse_of: :author, class_name: "WorkshopVariationIdea",
            foreign_key: :author_id, dependent: :restrict_with_error
+  has_many :workshop_logs_as_author, inverse_of: :author, class_name: "WorkshopLog", foreign_key: :author_id,
+           dependent: :restrict_with_error
+  has_many :monthly_reports_as_author, inverse_of: :author, class_name: "MonthlyReport", foreign_key: :author_id,
+           dependent: :restrict_with_error
   # has_many through
   has_many :event_registrations, foreign_key: :registrant_id, dependent: :destroy
   has_many :topic_subscriptions, dependent: :destroy

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -1,5 +1,8 @@
 class WorkshopLog < ApplicationRecord
+  include AuthorCreditable
+
   belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :author, class_name: "Person", optional: true
   belongs_to :organization, optional: true
   belongs_to :windows_type, optional: true
   belongs_to :workshop, optional: true

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -1,5 +1,8 @@
 class WorkshopVariation < ApplicationRecord
   include AuthorCreditable
+  # No explicit author → credit the creator's person by name, else "Anonymous".
+  self.unattributed_author_label = "Anonymous"
+
   include Publishable, Trendable, RichTextSearchable
   include SearchCop
   search_scope :search do
@@ -63,6 +66,14 @@ class WorkshopVariation < ApplicationRecord
 
   def title
     name
+  end
+
+  # The legacy (pre-Person-author) credit for a variation: the creator's person
+  # by name, honoring their credit preference — suppressed when the person opted
+  # out. Nil (no creator/person, or opted out) reads "Anonymous".
+  def legacy_author_name_text
+    person = created_by&.person
+    person.name unless person.nil? || person.anonymous_contributions?
   end
 
   def attach_assets_from_idea!

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -546,6 +546,7 @@
           <%= f.input :profile_show_workshop_variation_ideas, label: "Show variation ideas" %>
           <%= f.input :profile_show_workshop_ideas, label: "Show workshop ideas" %>
           <%= f.input :profile_show_workshop_logs, label: "Show workshop logs" %>
+          <%= f.input :profile_show_monthly_reports, label: "Show monthly reports" %>
           <%= f.input :profile_show_workshop_variations, label: "Show workshop variations" %>
           <%= f.input :profile_show_workshops, label: "Show workshops" %>
         </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -546,7 +546,7 @@
           <%= f.input :profile_show_workshop_variation_ideas, label: "Show variation ideas" %>
           <%= f.input :profile_show_workshop_ideas, label: "Show workshop ideas" %>
           <%= f.input :profile_show_workshop_logs, label: "Show workshop logs" %>
-          <%= f.input :profile_show_monthly_reports, label: "Show monthly reports" %>
+          <%= f.input :profile_show_monthly_reports, label: "Show monthly reports" if f.object.any_monthly_reports? %>
           <%= f.input :profile_show_workshop_variations, label: "Show workshop variations" %>
           <%= f.input :profile_show_workshops, label: "Show workshops" %>
         </div>

--- a/app/views/people/sections/_monthly_reports.html.erb
+++ b/app/views/people/sections/_monthly_reports.html.erb
@@ -1,0 +1,18 @@
+<%= turbo_frame_tag "person_monthly_reports_section" do %>
+  <% if monthly_reports.any? %>
+    <ul class="divide-y divide-gray-200 blur-on-submit">
+      <% monthly_reports.each do |report| %>
+        <li class="flex items-center justify-between gap-3 py-2">
+          <%= link_to report.name, monthly_report_path(report), class: "#{eyebrow_link_class} hover:underline",
+                      data: { turbo_frame: "_top" } %>
+          <span class="text-sm text-gray-400"><%= report.display_date %></span>
+        </li>
+      <% end %>
+    </ul>
+    <div class="mt-6 flex justify-center">
+      <%= tailwind_paginate monthly_reports, params: { section: "monthly_reports" } %>
+    </div>
+  <% else %>
+    <p class="text-gray-500 italic">No monthly reports submitted yet.</p>
+  <% end %>
+<% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -339,6 +339,15 @@
               <% end %>
             </div>
           <% end %>
+          <!-- Monthly reports (admin/owner only) -->
+          <% if @person.profile_show_monthly_reports? %>
+            <div id="monthly_reports" class="admin-or-owner p-3">
+              <h2 class="text-lg font-semibold text-gray-800 mb-3">Monthly reports submitted</h2>
+              <%= turbo_frame_tag "person_monthly_reports_section", src: person_path(@person, section: "monthly_reports"), loading: :lazy do %>
+                <p class="text-gray-500 italic">Loading monthly reports...</p>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -339,8 +339,8 @@
               <% end %>
             </div>
           <% end %>
-          <!-- Monthly reports (admin/owner only) -->
-          <% if @person.profile_show_monthly_reports? %>
+          <!-- Monthly reports (admin/owner only; deprecated — only for people who have some) -->
+          <% if @person.profile_show_monthly_reports? && @person.any_monthly_reports? %>
             <div id="monthly_reports" class="admin-or-owner p-3">
               <h2 class="text-lg font-semibold text-gray-800 mb-3">Monthly reports submitted</h2>
               <%= turbo_frame_tag "person_monthly_reports_section", src: person_path(@person, section: "monthly_reports"), loading: :lazy do %>

--- a/db/migrate/20260822151059_add_author_to_workshop_logs_and_reports.rb
+++ b/db/migrate/20260822151059_add_author_to_workshop_logs_and_reports.rb
@@ -1,0 +1,33 @@
+class AddAuthorToWorkshopLogsAndReports < ActiveRecord::Migration[8.1]
+  # Bring workshop logs and monthly reports into the author-credit system (an
+  # explicit Person author + the credit-preference snapshot AuthorCreditable
+  # stores), matching workshops/stories/variations. Nullable, no backfill — the
+  # legacy credit derives from created_by.person at read time.
+  def up
+    add_author_columns(:workshop_logs)
+    add_author_columns(:reports)
+  end
+
+  def down
+    remove_author_columns(:reports)
+    remove_author_columns(:workshop_logs)
+  end
+
+  private
+
+  def add_author_columns(table)
+    add_column table, :author_credit_preference, :string unless column_exists?(table, :author_credit_preference)
+    add_column table, :author_id, :bigint unless column_exists?(table, :author_id)
+    add_index table, :author_id unless index_exists?(table, :author_id)
+    unless foreign_key_exists?(table, :people, column: :author_id)
+      add_foreign_key table, :people, column: :author_id
+    end
+  end
+
+  def remove_author_columns(table)
+    remove_foreign_key table, :people, column: :author_id, if_exists: true
+    remove_index table, :author_id, if_exists: true
+    remove_column table, :author_id, if_exists: true
+    remove_column table, :author_credit_preference, if_exists: true
+  end
+end

--- a/db/migrate/20260822154039_add_profile_show_monthly_reports_to_people.rb
+++ b/db/migrate/20260822154039_add_profile_show_monthly_reports_to_people.rb
@@ -1,0 +1,11 @@
+class AddProfileShowMonthlyReportsToPeople < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:people, :profile_show_monthly_reports)
+      add_column :people, :profile_show_monthly_reports, :boolean, default: true, null: false
+    end
+  end
+
+  def down
+    remove_column :people, :profile_show_monthly_reports, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1082,6 +1082,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
     t.boolean "profile_show_email", default: true, null: false
     t.boolean "profile_show_events_registered", default: true, null: false
     t.boolean "profile_show_member_since", default: true, null: false
+    t.boolean "profile_show_monthly_reports", default: true, null: false
     t.boolean "profile_show_phone", default: true, null: false
     t.boolean "profile_show_pronouns", default: true, null: false
     t.boolean "profile_show_resources", default: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1230,6 +1230,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   create_table "reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "adults_first_time", default: 0
     t.integer "adults_ongoing", default: 0
+    t.string "author_credit_preference"
+    t.bigint "author_id"
     t.integer "children_first_time", default: 0
     t.integer "children_ongoing", default: 0
     t.datetime "created_at", precision: nil, null: false
@@ -1253,6 +1255,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
     t.integer "windows_type_id"
     t.integer "workshop_id"
     t.string "workshop_name"
+    t.index ["author_id"], name: "index_reports_on_author_id"
     t.index ["created_by_id"], name: "index_reports_on_created_by_id"
     t.index ["organization_id"], name: "index_reports_on_organization_id"
     t.index ["type", "date"], name: "index_reports_on_type_and_date"
@@ -1668,6 +1671,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   create_table "workshop_logs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "adults_first_time", default: 0
     t.integer "adults_ongoing", default: 0
+    t.string "author_credit_preference"
+    t.bigint "author_id"
     t.integer "children_first_time", default: 0
     t.integer "children_ongoing", default: 0
     t.datetime "created_at", precision: nil, null: false
@@ -1684,6 +1689,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
     t.integer "windows_type_id"
     t.date "workshop_held_on"
     t.integer "workshop_id"
+    t.index ["author_id"], name: "index_workshop_logs_on_author_id"
     t.index ["created_by_id"], name: "index_workshop_logs_on_created_by_id"
     t.index ["organization_id", "workshop_held_on"], name: "index_workshop_logs_on_org_and_workshop_held_on"
     t.index ["organization_id"], name: "index_workshop_logs_on_organization_id"
@@ -1956,6 +1962,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   add_foreign_key "report_form_field_answers", "reports"
   add_foreign_key "report_form_field_answers", "workshop_logs"
   add_foreign_key "reports", "organizations"
+  add_foreign_key "reports", "people", column: "author_id"
   add_foreign_key "reports", "users", column: "created_by_id"
   add_foreign_key "reports", "windows_types"
   add_foreign_key "resources", "people", column: "author_id"
@@ -2001,6 +2008,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   add_foreign_key "workshop_ideas", "users", column: "updated_by_id"
   add_foreign_key "workshop_ideas", "windows_types"
   add_foreign_key "workshop_logs", "organizations"
+  add_foreign_key "workshop_logs", "people", column: "author_id"
   add_foreign_key "workshop_logs", "users", column: "created_by_id"
   add_foreign_key "workshop_logs", "windows_types"
   add_foreign_key "workshop_logs", "workshops"

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -1,6 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe MonthlyReport do
+  it_behaves_like "author_creditable", factory: :monthly_report, org_credited: false, credits_creator_legacy: true
+
+  describe "#author_credit" do
+    it "credits an unauthored report to the creator's person by name" do
+      creator = create(:user, :with_person)
+      report = create(:monthly_report, author: nil, created_by: creator)
+      expect(report.author_credit).to eq(creator.person.name)
+    end
+
+    it "reads Anonymous when there is no author and no creator person" do
+      report = create(:monthly_report, author: nil, created_by: create(:user, person: nil))
+      expect(report.author_credit).to eq("Anonymous")
+    end
+
+    it "reads Anonymous when the creator's person opted out of being credited" do
+      creator = create(:user, person: create(:person, :anonymous_contributions))
+      report = create(:monthly_report, author: nil, created_by: creator)
+      expect(report.author_credit).to eq("Anonymous")
+    end
+  end
+
   it "uses the reports table" do
     expect(MonthlyReport.table_name).to eq("reports")
   end

--- a/spec/models/workshop_log_spec.rb
+++ b/spec/models/workshop_log_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
 
 RSpec.describe WorkshopLog do
+  it_behaves_like "author_creditable", factory: :workshop_log, org_credited: false
+
   describe "associations" do
     it { should belong_to(:created_by).optional }
+    it { should belong_to(:author).class_name("Person").optional }
     it { should belong_to(:organization).optional }
     it { should belong_to(:windows_type).optional }
     it { should belong_to(:workshop).optional }

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe WorkshopVariation do
-  it_behaves_like "author_creditable", factory: :workshop_variation, org_credited: false
+  it_behaves_like "author_creditable", factory: :workshop_variation, org_credited: false, credits_creator_legacy: true
 
   describe "associations" do
     it { should belong_to(:workshop).optional }
@@ -12,10 +12,22 @@ RSpec.describe WorkshopVariation do
   end
 
   describe "#missing_author_label" do
-    it "credits unattributed variations to AWBW Facilitator" do
+    it "credits an unauthored variation to the creator's person by name" do
+      creator = create(:user, :with_person)
+      variation = create(:workshop_variation, author: nil, created_by: creator)
+      expect(variation.author_credit).to eq(creator.person.name)
+    end
+
+    it "reads Anonymous when there is no author and no creator person" do
       variation = create(:workshop_variation, author: nil, created_by: create(:user, person: nil))
-      expect(variation.missing_author_label).to eq("AWBW Facilitator")
-      expect(variation.author_credit).to eq("AWBW Facilitator")
+      expect(variation.missing_author_label).to eq("Anonymous")
+      expect(variation.author_credit).to eq("Anonymous")
+    end
+
+    it "reads Anonymous when the creator's person opted out of being credited" do
+      creator = create(:user, person: create(:person, :anonymous_contributions))
+      variation = create(:workshop_variation, author: nil, created_by: creator)
+      expect(variation.author_credit).to eq("Anonymous")
     end
   end
 

--- a/spec/requests/people_monthly_reports_section_spec.rb
+++ b/spec/requests/people_monthly_reports_section_spec.rb
@@ -47,4 +47,23 @@ RSpec.describe "Person profile monthly reports section", type: :request do
 
     expect(response).to redirect_to(root_path)
   end
+
+  describe "section visibility on the full profile (deprecated functionality)" do
+    it "shows the section heading when the person has monthly reports" do
+      sign_in owner_user
+      create(:monthly_report, created_by: owner_user)
+
+      get person_path(person)
+
+      expect(response.body).to include("Monthly reports submitted")
+    end
+
+    it "hides the section heading when the person has none" do
+      sign_in owner_user
+
+      get person_path(person)
+
+      expect(response.body).not_to include("Monthly reports submitted")
+    end
+  end
 end

--- a/spec/requests/people_monthly_reports_section_spec.rb
+++ b/spec/requests/people_monthly_reports_section_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Person profile monthly reports section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+  let(:outsider) { create(:user) }
+
+  def get_monthly_reports_section
+    get person_path(person, section: "monthly_reports"),
+        headers: { "Turbo-Frame" => "person_monthly_reports_section" }
+  end
+
+  it "lists an unauthored report the person's user created (legacy fallback)" do
+    sign_in owner_user
+    report = create(:monthly_report, created_by: owner_user, author: nil)
+
+    get_monthly_reports_section
+
+    expect(response).to be_successful
+    expect(response.body).to include(monthly_report_path(report))
+  end
+
+  it "lists a report the person explicitly authored" do
+    sign_in admin
+    report = create(:monthly_report, created_by: create(:user), author: person)
+
+    get_monthly_reports_section
+
+    expect(response.body).to include(monthly_report_path(report))
+  end
+
+  it "excludes a report created by their user but authored by someone else" do
+    sign_in owner_user
+    report = create(:monthly_report, created_by: owner_user, author: create(:person))
+
+    get_monthly_reports_section
+
+    expect(response.body).not_to include(monthly_report_path(report))
+  end
+
+  it "denies the section to a non-owner" do
+    sign_in outsider
+    create(:monthly_report, created_by: owner_user)
+
+    get_monthly_reports_section
+
+    expect(response).to redirect_to(root_path)
+  end
+end

--- a/spec/requests/people_resources_section_spec.rb
+++ b/spec/requests/people_resources_section_spec.rb
@@ -22,11 +22,20 @@ RSpec.describe "Person profile resources section", type: :request do
     expect(response.body).to include("Authored Resource")
   end
 
-  it "excludes resources the person's user merely created (audit trail only)" do
-    create(:resource, :published, title: "Only Created Resource", created_by: owner_user)
+  it "includes unauthored resources the person's user created (legacy fallback)" do
+    create(:resource, :published, title: "Only Created Resource", created_by: owner_user, author: nil)
 
     get_resources_section
 
-    expect(response.body).not_to include("Only Created Resource")
+    expect(response.body).to include("Only Created Resource")
+  end
+
+  it "excludes resources the person's user created but credited to someone else" do
+    create(:resource, :published, title: "Someone Elses Resource",
+                                  created_by: owner_user, author: create(:person))
+
+    get_resources_section
+
+    expect(response.body).not_to include("Someone Elses Resource")
   end
 end

--- a/spec/requests/people_workshop_variations_section_spec.rb
+++ b/spec/requests/people_workshop_variations_section_spec.rb
@@ -22,11 +22,20 @@ RSpec.describe "Person profile workshop variations section", type: :request do
     expect(response.body).to include("Authored Variation")
   end
 
-  it "excludes variations the person's user merely created (audit trail only)" do
-    create(:workshop_variation, name: "Only Created Variation", created_by: owner_user)
+  it "includes unauthored variations the person's user created (legacy fallback)" do
+    create(:workshop_variation, name: "Only Created Variation", created_by: owner_user, author: nil)
 
     get_workshop_variations_section
 
-    expect(response.body).not_to include("Only Created Variation")
+    expect(response.body).to include("Only Created Variation")
+  end
+
+  it "excludes variations the person's user created but credited to someone else" do
+    create(:workshop_variation, name: "Someone Elses Variation",
+                                created_by: owner_user, author: create(:person))
+
+    get_workshop_variations_section
+
+    expect(response.body).not_to include("Someone Elses Variation")
   end
 end

--- a/spec/requests/people_workshops_section_spec.rb
+++ b/spec/requests/people_workshops_section_spec.rb
@@ -22,12 +22,21 @@ RSpec.describe "Person profile workshops section", type: :request do
     expect(response.body).to include("Authored Workshop")
   end
 
-  it "excludes workshops the person's user merely created (audit trail only)" do
-    create(:workshop, :published, title: "Only Created Workshop", created_by: owner_user)
+  it "includes unauthored workshops the person's user created (legacy fallback)" do
+    create(:workshop, :published, title: "Only Created Workshop", created_by: owner_user, author: nil)
 
     get_workshops_section
 
-    expect(response.body).not_to include("Only Created Workshop")
+    expect(response.body).to include("Only Created Workshop")
+  end
+
+  it "excludes workshops the person's user created but credited to someone else" do
+    create(:workshop, :published, title: "Someone Elses Workshop",
+                                  created_by: owner_user, author: create(:person))
+
+    get_workshops_section
+
+    expect(response.body).not_to include("Someone Elses Workshop")
   end
 
   it "flags an anonymously-credited authored workshop for an admin" do

--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -354,6 +354,15 @@ RSpec.describe "/workshop_logs", type: :request do
         expect(response).to have_http_status(:redirect)
       end
 
+      it "sets the workshop log author to the creator's person" do
+        person = create(:person)
+        user.update!(person: person)
+
+        post workshop_logs_path, params: { workshop_log: valid_attributes }
+
+        expect(WorkshopLog.last.author).to eq(person)
+      end
+
       it "credits nested quotes to the current user without setting the quote author" do
         post workshop_logs_path, params: {
           workshop_log: valid_attributes.merge(

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -187,6 +187,28 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_c
     end
   end
 
+  if names_author
+    describe ".credited_to_person" do
+      let(:person) { create(:person) }
+      let(:their_user) { create(:user, person: person) }
+
+      it "includes records they explicitly authored" do
+        record = create(factory, author: person, created_by: create(:user))
+        expect(model.credited_to_person(person)).to include(record)
+      end
+
+      it "includes unauthored records their user created (legacy fallback)" do
+        record = create(factory, author: nil, created_by: their_user)
+        expect(model.credited_to_person(person)).to include(record)
+      end
+
+      it "excludes records authored by someone else, even if their user created them" do
+        record = create(factory, author: create(:person), created_by: their_user)
+        expect(model.credited_to_person(person)).not_to include(record)
+      end
+    end
+  end
+
   describe ".by_credited_person_name" do
     if names_author
       let(:author_user) { create(:user, :with_person) }

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,9 +1,15 @@
-RSpec.shared_examples "author_creditable" do |factory:, org_credited:|
+RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_creator_legacy: false|
   model = factory.to_s.camelize.constantize
   names_author = model.column_names.include?("author_id")
-  # What an unattributed record credits to: "AWBW Staff" for org-produced content,
-  # otherwise the generic facilitator label.
-  org_label = org_credited ? "AWBW Staff" : "AWBW Facilitator"
+  # What an unattributed record credits to. Most models fall to a generic label
+  # ("AWBW Staff" for org-produced content, otherwise the facilitator label).
+  # A creator-legacy model (workshop variation, monthly report) instead credits
+  # the creator's person by name, and reads "Anonymous" only when there is none.
+  unattributed_label = if credits_creator_legacy
+    "Anonymous"
+  else
+    org_credited ? "AWBW Staff" : "AWBW Facilitator"
+  end
 
   # Only a model with an author_id credits a person; the idea models (no author_id)
   # never credit whoever entered them, so they always fall to the generic label.
@@ -70,11 +76,11 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:|
       context "when the profile marks contributions anonymous" do
         before { person.update!(anonymous_contributions: true) }
 
-        # Behind a login, so a suppressed credit names the org rather than saying
-        # "Anonymous", which would read as being about the reader's access.
-        it "returns the generic label regardless of the name format" do
+        # A suppressed explicit-author credit reads the unattributed label rather
+        # than the profile name — the org label, or "Anonymous" for creator-legacy.
+        it "returns the unattributed label regardless of the name format" do
           person.update!(display_name_preference: "full_name")
-          expect(record.author_credit).to eq(org_label)
+          expect(record.author_credit).to eq(unattributed_label)
         end
 
         it "does not link the credit to a profile" do
@@ -87,7 +93,7 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:|
 
         it "stays suppressed even though the profile says otherwise" do
           person.update!(display_name_preference: "full_name", anonymous_contributions: false)
-          expect(record.author_credit).to eq(org_label)
+          expect(record.author_credit).to eq(unattributed_label)
         end
 
         it "does not link the credit to a profile" do
@@ -96,17 +102,27 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:|
       end
 
       context "when the author is removed" do
-        it "falls back to the generic label rather than crediting the creator" do
-          record.update!(author: nil, author_credit_preference: nil)
-          expect(record.missing_author_label).to eq(org_label)
-          expect(record.author_credit).to eq(org_label)
+        before { record.update!(author: nil, author_credit_preference: nil) }
+
+        it "uses the unattributed label as the missing-author label" do
+          expect(record.missing_author_label).to eq(unattributed_label)
+        end
+
+        if credits_creator_legacy
+          it "credits the creator's person by name instead of the generic label" do
+            expect(record.author_credit).to eq(person.name)
+          end
+        else
+          it "falls back to the generic label rather than crediting the creator" do
+            expect(record.author_credit).to eq(unattributed_label)
+          end
         end
       end
     else
       context "on an idea record, which names no author" do
         it "always credits the generic label, never the creator" do
           person.update!(display_name_preference: "full_name")
-          expect(record.author_credit).to eq(org_label)
+          expect(record.author_credit).to eq(unattributed_label)
         end
 
         it "does not link the credit to a profile" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 schema change across 3 tables + AuthorCreditable wiring on 4 models + profile-credit rework + shared-spec parameterization

## What
Bring the remaining content models into the author-credit system and move the **person profile** onto uniform `author_person` crediting.

### Models — all six now carry a Person `author`
| Model | Change |
|---|---|
| Workshop, Story, StoryIdea, WorkshopVariation | already had `author` |
| **WorkshopLog** | + `author` column + AuthorCreditable; `create` sets `author = created_by.person` |
| **MonthlyReport** (STI on `reports`) | + `author` column + AuthorCreditable |

- **Migration:** `author_id` (+ index + FK to `people`) and `author_credit_preference` on `workshop_logs` and `reports`. Nullable, **no backfill**.
- **WorkshopVariation + MonthlyReport:** when unauthored, credit falls back to the **creator's person by name** (honoring their display/anonymity preference), else **"Anonymous"**.

### Person profile — move off created_by, onto author_person
Previously the profile was split: content sections credited **author only** ("created_by is a pure audit trail"), while the workshop-logs section credited **created_by only**. Now every content section uses one rule — **`AuthorCreditable.credited_to_person`**: the explicit author, or (only when nobody else is the author) what the person's user account created.

- Applied to workshops, variations, stories, resources, and the three idea sections + workshop logs.
- **New "Monthly reports" profile section** (private, admin/owner) with a `profile_show_monthly_reports` toggle.
- Events section unchanged (registrant).

## Fixes #2326
Adds the Person `author` column #2326 said WorkshopLog lacked. (#2331 also references #2326 by confirming the created_by.person fallback — complementary.)

## Design note
For WorkshopVariation and MonthlyReport, and for the profile listings, this **intentionally reverses** AuthorCreditable's old "a creator fallback never declared authorship" rule — the direction is author-primary with a legacy created_by fallback. The other models keep the generic-label behavior; the shared `author_creditable` spec is parameterized (`credits_creator_legacy:`).

## Tests
- Shared `author_creditable` examples now cover WorkshopLog + MonthlyReport and the new `credited_to_person` scope.
- Profile section request specs updated to the new author-or-legacy behavior; new Monthly-reports section spec.
- Full model suite green.

Closes #2326