### PR TITLE
Upcoming is its own facilitator status, and "Linked" is a real organization link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,14 +441,14 @@ Tailwind only scans the paths listed in the `@source` directives at the top of t
 
 | Directory | Count | Purpose |
 |---|---|---|
-| `spec/models/` | ~71 | Model unit tests |
-| `spec/views/` | ~77 | View template tests |
-| `spec/requests/` | ~91 | HTTP request/integration tests |
-| `spec/system/` | ~20 | End-to-end browser tests (Capybara) |
-| `spec/routing/` | ~15 | Route definition tests |
-| `spec/policies/` | ~15 | Authorization policy tests |
-| `spec/decorators/` | ~15 | Decorator tests |
-| `spec/services/` | ~25 | Service object tests |
+| `spec/models/` | ~86 | Model unit tests |
+| `spec/views/` | ~82 | View template tests |
+| `spec/requests/` | ~137 | HTTP request/integration tests |
+| `spec/system/` | ~25 | End-to-end browser tests (Capybara) |
+| `spec/routing/` | ~18 | Route definition tests |
+| `spec/policies/` | ~19 | Authorization policy tests |
+| `spec/decorators/` | ~29 | Decorator tests |
+| `spec/services/` | ~68 | Service object tests |
 | `spec/mailers/` | ~5 | Mailer tests |
 | `spec/helpers/` | ~5 | Helper tests |
 | `spec/factories/` | ~67 | FactoryBot factory definitions |

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -991,8 +991,9 @@ class EventsController < ApplicationController
       .select(:registrant_id)
   end
 
-  # Person ids with at least one affiliation in the given status (Active / Pending
-  # / Inactive).
+  # Person ids with at least one affiliation in the given status (Affiliation::
+  # STATUSES — Active / Upcoming / Inactive), judged as of today to match the
+  # roster's Affiliation status column.
   def person_affiliation_status_ids(status)
     Affiliation.with_status(status).select(:person_id)
   end

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -95,8 +95,13 @@ class FormSubmissionsController < ApplicationController
   # {submission_id => [Organization]} for the directly-linked orgs across the page,
   # in one query, so the index can show the linked org chips without an N+1 over
   # each submission's metadata id list.
+  # Both direct links per submission (ADR-0002 D5): the metadata ids, plus the
+  # registration-org rows pinned to these submissions — one query for the page.
   def linked_orgs_for(submissions)
     ids_by_submission = submissions.to_h { |submission| [ submission.id, submission.linked_organization_ids ] }
+    EventRegistrationOrganization.where(form_submission_id: ids_by_submission.keys)
+      .pluck(:form_submission_id, :organization_id)
+      .each { |submission_id, organization_id| ids_by_submission[submission_id] |= [ organization_id ] }
     all_ids = ids_by_submission.values.flatten.uniq
     orgs = all_ids.any? ? Organization.where(id: all_ids).index_by(&:id) : {}
     ids_by_submission.transform_values { |ids| ids.filter_map { |id| orgs[id] } }
@@ -132,17 +137,30 @@ class FormSubmissionsController < ApplicationController
     Organization.where("LOWER(name) = ?", name.downcase).exists? ? [] : [ name ]
   end
 
-  # The org this submission resolves to: an explicitly linked one first (an
-  # admin's resolution, which survives a submitted name that doesn't match the
-  # org), else the org whose name matches the submitted answer among the
-  # person's active affiliations — the same rule as the index's Linked chip.
+  # The org this submission resolves to, by direct link only — an affiliation the
+  # person happens to hold under the submitted name is not a link. Two links
+  # carry it: the explicit one an admin recorded on the submission (which
+  # survives a submitted name that doesn't match the org it resolved to), and
+  # the registration-org row this submission is pinned to (public registration
+  # pins the submission as it creates the link).
   def matched_organization
-    explicit = @form_submission.linked_organizations.first
-    return explicit if explicit
-    return if @submitted_org_name.blank?
+    @form_submission.linked_organizations.first || registration_linked_organization
+  end
 
-    @person.affiliations.select { |a| a.active? && a.organization.name.casecmp?(@submitted_org_name.strip) }
-           .map(&:organization).first
+  # The org on the registration-org link pinned to this submission. Rows created
+  # before that pin existed fall back to the registration's sole linked org — the
+  # same single-org rule the registration editor pairs submitted answers by.
+  def registration_linked_organization
+    return if @form_submission.person_id.blank?
+
+    pinned = EventRegistrationOrganization.find_by(form_submission_id: @form_submission.id)
+    return pinned.organization if pinned
+    return if @form_submission.event_id.blank?
+
+    links = EventRegistrationOrganization.joins(:event_registration).where(
+      event_registrations: { event_id: @form_submission.event_id, registrant_id: @form_submission.person_id }
+    )
+    links.sole.organization if links.count == 1
   end
 
   def profile_diff_for(organization)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -104,7 +104,7 @@ class PeopleController < ApplicationController
         @workshop_variation_ideas = WorkshopVariationIdea.credited_to_person(@person).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/workshop_variation_ideas", locals: { person: @person, workshop_variation_ideas: @workshop_variation_ideas }
       when "affiliations"
-        @affiliations = @person.affiliations.active.includes(organization: :logo_attachment).paginate(page: params[:page], per_page: per_page)
+        @affiliations = @person.affiliations.active_or_pending.includes(organization: :logo_attachment).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/affiliations", locals: { person: @person, affiliations: @affiliations }
       end
     end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -140,7 +140,11 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   # E.g. a stored "Active" on an org that never had a facilitator affiliation.
+  # The legacy column has no Upcoming of its own, so a scheduled-but-not-started
+  # program is fairly recorded as Pending (or blank/Unknown, which bucket with it).
   def legacy_status_mismatch?
+    return stored_status_bucket != :never_active if organization_status_bucket == :upcoming
+
     organization_status_bucket != stored_status_bucket
   end
 

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -148,8 +148,23 @@ class OrganizationDecorator < ApplicationDecorator
     organization_status_bucket != stored_status_bucket
   end
 
-  def organization_status_label
-    ORG_STATUS_BUCKET_LABELS.fetch(organization_status_bucket)
+  # Upcoming is an admin-only distinction. Everyone else sees a program that
+  # hasn't started as plain "Inactive", neutral like Never active (it has never
+  # facilitated), so a public-facing index reflects the state of the world today
+  # rather than a scheduled future one. See ADR-0001 D3.
+  PUBLIC_UPCOMING = { label: "Inactive", bucket: :never_active }.freeze
+
+  def self.display_bucket(bucket, admin:)
+    bucket == :upcoming && !admin ? PUBLIC_UPCOMING[:bucket] : bucket
+  end
+
+  def self.display_label(bucket, admin:)
+    return PUBLIC_UPCOMING[:label] if bucket == :upcoming && !admin
+    ORG_STATUS_BUCKET_LABELS.fetch(bucket)
+  end
+
+  def organization_status_label(admin: false)
+    self.class.display_label(organization_status_bucket, admin: admin)
   end
 
   def self.status_classes_for_bucket(bucket)
@@ -162,28 +177,30 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   # Lets the edit form's Stimulus controller re-render the chip live without
-  # hard-coding theme classes in JS.
-  def self.status_bucket_styles
+  # hard-coding theme classes in JS. Takes the same admin flag as the server-side
+  # chip so the live value can't disagree with the rendered one.
+  def self.status_bucket_styles(admin: false)
     ORG_STATUS_BUCKET_LABELS.each_key.to_h do |bucket|
-      [ bucket, { label: ORG_STATUS_BUCKET_LABELS.fetch(bucket), classes: status_classes_for_bucket(bucket) } ]
+      [ bucket, { label: display_label(bucket, admin: admin),
+                  classes: status_classes_for_bucket(display_bucket(bucket, admin: admin)) } ]
     end
   end
 
-  def organization_status_classes
-    self.class.status_classes_for_bucket(organization_status_bucket)
+  def organization_status_classes(admin: false)
+    self.class.status_classes_for_bucket(self.class.display_bucket(organization_status_bucket, admin: admin))
   end
 
-  def organization_status_chip(data: {})
-    h.content_tag(:span, organization_status_label,
+  def organization_status_chip(data: {}, admin: false)
+    h.content_tag(:span, organization_status_label(admin: admin),
                   data: data,
-                  class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{organization_status_classes}")
+                  class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{organization_status_classes(admin: admin)}")
   end
 
   # Facilitator years, coloured by the org's status; falls back to the status
   # label when there are no facilitator years to show.
-  def program_since_chip(years = program_since_display)
-    h.content_tag(:span, years.presence || organization_status_label,
-                  class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{organization_status_classes}")
+  def program_since_chip(years = program_since_display, admin: false)
+    h.content_tag(:span, years.presence || organization_status_label(admin: admin),
+                  class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{organization_status_classes(admin: admin)}")
   end
 
   # Reads the already-loaded affiliations, so a profile classifies many events

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -117,19 +117,21 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   ORG_STATUS_BUCKET_LABELS = {
-    active: "Active", formerly_active: "Formerly active", never_active: "Never active"
+    active: "Active", upcoming: "Upcoming", formerly_active: "Formerly active", never_active: "Never active"
   }.freeze
   ORG_STATUS_BUCKET_THEMES = {
-    active: :org_active, formerly_active: :org_formerly_active, never_active: :org_never_active
+    active: :org_active, upcoming: :org_upcoming, formerly_active: :org_formerly_active, never_active: :org_never_active
   }.freeze
 
   # Derived purely from facilitator affiliations; the stored organization_status
-  # never feeds into this (ADR-0001 D3).
+  # never feeds into this (ADR-0001 D3). Upcoming (a facilitator scheduled but not
+  # started) is distinct from Active and from a lapsed Formerly active.
   def organization_status_bucket
     facilitators = object.affiliations.select(&:facilitator?)
     return :never_active if facilitators.none?
-
-    facilitators.any?(&:active?) ? :active : :formerly_active
+    return :active if facilitators.any?(&:active?)
+    return :upcoming if facilitators.any?(&:upcoming?)
+    :formerly_active
   end
 
   # Only used to flag where the legacy column disagrees with the affiliations.

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -86,11 +86,11 @@ class PersonDecorator < ApplicationDecorator
   end
 
   # The person's facilitator standing for list display: Active if any facilitator
-  # affiliation is current, Upcoming if one is scheduled but none active, Inactive
-  # if every facilitator term has ended, nil if they were never a facilitator.
+  # affiliation is current, Upcoming if one is scheduled but none active, otherwise
+  # Inactive — which covers both a lapsed facilitator and someone who was never a
+  # facilitator (neither is a currently-active facilitator).
   def facilitator_status_label
     facilitator_affiliations = affiliations.select(&:facilitator?)
-    return nil if facilitator_affiliations.none?
     return "Active" if facilitator_affiliations.any?(&:active?)
     return "Upcoming" if facilitator_affiliations.any?(&:upcoming?)
     "Inactive"

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -77,6 +77,25 @@ class PersonDecorator < ApplicationDecorator
     @affiliated_since_date ||= affiliations.filter_map(&:start_date).min
   end
 
+  # Facilitator-since year for list pages — the Ruby (no per-row query) twin of
+  # facilitator_since_date, falling back to the legacy member_since like the edit
+  # form. Computed from the eager-loaded affiliations.
+  def facilitator_since_year
+    earliest = affiliations.select(&:facilitator?).filter_map(&:start_date).min
+    (earliest || member_since)&.year
+  end
+
+  # The person's facilitator standing for list display: Active if any facilitator
+  # affiliation is current, Upcoming if one is scheduled but none active, Inactive
+  # if every facilitator term has ended, nil if they were never a facilitator.
+  def facilitator_status_label
+    facilitator_affiliations = affiliations.select(&:facilitator?)
+    return nil if facilitator_affiliations.none?
+    return "Active" if facilitator_affiliations.any?(&:active?)
+    return "Upcoming" if facilitator_affiliations.any?(&:upcoming?)
+    "Inactive"
+  end
+
   def facilitator_since_range
     date_range_display(facilitator_since_date, facilitation_end_date, ended_title: "No active facilitator affiliations")
   end

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -78,11 +78,15 @@ class PersonDecorator < ApplicationDecorator
   end
 
   # Facilitator-since year for list pages — the Ruby (no per-row query) twin of
-  # facilitator_since_date, falling back to the legacy member_since like the edit
-  # form. Computed from the eager-loaded affiliations.
+  # facilitator_since_date. Nil for someone who has never held a facilitator
+  # affiliation, so the column can't show an unrelated affiliation/membership year
+  # under a "Facilitator since" heading. For an actual facilitator whose rows carry
+  # no start date, falls back to the legacy member_since like the edit form.
   def facilitator_since_year
-    earliest = affiliations.select(&:facilitator?).filter_map(&:start_date).min
-    (earliest || member_since)&.year
+    facilitator_affiliations = affiliations.select(&:facilitator?)
+    return nil if facilitator_affiliations.none?
+
+    (facilitator_affiliations.filter_map(&:start_date).min || member_since)&.year
   end
 
   # The person's facilitator standing for list display: Active if any facilitator

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -214,7 +214,7 @@ export default class extends Controller {
     if (!target) return
     let html = ""
     if (endDate) {
-      html += '<i class="fa-solid fa-circle-xmark text-red-400 mr-1" title="No active affiliations"></i>'
+      html += '<i class="fa-solid fa-circle-xmark mr-1 text-red-400" title="No active affiliations"></i>'
     }
     html += sinceDate ? this.formatDate(sinceDate) : "—"
     if (endDate) html += ` – ${this.formatDate(endDate)}`

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -88,11 +88,17 @@ export default class extends Controller {
 
     // Mirrors OrganizationDecorator#organization_status_bucket.
     if (this.hasProgramStatusTarget) {
+      const started = a => !a.startDate || new Date(a.startDate) <= today
+      const notEnded = a => !a.endDate || new Date(a.endDate) >= today
       let bucket
       if (facilitatorAffiliations.length === 0) {
         bucket = "never_active"
+      } else if (facilitatorAffiliations.some(a => started(a) && notEnded(a))) {
+        bucket = "active"
+      } else if (facilitatorAffiliations.some(a => !started(a) && notEnded(a))) {
+        bucket = "upcoming"
       } else {
-        bucket = allFacInactive ? "formerly_active" : "active"
+        bucket = "formerly_active"
       }
       this.updateProgramStatus(bucket)
     }

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -8,7 +8,7 @@ import { isFacilitatorTitle } from "../lib/affiliation";
 // ended) additionally shows an "Upcoming" badge.
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar", "valueField", "startDate", "upcomingBadge", "inactiveBadge"]
-  static values = { expired: Boolean }
+  static values = { expired: Boolean, today: String }
 
   connect() {
     if (this.hasTitleTarget) this.updateBorder();
@@ -57,10 +57,16 @@ export default class extends Controller {
     return value > this.todayISO();
   }
 
-  // Local "today" as YYYY-MM-DD, compared against the date inputs' own
-  // YYYY-MM-DD values as strings — no cross-timezone Date parsing (a UTC-parsed
-  // date input vs a local "today" would misjudge a start/end that equals today).
+  // "Today" as YYYY-MM-DD, compared against the date inputs' own YYYY-MM-DD values
+  // as strings — no cross-timezone Date parsing. It comes from the server, because
+  // the ERB badges are rendered against the app's Date.current: a browser whose
+  // local date is a day behind (e.g. US evening under a UTC app zone) would
+  // otherwise call a row starting today "Upcoming" while the server didn't.
   todayISO() {
+    return this.todayValue || this.browserToday();
+  }
+
+  browserToday() {
     const d = new Date();
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
   }

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -4,9 +4,10 @@ import { isFacilitatorTitle } from "../lib/affiliation";
 // Live styling for the affiliation editor row as you edit, before saving. Four
 // states by colour: role is the hue (facilitator = purple, else blue) and status
 // is the saturation (active = full, inactive = super-light). Inactive rows also
-// strike their fields (.aff-ended).
+// strike their fields (.aff-ended). A not-yet-started row (future start date, not
+// ended) additionally shows an "Upcoming" badge.
 export default class extends Controller {
-  static targets = ["endDate", "title", "row", "accentBar", "valueField"]
+  static targets = ["endDate", "title", "row", "accentBar", "valueField", "startDate", "upcomingBadge"]
   static values = { expired: Boolean }
 
   connect() {
@@ -36,7 +37,22 @@ export default class extends Controller {
     this.updateRowBackground();
     this.styleTitle();
     this.paintFields();
+    this.updateUpcoming();
     this.rowTarget.classList.toggle("aff-ended", this.isPast());
+  }
+
+  // Show the "Upcoming" badge when the affiliation has a future start date and
+  // has not ended.
+  updateUpcoming() {
+    if (!this.hasUpcomingBadgeTarget) return;
+    this.upcomingBadgeTarget.classList.toggle("hidden", !this.isUpcoming());
+  }
+
+  isUpcoming() {
+    if (this.isPast()) return false;
+    const value = this.hasStartDateTarget ? this.startDateTarget.value : "";
+    if (!value) return false;
+    return new Date(value) > new Date(new Date().toDateString());
   }
 
   styleTitle() {

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -7,7 +7,7 @@ import { isFacilitatorTitle } from "../lib/affiliation";
 // strike their fields (.aff-ended). A not-yet-started row (future start date, not
 // ended) additionally shows an "Upcoming" badge.
 export default class extends Controller {
-  static targets = ["endDate", "title", "row", "accentBar", "valueField", "startDate", "upcomingBadge"]
+  static targets = ["endDate", "title", "row", "accentBar", "valueField", "startDate", "upcomingBadge", "inactiveBadge"]
   static values = { expired: Boolean }
 
   connect() {
@@ -37,15 +37,17 @@ export default class extends Controller {
     this.updateRowBackground();
     this.styleTitle();
     this.paintFields();
-    this.updateUpcoming();
+    this.updateBadges();
     this.rowTarget.classList.toggle("aff-ended", this.isPast());
   }
 
-  // Show the "Upcoming" badge when the affiliation has a future start date and
-  // has not ended.
-  updateUpcoming() {
-    if (!this.hasUpcomingBadgeTarget) return;
-    this.upcomingBadgeTarget.classList.toggle("hidden", !this.isUpcoming());
+  // "Inactive" whenever the affiliation isn't currently active (ended, flagged,
+  // or not-yet-started); "Upcoming" additionally for a future start — so an
+  // upcoming row shows both and an ended one shows only Inactive.
+  updateBadges() {
+    const notActive = this.isPast() || this.isUpcoming();
+    if (this.hasInactiveBadgeTarget) this.inactiveBadgeTarget.classList.toggle("hidden", !notActive);
+    if (this.hasUpcomingBadgeTarget) this.upcomingBadgeTarget.classList.toggle("hidden", !this.isUpcoming());
   }
 
   isUpcoming() {

--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -52,7 +52,15 @@ export default class extends Controller {
     if (this.isPast()) return false;
     const value = this.hasStartDateTarget ? this.startDateTarget.value : "";
     if (!value) return false;
-    return new Date(value) > new Date(new Date().toDateString());
+    return value > this.todayISO();
+  }
+
+  // Local "today" as YYYY-MM-DD, compared against the date inputs' own
+  // YYYY-MM-DD values as strings — no cross-timezone Date parsing (a UTC-parsed
+  // date input vs a local "today" would misjudge a start/end that equals today).
+  todayISO() {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
   }
 
   styleTitle() {
@@ -105,7 +113,7 @@ export default class extends Controller {
   // server's inactive flag, so trust the server-rendered `expired` value.
   isPast() {
     const value = this.hasEndDateTarget ? this.endDateTarget.value : "";
-    if (value) return new Date(value) < new Date(new Date().toDateString());
+    if (value) return value < this.todayISO();
     return this.expiredValue;
   }
 

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -46,13 +46,10 @@ class Affiliation < ApplicationRecord
   }
 
   # Genuinely active *now*: not flagged inactive, already started (no future
-  # start), and not past its end date. The SQL twin of #active? and of
-  # status_on == "Active" — a future-start row is Upcoming, not Active.
-  scope :active, -> {
-    where(inactive: false)
-      .where("affiliations.start_date IS NULL OR affiliations.start_date <= ?", Date.current)
-      .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
-  }
+  # start), and not past its end date. A future-start row is Upcoming, not Active.
+  # Delegates to with_status so the SQL lives in one place, the way #active?
+  # delegates to #status_on.
+  scope :active, -> { with_status("Active") }
 
   # Affiliations that overlapped a given date, judged purely by their start/end
   # dates rather than the cached `inactive` flag (which reflects "now"). Use this

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -37,13 +37,22 @@ class Affiliation < ApplicationRecord
 
   # Not flagged inactive and not past its end date. Includes affiliations whose
   # start_date is still in the future (e.g. a Facilitator affiliation dated to an
-  # upcoming training) — they are "pending" but counted here.
+  # upcoming training) — they are "pending" but counted here. Use this for
+  # "active or not-yet-started" checks (e.g. registration dedup); use `active` for
+  # genuinely-current rows.
   scope :active_or_pending, -> {
     where(inactive: false)
       .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
   }
 
-  scope :active, -> { active_or_pending }
+  # Genuinely active *now*: not flagged inactive, already started (no future
+  # start), and not past its end date. The SQL twin of #active? and of
+  # status_on == "Active" — a future-start row is Upcoming, not Active.
+  scope :active, -> {
+    where(inactive: false)
+      .where("affiliations.start_date IS NULL OR affiliations.start_date <= ?", Date.current)
+      .where("affiliations.end_date IS NULL OR affiliations.end_date >= ?", Date.current)
+  }
 
   # Affiliations that overlapped a given date, judged purely by their start/end
   # dates rather than the cached `inactive` flag (which reflects "now"). Use this
@@ -100,11 +109,12 @@ class Affiliation < ApplicationRecord
     title.to_s.strip == FACILITATOR_TITLE
   end
 
-  # Current: not flagged inactive and not past its end date. Mirrors the `active`
-  # scope so already-loaded affiliations can be filtered in Ruby without another
-  # query (e.g. on list pages that preload affiliations).
+  # Genuinely active now — the in-memory twin of the `active` scope and of
+  # status_on == "Active", so already-loaded affiliations can be filtered in Ruby
+  # without another query (e.g. on list pages that preload affiliations). A
+  # future-start row is Upcoming, not Active.
   def active?
-    !inactive? && (end_date.nil? || end_date >= Date.current)
+    status_on == "Active"
   end
 
   # This affiliation's status as of a date: Inactive (flagged or ended), Upcoming

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -212,10 +212,15 @@ class Affiliation < ApplicationRecord
 
   # Org status tracks active *Facilitator* affiliations specifically (mirroring the
   # form's status indicator) — a non-facilitator affiliation does not keep an org active.
+  # An upcoming-only program is left alone in both directions: a facilitator dated
+  # to a future training must not stamp the org Inactive (nothing re-runs this when
+  # the start date arrives), but it hasn't started, so it must not stamp it Active
+  # either — either way the stored value would read as drift on the edit form.
   def sync_organization_status_with_affiliations
-    if organization.affiliations.facilitators.active.exists?
+    facilitators = organization.affiliations.facilitators
+    if facilitators.active.exists?
       reactivate_organization_if_inactive
-    else
+    elsif facilitators.with_status("Upcoming").none?
       deactivate_organization_if_no_active_people
     end
   end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -117,6 +117,12 @@ class Affiliation < ApplicationRecord
     status_on == "Active"
   end
 
+  # Not yet started: a future start date, not flagged inactive and not ended.
+  # The in-memory twin of status_on == "Upcoming".
+  def upcoming?
+    status_on == "Upcoming"
+  end
+
   # This affiliation's status as of a date: Inactive (flagged or ended), Upcoming
   # (future start), otherwise Active. The in-memory twin of the .with_status scope.
   def status_on(date = Date.current)

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -120,6 +120,14 @@ class Affiliation < ApplicationRecord
     status_on == "Upcoming"
   end
 
+  # Ended or flagged, as of a date — the in-memory twin of status_on == "Inactive".
+  # Prefer this to the raw `inactive` column when judging a row for display: the
+  # column is only re-derived on save (set_inactive_from_dates), so a term that
+  # simply lapsed still reads `inactive: false` until something touches it.
+  def inactive_on?(date = Date.current)
+    status_on(date) == "Inactive"
+  end
+
   # This affiliation's status as of a date: Inactive (flagged or ended), Upcoming
   # (future start), otherwise Active. The in-memory twin of the .with_status scope.
   def status_on(date = Date.current)

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -481,17 +481,31 @@ class EventRegistration < ApplicationRecord
     case value
     when "linked" then where(id: linked)
     when "unlinked" then where.not(id: linked)
-    when "pending"
-      field = event.registration_form&.form_fields&.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
-      next none unless field
-      submitted = FormAnswer.joins(:form_submission)
-        .where(form_field_id: field.id, form_submissions: { form_id: event.registration_form.id })
-        .where.not(submitted_answer: [ nil, "" ])
-        .select(Arel.sql("form_submissions.person_id"))
-      where(registrant_id: submitted).where.not(id: linked)
+    when "pending", "none"
+      answered = org_name_answer_person_ids(event)
+      # No organization field on the registration form: nobody could answer it,
+      # so every unlinked registration is "No org provided" and none is Pending.
+      next(value == "pending" ? none : where.not(id: linked)) if answered.nil?
+
+      scope = value == "pending" ? where(registrant_id: answered) : where.not(registrant_id: answered)
+      scope.where.not(id: linked)
     else all
     end
   }
+
+  # People who answered this event's registration form's organization-name field.
+  # Nil (not empty) when the form has no such field, so the caller can tell
+  # "nobody answered" from "there was nothing to answer".
+  def self.org_name_answer_person_ids(event)
+    form = event.registration_form
+    field = form&.form_fields&.find_by(field_identifier: FormField.aliased_identifiers("organization_name"))
+    return nil unless field
+
+    FormAnswer.joins(:form_submission)
+      .where(form_field_id: field.id, form_submissions: { form_id: form.id })
+      .where.not(submitted_answer: [ nil, "" ])
+      .select(Arel.sql("form_submissions.person_id"))
+  end
   # Filter by how many form submissions the registrant made for this event:
   # none, at least one, or more than one.
   scope :submission_status, ->(value, event) {

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -20,7 +20,7 @@ class FormSubmission < ApplicationRecord
   UNREADABLE_UPLOAD_MESSAGE = "We couldn't read one of your uploaded files. Please choose it again.".freeze
 
   # The index's "Organization linking" filter vocabulary, keyed on whether an org
-  # is linked directly to the submission (see #link_organization!):
+  # is linked directly to the submission (see DIRECT_ORG_LINK_SQL):
   #   pending  — gave an org answer, not linked yet (the actionable queue).
   #   linked   — an org was linked (processed).
   #   unlinked — not linked, either kind: pending or no-org-answer.
@@ -62,14 +62,15 @@ class FormSubmission < ApplicationRecord
     scope
   }
 
-  # Submissions with the organization linked directly to them — the explicit link
-  # an admin makes in the org-linking editor, recorded in metadata (see
-  # #link_organization!). Nothing else counts: a matching affiliation or an org on
-  # the submission's event registration doesn't make the submission match.
+  # Submissions this organization is directly linked to, by either link
+  # (ADR-0002 D5). A matching affiliation the person happens to hold is not a
+  # link and does not make the submission match.
   scope :for_organization, ->(organization_id) {
+    id = organization_id.to_i
     where(
-      "JSON_CONTAINS(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids'), CAST(? AS JSON))",
-      organization_id.to_i
+      "JSON_CONTAINS(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids'), CAST(? AS JSON)) " \
+      "OR EXISTS (#{PINNED_ORG_LINK_SQL} AND event_registration_organizations.organization_id = ?)",
+      id, id
     )
   }
 
@@ -88,13 +89,22 @@ class FormSubmission < ApplicationRecord
       .where.not(submitted_answer: [ nil, "" ])
   end
 
-  # SQL test for an explicit admin link recorded in metadata (see
-  # #link_organization!). COALESCE: metadata (or the key) may be absent.
-  EXPLICIT_ORG_LINK_SQL = "COALESCE(JSON_LENGTH(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids')), 0) > 0".freeze
+  # The registration-org row a submission is pinned to — the link public
+  # registration records (EventRegistrationOrganization#form_submission_id)
+  # instead of writing metadata. Fragment, so callers can add their own AND.
+  PINNED_ORG_LINK_SQL = "SELECT 1 FROM event_registration_organizations " \
+    "WHERE event_registration_organizations.form_submission_id = form_submissions.id".freeze
+
+  # SQL test for either direct link (ADR-0002 D5): the explicit one an admin
+  # records in metadata, or the registration-org row this submission is pinned
+  # to. COALESCE: metadata (or the key) may be absent.
+  DIRECT_ORG_LINK_SQL = "(COALESCE(JSON_LENGTH(JSON_EXTRACT(form_submissions.metadata, " \
+    "'$.linked_organization_ids')), 0) > 0 OR EXISTS (#{PINNED_ORG_LINK_SQL}))".freeze
 
   # Linking status keyed on whether an org is *directly linked to the submission*
-  # (the metadata link an admin sets in the editor) — a matching affiliation the
-  # person happens to hold does NOT count. Mirrors the registrants roster:
+  # — a matching affiliation the person happens to hold does NOT count. Same
+  # vocabulary and the same join-backed answer as the registrants roster
+  # (EventRegistration.organization_linking_status):
   #   linked   — an org was linked (processed).
   #   unlinked — no org linked, whichever kind: pending or no org answer (broad).
   #   pending  — gave an org answer but nothing linked yet — the actionable queue.
@@ -102,10 +112,10 @@ class FormSubmission < ApplicationRecord
   scope :org_link_status, ->(value) {
     answered = org_name_answers.select(:form_submission_id)
     case value
-    when "linked" then where(EXPLICIT_ORG_LINK_SQL)
-    when "unlinked" then where.not(EXPLICIT_ORG_LINK_SQL)
-    when "pending" then where(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
-    when "none" then where.not(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
+    when "linked" then where(DIRECT_ORG_LINK_SQL)
+    when "unlinked" then where.not(DIRECT_ORG_LINK_SQL)
+    when "pending" then where(id: answered).where.not(DIRECT_ORG_LINK_SQL)
+    when "none" then where.not(id: answered).where.not(DIRECT_ORG_LINK_SQL)
     else all
     end
   }
@@ -266,7 +276,7 @@ class FormSubmission < ApplicationRecord
   # submission's own org-linking editor, or back-applied by the event
   # registration editor when this submission's answers describe the org. Keeps
   # a submitted name that was resolved to a differently-named org reading as
-  # linked, where the affiliation-name match alone would not.
+  # linked (ADR-0002 D5).
 
   def linked_organization_ids
     (metadata || {}).fetch("linked_organization_ids", [])

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -131,6 +131,18 @@ class Organization < ApplicationRecord
     end
   }
 
+  # The index's Program status dropdown, in display order. "Inactive" is the
+  # not-active umbrella (formerly + never + upcoming) with the two narrower
+  # buckets after it, mirroring Person::FACILITATOR_STATUS_FILTER_OPTIONS so the
+  # two indexes read the same way.
+  PROGRAM_STATUS_FILTER_OPTIONS = [
+    [ "Active", "active" ],
+    [ "Inactive", "formerly_or_never" ],
+    [ "Upcoming", "upcoming" ],
+    [ "Formerly active", "formerly_active" ],
+    [ "Never active", "never_active" ]
+  ].freeze
+
   # Matches a tag on the org itself OR an affiliated person's PRIMARY tag —
   # mirroring the aggregate the index/profile columns show.
   scope :sector_name_including_people, ->(name) {

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -120,9 +120,11 @@ class Organization < ApplicationRecord
   scope :program_status, ->(bucket) {
     fac_ids = Affiliation.facilitators.select(:organization_id)
     active_fac_ids = Affiliation.facilitators.active.select(:organization_id)
+    upcoming_fac_ids = Affiliation.facilitators.with_status("Upcoming").select(:organization_id)
     case bucket.to_s
     when "active"            then where(id: active_fac_ids)
-    when "formerly_active"   then where(id: fac_ids).where.not(id: active_fac_ids)
+    when "upcoming"          then where(id: upcoming_fac_ids).where.not(id: active_fac_ids)
+    when "formerly_active"   then where(id: fac_ids).where.not(id: active_fac_ids).where.not(id: upcoming_fac_ids)
     when "never_active"      then where.not(id: fac_ids)
     when "formerly_or_never" then where.not(id: active_fac_ids)
     else all

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -211,10 +211,18 @@ class Person < ApplicationRecord
   # People with at least one currently-active facilitator affiliation.
   scope :facilitators_active, -> {
     where(id: Affiliation.facilitators.active.select(:person_id)) }
-  # People with facilitator affiliation(s) but none currently active.
+  # People with a facilitator affiliation not yet started (future start, none
+  # active) — Upcoming, not Active or Inactive.
+  scope :facilitators_upcoming, -> {
+    where(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id))
+      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+  # People with facilitator affiliation(s) but none active or upcoming — every
+  # facilitator term has ended (or is flagged inactive). A future-start-only
+  # facilitator is Upcoming, so it is excluded here.
   scope :facilitators_inactive, -> {
     where(id: Affiliation.facilitators.select(:person_id))
-      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+      .where.not(id: Affiliation.facilitators.active.select(:person_id))
+      .where.not(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id)) }
   # Not currently active, but a past facilitator term genuinely ended (real end
   # date in the past) — distinguishes "used to facilitate" from merely flagged inactive.
   scope :facilitators_formerly_active, -> {
@@ -238,6 +246,7 @@ class Person < ApplicationRecord
   scope :by_facilitator_status, ->(status) {
     case status
     when "active" then facilitators_active
+    when "upcoming" then facilitators_upcoming
     when "inactive" then facilitators_inactive
     when "boomerang" then boomerang_facilitators
     when "formerly_active" then facilitators_formerly_active
@@ -305,6 +314,7 @@ class Person < ApplicationRecord
   FACILITATOR_STATUS_FILTER_OPTIONS = [
     [ "Active", "active" ],
     [ "Inactive", "inactive" ],
+    [ "Upcoming", "upcoming" ],
     [ "Boomerang (left, then active again)", "boomerang" ],
     [ "Formerly active", "formerly_active" ]
   ].freeze

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -216,13 +216,14 @@ class Person < ApplicationRecord
   scope :facilitators_upcoming, -> {
     where(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id))
       .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
-  # People with facilitator affiliation(s) but none active or upcoming — every
-  # facilitator term has ended (or is flagged inactive). A future-start-only
-  # facilitator is Upcoming, so it is excluded here.
+  # People with facilitator affiliation(s) but none currently active — the
+  # not-active umbrella. Upcoming (future-start) facilitators are included here
+  # since they aren't active now, mirroring the org index's "Inactive"
+  # (formerly_or_never) filter, even though Upcoming is also its own filter option
+  # and status (ADR-0001 D3).
   scope :facilitators_inactive, -> {
     where(id: Affiliation.facilitators.select(:person_id))
-      .where.not(id: Affiliation.facilitators.active.select(:person_id))
-      .where.not(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id)) }
+      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
   # Not currently active, but a past facilitator term genuinely ended (real end
   # date in the past) — distinguishes "used to facilitate" from merely flagged inactive.
   scope :facilitators_formerly_active, -> {

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -220,14 +220,13 @@ class Person < ApplicationRecord
   scope :facilitators_upcoming, -> {
     where(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id))
       .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
-  # People with facilitator affiliation(s) but none currently active — the
-  # not-active umbrella. Upcoming (future-start) facilitators are included here
-  # since they aren't active now, mirroring the org index's "Inactive"
-  # (formerly_or_never) filter, even though Upcoming is also its own filter option
-  # and status (ADR-0001 D3).
+  # Everyone who is not a currently-active facilitator — the not-active umbrella:
+  # people whose facilitator affiliation has ended/is flagged or is upcoming, AND
+  # people with no facilitator affiliation at all. Mirrors the org index's
+  # "Inactive" (formerly_or_never) filter; Upcoming and Formerly active are
+  # narrower options within this set (ADR-0001 D3).
   scope :facilitators_inactive, -> {
-    where(id: Affiliation.facilitators.select(:person_id))
-      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+    where.not(id: Affiliation.facilitators.active.select(:person_id)) }
   # Not currently active, but a past facilitator term genuinely ended (real end
   # date in the past) — distinguishes "used to facilitate" from merely flagged inactive.
   scope :facilitators_formerly_active, -> {

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -215,11 +215,11 @@ class Person < ApplicationRecord
   # People with at least one currently-active facilitator affiliation.
   scope :facilitators_active, -> {
     where(id: Affiliation.facilitators.active.select(:person_id)) }
-  # People with a facilitator affiliation not yet started (future start, none
-  # active) — Upcoming, not Active or Inactive.
+  # People with a facilitator affiliation that hasn't started yet (future start,
+  # not ended). Independent of the Active filter — someone active at one org and
+  # scheduled at another is returned by both.
   scope :facilitators_upcoming, -> {
-    where(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id))
-      .where.not(id: Affiliation.facilitators.active.select(:person_id)) }
+    where(id: Affiliation.facilitators.with_status("Upcoming").select(:person_id)) }
   # Everyone who is not a currently-active facilitator — the not-active umbrella:
   # people whose facilitator affiliation has ended/is flagged or is upcoming, AND
   # people with no facilitator affiliation at all. Mirrors the org index's

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -168,11 +168,15 @@ class Person < ApplicationRecord
 
   scope :organization_ids, ->(organization_ids)  { joins(:affiliations)
                                                      .where(affiliations: { organization_id: organization_ids }) }
-  scope :published, -> { searchable.with_active_affiliations }
+  scope :published, -> { searchable.with_active_facilitator_affiliations }
   scope :searchable, ->(searchable = nil) { searchable ? where(profile_is_searchable: searchable) : where(profile_is_searchable: true) }
-  scope :with_active_affiliations, -> {
+  # The public people directory is a directory of *active facilitators*, so only
+  # a currently-active Facilitator affiliation makes a person publicly visible —
+  # a non-facilitator role (Counselor, Board Member) or a lapsed/upcoming
+  # facilitator does not. Non-admins see only these; everyone else is admin-only.
+  scope :with_active_facilitator_affiliations, -> {
     joins(:affiliations)
-      .merge(Affiliation.active)
+      .merge(Affiliation.facilitators.active)
       .distinct
   }
   scope :where_user_not_locked, -> {
@@ -337,8 +341,12 @@ class Person < ApplicationRecord
     results
   end
 
+  # Publicly visible = searchable and a currently-active *facilitator*. The
+  # in-memory twin of the `published` scope; computed from the (eager-loaded)
+  # affiliations so the people index pays no per-row query. A non-facilitator
+  # role or a lapsed/upcoming facilitator is not published (admin-only).
   def published?
-    profile_is_searchable? && affiliations.active.exists?
+    profile_is_searchable? && affiliations.any? { |a| a.facilitator? && a.active? }
   end
 
   def membership_current?(as_of: Date.current)

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -59,7 +59,7 @@ class PersonPolicy < ApplicationPolicy
 
   relation_scope do |relation|
     next relation if admin?
-    relation.searchable.with_active_affiliations.where_user_not_locked
+    relation.searchable.with_active_facilitator_affiliations.where_user_not_locked
   end
 
   private

--- a/app/services/attendees_roster.rb
+++ b/app/services/attendees_roster.rb
@@ -115,10 +115,13 @@ class AttendeesRoster
     end
   end
 
-  # Distinct program statuses of each person's affiliated organizations.
+  # Distinct program statuses of each person's affiliated organizations, each
+  # judged at the start date of the event whose registration linked it — the
+  # roster spans events but every row knows its own, so nothing falls back to the
+  # year anchor. An org linked at two trainings is judged separately at each.
   def program_statuses_by_registrant
-    @program_statuses_by_registrant ||= organization_ids_by_registrant.transform_values do |organization_ids|
-      organization_ids.filter_map { |organization_id| program_status_by_organization[organization_id] }.uniq(&:status)
+    @program_statuses_by_registrant ||= linked_org_anchors_by_registrant.transform_values do |anchors|
+      anchors.filter_map { |organization_id, anchor| program_status_for(organization_id, anchor) }.uniq(&:status)
     end
   end
 
@@ -191,27 +194,42 @@ class AttendeesRoster
       .transform_values(&:first)
   end
 
-  # Organization ids linked on each person's in-scope registrations
-  # (EventRegistrationOrganization), uniqued per person.
-  def linked_org_ids_by_registrant
-    @linked_org_ids_by_registrant ||= EventRegistrationOrganization
-      .joins(:event_registration)
+  # [ organization_id, event start date ] pairs per person, from the in-scope
+  # registrations (EventRegistrationOrganization) that linked each org. The event
+  # comes along because it is what each org's program status is anchored on.
+  def linked_org_anchors_by_registrant
+    @linked_org_anchors_by_registrant ||= EventRegistrationOrganization
+      .joins(event_registration: :event)
       .where(event_registration_id: registration_ids)
-      .pluck(Arel.sql("event_registrations.registrant_id"), :organization_id)
-      .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(registrant_id, organization_id), map|
-        map[registrant_id] << organization_id unless map[registrant_id].include?(organization_id)
+      .pluck(Arel.sql("event_registrations.registrant_id"), :organization_id, Arel.sql("events.start_date"))
+      .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(registrant_id, organization_id, start_date), map|
+        anchor = [ organization_id, start_date&.to_date ]
+        map[registrant_id] << anchor unless map[registrant_id].include?(anchor)
       end
+  end
+
+  # Organization ids linked on each person's in-scope registrations, uniqued per
+  # person — the roster's Organization column, which doesn't care which event.
+  def linked_org_ids_by_registrant
+    @linked_org_ids_by_registrant ||= linked_org_anchors_by_registrant
+      .transform_values { |anchors| anchors.map(&:first).uniq }
+  end
+
+  def organizations_by_id
+    @organizations_by_id ||= organizations.index_by(&:id)
+  end
+
+  # Memoized per (organization, anchor) so an org linked on several people's
+  # registrations at the same event is classified once.
+  def program_status_for(organization_id, anchor)
+    organization = organizations_by_id[organization_id]
+    return nil unless organization
+
+    @program_status_for ||= {}
+    @program_status_for[[ organization_id, anchor ]] ||= organization.facilitator_program_status(as_of: anchor)
   end
 
   def affiliation_status(affiliation)
     affiliation.status_on
-  end
-
-  # No event to anchor on (the index spans them), so the status falls back to the
-  # start of the current year and flags itself `year_anchored?` for the caveat.
-  def program_status_by_organization
-    @program_status_by_organization ||= organizations.to_h do |organization|
-      [ organization.id, organization.facilitator_program_status ]
-    end
   end
 end

--- a/app/services/attendees_roster.rb
+++ b/app/services/attendees_roster.rb
@@ -106,8 +106,9 @@ class AttendeesRoster
     linked_org_ids_by_registrant
   end
 
-  # Distinct affiliation statuses (Active / Pending / Inactive) per person, in
-  # display order — the index-only Affiliation status column and filter.
+  # Distinct affiliation statuses (Affiliation::STATUSES — Active / Upcoming /
+  # Inactive) per person, in display order — the index-only Affiliation status
+  # column and filter.
   def affiliation_statuses_by_registrant
     @affiliation_statuses_by_registrant ||= people.to_h do |person|
       statuses = person.affiliations.map { |affiliation| affiliation_status(affiliation) }.uniq
@@ -229,6 +230,12 @@ class AttendeesRoster
     @program_status_for[[ organization_id, anchor ]] ||= organization.facilitator_program_status(as_of: anchor)
   end
 
+  # Deliberately "as of today", unlike the program status above, which anchors on
+  # each row's event. This column answers a different question — where does this
+  # person stand *now*, so you can chase a lapsed affiliation — and its filter
+  # (EventsController#person_affiliation_status_ids) is Affiliation.with_status,
+  # which also judges today. Anchoring the column on the event would leave it
+  # disagreeing with the filter that selected the rows.
   def affiliation_status(affiliation)
     affiliation.status_on
   end

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -261,14 +261,17 @@ class EventDashboard
 
   # Shout outs for the recipients page: each active registrant the admin flagged
   # for a shout-out who also has shout-out text on their profile, paired with that
-  # text, their first active affiliated organization (if any), and their primary
-  # sector / age group (from their profile) for the parenthetical after their name.
+  # text, their first still-standing affiliated organization (if any), and their
+  # primary sector / age group (from their profile) for the parenthetical after
+  # their name. "Still standing" is judged on the dates as well as the cached flag,
+  # and keeps a not-yet-started affiliation — a registrant here to be trained is
+  # credited to the org they're about to facilitate for.
   # Flagged registrants with blank shout-out text are omitted; org/sector/age are optional.
   def shoutouts
     @shoutouts ||= shoutout_registrants.filter_map do |person|
       text = person.shoutout_text.to_s.strip.presence
       next unless text
-      organization = person.affiliations.reject(&:inactive?).filter_map(&:organization).first
+      organization = person.affiliations.reject(&:inactive_on?).filter_map(&:organization).first
       Shoutout.new(
         recipient: person,
         organization: organization,

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -37,7 +37,8 @@
      end %>
   <% record = person_side ? f.object.person : f.object.organization %>
   <% label = person_side ? "Person" : "Organization" %>
-  <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>" class="relative mb-2">
+  <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>"
+       data-inactive-toggle-today-value="<%= Date.current.iso8601 %>" class="relative mb-2">
     <%# Left accent rendered outside the row so it keeps full color regardless of the row's border. %>
     <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= accent %>"
           data-inactive-toggle-target="accentBar"></span>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -79,7 +79,7 @@
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
         <span data-inactive-toggle-target="upcomingBadge"
-              class="<%= "hidden" unless upcoming %> mt-1 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+              class="<%= "hidden" unless upcoming %> mt-1 inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
           <i class="fa-solid fa-clock"></i>Upcoming
         </span>
       </div>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -6,9 +6,13 @@
 <% manage_subject = person_side ? Organization : Person %>
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
-  <%# Not yet started: a future start date, and not already ended. Shown as an
-      "Upcoming" badge; kept live by inactive-toggle as the start date is edited. %>
+  <%# Not yet started: a future start date, and not already ended. %>
   <% upcoming = !expired && f.object.start_date.present? && f.object.start_date > Date.current %>
+  <%# Status badges (kept live by inactive-toggle as the dates are edited):
+      "Inactive" whenever the affiliation isn't currently active (ended, flagged,
+      or not-yet-started), plus "Upcoming" for a future start — so an upcoming row
+      shows both, while an ended one shows only Inactive. %>
+  <% not_active = expired || upcoming %>
   <%# A blank title displays (and saves) as the "Facilitator" default, so treat it
       as a facilitator for the row styling too — otherwise the JS (which reads the
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
@@ -78,10 +82,16 @@
             label: label,
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
-        <span data-inactive-toggle-target="upcomingBadge"
-              class="<%= "hidden" unless upcoming %> mt-1 inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
-          <i class="fa-solid fa-clock"></i>Upcoming
-        </span>
+        <div class="mt-1 flex flex-wrap gap-1">
+          <span data-inactive-toggle-target="inactiveBadge"
+                class="<%= "hidden" unless not_active %> inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+            <i class="fa-solid fa-circle-minus"></i>Inactive
+          </span>
+          <span data-inactive-toggle-target="upcomingBadge"
+                class="<%= "hidden" unless upcoming %> inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+            <i class="fa-solid fa-clock"></i>Upcoming
+          </span>
+        </div>
       </div>
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
@@ -112,7 +122,7 @@
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
                       class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.start_date.present? || !f.object.persisted?)}",
                       style: "height: 42px;",
-                      data: { inactive_toggle_target: "valueField startDate", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields change->inactive-toggle#updateUpcoming" }
+                      data: { inactive_toggle_target: "valueField startDate", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields change->inactive-toggle#updateBadges" }
                     } %>
       </div>
 

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -6,6 +6,9 @@
 <% manage_subject = person_side ? Organization : Person %>
 <% if allowed_to?(:manage?, manage_subject) %>
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
+  <%# Not yet started: a future start date, and not already ended. Shown as an
+      "Upcoming" badge; kept live by inactive-toggle as the start date is edited. %>
+  <% upcoming = !expired && f.object.start_date.present? && f.object.start_date > Date.current %>
   <%# A blank title displays (and saves) as the "Facilitator" default, so treat it
       as a facilitator for the row styling too — otherwise the JS (which reads the
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
@@ -75,6 +78,10 @@
             label: label,
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
+        <span data-inactive-toggle-target="upcomingBadge"
+              class="<%= "hidden" unless upcoming %> mt-1 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+          <i class="fa-solid fa-clock"></i>Upcoming
+        </span>
       </div>
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
@@ -105,7 +112,7 @@
                       value: (f.object.start_date || (Date.current unless f.object.persisted?))&.strftime("%Y-%m-%d"),
                       class: "w-full rounded-md border-gray-300! focus:ring-blue-500 focus:border-blue-500 text-sm #{field_bg.call(f.object.start_date.present? || !f.object.persisted?)}",
                       style: "height: 42px;",
-                      data: { inactive_toggle_target: "valueField", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields" }
+                      data: { inactive_toggle_target: "valueField startDate", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields change->inactive-toggle#updateUpcoming" }
                     } %>
       </div>
 

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -140,7 +140,8 @@
         </div>
       <% end %>
 
-      <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>">
+      <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>"
+           data-inactive-toggle-today-value="<%= Date.current.iso8601 %>">
         <div class="flex flex-wrap items-start gap-4 rounded-lg border p-3 <%= row_bg %> <%= 'aff-ended' if expired %>"
              data-inactive-toggle-target="row">
           <div class="min-w-[200px] flex-1">

--- a/app/views/event_registrations/_org_affiliation_pills.html.erb
+++ b/app/views/event_registrations/_org_affiliation_pills.html.erb
@@ -2,14 +2,13 @@
     when the person has no affiliation for the org.
     Locals: org, affiliations, submitted_org_name, submitted_position, neutral (optional) %>
 <% if affiliations.any? %>
-  <% active = ->(a) { !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
   <% position = submitted_position.to_s.strip %>
   <% is_submitted_org = submitted_org_name.to_s.strip.present? && org.name.to_s.strip.casecmp?(submitted_org_name.to_s.strip) %>
   <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
     <span class="text-2xs font-semibold uppercase tracking-wide text-gray-400">Affiliations:</span>
     <% affiliations.each do |a| %>
-      <% a_active = active.call(a) %>
-      <% color = a_active && !local_assigns[:neutral] ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
+      <% status = a.status_on %>
+      <% color = status == "Active" && !local_assigns[:neutral] ? "bg-green-50 text-green-700 border-green-200" : "bg-gray-100 text-gray-600 border-gray-200" %>
       <% start_month = a.start_date&.strftime("%B %Y") %>
       <% end_month = a.end_date&.strftime("%B %Y") %>
       <% dates =
@@ -22,7 +21,7 @@
            else
              "no dates"
            end %>
-      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")} (#{dates})#{" — inactive" unless a_active}" %>
+      <% label = "#{a.facilitator? ? "Facilitator" : (a.title.presence || "No title")} (#{dates})#{" — #{status.downcase}" unless status == "Active"}" %>
       <% title_attr = a.facilitator? ? "Facilitator role — determines whether the org is active with AWBW" : nil %>
       <%= render "shared/badge", label: label, classes: color, title: title_attr %>
     <% end %>

--- a/app/views/events/_registrant_filters.html.erb
+++ b/app/views/events/_registrant_filters.html.erb
@@ -94,7 +94,8 @@
         selected: params[:submission_status], blank: "All statuses", field_class: field_class %>
 
   <%= render "events/filter_select", param: :org_status, label: "Organization linking",
-        options: [ [ "Pending", "pending" ], [ "Linked", "linked" ], [ "Unlinked", "unlinked" ] ],
+        options: [ [ "Pending", "pending" ], [ "Linked", "linked" ], [ "Unlinked", "unlinked" ],
+                   [ "No org provided", "none" ] ],
         selected: params[:org_status], blank: "Any linking", field_class: field_class %>
 
   <% if has_cost %>

--- a/app/views/form_submissions/_processing_panel.html.erb
+++ b/app/views/form_submissions/_processing_panel.html.erb
@@ -75,11 +75,11 @@
               <td class="py-2 pr-3 whitespace-nowrap text-gray-600"><%= affiliation.start_date&.to_fs(:long) || "—" %></td>
               <td class="py-2 pr-3 whitespace-nowrap text-gray-600"><%= affiliation.end_date&.to_fs(:long) || "—" %></td>
               <td class="py-2 pr-3">
-                <% if affiliation.active? %>
-                  <span class="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">Active</span>
-                <% else %>
-                  <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">Inactive</span>
-                <% end %>
+                <% status = affiliation.status_on %>
+                <% status_classes = { "Active" => "bg-green-50 text-green-700",
+                                      "Upcoming" => "bg-blue-50 text-blue-700",
+                                      "Inactive" => "bg-gray-100 text-gray-600" } %>
+                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium <%= status_classes.fetch(status) %>"><%= status %></span>
                 <% if submission.scenario_ended_affiliation_ids.include?(affiliation.id) %>
                   <span class="ml-1 inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700"
                         title="End-dated automatically when the submitted organization was linked — edit the affiliation if this was wrong (e.g. they stayed at this organization too)."><i class="fa-solid fa-wand-magic-sparkles text-3xs"></i>Ended by this agreement</span>
@@ -89,7 +89,9 @@
                 <%# Ends the day before the agreement takes effect, matching the
                     automatic scenario end-dating (see ADR-0002 D4). %>
                 <% end_on = submission.created_at.to_date - 1.day %>
-                <% if scenario == "new_job" && affiliation.active? && !matches_submitted %>
+                <%# A not-yet-started row is end-datable too — ApplyScenarioEndDating
+                    ends those automatically, so the manual button has to match. %>
+                <% if scenario == "new_job" && !affiliation.inactive_on? && !matches_submitted %>
                   <%= button_to "End", end_affiliation_path(affiliation, form_submission_id: submission.id, end_date: end_on.iso8601),
                                 class: "btn btn-secondary-outline whitespace-nowrap",
                                 form: { data: { turbo_confirm: "End #{person.name}'s affiliation with #{affiliation.organization.name} as of #{end_on.to_fs(:long)} (the day before this agreement)?" } } %>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -36,7 +36,7 @@
                     data: { turbo_frame: "_top" } do %>
           <i class="fa-solid fa-file-lines text-green-600 group-hover:text-green-800 mt-1 shrink-0"></i>
           <div class="min-w-0">
-            <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong><% if @submitted_org_name.present? && @matched_organization.nil? %> <%= render "shared/badge", label: "Pending", classes: "bg-amber-50 text-amber-700 border-amber-200", icon: "fa-solid fa-circle-exclamation text-2xs", extra: "ml-1", title: "The person submitted this organization, but they have no active affiliation with it yet." %><% end %></p>
+            <p class="text-base text-gray-800">Organization: <strong><%= @submitted_org_name.presence || "—" %></strong><% if @submitted_org_name.present? && @matched_organization.nil? %> <%= render "shared/badge", label: "Pending", classes: "bg-amber-50 text-amber-700 border-amber-200", icon: "fa-solid fa-circle-exclamation text-2xs", extra: "ml-1", title: "The person submitted this organization, but it isn't linked to this submission or their registration yet." %><% end %></p>
             <p class="text-base text-gray-800">Position / title: <strong><%= @submitted_position.presence || "—" %></strong></p>
           </div>
         <% end %>
@@ -47,7 +47,8 @@
       <% end %>
     </div>
 
-    <%# === The linked (affiliation-matched) organization + add actions — tinted
+    <%# === The linked organization (an explicit link, or the registration-org row
+        this submission is pinned to) + add actions — tinted
         green to stand apart, like the registration editor's linked cards. %>
     <% org_swatch = DomainTheme.swatch(:green) %>
     <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Linked organization</h2>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for(@organization, html: { data: {
       controller: "affiliation-dates affiliation-facilitator-warning",
       affiliation_dates_merged_periods_value: true,
-      affiliation_dates_status_buckets_value: OrganizationDecorator.status_bucket_styles.to_json
+      affiliation_dates_status_buckets_value: OrganizationDecorator.status_bucket_styles(admin: allowed_to?(:manage?, Organization)).to_json
     } }) do |f| %>
   <%= render 'shared/errors', resource: @organization if @organization.errors.any? %>
   <%= render "duplicate_organizations_warning" %>
@@ -325,7 +325,7 @@
                 • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).</p>
             </div>
             <div class="flex flex-wrap items-center gap-2 pt-1">
-              <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }) %>
+              <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }, admin: allowed_to?(:manage?, Organization)) %>
               <%= render "organizations/program_status_event_chips",
                          organization: f.object, events: org_events, return_to: "organization_edit" %>
             </div>

--- a/app/views/organizations/_search_boxes.html.erb
+++ b/app/views/organizations/_search_boxes.html.erb
@@ -36,6 +36,7 @@
         <%= select_tag :program_status,
                        options_for_select([
                          [ "Active", "active" ],
+                         [ "Upcoming", "upcoming" ],
                          [ "Inactive", "formerly_or_never" ],
                          [ "Formerly active", "formerly_active" ],
                          [ "Never active", "never_active" ]

--- a/app/views/organizations/_search_boxes.html.erb
+++ b/app/views/organizations/_search_boxes.html.erb
@@ -34,14 +34,8 @@
       <div class="admin-only bg-blue-100">
         <%= label_tag :program_status, "Program status", class: "text-sm font-medium text-gray-700 mb-1 block" %>
         <%= select_tag :program_status,
-                       options_for_select([
-                         [ "Active", "active" ],
-                         [ "Upcoming", "upcoming" ],
-                         [ "Inactive", "formerly_or_never" ],
-                         [ "Formerly active", "formerly_active" ],
-                         [ "Never active", "never_active" ]
-                       ], params[:program_status]),
-                       include_blank: "All statuses",
+                       options_for_select(Organization::PROGRAM_STATUS_FILTER_OPTIONS, params[:program_status]),
+                       include_blank: "Any status",
                        class: "w-44 rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
                                      focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
       </div>

--- a/app/views/organizations/organizations_results.html.erb
+++ b/app/views/organizations/organizations_results.html.erb
@@ -49,7 +49,7 @@
               </td>
 
               <td class="px-4 py-2 text-sm text-gray-700 whitespace-nowrap">
-                <%= organization.decorate.program_since_chip(@program_since_display[organization.id]) %>
+                <%= organization.decorate.program_since_chip(@program_since_display[organization.id], admin: allowed_to?(:manage?, Organization)) %>
               </td>
 
               <td class="px-4 py-2 text-center text-sm">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -41,7 +41,7 @@
           </h1>
           <% if allowed_to?(:manage?, @organization) %>
             <span id="program-status" class="admin-only scroll-mt-20 rounded-lg bg-blue-100 px-2 py-1">
-              <%= org_decorated.organization_status_chip %>
+              <%= org_decorated.organization_status_chip(admin: allowed_to?(:manage?, Organization)) %>
             </span>
           <% end %>
         </div>

--- a/app/views/people/_results_skeleton.html.erb
+++ b/app/views/people/_results_skeleton.html.erb
@@ -4,7 +4,7 @@
       <thead class="bg-gray-100">
         <tr>
           <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-          <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Affiliated since</th>
+          <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Facilitator since</th>
           <th class="w-1/5 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary sector</th>
           <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary age range</th>
           <th class="w-1/4 px-4 py-2 text-left text-sm font-semibold text-gray-700">Affiliation(s)</th>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -73,7 +73,7 @@
                 </td>
                 <!-- Affiliations -->
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% affiliations = person.affiliations.select { |a| a.organization.present? && a.active? } %>
+                  <% affiliations = person.affiliations.select { |a| a.organization.present? && (a.active? || a.upcoming?) } %>
                   <% if affiliations.any? %>
                     <%# Org names are long and multi-word, so a stacked list of
                         truncated links reads better than chips, which squeeze the

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -68,7 +68,7 @@
                 </td>
                 <!-- Affiliations -->
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% affiliations = person.affiliations.select { |a| a.organization.present? && !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) } %>
+                  <% affiliations = person.affiliations.select { |a| a.organization.present? && a.active? } %>
                   <% if affiliations.any? %>
                     <%# Org names are long and multi-word, so a stacked list of
                         truncated links reads better than chips, which squeeze the

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -8,7 +8,7 @@
           <thead class="bg-gray-100">
             <tr>
               <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-              <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Affiliated since</th>
+              <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Facilitator since</th>
               <th class="w-1/5 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary sector</th>
               <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary age range</th>
               <th class="w-1/4 px-4 py-2 text-left text-sm font-semibold text-gray-700">Affiliation(s)</th>
@@ -34,7 +34,12 @@
                   <% end %>
                 </td>
                 <td class="px-4 py-2 text-center text-sm text-gray-800">
-                  <%= (person.decorate.affiliated_since_date || person.member_since)&.year || "--" %>
+                  <% decorated = person.decorate %>
+                  <%= decorated.facilitator_since_year || "--" %>
+                  <% status = decorated.facilitator_status_label %>
+                  <% if status && status != "Active" %>
+                    <div class="text-xs text-blue-700"><%= status %></div>
+                  <% end %>
                 </td>
                 <!-- Sectors -->
                 <td class="px-4 py-2 text-sm text-gray-800">

--- a/config/features.yml
+++ b/config/features.yml
@@ -242,6 +242,21 @@
   pro_tips:
     - "Add ?admin=true to the affiliation editor URL to reveal the registration picker."
 
+- name: "\"Linked\" means a real organization link, everywhere"
+  area: registration
+  display_status: admin_facing
+  released_on: 2026-08-28
+  action_path: "/form_submissions"
+  pr_number: 2336
+  summary: >-
+    A submission reads as linked when an organization is really linked to it or to
+    the registration behind it, not because the person has a same-named
+    affiliation. Public registrations now read as Linked instead of waiting in the
+    Pending queue.
+  pro_tips:
+    - "Pending now means what it says: an organization was typed on the form and nobody has linked it yet."
+    - "The registrants roster gains a \"No org provided\" filter, matching the submissions index."
+
 - name: "Scholarship program status is judged at its own training"
   area: scholarships
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -260,6 +260,7 @@
   display_status: admin_facing
   released_on: 2026-08-22
   action_path: "/people"
+  pr_number: 2336
   summary: >-
     A facilitator affiliation with a future start date now reads as "Upcoming"
     rather than Active — on the person edit form and the people directory, whose

--- a/config/features.yml
+++ b/config/features.yml
@@ -263,10 +263,10 @@
   pr_number: 2336
   summary: >-
     A facilitator affiliation with a future start date now reads as "Upcoming"
-    rather than Active — on the person edit form and the people directory, whose
-    facilitator-status filter gains an "Upcoming" option.
+    rather than Active — for people and organizations. The people and organization
+    indexes each gain an "Upcoming" status filter, and orgs show an Upcoming badge.
   pro_tips:
-    - "Active means started and not ended; a future start date reads as Upcoming until that date arrives, then no longer shows under Inactive."
+    - "Active means started and not ended; a future start reads as Upcoming until that date arrives. Upcoming orgs also still appear under the Inactive filter."
 
 - name: "Activity log: readable details column"
   area: reporting

--- a/config/features.yml
+++ b/config/features.yml
@@ -255,6 +255,18 @@
   pro_tips:
     - "An award with no registration behind it falls back to the start of the current year — the hover text says so."
 
+- name: "Upcoming facilitators read as their own status, not Active"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  summary: >-
+    A facilitator affiliation with a future start date now reads as "Upcoming"
+    rather than Active — on the person edit form and the people directory, whose
+    facilitator-status filter gains an "Upcoming" option.
+  pro_tips:
+    - "Active means started and not ended; a future start date reads as Upcoming until that date arrives, then no longer shows under Inactive."
+
 - name: "Activity log: readable details column"
   area: reporting
   display_status: admin_facing

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1619,9 +1619,9 @@ if facilitator_training && registration_form
       answer.update!(submitted_answer: value.to_s, question_name_when_answered: field.name)
     end
   end
-  add_affiliation = ->(person, organization, title:, end_date: nil) do
+  add_affiliation = ->(person, organization, title:, start_date: Date.current - 1.year, end_date: nil) do
     Affiliation.find_or_create_by!(person: person, organization: organization, title: title) do |aff|
-      aff.start_date = Date.current - 1.year
+      aff.start_date = start_date
       aff.end_date = end_date
     end
   end
@@ -1682,6 +1682,20 @@ if facilitator_training && registration_form
       submission.form_answers.create!(form_field: agency_field, submitted_answer: org.name, question_name_when_answered: agency_field.name) if agency_field
       link_org.call(registration, org)
     end
+  end
+
+  # A7: a facilitator dated to a future training — not started yet, so their
+  # facilitator status reads "Upcoming" (person and org), distinct from Active
+  # and from a lapsed Formerly active. The Counselor role is already active, so
+  # the row shows an active job alongside an Upcoming Facilitator affiliation.
+  if aff_org
+    person = Person.create!(email: "affdemo.7@seed.example.com", first_name: "Demo Affiliation", last_name: "A7 Upcoming facilitator")
+    registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
+    registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
+    add_affiliation.call(person, aff_org, title: "Counselor")
+    add_affiliation.call(person, aff_org, title: "Facilitator", start_date: Date.current + 1.month)
+    submit_field.call(registration, agency_field, aff_org.name)
+    submit_field.call(registration, position_field, "Counselor")
   end
 end
 

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1685,16 +1685,21 @@ if facilitator_training && registration_form
   end
 
   # A7: a facilitator dated to a future training — not started yet, so their
-  # facilitator status reads "Upcoming" (person and org), distinct from Active
-  # and from a lapsed Formerly active. The Counselor role is already active, so
-  # the row shows an active job alongside an Upcoming Facilitator affiliation.
+  # facilitator status reads "Upcoming" (distinct from Active and from a lapsed
+  # Formerly active). The upcoming Facilitator role sits on a dedicated org whose
+  # ONLY facilitator is this one, so that org's program-status chip and the
+  # "Upcoming" index filter read Upcoming too; an active Counselor role at aff_org
+  # shows an active job alongside it.
   if aff_org
+    upcoming_org = Organization.find_or_create_by!(name: "Windows Program (starting soon)") do |o|
+      o.organization_status = OrganizationStatus.find_by(name: "Pending") || active_status
+    end
     person = Person.create!(email: "affdemo.7@seed.example.com", first_name: "Demo Affiliation", last_name: "A7 Upcoming facilitator")
     registration = EventRegistration.find_or_create_by!(event: facilitator_training, registrant: person) { |reg| reg.status = "registered" }
-    registration.event_registration_organizations.find_or_create_by!(organization: aff_org)
+    registration.event_registration_organizations.find_or_create_by!(organization: upcoming_org)
     add_affiliation.call(person, aff_org, title: "Counselor")
-    add_affiliation.call(person, aff_org, title: "Facilitator", start_date: Date.current + 1.month)
-    submit_field.call(registration, agency_field, aff_org.name)
+    add_affiliation.call(person, upcoming_org, title: "Facilitator", start_date: Date.current + 1.month)
+    submit_field.call(registration, agency_field, upcoming_org.name)
     submit_field.call(registration, position_field, "Counselor")
   end
 end

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -90,15 +90,20 @@ was maintained by hand and drifted; an org is "active" because someone is
 facilitating there, not because a column says so. The same rule backs the index
 filter (`Organization.program_status`), so the filter and the chip agree.
 
-**The "Inactive" filter is a not-active umbrella.** On both the organization
-index and the people directory, the facilitator-status filter offers **Upcoming**
-as its own option, **and** its **Inactive** option returns everyone/every org
-that is not a currently-active facilitator — Formerly active, Never active (no
+**The filter dropdown has one more option than the chip.** The chip is only ever
+one of the four buckets above; **Inactive is a filter option, never a chip**. Both
+the organization index and the people directory offer five, in this order —
+**Active / Inactive / Upcoming / Formerly active / Never active**
+(`Organization::PROGRAM_STATUS_FILTER_OPTIONS`,
+`Person::FACILITATOR_STATUS_FILTER_OPTIONS`).
+
+**"Inactive" is the not-active umbrella.** It returns everyone/every org that is
+not a currently-active facilitator — Formerly active, Never active (no
 facilitator affiliation at all), **and Upcoming** — because none of them are
 active right now
 (`Organization.program_status("formerly_or_never")`, `Person.facilitators_inactive`).
-So an upcoming org/person shows an *Upcoming* chip but is still found when you
-filter by Inactive.
+Upcoming and Formerly active are the narrower options inside it. So an upcoming
+org/person shows an *Upcoming* chip but is still found when you filter by Inactive.
 
 On the edit form this chip **live-updates** from the visible facilitator rows.
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -10,7 +10,8 @@ that are easy to confuse with one another:
 
 - **Affiliated since**
 - **Facilitators since**
-- an org-wide **status chip** (Active / Upcoming / Formerly active / Never active)
+- an org-wide **status chip** (Active / Upcoming / Formerly active / Never
+  active; non-admins see Upcoming as "Inactive")
 - per-event **program-status chips** (New / Ongoing / Reinstate)
 
 Several code paths compute overlapping-but-distinct classifications with subtle
@@ -90,9 +91,11 @@ was maintained by hand and drifted; an org is "active" because someone is
 facilitating there, not because a column says so. The same rule backs the index
 filter (`Organization.program_status`), so the filter and the chip agree.
 
-**The filter dropdown has one more option than the chip.** The chip is only ever
-one of the four buckets above; **Inactive is a filter option, never a chip**. Both
-the organization index and the people directory offer five, in this order —
+**The filter dropdown has one more option than the chip.** For an admin the chip
+is only ever one of the four buckets above, so **Inactive is a filter option, not
+an admin chip value** (non-admins are the exception — see the audience rule
+below). Both the organization index and the people directory offer five, in this
+order —
 **Active / Inactive / Upcoming / Formerly active / Never active**
 (`Organization::PROGRAM_STATUS_FILTER_OPTIONS`,
 `Person::FACILITATOR_STATUS_FILTER_OPTIONS`).
@@ -103,7 +106,18 @@ facilitator affiliation at all), **and Upcoming** — because none of them are
 active right now
 (`Organization.program_status("formerly_or_never")`, `Person.facilitators_inactive`).
 Upcoming and Formerly active are the narrower options inside it. So an upcoming
-org/person shows an *Upcoming* chip but is still found when you filter by Inactive.
+org/person shows an *Upcoming* chip to an admin and is still found when you filter
+by Inactive.
+
+**Upcoming is an admin-only chip.** Non-admins see a not-yet-started program as
+plain **"Inactive"**, coloured neutrally like Never active (it has never
+facilitated) — the org index is becoming more than admin-facing and must reflect
+the state of the world *today*, not a scheduled future one. Admins keep the
+Upcoming chip, which is the operationally useful distinction. The bucket itself
+is unchanged; only the label and colour collapse
+(`OrganizationDecorator#organization_status_label(admin:)`), and
+`.status_bucket_styles(admin:)` takes the same flag so the edit form's live chip
+can't disagree with the server render for a non-admin owner.
 
 On the edit form this chip **live-updates** from the visible facilitator rows.
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -10,7 +10,7 @@ that are easy to confuse with one another:
 
 - **Affiliated since**
 - **Facilitators since**
-- an org-wide **status chip** (Active / Formerly active / Never active)
+- an org-wide **status chip** (Active / Upcoming / Formerly active / Never active)
 - per-event **program-status chips** (New / Ongoing / Reinstate)
 
 Several code paths compute overlapping-but-distinct classifications with subtle
@@ -28,10 +28,17 @@ decisions that resolve the ambiguities so they're written down once.
   `"Facilitator"`** (trimmed, case-sensitive). No fuzzy/`LIKE` matching; "Lead
   Facilitator" and "facilitator" do **not** count. See `Affiliation#facilitator?`
   and the `.facilitators` scope.
-- **Active affiliation** — `inactive == false` **and** (`end_date` is null or
-  `>= today`). `inactive` is a cached column derived from the dates on save
-  (`set_inactive_from_dates`: `inactive = end_date.present? && end_date < today`),
-  so in practice "active" reduces to **no end date, or end date ≥ today**.
+- **Active affiliation** — `inactive == false`, **started** (`start_date` is null
+  or `<= today`), **and** not ended (`end_date` is null or `>= today`). A row whose
+  `start_date` is still in the future is **Upcoming**, not Active. `inactive` is a
+  cached column derived from the end date on save (`set_inactive_from_dates`:
+  `inactive = end_date.present? && end_date < today`). See `Affiliation#active?` /
+  `#status_on` and the `.active` scope.
+- **Upcoming affiliation** — `inactive == false` and `start_date > today` (a
+  facilitator scheduled but not yet started, e.g. dated to a future training). See
+  `Affiliation#upcoming?`. The looser `.active_or_pending` scope counts Active
+  **and** Upcoming together (used for registration dedup); `.active` counts Active
+  only.
 - **Facilitator-training event** — `events.facilitator_training == true`. The
   only events for which per-event program status is meaningful.
 
@@ -62,19 +69,35 @@ previously rendered its own earliest-start→latest-end span, which collapsed a
 lapse-and-return into a single unbroken range and hid the gap; that is why this
 is a single decorator method rather than per-page view logic.
 
-### D3 — Org-wide status chip: Active / Formerly active / Never active
+### D3 — Org-wide status chip: Active / Upcoming / Formerly active / Never active
 
-Three display buckets (`OrganizationDecorator#organization_status_bucket`), **not
-event-relative**, derived from **facilitator affiliations only**:
+Four display buckets (`OrganizationDecorator#organization_status_bucket`), **not
+event-relative**, derived from **facilitator affiliations only** and checked in
+precedence order:
 
 - Any **active** facilitator affiliation → **Active**
+- Otherwise any **upcoming** (future-start, not yet started) facilitator
+  affiliation → **Upcoming**
 - Facilitator affiliation(s), but **all ended** → **Formerly active**
 - **No** facilitator affiliation → **Never active**
+
+Upcoming is distinct from Formerly active: an org whose only facilitator is
+scheduled for a future training was never active, so it must not read as
+"Formerly active".
 
 The stored `OrganizationStatus` column plays **no part**. It is legacy data that
 was maintained by hand and drifted; an org is "active" because someone is
 facilitating there, not because a column says so. The same rule backs the index
-filter (`Organization.program_status`), so the filter and the chip can't disagree.
+filter (`Organization.program_status`), so the filter and the chip agree.
+
+**The "Inactive" filter is a not-active umbrella.** On both the organization
+index and the people directory, the facilitator-status filter offers **Upcoming**
+as its own option, **and** its **Inactive** option returns every
+not-currently-active facilitator — Formerly active, Never active, **and
+Upcoming** — because none of them are active right now
+(`Organization.program_status("formerly_or_never")`, `Person.facilitators_inactive`).
+So an upcoming org/person shows an *Upcoming* chip but is still found when you
+filter by Inactive.
 
 On the edit form this chip **live-updates** from the visible facilitator rows.
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -92,9 +92,10 @@ filter (`Organization.program_status`), so the filter and the chip agree.
 
 **The "Inactive" filter is a not-active umbrella.** On both the organization
 index and the people directory, the facilitator-status filter offers **Upcoming**
-as its own option, **and** its **Inactive** option returns every
-not-currently-active facilitator — Formerly active, Never active, **and
-Upcoming** — because none of them are active right now
+as its own option, **and** its **Inactive** option returns everyone/every org
+that is not a currently-active facilitator — Formerly active, Never active (no
+facilitator affiliation at all), **and Upcoming** — because none of them are
+active right now
 (`Organization.program_status("formerly_or_never")`, `Person.facilitators_inactive`).
 So an upcoming org/person shows an *Upcoming* chip but is still found when you
 filter by Inactive.

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -111,6 +111,11 @@ show a warning where it contradicts the affiliations
 (`OrganizationDecorator#legacy_status_mismatch?`). Nothing else reads it. Expect
 the warning on a fair number of orgs — that is the drift it exists to surface.
 
+The column has no **Upcoming** of its own, so a derived `:upcoming` is compared
+as `:never_active`: a scheduled-but-not-started program is fairly recorded as
+`Pending` (or blank/`Unknown`, which bucket with it), and only a stored
+`Active`/`Reinstate` or `Inactive`/`Suspended` counts as drift.
+
 ### D4 — Program status: New / Ongoing / Reinstate, judged on one anchor date
 
 **One value per (organization, anchor date)**, computed over **all** of the org's

--- a/docs/adr/0002-org-linking-flows-and-agreement-scenarios.md
+++ b/docs/adr/0002-org-linking-flows-and-agreement-scenarios.md
@@ -103,16 +103,35 @@ the same date. Every affiliation a scenario ends is recorded on the submission
 new job is deliberately blunt, and the flag is how a wrongly-ended row (a
 multi-org facilitator changing only one job) gets corrected.
 
-### D5 — "Linked" on the submission side is explicit-link OR name-match; no join table
+### D5 — "Linked" on the submission side is a direct link only; no join table
 
-A submission reads as linked when an org was explicitly linked to it, or when
-an active affiliation matches the submitted name. The explicit link is an id
+A submission reads as linked only through a real link to an org — never because
+the person happens to hold an affiliation whose org name matches what they
+typed. Two links carry it: the explicit one in `form_submissions.metadata`, and
+the `EventRegistrationOrganization` row this submission is pinned to
+(`form_submission_id`, set by public registration and by the event editor).
+**Both count everywhere** — the index's "Organization linking" filter and org
+chip, `for_organization`, and the linking editor's matched org — because public
+registration records only the pin, and counting the metadata alone left those
+submissions in the "Pending" queue with nothing to action while the registrants
+roster already called the same registration Linked
+(`FormSubmission::DIRECT_ORG_LINK_SQL`). On the editor page only, rows predating
+the pin fall back to the registration's **sole** linked org, the same single-org
+rule the event editor pairs submitted answers by. An affiliation is
+downstream of linking, not evidence of it: every path that links an org also
+mints the affiliation, so the affiliation match only ever restated the link less
+precisely — and it wrongly claimed a link for a name collision with an org the
+person is affiliated with for unrelated reasons. The explicit link is an id
 array in `form_submissions.metadata` (the `linked_registration_ids` pattern),
 **not** a submission↔org join model — the event side already has
 `EventRegistrationOrganization` for its richer needs (pin, autofill notes), and
 a second join for the rarer standalone case wasn't worth the schema. Event
 linking **back-applies** the explicit link onto the submission its pinning
 rules pair with the org, so a typo'd name resolved to a differently-named org
-reads as linked everywhere. Event-page **Unlink** deliberately does *not*
+reads as linked everywhere. Both indexes offer the same four values — Linked /
+Unlinked / Pending / No org provided (`FormSubmission.org_link_status`,
+`EventRegistration.organization_linking_status`) — so a registration and the
+submission behind it can't be filed under different words.
+Event-page **Unlink** deliberately does *not*
 retract the back-applied link (it can't be told apart from one made directly in
 the submission editor, and Unlink is scoped to the registration join only).

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -56,10 +56,11 @@ module DomainTheme
     program_reinstated:       :purple,
 
     # Org-wide program status (the stored organization_status): Active is the
-    # positive current state, Upcoming a not-yet-started one, Formerly active a
-    # lapsed one, Never active neutral.
+    # positive current state, Upcoming a not-yet-started one (blue — a benign
+    # not-active state, not an amber warning), Formerly active a lapsed one, Never
+    # active neutral.
     org_active:               :green,
-    org_upcoming:             :amber,
+    org_upcoming:             :blue,
     org_formerly_active:      :orange,
     org_never_active:         :gray,
 

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -56,8 +56,10 @@ module DomainTheme
     program_reinstated:       :purple,
 
     # Org-wide program status (the stored organization_status): Active is the
-    # positive current state, Formerly active a lapsed one, Never active neutral.
+    # positive current state, Upcoming a not-yet-started one, Formerly active a
+    # lapsed one, Never active neutral.
     org_active:               :green,
+    org_upcoming:             :amber,
     org_formerly_active:      :orange,
     org_never_active:         :gray,
 

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -144,6 +144,18 @@ RSpec.describe OrganizationDecorator do
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Pending"))
       expect(org.decorate).not_to be_legacy_status_mismatch
     end
+
+    it "is false for a stored 'Pending' org whose only facilitator is upcoming" do
+      org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Pending"))
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(org.reload.decorate).not_to be_legacy_status_mismatch
+    end
+
+    it "is true for a stored 'Active' org whose only facilitator is upcoming" do
+      org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(org.reload.decorate).to be_legacy_status_mismatch
+    end
   end
 
   describe "#organization_status_chip" do

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe OrganizationDecorator do
       create(:affiliation, organization: org, person: create(:person), title: "Volunteer", start_date: 1.year.ago, end_date: nil)
       expect(org.reload.decorate.organization_status_bucket).to eq(:never_active)
     end
+
+    it "is not :active when its only facilitator affiliation has not started yet (future start)" do
+      org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(org.reload.decorate.organization_status_bucket).not_to eq(:active)
+    end
   end
 
   describe "#legacy_status_mismatch?" do

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -98,10 +98,27 @@ RSpec.describe OrganizationDecorator do
       expect(org.reload.decorate.organization_status_bucket).to eq(:never_active)
     end
 
-    it "is not :active when its only facilitator affiliation has not started yet (future start)" do
+    it "is :upcoming when its only facilitator affiliation has not started yet (future start)" do
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
-      expect(org.reload.decorate.organization_status_bucket).not_to eq(:active)
+      expect(org.reload.decorate.organization_status_bucket).to eq(:upcoming)
+      expect(org.reload.decorate.organization_status_label).to eq("Upcoming")
+    end
+
+    it "prefers :active over :upcoming when a facilitator is active and another is upcoming" do
+      org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
+      person = create(:person)
+      create(:affiliation, organization: org, person: person, title: "Facilitator", start_date: 1.year.ago, end_date: nil)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(org.reload.decorate.organization_status_bucket).to eq(:active)
+    end
+
+    it "prefers :upcoming over :formerly_active when a lapsed facilitator has a new upcoming term" do
+      org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
+      person = create(:person)
+      create(:affiliation, organization: org, person: person, title: "Facilitator", start_date: 3.years.ago, end_date: 1.year.ago)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(org.reload.decorate.organization_status_bucket).to eq(:upcoming)
     end
   end
 

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe OrganizationDecorator do
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
       expect(org.reload.decorate.organization_status_bucket).to eq(:upcoming)
-      expect(org.reload.decorate.organization_status_label).to eq("Upcoming")
+      expect(org.reload.decorate.organization_status_label(admin: true)).to eq("Upcoming")
     end
 
     it "prefers :active over :upcoming when a facilitator is active and another is upcoming" do
@@ -119,6 +119,43 @@ RSpec.describe OrganizationDecorator do
       create(:affiliation, organization: org, person: person, title: "Facilitator", start_date: 3.years.ago, end_date: 1.year.ago)
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
       expect(org.reload.decorate.organization_status_bucket).to eq(:upcoming)
+    end
+  end
+
+  describe "who sees the Upcoming chip" do
+    let(:org) do
+      organization = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Pending"))
+      create(:affiliation, organization: organization, person: create(:person), title: "Facilitator",
+                           start_date: 1.month.from_now, end_date: nil)
+      organization.reload.decorate
+    end
+
+    it "shows admins the Upcoming label and its blue theme" do
+      expect(org.organization_status_label(admin: true)).to eq("Upcoming")
+      expect(org.organization_status_classes(admin: true)).to include("blue")
+    end
+
+    it "shows everyone else plain Inactive, coloured like Never active" do
+      expect(org.organization_status_label).to eq("Inactive")
+      expect(org.organization_status_classes).to eq(described_class.status_classes_for_bucket(:never_active))
+    end
+
+    it "leaves the other buckets alone for both audiences" do
+      active = create(:organization)
+      create(:affiliation, organization: active, person: create(:person), title: "Facilitator", start_date: 1.year.ago)
+
+      expect(active.reload.decorate.organization_status_label).to eq("Active")
+      expect(active.decorate.organization_status_label(admin: true)).to eq("Active")
+    end
+
+    # The edit form is admin-or-owner, so its live-updating chip has to collapse
+    # Upcoming for a non-admin owner exactly the way the server render does.
+    it "collapses Upcoming in the styles the edit form hands to Stimulus" do
+      expect(described_class.status_bucket_styles(admin: true)[:upcoming][:label]).to eq("Upcoming")
+
+      public_styles = described_class.status_bucket_styles
+      expect(public_styles[:upcoming][:label]).to eq("Inactive")
+      expect(public_styles[:upcoming][:classes]).to eq(public_styles[:never_active][:classes])
     end
   end
 

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -145,13 +145,18 @@ RSpec.describe OrganizationDecorator do
       expect(org.decorate).not_to be_legacy_status_mismatch
     end
 
+    # The affiliation save callback only reaches the stored status when the
+    # "Inactive" status row exists, so seed it or these pass vacuously.
     it "is false for a stored 'Pending' org whose only facilitator is upcoming" do
+      OrganizationStatus.find_or_create_by!(name: "Inactive")
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Pending"))
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
-      expect(org.reload.decorate).not_to be_legacy_status_mismatch
+      expect(org.reload.organization_status.name).to eq("Pending")
+      expect(org.decorate).not_to be_legacy_status_mismatch
     end
 
     it "is true for a stored 'Active' org whose only facilitator is upcoming" do
+      OrganizationStatus.find_or_create_by!(name: "Inactive")
       org = create(:organization, organization_status: OrganizationStatus.find_or_create_by!(name: "Active"))
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
       expect(org.reload.decorate).to be_legacy_status_mismatch

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -81,9 +81,21 @@ RSpec.describe PersonDecorator do
       expect(person.decorate.facilitator_since_year).to eq(2020)
     end
 
-    it "falls back to member_since when there is no facilitator start date" do
+    it "falls back to member_since for a facilitator affiliation with no start date" do
       person.update!(member_since: Date.new(2018, 3, 1))
+      create(:affiliation, person: person, title: "Facilitator", start_date: nil)
       expect(person.decorate.facilitator_since_year).to eq(2018)
+    end
+
+    it "is nil when the person has never held a facilitator affiliation" do
+      person.update!(member_since: Date.new(2018, 3, 1))
+      create(:affiliation, person: person, title: "Counselor", start_date: Date.new(2015, 1, 1))
+      expect(person.decorate.facilitator_since_year).to be_nil
+    end
+
+    it "is nil when the person has no affiliations at all" do
+      person.update!(member_since: Date.new(2018, 3, 1))
+      expect(person.decorate.facilitator_since_year).to be_nil
     end
   end
 

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -72,6 +72,45 @@ RSpec.describe PersonDecorator do
     end
   end
 
+  describe "#facilitator_since_year" do
+    let(:person) { create(:person) }
+
+    it "returns the earliest facilitator affiliation year, ignoring other roles" do
+      create(:affiliation, person: person, title: "Volunteer", start_date: Date.new(2015, 1, 1))
+      create(:affiliation, person: person, title: "Facilitator", start_date: Date.new(2020, 6, 1))
+      expect(person.decorate.facilitator_since_year).to eq(2020)
+    end
+
+    it "falls back to member_since when there is no facilitator start date" do
+      person.update!(member_since: Date.new(2018, 3, 1))
+      expect(person.decorate.facilitator_since_year).to eq(2018)
+    end
+  end
+
+  describe "#facilitator_status_label" do
+    let(:person) { create(:person) }
+
+    it "is nil when the person has never been a facilitator" do
+      create(:affiliation, person: person, title: "Volunteer", start_date: 1.year.ago)
+      expect(person.decorate.facilitator_status_label).to be_nil
+    end
+
+    it "is Active with a current facilitator affiliation" do
+      create(:affiliation, person: person, title: "Facilitator", start_date: 1.year.ago, end_date: nil)
+      expect(person.decorate.facilitator_status_label).to eq("Active")
+    end
+
+    it "is Upcoming when a facilitator affiliation is scheduled but none is active" do
+      create(:affiliation, person: person, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+      expect(person.decorate.facilitator_status_label).to eq("Upcoming")
+    end
+
+    it "is Inactive when every facilitator term has ended" do
+      create(:affiliation, person: person, title: "Facilitator", start_date: 3.years.ago, end_date: 1.year.ago)
+      expect(person.decorate.facilitator_status_label).to eq("Inactive")
+    end
+  end
+
   describe "#affiliated_since_note" do
     let(:person) { create(:person) }
 

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe PersonDecorator do
   describe "#facilitator_status_label" do
     let(:person) { create(:person) }
 
-    it "is nil when the person has never been a facilitator" do
+    it "is Inactive when the person has never been a facilitator" do
       create(:affiliation, person: person, title: "Volunteer", start_date: 1.year.ago)
-      expect(person.decorate.facilitator_status_label).to be_nil
+      expect(person.decorate.facilitator_status_label).to eq("Inactive")
     end
 
     it "is Active with a current facilitator affiliation" do

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -98,6 +98,21 @@ RSpec.describe Affiliation, type: :model do
     end
   end
 
+  describe '#upcoming?' do
+    it 'is true for a future start date that has not ended' do
+      expect(build(:affiliation, inactive: false, start_date: 1.month.from_now, end_date: nil).upcoming?).to be true
+    end
+
+    it 'is false for a past or absent start date' do
+      expect(build(:affiliation, inactive: false, start_date: 1.year.ago, end_date: nil).upcoming?).to be false
+      expect(build(:affiliation, inactive: false, start_date: nil, end_date: nil).upcoming?).to be false
+    end
+
+    it 'is false when flagged inactive, even with a future start' do
+      expect(build(:affiliation, inactive: true, start_date: 1.month.from_now, end_date: nil).upcoming?).to be false
+    end
+  end
+
   describe '.active' do
     let!(:active_op) { create(:affiliation, inactive: false, end_date: nil) }
     let!(:active_with_future_end) { create(:affiliation, inactive: false, end_date: 1.month.from_now) }

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe Affiliation, type: :model do
     it 'is false when the end date has passed' do
       expect(build(:affiliation, inactive: false, end_date: 1.day.ago).active?).to be false
     end
+
+    it 'is false when the start date is in the future (Upcoming, not Active)' do
+      expect(build(:affiliation, inactive: false, start_date: 1.month.from_now, end_date: nil).active?).to be false
+    end
+
+    it 'is true when the start date is today or in the past and there is no end date' do
+      expect(build(:affiliation, inactive: false, start_date: Date.current, end_date: nil).active?).to be true
+      expect(build(:affiliation, inactive: false, start_date: 1.year.ago, end_date: nil).active?).to be true
+    end
   end
 
   describe '.active' do
@@ -94,6 +103,7 @@ RSpec.describe Affiliation, type: :model do
     let!(:active_with_future_end) { create(:affiliation, inactive: false, end_date: 1.month.from_now) }
     let!(:inactive_by_flag) { create(:affiliation, inactive: true, end_date: nil) }
     let!(:inactive_by_end_date) { create(:affiliation, inactive: false, end_date: 1.day.ago) }
+    let!(:upcoming_future_start) { create(:affiliation, inactive: false, start_date: 1.month.from_now, end_date: nil) }
 
     it 'includes records with inactive: false and no end date' do
       expect(described_class.active).to include(active_op)
@@ -109,6 +119,10 @@ RSpec.describe Affiliation, type: :model do
 
     it 'excludes records with past end date' do
       expect(described_class.active).not_to include(inactive_by_end_date)
+    end
+
+    it 'excludes records whose start date is in the future (Upcoming, not Active)' do
+      expect(described_class.active).not_to include(upcoming_future_start)
     end
 
     it 'qualifies end_date when joined with organizations (which also has end_date)' do

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -231,6 +231,22 @@ RSpec.describe Affiliation, type: :model do
       expect(org.reload.organization_status).to eq(inactive_status)
     end
 
+    it 'leaves an organization alone when its only facilitator is dated to a future training' do
+      org = create(:organization, organization_status: active_status)
+
+      create(:affiliation, organization: org, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+      expect(org.reload.organization_status).to eq(active_status)
+    end
+
+    it 'leaves an Inactive organization alone when its new facilitator has not started yet' do
+      org = create(:organization, organization_status: inactive_status)
+
+      create(:affiliation, organization: org, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+      expect(org.reload.organization_status).to eq(inactive_status)
+    end
+
     %w[Pending Reinstate Unknown].each do |status_name|
       it "leaves a #{status_name} organization untouched when it regains an active affiliation" do
         status = OrganizationStatus.find_or_create_by!(name: status_name)

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1311,6 +1311,33 @@ RSpec.describe EventRegistration, type: :model do
 
       expect(EventRegistration.organization_linking_status("pending", event)).to contain_exactly(pending)
     end
+
+    it "filters none: no organization name submitted and nothing linked" do
+      form = create(:form)
+      create(:event_form, :registration, event: event, form: form)
+      field = create(:form_field, form: form, field_identifier: "organization_name")
+
+      pending = create(:event_registration, event: event)
+      pending_submission = create(:form_submission, person: pending.registrant, form: form)
+      create(:form_answer, form_submission: pending_submission, form_field: field, submitted_answer: "Unlisted Org")
+
+      linked = create(:event_registration, event: event)
+      create(:event_registration_organization, event_registration: linked)
+
+      no_answer = create(:event_registration, event: event)
+
+      expect(EventRegistration.organization_linking_status("none", event)).to contain_exactly(no_answer)
+    end
+
+    it "treats every unlinked registration as none when the form has no organization field" do
+      create(:event_form, :registration, event: event, form: create(:form))
+      linked = create(:event_registration, event: event)
+      create(:event_registration_organization, event_registration: linked)
+      no_answer = create(:event_registration, event: event)
+
+      expect(EventRegistration.organization_linking_status("none", event)).to contain_exactly(no_answer)
+      expect(EventRegistration.organization_linking_status("pending", event)).to be_empty
+    end
   end
 
   describe "#paid_in_full?" do

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -121,6 +121,23 @@ RSpec.describe FormSubmission do
       end
     end
 
+    describe ".for_organization" do
+      it "matches a metadata link and a pinned registration-org row alike" do
+        organization = create(:organization)
+        by_metadata = create(:form_submission)
+        by_metadata.link_organization!(organization.id)
+        by_pin = create(:form_submission)
+        create(:event_registration_organization, form_submission: by_pin, organization: organization,
+               event_registration: create(:event_registration, registrant: by_pin.person))
+        unrelated = create(:form_submission)
+
+        results = described_class.for_organization(organization.id)
+
+        expect(results).to contain_exactly(by_metadata, by_pin)
+        expect(results).not_to include(unrelated)
+      end
+    end
+
     describe ".org_link_status" do
       it "separates linked, pending, none, and unlinked by the direct submission link" do
         linked = submission_with_org_answer("Harbor Family Shelter")
@@ -144,6 +161,19 @@ RSpec.describe FormSubmission do
         # Still needs processing — nothing has been linked to the submission.
         expect(described_class.org_link_status("linked")).to be_empty
         expect(described_class.org_link_status("pending")).to contain_exactly(submission)
+      end
+
+      it "counts the registration-org row the submission is pinned to, with no metadata link" do
+        submission = submission_with_org_answer("Harbor Family Shelter")
+        create(:event_registration_organization, form_submission: submission,
+               organization: create(:organization, name: "Harbor Family Shelter"),
+               event_registration: create(:event_registration, registrant: submission.person))
+
+        # Public registration pins the submission instead of writing metadata, so
+        # this org is linked and the submission is out of the actionable queue.
+        expect(described_class.org_link_status("linked")).to contain_exactly(submission)
+        expect(described_class.org_link_status("pending")).to be_empty
+        expect(described_class.org_link_status("unlinked")).to be_empty
       end
 
       it "counts an explicitly linked org even when the submitted name doesn't match it" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -248,6 +248,7 @@ RSpec.describe Organization do
     end
 
     let!(:active_fac) { org_with("Suspended", start_date: 1.year.ago, end_date: nil) }
+    let!(:upcoming_fac) { org_with("Active", start_date: 1.month.from_now, end_date: nil) }
     let!(:lapsed_fac) { org_with("Active", start_date: 3.years.ago, end_date: 1.year.ago) }
     let!(:no_fac) { org_with("Active") }
     let!(:non_fac_only) do
@@ -260,7 +261,11 @@ RSpec.describe Organization do
       expect(Organization.program_status("active")).to contain_exactly(active_fac)
     end
 
-    it "buckets only-lapsed facilitator affiliations as formerly_active" do
+    it "buckets a not-yet-started facilitator affiliation as upcoming" do
+      expect(Organization.program_status("upcoming")).to contain_exactly(upcoming_fac)
+    end
+
+    it "buckets only-lapsed facilitator affiliations as formerly_active (excludes upcoming)" do
       expect(Organization.program_status("formerly_active")).to contain_exactly(lapsed_fac)
     end
 
@@ -268,8 +273,8 @@ RSpec.describe Organization do
       expect(Organization.program_status("never_active")).to contain_exactly(no_fac, non_fac_only)
     end
 
-    it "combines formerly + never" do
-      expect(Organization.program_status("formerly_or_never")).to contain_exactly(lapsed_fac, no_fac, non_fac_only)
+    it "combines formerly + never + upcoming under the Inactive (not-active) umbrella" do
+      expect(Organization.program_status("formerly_or_never")).to contain_exactly(lapsed_fac, no_fac, non_fac_only, upcoming_fac)
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -658,6 +658,23 @@ RSpec.describe Person, type: :model do
         expect(results).to include(person_alice, person_bob)
       end
 
+      it "active: excludes people whose only facilitator affiliation starts in the future" do
+        upcoming = create(:person, first_name: "Upcoming", last_name: "Fac")
+        create(:affiliation, person: upcoming, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+        results = Person.search_by_params(facilitator_status: "active")
+        expect(results).not_to include(upcoming)
+      end
+
+      it "upcoming: includes people whose facilitator affiliation has not yet started" do
+        upcoming = create(:person, first_name: "Upcoming", last_name: "Fac")
+        create(:affiliation, person: upcoming, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+        results = Person.search_by_params(facilitator_status: "upcoming")
+        expect(results).to include(upcoming)
+        expect(results).not_to include(person_alice)
+      end
+
       it "inactive: includes people whose facilitator affiliations are all inactive" do
         lapsed = create(:person, first_name: "Lapsed", last_name: "Fac")
         create(:affiliation, person: lapsed, title: "Facilitator", end_date: 1.year.ago)
@@ -665,6 +682,14 @@ RSpec.describe Person, type: :model do
         results = Person.search_by_params(facilitator_status: "inactive")
         expect(results).to include(lapsed)
         expect(results).not_to include(person_alice)
+      end
+
+      it "inactive: excludes people whose facilitator affiliation is upcoming (not yet started)" do
+        upcoming = create(:person, first_name: "Upcoming", last_name: "Fac")
+        create(:affiliation, person: upcoming, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+        results = Person.search_by_params(facilitator_status: "inactive")
+        expect(results).not_to include(upcoming)
       end
 
       it "boomerang: includes people whose active term began after an earlier term ended" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -698,6 +698,16 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_alice)
       end
 
+      it "inactive: includes people with no facilitator affiliation (never active)" do
+        member = create(:person, first_name: "Member", last_name: "Only")
+        create(:affiliation, person: member, title: "Counselor", end_date: nil)
+        never_affiliated = create(:person, first_name: "Never", last_name: "Affiliated")
+
+        results = Person.search_by_params(facilitator_status: "inactive")
+        expect(results).to include(member, never_affiliated)
+        expect(results).not_to include(person_alice)
+      end
+
       it "inactive: includes an upcoming (not-yet-started) facilitator — the not-active umbrella" do
         upcoming = create(:person, first_name: "Upcoming", last_name: "Fac")
         create(:affiliation, person: upcoming, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -684,12 +684,12 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_alice)
       end
 
-      it "inactive: excludes people whose facilitator affiliation is upcoming (not yet started)" do
+      it "inactive: includes an upcoming (not-yet-started) facilitator — the not-active umbrella" do
         upcoming = create(:person, first_name: "Upcoming", last_name: "Fac")
         create(:affiliation, person: upcoming, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
 
         results = Person.search_by_params(facilitator_status: "inactive")
-        expect(results).not_to include(upcoming)
+        expect(results).to include(upcoming)
       end
 
       it "boomerang: includes people whose active term began after an earlier term ended" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -689,6 +689,15 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_alice)
       end
 
+      it "upcoming and active both include someone active at one org and upcoming at another" do
+        both = create(:person, first_name: "Both", last_name: "Fac")
+        create(:affiliation, person: both, title: "Facilitator", start_date: 1.year.ago, end_date: nil)
+        create(:affiliation, person: both, title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
+
+        expect(Person.search_by_params(facilitator_status: "upcoming")).to include(both)
+        expect(Person.search_by_params(facilitator_status: "active")).to include(both)
+      end
+
       it "inactive: includes people whose facilitator affiliations are all inactive" do
         lapsed = create(:person, first_name: "Lapsed", last_name: "Fac")
         create(:affiliation, person: lapsed, title: "Facilitator", end_date: 1.year.ago)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -341,28 +341,42 @@ RSpec.describe Person, type: :model do
         expect(person.published?).to be false
       end
     end
+
+    context "when the only active affiliation is a non-facilitator role" do
+      before { create(:affiliation, person: person, title: "Counselor", inactive: false, end_date: nil) }
+
+      it "returns false — only active facilitators are published" do
+        expect(person.published?).to be false
+      end
+    end
   end
 
-  describe ".with_active_affiliations" do
+  describe ".with_active_facilitator_affiliations" do
     let!(:person_with_active) { create(:person) }
     let!(:person_with_inactive) { create(:person) }
+    let!(:person_non_facilitator) { create(:person) }
     let!(:person_without) { create(:person) }
 
     before do
       create(:affiliation, person: person_with_active, inactive: false, end_date: nil)
       create(:affiliation, person: person_with_inactive, inactive: true, end_date: nil)
+      create(:affiliation, person: person_non_facilitator, title: "Counselor", inactive: false, end_date: nil)
     end
 
-    it "includes people with active affiliations" do
-      expect(Person.with_active_affiliations).to include(person_with_active)
+    it "includes people with an active facilitator affiliation" do
+      expect(Person.with_active_facilitator_affiliations).to include(person_with_active)
     end
 
     it "excludes people with only inactive affiliations" do
-      expect(Person.with_active_affiliations).not_to include(person_with_inactive)
+      expect(Person.with_active_facilitator_affiliations).not_to include(person_with_inactive)
+    end
+
+    it "excludes people whose only active affiliation is a non-facilitator role" do
+      expect(Person.with_active_facilitator_affiliations).not_to include(person_non_facilitator)
     end
 
     it "excludes people with no affiliations" do
-      expect(Person.with_active_affiliations).not_to include(person_without)
+      expect(Person.with_active_facilitator_affiliations).not_to include(person_without)
     end
   end
 
@@ -498,9 +512,9 @@ RSpec.describe Person, type: :model do
       expect(results).not_to include(person_bob)
     end
 
-    it 'chains with_active_affiliations and organization_name without an ambiguous end_date error' do
+    it 'chains with_active_facilitator_affiliations and organization_name without an ambiguous end_date error' do
       expect {
-        Person.with_active_affiliations.search_by_params(organization_name: 'Alpha').to_a
+        Person.with_active_facilitator_affiliations.search_by_params(organization_name: 'Alpha').to_a
       }.not_to raise_error
     end
 

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -416,6 +416,18 @@ RSpec.describe "FormSubmissions", type: :request do
         )
       end
 
+      it "offers the End button for a not-yet-started affiliation too" do
+        affiliation = create(:affiliation, person: person, start_date: 1.month.from_now,
+                             organization: create(:organization, name: "Old Org"))
+
+        get form_submission_path(submission)
+
+        expect(response.body).to include(
+          CGI.escapeHTML(end_affiliation_path(affiliation, form_submission_id: submission.id,
+                                              end_date: (submission.created_at.to_date - 1.day).iso8601))
+        )
+      end
+
       it "offers no End button outside the new-job scenario" do
         reinstatement = create(:form_submission, person: person,
                                form: create(:form, role: "reinstatement"))

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -479,22 +479,35 @@ RSpec.describe "FormSubmissions", type: :request do
           expect(response.body).to include(CGI.escapeHTML(create_organization_form_submission_path(submission)))
         end
 
-        it "shows the matched organization when an active affiliation matches the submitted name" do
+        it "shows the matched organization for the registration-org link this submission is pinned to" do
+          add_answer("organization_name", "Harbor Family Shelter")
+          organization = create(:organization, name: "Harbor Family Shelter")
+          registration = create(:event_registration, registrant: person)
+          create(:event_registration_organization, event_registration: registration,
+                 organization: organization, form_submission: submission)
+
+          get link_organization_form_submission_path(submission)
+
+          expect(response.body).to include(CGI.escapeHTML("Edit #{person.first_name}'s affiliations"))
+          expect(response.body).not_to include("linked to this submission or their registration yet")
+        end
+
+        it "does not treat a name-matching affiliation as a link" do
           add_answer("organization_name", "Harbor Family Shelter")
           create(:affiliation, person: person, organization: create(:organization, name: "Harbor Family Shelter"))
 
           get link_organization_form_submission_path(submission)
 
-          expect(response.body).to include("Harbor Family Shelter")
-          expect(response.body).not_to include("Create and link")
-          expect(response.body).to include("Affiliations:")
+          expect(response.body).to include("linked to this submission or their registration yet")
+          expect(response.body).not_to include(CGI.escapeHTML("Edit #{person.first_name}'s affiliations"))
         end
 
         it "leaves the already-linked org out of the suggested matches" do
           add_answer("organization_name", "Harbor Family Shelter")
           matched = create(:organization, name: "Harbor Family Shelter")
           other = create(:organization, name: "Harbor Family Shelter East")
-          create(:affiliation, person: person, organization: matched)
+          create(:event_registration_organization, organization: matched, form_submission: submission,
+                 event_registration: create(:event_registration, registrant: person))
 
           get link_organization_form_submission_path(submission)
 

--- a/spec/requests/people_affiliation_status_badges_spec.rb
+++ b/spec/requests/people_affiliation_status_badges_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+# The server-rendered half of the affiliation editor's status badges. The live
+# half (badges following the start date as it's edited) is spec/system/upcoming_badge_spec.rb.
+RSpec.describe "Affiliation status badges on the person edit form", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:person) { create(:person) }
+  let(:org) { create(:organization) }
+
+  before { sign_in admin }
+
+  # Each row's title paired with which of its two badges rendered visible.
+  def shown_badges_by_title
+    Capybara.string(response.body).all(".nested-fields").to_h do |row|
+      shown = %w[ inactiveBadge upcomingBadge ].select do |target|
+        badge = row.first("[data-inactive-toggle-target='#{target}']", minimum: 0)
+        badge && !badge[:class].split.include?("hidden")
+      end
+      [ row.first("input[name*='title']")[:value], shown ]
+    end
+  end
+
+  it "renders Inactive for not-active rows and adds Upcoming for a future start" do
+    create(:affiliation, person: person, organization: org, title: "PastActive",
+                         start_date: 1.year.ago.to_date, end_date: nil)
+    create(:affiliation, person: person, organization: org, title: "Ended",
+                         start_date: 2.years.ago.to_date, end_date: 1.month.ago.to_date)
+    create(:affiliation, person: person, organization: org, title: "FutureUp",
+                         start_date: 1.month.from_now.to_date, end_date: nil)
+    create(:affiliation, person: person, organization: org, title: "StartsToday",
+                         start_date: Date.current, end_date: nil)
+
+    get edit_person_path(person)
+
+    expect(shown_badges_by_title).to eq(
+      "PastActive" => [],
+      "StartsToday" => [],
+      "Ended" => [ "inactiveBadge" ],
+      "FutureUp" => [ "inactiveBadge", "upcomingBadge" ]
+    )
+  end
+end

--- a/spec/services/attendees_roster_spec.rb
+++ b/spec/services/attendees_roster_spec.rb
@@ -103,4 +103,29 @@ RSpec.describe AttendeesRoster do
       expect(roster.affiliation_statuses_by_registrant[person.id]).to eq([ "Active", "Upcoming", "Inactive" ])
     end
   end
+
+  describe "#program_statuses_by_registrant" do
+    # The roster spans events, but each row knows the registration that linked the
+    # org, so each org is judged at its own training rather than at the year anchor.
+    it "judges each linked organization at the event that linked it" do
+      org = create(:organization)
+      person = create(:person)
+      create(:affiliation, person: create(:person), organization: org,
+                           title: "Facilitator", start_date: Date.new(2020, 1, 1), end_date: nil)
+
+      early = create(:event, facilitator_training: true, start_date: Date.new(2018, 6, 1))
+      late = create(:event, facilitator_training: true, start_date: Date.new(2024, 6, 1))
+      [ early, late ].each do |event|
+        registration = create(:event_registration, event: event, registrant: person, status: "attended")
+        registration.event_registration_organizations.create!(organization: org)
+      end
+
+      roster = described_class.new([ person ])
+      statuses = roster.program_statuses_by_registrant[person.id]
+
+      expect(statuses.map(&:status)).to contain_exactly(:new, :ongoing)
+      expect(statuses).to all(satisfy { |status| !status.year_anchored? })
+      expect(statuses.map(&:as_of)).to contain_exactly(Date.new(2018, 6, 1), Date.new(2024, 6, 1))
+    end
+  end
 end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -596,6 +596,30 @@ RSpec.describe EventDashboard do
         expect(shoutout.organization).to eq(org)
       end
 
+      # `inactive` is only re-derived on save, so a term that simply lapsed still
+      # reads inactive: false — judging on the flag alone credited the shout-out to
+      # an org the person had already left.
+      it "skips an organization whose affiliation ended, even with a stale inactive flag" do
+        opt_in(embedded_applicant, text: "Thank you.")
+        lapsed = create(:organization, name: "Lapsed Org")
+        ended = create(:affiliation, person: embedded_applicant, organization: lapsed,
+                                     start_date: 3.years.ago.to_date, end_date: 1.year.ago.to_date)
+        ended.update_column(:inactive, false)
+
+        shoutout = dashboard.shoutouts.find { |s| s.recipient == embedded_applicant }
+        expect(shoutout.organization).to be_nil
+      end
+
+      it "keeps an organization the registrant is about to start facilitating for" do
+        opt_in(embedded_applicant, text: "Excited to begin.")
+        upcoming_org = create(:organization, name: "Starting Soon Org")
+        create(:affiliation, person: embedded_applicant, organization: upcoming_org,
+                             title: "Facilitator", start_date: 1.month.from_now.to_date, end_date: nil)
+
+        shoutout = dashboard.shoutouts.find { |s| s.recipient == embedded_applicant }
+        expect(shoutout.organization).to eq(upcoming_org)
+      end
+
       it "exposes the registrant's primary sector and age group" do
         age_range = create(:category_type, name: "AgeRange")
         embedded_applicant.sectorable_items.create!(sector: create(:sector, name: "Sexual Assault"), is_primary: true)

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -105,6 +105,27 @@ RSpec.describe FacilitatorProgramStatus do
       expect(status.as_of).to eq(Date.current.beginning_of_year)
       expect(status).to be_year_anchored
     end
+
+    # The anchor is the event's start date, never "today", so an org whose only
+    # facilitator affiliation was minted at a training reads New at that training
+    # whenever you look — on any day of a multi-day event, and years afterward.
+    it "reads New at the training on every day of it and looking back" do
+      org = create(:organization)
+      training_start = Date.new(2026, 9, 10)
+      create(:affiliation, person: create(:person), organization: org,
+                           title: "Facilitator", start_date: training_start, end_date: nil)
+      org.reload
+
+      [ training_start, training_start + 1.day, training_start + 2.days ].each do |viewed_on|
+        travel_to(viewed_on) do
+          expect(org.facilitator_program_status(as_of: training_start).status).to eq(:new)
+        end
+      end
+
+      travel_to(training_start + 3.years) do
+        expect(org.facilitator_program_status(as_of: training_start).status).to eq(:new)
+      end
+    end
   end
 
   describe "#explanation" do

--- a/spec/system/upcoming_badge_spec.rb
+++ b/spec/system/upcoming_badge_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Affiliation status badges", type: :system do
-  let(:admin) { create(:user, :admin) }
+  # Requests render in the signed-in user's zone (ApplicationController
+  # #set_time_zone_from_user), so pin it to the spec process's own zone —
+  # otherwise "starts today" straddles a date boundary depending on the hour.
+  let(:admin) { create(:user, :admin, time_zone: Time.zone.name) }
   let!(:person) { create(:person, user: admin) }
   let!(:org) { create(:organization, name: "Zeta Test Center") }
 

--- a/spec/system/upcoming_badge_spec.rb
+++ b/spec/system/upcoming_badge_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Upcoming affiliation badge", type: :system do
+RSpec.describe "Affiliation status badges", type: :system do
   let(:admin) { create(:user, :admin) }
   let!(:person) { create(:person, user: admin) }
   let!(:org) { create(:organization, name: "Zeta Test Center") }
@@ -10,19 +10,24 @@ RSpec.describe "Upcoming affiliation badge", type: :system do
     sign_in admin
   end
 
-  # Maps each row's title to whether its Upcoming badge is hidden, read straight
-  # from the live DOM after the inactive-toggle controller has run.
-  def badge_hidden_by_title
-    page.evaluate_script(<<~JS).to_h { |r| [ r["title"], r["hidden"] ] }
+  # Maps each row's title to whether its Inactive/Upcoming badges are hidden,
+  # read straight from the live DOM after the inactive-toggle controller has run.
+  def badges_by_title
+    page.evaluate_script(<<~JS).to_h { |r| [ r["title"], r ] }
       Array.from(document.querySelectorAll('.nested-fields')).map(function(row){
         var title = row.querySelector("input[name*='title']");
-        var badge = row.querySelector("[data-inactive-toggle-target='upcomingBadge']");
-        return { title: title ? title.value : null, hidden: badge ? badge.classList.contains('hidden') : null };
+        var inactive = row.querySelector("[data-inactive-toggle-target='inactiveBadge']");
+        var upcoming = row.querySelector("[data-inactive-toggle-target='upcomingBadge']");
+        return {
+          title: title ? title.value : null,
+          inactiveHidden: inactive ? inactive.classList.contains('hidden') : null,
+          upcomingHidden: upcoming ? upcoming.classList.contains('hidden') : null
+        };
       });
     JS
   end
 
-  it "badges Upcoming only for a future start that has not ended" do
+  it "shows Inactive for not-active rows and adds Upcoming for future starts" do
     create(:affiliation, person: person, organization: org, title: "PastActive",
                          start_date: 1.year.ago.to_date, end_date: nil)
     create(:affiliation, person: person, organization: org, title: "Ended",
@@ -31,17 +36,17 @@ RSpec.describe "Upcoming affiliation badge", type: :system do
                          start_date: 1.month.from_now.to_date, end_date: nil)
     create(:affiliation, person: person, organization: org, title: "StartsToday",
                          start_date: Date.current, end_date: nil)
-    create(:affiliation, person: person, organization: org, title: "StartsTomorrow",
-                         start_date: Date.current + 1.day, end_date: nil)
 
     visit edit_person_path(person)
-    expect(page).to have_css(".nested-fields", minimum: 5, wait: 10)
+    expect(page).to have_css(".nested-fields", minimum: 4, wait: 10)
+    rows = badges_by_title
 
-    hidden = badge_hidden_by_title
-    expect(hidden["PastActive"]).to be(true)
-    expect(hidden["Ended"]).to be(true)
-    expect(hidden["StartsToday"]).to be(true)
-    expect(hidden["FutureUp"]).to be(false)
-    expect(hidden["StartsTomorrow"]).to be(false)
+    # Active now → no badges.
+    expect(rows["PastActive"]).to include("inactiveHidden" => true, "upcomingHidden" => true)
+    expect(rows["StartsToday"]).to include("inactiveHidden" => true, "upcomingHidden" => true)
+    # Ended → Inactive only.
+    expect(rows["Ended"]).to include("inactiveHidden" => false, "upcomingHidden" => true)
+    # Future start → Inactive AND Upcoming.
+    expect(rows["FutureUp"]).to include("inactiveHidden" => false, "upcomingHidden" => false)
   end
 end

--- a/spec/system/upcoming_badge_spec.rb
+++ b/spec/system/upcoming_badge_spec.rb
@@ -13,43 +13,42 @@ RSpec.describe "Affiliation status badges", type: :system do
     sign_in admin
   end
 
-  # Maps each row's title to whether its Inactive/Upcoming badges are hidden,
-  # read straight from the live DOM after the inactive-toggle controller has run.
-  def badges_by_title
-    page.evaluate_script(<<~JS).to_h { |r| [ r["title"], r ] }
-      Array.from(document.querySelectorAll('.nested-fields')).map(function(row){
-        var title = row.querySelector("input[name*='title']");
-        var inactive = row.querySelector("[data-inactive-toggle-target='inactiveBadge']");
-        var upcoming = row.querySelector("[data-inactive-toggle-target='upcomingBadge']");
-        return {
-          title: title ? title.value : null,
-          inactiveHidden: inactive ? inactive.classList.contains('hidden') : null,
-          upcomingHidden: upcoming ? upcoming.classList.contains('hidden') : null
-        };
-      });
+  # Read from classList rather than Capybara visibility: `hidden` only hides once
+  # the Tailwind build is loaded, and the fast test path skips that build.
+  def badge_hidden?(row, target)
+    page.evaluate_script(
+      "arguments[0].querySelector(\"[data-inactive-toggle-target='#{target}']\").classList.contains('hidden')",
+      row.native
+    )
+  end
+
+  # The controller reacts to `change` on the start-date input; set the value and
+  # fire it, rather than driving Chrome's segmented date widget by keystroke.
+  def set_start_date(row, value)
+    page.execute_script(<<~JS, row.find("input[data-inactive-toggle-target~='startDate']").native, value.to_s)
+      arguments[0].value = arguments[1];
+      arguments[0].dispatchEvent(new Event("change", { bubbles: true }));
     JS
   end
 
-  it "shows Inactive for not-active rows and adds Upcoming for future starts" do
-    create(:affiliation, person: person, organization: org, title: "PastActive",
+  it "adds and removes the badges live as the start date is edited" do
+    create(:affiliation, person: person, organization: org, title: "Counselor",
                          start_date: 1.year.ago.to_date, end_date: nil)
-    create(:affiliation, person: person, organization: org, title: "Ended",
-                         start_date: 2.years.ago.to_date, end_date: 1.month.ago.to_date)
-    create(:affiliation, person: person, organization: org, title: "FutureUp",
-                         start_date: 1.month.from_now.to_date, end_date: nil)
-    create(:affiliation, person: person, organization: org, title: "StartsToday",
-                         start_date: Date.current, end_date: nil)
 
     visit edit_person_path(person)
-    expect(page).to have_css(".nested-fields", minimum: 4, wait: 10)
-    rows = badges_by_title
+    row = find(".nested-fields", wait: 10)
 
-    # Active now → no badges.
-    expect(rows["PastActive"]).to include("inactiveHidden" => true, "upcomingHidden" => true)
-    expect(rows["StartsToday"]).to include("inactiveHidden" => true, "upcomingHidden" => true)
-    # Ended → Inactive only.
-    expect(rows["Ended"]).to include("inactiveHidden" => false, "upcomingHidden" => true)
-    # Future start → Inactive AND Upcoming.
-    expect(rows["FutureUp"]).to include("inactiveHidden" => false, "upcomingHidden" => false)
+    # Active as rendered — neither badge showing.
+    expect(badge_hidden?(row, "inactiveBadge")).to be true
+    expect(badge_hidden?(row, "upcomingBadge")).to be true
+
+    set_start_date(row, 1.month.from_now.to_date.iso8601)
+    expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge']:not(.hidden)", wait: 5)
+    expect(badge_hidden?(row, "inactiveBadge")).to be false
+
+    # Back to a started date: both badges go away again.
+    set_start_date(row, 1.year.ago.to_date.iso8601)
+    expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge'].hidden", wait: 5)
+    expect(badge_hidden?(row, "inactiveBadge")).to be true
   end
 end

--- a/spec/system/upcoming_badge_spec.rb
+++ b/spec/system/upcoming_badge_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Upcoming affiliation badge", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:person) { create(:person, user: admin) }
+  let!(:org) { create(:organization, name: "Zeta Test Center") }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    sign_in admin
+  end
+
+  # Maps each row's title to whether its Upcoming badge is hidden, read straight
+  # from the live DOM after the inactive-toggle controller has run.
+  def badge_hidden_by_title
+    page.evaluate_script(<<~JS).to_h { |r| [ r["title"], r["hidden"] ] }
+      Array.from(document.querySelectorAll('.nested-fields')).map(function(row){
+        var title = row.querySelector("input[name*='title']");
+        var badge = row.querySelector("[data-inactive-toggle-target='upcomingBadge']");
+        return { title: title ? title.value : null, hidden: badge ? badge.classList.contains('hidden') : null };
+      });
+    JS
+  end
+
+  it "badges Upcoming only for a future start that has not ended" do
+    create(:affiliation, person: person, organization: org, title: "PastActive",
+                         start_date: 1.year.ago.to_date, end_date: nil)
+    create(:affiliation, person: person, organization: org, title: "Ended",
+                         start_date: 2.years.ago.to_date, end_date: 1.month.ago.to_date)
+    create(:affiliation, person: person, organization: org, title: "FutureUp",
+                         start_date: 1.month.from_now.to_date, end_date: nil)
+    create(:affiliation, person: person, organization: org, title: "StartsToday",
+                         start_date: Date.current, end_date: nil)
+    create(:affiliation, person: person, organization: org, title: "StartsTomorrow",
+                         start_date: Date.current + 1.day, end_date: nil)
+
+    visit edit_person_path(person)
+    expect(page).to have_css(".nested-fields", minimum: 5, wait: 10)
+
+    hidden = badge_hidden_by_title
+    expect(hidden["PastActive"]).to be(true)
+    expect(hidden["Ended"]).to be(true)
+    expect(hidden["StartsToday"]).to be(true)
+    expect(hidden["FutureUp"]).to be(false)
+    expect(hidden["StartsTomorrow"]).to be(false)
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 changes shared `active?` semantics feeding person + org facilitator status, filters, decorators, policies and two Stimulus controllers, plus what "Linked" means on three org-linking surfaces

### Goal
- A facilitator affiliation whose **start date is in the future** reads as **Upcoming**, not Active.
- "Active" now means: not flagged inactive, **started** (no future start), and not ended — i.e. `status_on == "Active"`.

### Affiliations
- `#active?` → `status_on == "Active"`; new `#upcoming?`; the `active` scope gains the start-date clause.
- `active_or_pending` unchanged — registration dedup and scenario end-dating still count future starts.
- Editor row shows live **Inactive** / **Upcoming** badges as the dates are edited.
- Those badges take **today from the server**, not the browser. Requests render in the signed-in user's zone (`set_time_zone_from_user`), so a viewer whose OS zone sits ahead of their profile zone would otherwise see a row starting today badged Upcoming while the server disagreed.

### People
- Facilitator-status filter gains **Upcoming**.
- **Inactive is the not-active umbrella** — everyone who is not a currently-active facilitator, including never-facilitators and upcoming ones. Mirrors the org index's Inactive.
- Index column is now **Facilitator since** — facilitator affiliations only, **blank for someone who never facilitated** (the old `member_since` fallback would have printed a membership year under that heading; it still applies to a real facilitator whose rows carry no start date). Upcoming/Inactive label under the year.
- The Affiliation(s) column and the profile's affiliations tab **keep upcoming rows** — otherwise a row labelled "Upcoming" showed no org beside it.
- Public directory = active **facilitators** only: `with_active_affiliations` → `with_active_facilitator_affiliations`, behind `published` / `PersonPolicy`. A Counselor-only or lapsed person is now admin-visible only.

### Organizations
- New distinct **`:upcoming`** status bucket (precedence: active → upcoming → formerly_active → never_active), blue `:org_upcoming` badge.
- `Organization.program_status`: new `upcoming` bucket; `formerly_active` excludes it; **`formerly_or_never` ("Inactive") still includes it**, so upcoming orgs also surface under Inactive.
- Index dropdown options moved to `Organization::PROGRAM_STATUS_FILTER_OPTIONS`, ordered like the people filter (Active, Inactive, Upcoming, Formerly active, Never active).
- `affiliation_dates_controller.js` mirrors the new bucket for the edit form's live status chip.
- **Legacy-status warning:** the stored column has no Upcoming, so `:upcoming` is compared as `:never_active` — a stored `Pending` (or blank/`Unknown`) on an upcoming org isn't drift.

### Organization linking ("Linked")

Fallout from the `active?` change, then the rule underneath it.

- The **linking editor** decided "linked" by matching the submitted org name against the person's *active* affiliations — so narrowing `active?` made a facilitator dated to an upcoming training read as Pending.
- Fixed by dropping affiliation matching entirely. An affiliation is downstream of linking, not evidence of it: every path that links an org also mints the affiliation, so the name match only restated the link less precisely — and claimed one for a name collision with an unrelated org.
- **Linked now means a real link**, either kind: the explicit id in `form_submissions.metadata`, or the `event_registration_organizations` row the submission is pinned to (`form_submission_id`). Both count on the index filter, its org chip, `for_organization`, and the editor.
- That closes a **pre-existing split**: public registration records only the pin, so those submissions sat in the submissions index's Pending queue with nothing to action while the registrants roster already called the same registration Linked.
- Registrants roster gains **No org provided**, so both indexes offer the same four values (Linked / Unlinked / Pending / No org provided).
- The processing panel's affiliation pill now shows all three states and offers **End** for an upcoming row — `ApplyScenarioEndDating` already end-dates those, so the manual control was disagreeing with what linking does.
- ADR-0002 D5 rewritten.

### Notes for reviewers
- **The stored `organization_status` is a no-op for upcoming-only programs.** The affiliation-save callback deactivates on all-lapsed/none and reactivates on active, but leaves an org alone when its only facilitator hasn't started — stamping it Inactive would stick (nothing re-runs when the start date arrives) and stamping it Active would claim a program that hasn't begun. Either way the legacy-drift warning above would misfire. The displayed bucket (`organization_status_bucket`, ADR-0001 D3) and `published?` re-derive live regardless.
- ADR-0001 updated: Active vs Upcoming definitions, the four-bucket chip vs the **five**-option filter (Inactive is a filter value, never a chip), and the Inactive umbrella.
- Rebased on `main` after #2367 (the scholarship program-status anchoring, split out of this branch) merged — those commits dropped out, so this PR is now purely the Upcoming taxonomy.
- **Expect the Pending queue on `/form_submissions` to shrink**, possibly a lot — every public registration that resolved an existing org was sitting in it.
- UI screenshots (Upcoming badges + filters) to add.

### Tests
- `#active?` / `#upcoming?` / `.active`; people Active/Upcoming/Inactive buckets; org bucket precedence + `program_status` scope buckets; a system spec for the editor's live badges.
- Org-status callback: upcoming-only leaves the stored status untouched in both directions. The two legacy-mismatch specs now seed the `Inactive` status row — without it the callback early-returned and they passed vacuously.
- Linking: a pinned registration-org row reads Linked (and drops out of Pending/Unlinked); `for_organization` matches either link kind; roster `none`, including when the form has no org field.
- The editor's badge system spec now **edits a start date and watches the badges follow** — it previously asserted only what the ERB already rendered, so it passed with the Stimulus controller deleted. Its static matrix moved to a request spec.



