### PR TITLE
Form submissions: direct-link org filter + Pending/Linked/Unlinked status

### DIFF
--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -12,7 +12,7 @@ class FormSubmissionsController < ApplicationController
         .includes(:form, :event, { person: :user }, { form_answers: :form_field })
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 50)
-      @linked_org_names = linked_org_names_for(@form_submissions)
+      @linked_orgs = linked_orgs_for(@form_submissions)
       render :form_submissions_results
     else
       @forms = Form.order(:name)
@@ -89,14 +89,14 @@ class FormSubmissionsController < ApplicationController
     @form_submission = FormSubmission.includes(:form, person: { affiliations: :organization }).find(params[:id])
   end
 
-  # {submission_id => [org names]} for the directly-linked orgs across the page, in
-  # one query, so the index can show the linked org without an N+1 over each
-  # submission's metadata id list.
-  def linked_org_names_for(submissions)
+  # {submission_id => [Organization]} for the directly-linked orgs across the page,
+  # in one query, so the index can show the linked org chips without an N+1 over
+  # each submission's metadata id list.
+  def linked_orgs_for(submissions)
     ids_by_submission = submissions.to_h { |submission| [ submission.id, submission.linked_organization_ids ] }
     all_ids = ids_by_submission.values.flatten.uniq
-    names = all_ids.any? ? Organization.where(id: all_ids).pluck(:id, :name).to_h : {}
-    ids_by_submission.transform_values { |ids| ids.filter_map { |id| names[id] } }
+    orgs = all_ids.any? ? Organization.where(id: all_ids).index_by(&:id) : {}
+    ids_by_submission.transform_values { |ids| ids.filter_map { |id| orgs[id] } }
   end
 
   # The org-related answers on this submission (canonical or legacy "agency_"

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -12,6 +12,7 @@ class FormSubmissionsController < ApplicationController
         .includes(:form, :event, { person: :user }, { form_answers: :form_field })
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 50)
+      @linked_org_names = linked_org_names_for(@form_submissions)
       render :form_submissions_results
     else
       @forms = Form.order(:name)
@@ -86,6 +87,16 @@ class FormSubmissionsController < ApplicationController
 
   def set_form_submission
     @form_submission = FormSubmission.includes(:form, person: { affiliations: :organization }).find(params[:id])
+  end
+
+  # {submission_id => [org names]} for the directly-linked orgs across the page, in
+  # one query, so the index can show the linked org without an N+1 over each
+  # submission's metadata id list.
+  def linked_org_names_for(submissions)
+    ids_by_submission = submissions.to_h { |submission| [ submission.id, submission.linked_organization_ids ] }
+    all_ids = ids_by_submission.values.flatten.uniq
+    names = all_ids.any? ? Organization.where(id: all_ids).pluck(:id, :name).to_h : {}
+    ids_by_submission.transform_values { |ids| ids.filter_map { |id| names[id] } }
   end
 
   # The org-related answers on this submission (canonical or legacy "agency_"

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -9,7 +9,7 @@ class FormSubmissionsController < ApplicationController
 
     if turbo_frame_request?
       @form_submissions = FormSubmission.search_by_params(params)
-        .includes(:form, :event, { person: [ :user, { affiliations: :organization } ] }, { form_answers: :form_field })
+        .includes(:form, :event, { person: :user }, { form_answers: :form_field })
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 50)
       render :form_submissions_results

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -307,8 +307,14 @@ class UsersController < ApplicationController
     @user.update(welcome_instructions_sent_at: Time.current, welcome_instructions_sent_by: current_user)
     @user.send_confirmation_instructions(sender: current_user)
 
-    # Back to the agreement submission the Invite button was on, when it came
-    # from a processing panel; the users index otherwise.
+    # Back to the form submissions index with the row highlighted, when invited
+    # from there; back to the submission itself when invited from its processing
+    # panel; the users index otherwise.
+    if params[:return_to] == "form_submissions" && params[:form_submission_id].present?
+      redirect_to form_submissions_path(anchor: helpers.form_submission_row_id(params[:form_submission_id]), highlight: params[:form_submission_id]), notice: "Invitation sent to #{@user.email}."
+      return
+    end
+
     if params[:return_to] == "form_submission" && params[:form_submission_id].present?
       redirect_to form_submission_path(params[:form_submission_id]), notice: "Invitation sent to #{@user.email}."
       return

--- a/app/helpers/form_submissions_helper.rb
+++ b/app/helpers/form_submissions_helper.rb
@@ -17,6 +17,13 @@ module FormSubmissionsHelper
     }.compact
   end
 
+  # Stable anchor id for a submission's row on the index, so return links (from
+  # the detail page or after inviting) can scroll to and highlight it.
+  def form_submission_row_id(record_or_id)
+    id = record_or_id.respond_to?(:id) ? record_or_id.id : record_or_id
+    "form-submission-row-#{id}"
+  end
+
   # True when any index filter is active — drives whether "Clear filters" shows.
   def form_submission_filters_active?(params)
     params.values_at(:person_id, :form_id, :event_id, :organization_id, :role,

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -15,10 +15,13 @@ class FormSubmission < ApplicationRecord
 
   # The index's "Organization linking" filter vocabulary: linked = the submitted
   # organization name matches one of the person's active affiliations.
+  # Mirrors the registrants roster (events/_registrant_filters): "pending" is the
+  # actionable queue (named an org, not linked), "unlinked" is the broad set (not
+  # linked, whichever — including no org answer), "linked" is processed.
   ORG_LINK_STATUS_FILTER_OPTIONS = [
-    [ "Linked to submission", "linked" ],
-    [ "Not linked to submission", "unlinked" ],
-    [ "No organization answer", "none" ]
+    [ "Pending", "pending" ],
+    [ "Linked", "linked" ],
+    [ "Unlinked", "unlinked" ]
   ].freeze
 
   scope :bulk_payment, -> { where(role: "bulk_payment") }
@@ -72,16 +75,18 @@ class FormSubmission < ApplicationRecord
   # #link_organization!). COALESCE: metadata (or the key) may be absent.
   EXPLICIT_ORG_LINK_SQL = "COALESCE(JSON_LENGTH(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids')), 0) > 0".freeze
 
-  # Whether an org has been *directly linked to the submission* (the metadata link
-  # an admin sets in the org-linking editor) — i.e. whether it's been processed.
-  # A matching affiliation the person happens to hold does NOT count: "unlinked" is
-  # the processing queue of submissions that named an org but haven't been linked.
+  # Linking status keyed on whether an org is *directly linked to the submission*
+  # (the metadata link an admin sets in the editor) — a matching affiliation the
+  # person happens to hold does NOT count. Mirrors the registrants roster:
+  #   linked   — an org was linked (processed).
+  #   unlinked — no org linked, whichever kind (broad; includes no org answer).
+  #   pending  — named an org but nothing linked yet — the actionable queue.
   scope :org_link_status, ->(value) {
     answered = org_name_answers.select(:form_submission_id)
     case value
     when "linked" then where(EXPLICIT_ORG_LINK_SQL)
-    when "unlinked" then where(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
-    when "none" then where.not(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
+    when "unlinked" then where.not(EXPLICIT_ORG_LINK_SQL)
+    when "pending" then where(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
     else all
     end
   }

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -16,8 +16,8 @@ class FormSubmission < ApplicationRecord
   # The index's "Organization linking" filter vocabulary: linked = the submitted
   # organization name matches one of the person's active affiliations.
   ORG_LINK_STATUS_FILTER_OPTIONS = [
-    [ "Linked", "linked" ],
-    [ "Not linked", "unlinked" ],
+    [ "Linked to submission", "linked" ],
+    [ "Not linked to submission", "unlinked" ],
     [ "No organization answer", "none" ]
   ].freeze
 
@@ -72,25 +72,16 @@ class FormSubmission < ApplicationRecord
   # #link_organization!). COALESCE: metadata (or the key) may be absent.
   EXPLICIT_ORG_LINK_SQL = "COALESCE(JSON_LENGTH(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids')), 0) > 0".freeze
 
+  # Whether an org has been *directly linked to the submission* (the metadata link
+  # an admin sets in the org-linking editor) — i.e. whether it's been processed.
+  # A matching affiliation the person happens to hold does NOT count: "unlinked" is
+  # the processing queue of submissions that named an org but haven't been linked.
   scope :org_link_status, ->(value) {
     answered = org_name_answers.select(:form_submission_id)
     case value
-    when "linked", "unlinked"
-      # Linked: the submitted name matches an org the person holds an active (or
-      # pending) affiliation with — the same rule as the index's Linked chip —
-      # or an admin explicitly linked an org to this submission (which covers a
-      # typo'd name resolved to a differently-named org).
-      affiliation_linked = org_name_answers
-        .joins(form_submission: { person: { affiliations: :organization } })
-        .merge(Affiliation.active_or_pending)
-        .where("organizations.name = form_answers.submitted_answer")
-        .select(:form_submission_id)
-      if value == "linked"
-        where(id: answered).and(where(id: affiliation_linked).or(where(EXPLICIT_ORG_LINK_SQL)))
-      else
-        where(id: answered).where.not(id: affiliation_linked).where.not(EXPLICIT_ORG_LINK_SQL)
-      end
-    when "none" then where.not(id: answered)
+    when "linked" then where(EXPLICIT_ORG_LINK_SQL)
+    when "unlinked" then where(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
+    when "none" then where.not(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
     else all
     end
   }

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -31,11 +31,26 @@ class FormSubmission < ApplicationRecord
     scope
   }
 
-  # Submissions linked to an organization through an event registration. This is
-  # the only queryable submission → organization path (the org an answer names is
-  # otherwise just free text); submissions that never linked an org won't match.
+  # Submissions associated with an organization, reconciling every signal:
+  #   1. directly — an explicit link recorded in metadata (see #link_organization!),
+  #   2. via the submission's event registration — the join row pinned to this
+  #      submission, or a registration for the same person + event linked to the org.
   scope :for_organization, ->(organization_id) {
-    where(id: EventRegistrationOrganization.where(organization_id: organization_id).select(:form_submission_id))
+    oid = organization_id.to_i
+    direct = where(
+      "JSON_CONTAINS(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids'), CAST(? AS JSON))", oid
+    )
+    pinned = EventRegistrationOrganization.where(organization_id: oid).select(:form_submission_id)
+    via_registration = joins(
+      "INNER JOIN event_registrations " \
+      "ON event_registrations.registrant_id = form_submissions.person_id " \
+      "AND event_registrations.event_id = form_submissions.event_id"
+    ).joins(
+      "INNER JOIN event_registration_organizations " \
+      "ON event_registration_organizations.event_registration_id = event_registrations.id"
+    ).where(event_registration_organizations: { organization_id: oid }).select(:id)
+
+    direct.or(where(id: pinned)).or(where(id: via_registration))
   }
 
   scope :search, ->(query) {

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -34,26 +34,15 @@ class FormSubmission < ApplicationRecord
     scope
   }
 
-  # Submissions associated with an organization, reconciling every signal:
-  #   1. directly — an explicit link recorded in metadata (see #link_organization!),
-  #   2. via the submission's event registration — the join row pinned to this
-  #      submission, or a registration for the same person + event linked to the org.
+  # Submissions with the organization linked directly to them — the explicit link
+  # an admin makes in the org-linking editor, recorded in metadata (see
+  # #link_organization!). Nothing else counts: a matching affiliation or an org on
+  # the submission's event registration doesn't make the submission match.
   scope :for_organization, ->(organization_id) {
-    oid = organization_id.to_i
-    direct = where(
-      "JSON_CONTAINS(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids'), CAST(? AS JSON))", oid
+    where(
+      "JSON_CONTAINS(JSON_EXTRACT(form_submissions.metadata, '$.linked_organization_ids'), CAST(? AS JSON))",
+      organization_id.to_i
     )
-    pinned = EventRegistrationOrganization.where(organization_id: oid).select(:form_submission_id)
-    via_registration = joins(
-      "INNER JOIN event_registrations " \
-      "ON event_registrations.registrant_id = form_submissions.person_id " \
-      "AND event_registrations.event_id = form_submissions.event_id"
-    ).joins(
-      "INNER JOIN event_registration_organizations " \
-      "ON event_registration_organizations.event_registration_id = event_registrations.id"
-    ).where(event_registration_organizations: { organization_id: oid }).select(:id)
-
-    direct.or(where(id: pinned)).or(where(id: via_registration))
   }
 
   scope :search, ->(query) {

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -20,9 +20,9 @@ class FormSubmission < ApplicationRecord
   #   unlinked — not linked, either kind: pending or no-org-answer.
   #   none     — no organization answer was provided.
   ORG_LINK_STATUS_FILTER_OPTIONS = [
-    [ "Pending", "pending" ],
     [ "Linked", "linked" ],
     [ "Unlinked", "unlinked" ],
+    [ "Pending", "pending" ],
     [ "No org provided", "none" ]
   ].freeze
 

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -13,15 +13,17 @@ class FormSubmission < ApplicationRecord
 
   UNREADABLE_UPLOAD_MESSAGE = "We couldn't read one of your uploaded files. Please choose it again.".freeze
 
-  # The index's "Organization linking" filter vocabulary: linked = the submitted
-  # organization name matches one of the person's active affiliations.
-  # Mirrors the registrants roster (events/_registrant_filters): "pending" is the
-  # actionable queue (named an org, not linked), "unlinked" is the broad set (not
-  # linked, whichever — including no org answer), "linked" is processed.
+  # The index's "Organization linking" filter vocabulary, keyed on whether an org
+  # is linked directly to the submission (see #link_organization!):
+  #   pending  — gave an org answer, not linked yet (the actionable queue).
+  #   linked   — an org was linked (processed).
+  #   unlinked — not linked, either kind: pending or no-org-answer.
+  #   none     — no organization answer was provided.
   ORG_LINK_STATUS_FILTER_OPTIONS = [
     [ "Pending", "pending" ],
     [ "Linked", "linked" ],
-    [ "Unlinked", "unlinked" ]
+    [ "Unlinked", "unlinked" ],
+    [ "No org provided", "none" ]
   ].freeze
 
   scope :bulk_payment, -> { where(role: "bulk_payment") }
@@ -68,14 +70,16 @@ class FormSubmission < ApplicationRecord
   # (the metadata link an admin sets in the editor) — a matching affiliation the
   # person happens to hold does NOT count. Mirrors the registrants roster:
   #   linked   — an org was linked (processed).
-  #   unlinked — no org linked, whichever kind (broad; includes no org answer).
-  #   pending  — named an org but nothing linked yet — the actionable queue.
+  #   unlinked — no org linked, whichever kind: pending or no org answer (broad).
+  #   pending  — gave an org answer but nothing linked yet — the actionable queue.
+  #   none     — no organization answer was provided.
   scope :org_link_status, ->(value) {
     answered = org_name_answers.select(:form_submission_id)
     case value
     when "linked" then where(EXPLICIT_ORG_LINK_SQL)
     when "unlinked" then where.not(EXPLICIT_ORG_LINK_SQL)
     when "pending" then where(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
+    when "none" then where.not(id: answered).where.not(EXPLICIT_ORG_LINK_SQL)
     else all
     end
   }

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -46,17 +46,17 @@
               </td>
               <% unless @person %><td class="px-4 py-3"><%= submission.person&.name %></td><% end %>
               <td class="px-4 py-3">
-                <%# The submitted organization answer, with whether the person already
-                    has an active affiliation to an organization of that name — the
-                    "link organization" signal for processing agreement submissions. %>
+                <%# The submitted organization answer, with whether an org has been
+                    directly linked to this submission yet — the "to process" signal.
+                    A matching affiliation the person holds doesn't count; only an
+                    explicit link made in the editor does. %>
                 <% answers = submission.answers_by_identifier %>
                 <% submitted_org = FormField.aliased_identifiers("organization_name").filter_map { |key| answers[key].presence }.first %>
                 <% if submitted_org %>
                   <%= submitted_org %>
                   <%# The chip doubles as the way into the submission's org-linking
                       editor, like the org chips on the registrants roster. %>
-                  <% linked = submission.linked_organization_ids.any? ||
-                       submission.person&.affiliations&.any? { |a| a.active? && a.organization.name.casecmp?(submitted_org) } %>
+                  <% linked = submission.linked_organization_ids.any? %>
                   <% editor_path = link_organization_form_submission_path(submission, return_to: "form_submissions") %>
                   <% if linked %>
                     <%= link_to editor_path, title: "Open the organization linking editor", data: { turbo_frame: "_top" },

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -103,8 +103,8 @@
               </td>
               <td class="px-4 py-3 whitespace-nowrap" data-column-toggle-col="submitted"><%= submission.created_at.to_fs(:long) %></td>
               <td class="px-4 py-3 text-right">
-                <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. %>
-                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: submission.person_id, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. person_id/form_id are carried only when they were active filters — the back-link anchors to this row via highlight, so it need not re-scope to this submission's person. %>
+                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: params[:person_id].presence, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -9,26 +9,35 @@
   </div>
 
   <% if @form_submissions.any? %>
+    <div data-column-toggle-root data-column-toggle-scope="form-submissions">
+    <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+      <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Columns</span>
+      <%= render "shared/column_toggle_switch", group: "role", label: "Role", on: true %>
+      <%= render "shared/column_toggle_switch", group: "event", label: "Event", on: true %>
+      <%= render "shared/column_toggle_switch", group: "submitted", label: "Submitted date", on: true %>
+      <%= render "shared/column_toggle_switch", group: "user_account", label: "User account", on: false %>
+    </div>
     <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
       <table class="w-full border-collapse">
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">
             <th class="px-4 py-3">Form</th>
-            <th class="px-4 py-3">Role</th>
-            <th class="px-4 py-3">Event</th>
+            <th class="px-4 py-3" data-column-toggle-col="role">Role</th>
+            <th class="px-4 py-3" data-column-toggle-col="event">Event</th>
             <% unless @person %><th class="px-4 py-3">Person</th><% end %>
             <th class="px-4 py-3">Organization</th>
-            <th class="px-4 py-3">User account</th>
-            <th class="px-4 py-3">Submitted</th>
+            <th class="px-4 py-3 hidden" data-column-toggle-col="user_account">User account</th>
+            <th class="px-4 py-3" data-column-toggle-col="submitted">Submitted</th>
             <th class="px-4 py-3"></th>
           </tr>
         </thead>
         <tbody>
           <% @form_submissions.each do |submission| %>
-            <tr class="border-b border-gray-100 text-sm text-gray-800 last:border-0">
+            <% highlighted = params[:highlight].to_s == submission.id.to_s %>
+            <tr id="<%= form_submission_row_id(submission) %>" class="scroll-mt-24 border-b border-gray-100 text-sm text-gray-800 transition-colors duration-150 last:border-0 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "" %>">
               <td class="px-4 py-3 font-medium"><%= submission.form&.display_name %></td>
-              <td class="px-4 py-3"><%= submission.role&.humanize %></td>
-              <td class="px-4 py-3">
+              <td class="px-4 py-3" data-column-toggle-col="role"><%= submission.role&.humanize %></td>
+              <td class="px-4 py-3" data-column-toggle-col="event">
                 <% if submission.resolved_event %>
                   <% event = submission.resolved_event %>
                   <span class="font-medium text-gray-900"><%= event.name %></span>
@@ -77,9 +86,9 @@
                   <%= render "shared/badge", label: "None", classes: "bg-gray-50 text-gray-500 border-gray-200", href: editor_path %>
                 <% end %>
               </td>
-              <td class="px-4 py-3">
+              <td class="px-4 py-3 hidden" data-column-toggle-col="user_account">
                 <% if submission.person&.user %>
-                  <%= render "users/confirmed_status", user: submission.person.user, invite_params: { return_to: "form_submission", form_submission_id: submission.id } %>
+                  <%= render "users/confirmed_status", user: submission.person.user, invite_params: { return_to: "form_submissions", form_submission_id: submission.id } %>
                 <% elsif submission.person %>
                   <%= link_to "Create user", new_user_path(person_id: submission.person.id),
                               class: "btn btn-secondary-outline whitespace-nowrap", data: { turbo_frame: "_top" } %>
@@ -87,7 +96,7 @@
                   <span class="text-gray-300">—</span>
                 <% end %>
               </td>
-              <td class="px-4 py-3 whitespace-nowrap"><%= submission.created_at.to_fs(:long) %></td>
+              <td class="px-4 py-3 whitespace-nowrap" data-column-toggle-col="submitted"><%= submission.created_at.to_fs(:long) %></td>
               <td class="px-4 py-3 text-right">
                 <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. %>
                 <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: submission.person_id, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
@@ -99,6 +108,7 @@
     </div>
 
     <div class="pagination mt-6 flex w-full justify-center"><%= tailwind_paginate @form_submissions %></div>
+    </div>
   <% else %>
     <div class="rounded-xl border border-dashed border-gray-300 bg-white py-12 text-center">
       <i class="fa-solid fa-file-signature text-3xl text-gray-300" aria-hidden="true"></i>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -52,12 +52,12 @@
                     explicit link made in the editor does. %>
                 <% answers = submission.answers_by_identifier %>
                 <% submitted_org = FormField.aliased_identifiers("organization_name").filter_map { |key| answers[key].presence }.first %>
+                <%# The chip doubles as the way into the submission's org-linking
+                    editor, like the org chips on the registrants roster. %>
+                <% editor_path = link_organization_form_submission_path(submission, return_to: "form_submissions") %>
                 <% if submitted_org %>
                   <%= submitted_org %>
-                  <%# The chip doubles as the way into the submission's org-linking
-                      editor, like the org chips on the registrants roster. %>
                   <% linked = submission.linked_organization_ids.any? %>
-                  <% editor_path = link_organization_form_submission_path(submission, return_to: "form_submissions") %>
                   <% if linked %>
                     <%= link_to editor_path, title: "Open the organization linking editor", data: { turbo_frame: "_top" },
                                 class: "ml-1 inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 transition hover:opacity-80 hover:shadow-sm" do %>
@@ -72,7 +72,9 @@
                     <% end %>
                   <% end %>
                 <% else %>
-                  <span class="text-gray-300">—</span>
+                  <%# No org submitted — grey "None" chip that still opens the editor,
+                      matching the registrants roster. %>
+                  <%= render "shared/badge", label: "None", classes: "bg-gray-50 text-gray-500 border-gray-200", href: editor_path %>
                 <% end %>
               </td>
               <td class="px-4 py-3">

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -64,25 +64,26 @@
                 <%# The chip doubles as the way into the submission's org-linking
                     editor, like the org chips on the registrants roster. %>
                 <% editor_path = link_organization_form_submission_path(submission, return_to: "form_submissions") %>
-                <% if submitted_org %>
+                <% linked_names = @linked_org_names[submission.id] || [] %>
+                <% if submission.linked_organization_ids.any? %>
+                  <%# An org was linked directly to this submission — show it, regardless
+                      of whether the submitter named one. %>
+                  <%= linked_names.to_sentence.presence || submitted_org %>
+                  <%= link_to editor_path, title: "Open the organization linking editor", data: { turbo_frame: "_top" },
+                              class: "ml-1 inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 transition hover:opacity-80 hover:shadow-sm" do %>
+                    <i class="fa-solid fa-check text-3xs"></i>Linked
+                  <% end %>
+                <% elsif submitted_org %>
                   <%= submitted_org %>
-                  <% linked = submission.linked_organization_ids.any? %>
-                  <% if linked %>
-                    <%= link_to editor_path, title: "Open the organization linking editor", data: { turbo_frame: "_top" },
-                                class: "ml-1 inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 transition hover:opacity-80 hover:shadow-sm" do %>
-                      <i class="fa-solid fa-check text-3xs"></i>Linked
-                    <% end %>
-                  <% else %>
-                    <%# Same amber "Pending" chip as the registrants roster: a submitted
-                        org that hasn't been linked to the submission yet. %>
-                    <%= link_to editor_path, title: "Link the submitted organization", data: { turbo_frame: "_top" },
-                                class: "ml-1 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 transition hover:opacity-80 hover:shadow-sm" do %>
-                      <i class="fa-solid fa-circle-exclamation text-3xs"></i>Pending
-                    <% end %>
+                  <%# Same amber "Pending" chip as the registrants roster: a submitted
+                      org that hasn't been linked to the submission yet. %>
+                  <%= link_to editor_path, title: "Link the submitted organization", data: { turbo_frame: "_top" },
+                              class: "ml-1 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 transition hover:opacity-80 hover:shadow-sm" do %>
+                    <i class="fa-solid fa-circle-exclamation text-3xs"></i>Pending
                   <% end %>
                 <% else %>
-                  <%# No org submitted — grey "None" chip that still opens the editor,
-                      matching the registrants roster. %>
+                  <%# No org submitted and none linked — grey "None" chip that still
+                      opens the editor, matching the registrants roster. %>
                   <%= render "shared/badge", label: "None", classes: "bg-gray-50 text-gray-500 border-gray-200", href: editor_path %>
                 <% end %>
               </td>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -64,9 +64,11 @@
                       <i class="fa-solid fa-check text-3xs"></i>Linked
                     <% end %>
                   <% else %>
+                    <%# Same amber "Pending" chip as the registrants roster: a submitted
+                        org that hasn't been linked to the submission yet. %>
                     <%= link_to editor_path, title: "Link the submitted organization", data: { turbo_frame: "_top" },
                                 class: "ml-1 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 transition hover:opacity-80 hover:shadow-sm" do %>
-                      <i class="fa-solid fa-circle-exclamation text-3xs"></i>Not linked
+                      <i class="fa-solid fa-circle-exclamation text-3xs"></i>Pending
                     <% end %>
                   <% end %>
                 <% else %>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -64,28 +64,32 @@
                 <%# The chip doubles as the way into the submission's org-linking
                     editor, like the org chips on the registrants roster. %>
                 <% editor_path = link_organization_form_submission_path(submission, return_to: "form_submissions") %>
-                <% linked_names = @linked_org_names[submission.id] || [] %>
-                <% if submission.linked_organization_ids.any? %>
-                  <%# An org was linked directly to this submission — show it, regardless
-                      of whether the submitter named one. %>
-                  <%= linked_names.to_sentence.presence || submitted_org %>
-                  <%= link_to editor_path, title: "Open the organization linking editor", data: { turbo_frame: "_top" },
-                              class: "ml-1 inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 transition hover:opacity-80 hover:shadow-sm" do %>
-                    <i class="fa-solid fa-check text-3xs"></i>Linked
+                <% linked_orgs = @linked_orgs[submission.id] || [] %>
+                <% pill_classes = "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full text-xs font-medium border px-3 py-0.5 transition hover:opacity-80 hover:shadow-sm" %>
+                <div class="flex flex-wrap gap-1.5">
+                  <% if linked_orgs.any? %>
+                    <%# Match the registrants roster: a linked org is shown as its own
+                        chip (no "Linked" label) plus a small link into the editor. %>
+                    <% org_btn_classes = "inline-flex items-center whitespace-nowrap rounded-md text-xs font-medium border px-3 py-0.5 transition bg-gray-50 text-gray-500 border-gray-200 hover:shadow-sm #{DomainTheme.bg_class_for(:organizations, intensity: 100, hover: true)} hover:text-emerald-800 hover:border-emerald-300" %>
+                    <% linked_orgs.each do |org| %>
+                      <span class="inline-flex items-center gap-1">
+                        <%= link_to truncate(org.name, length: 31), organization_path(org), title: org.name, class: org_btn_classes, data: { turbo_frame: "_top" } %>
+                        <% icon_only_pill = pill_classes.sub("gap-1.5 ", "") %>
+                        <%= link_to editor_path, title: "Edit linked organizations", class: "#{icon_only_pill} bg-gray-50 text-gray-500 border-gray-200", data: { turbo_frame: "_top" } do %>
+                          <span class="invisible w-0 min-w-0 overflow-hidden">None</span>
+                          <i class="fa-solid fa-arrow-up-right-from-square text-2xs opacity-70"></i>
+                        <% end %>
+                      </span>
+                    <% end %>
+                  <% elsif submitted_org %>
+                    <%# Amber "Pending" chip, like the registrants roster: a submitted
+                        org that hasn't been linked to the submission yet. %>
+                    <%= render "shared/badge", label: "Pending", classes: "bg-amber-50 text-amber-700 border-amber-200", icon: "fa-solid fa-circle-exclamation text-2xs", href: editor_path, title: submitted_org %>
+                  <% else %>
+                    <%# No org submitted and none linked — grey "None" chip. %>
+                    <%= render "shared/badge", label: "None", classes: "bg-gray-50 text-gray-500 border-gray-200", href: editor_path %>
                   <% end %>
-                <% elsif submitted_org %>
-                  <%= submitted_org %>
-                  <%# Same amber "Pending" chip as the registrants roster: a submitted
-                      org that hasn't been linked to the submission yet. %>
-                  <%= link_to editor_path, title: "Link the submitted organization", data: { turbo_frame: "_top" },
-                              class: "ml-1 inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 transition hover:opacity-80 hover:shadow-sm" do %>
-                    <i class="fa-solid fa-circle-exclamation text-3xs"></i>Pending
-                  <% end %>
-                <% else %>
-                  <%# No org submitted and none linked — grey "None" chip that still
-                      opens the editor, matching the registrants roster. %>
-                  <%= render "shared/badge", label: "None", classes: "bg-gray-50 text-gray-500 border-gray-200", href: editor_path %>
-                <% end %>
+                </div>
               </td>
               <td class="px-4 py-3 hidden" data-column-toggle-col="user_account">
                 <% if submission.person&.user %>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -131,9 +131,11 @@
         </div>
 
         <% if form_submission_filters_active?(params) %>
-          <div class="flex flex-col">
+          <div class="flex flex-col items-start">
             <span class="<%= search_label_class %>" aria-hidden="true">&nbsp;</span>
-            <%= render "shared/search_clear", url: form_submissions_path(return_to: params[:return_to].presence) %>
+            <%# Plain navigation to the unfiltered index — a reset that never depends
+                on JS clearing each remote-select field. %>
+            <%= link_to "Clear filters", form_submissions_path(return_to: params[:return_to].presence), class: "btn btn-utility whitespace-nowrap" %>
           </div>
         <% end %>
       </div>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -9,7 +9,7 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="mb-4">
     <% if params[:return_to] == "form_submissions" %>
-      <%= link_to "← Back to form submissions", form_submissions_path(form_id: @form_submission.form_id), class: "text-sm #{eyebrow_link_class}" %>
+      <%= link_to "← Back to form submissions", form_submissions_path(highlight: @form_submission.id, anchor: form_submission_row_id(@form_submission)), class: "text-sm #{eyebrow_link_class}" %>
     <% else %>
       <%= link_to "← Back to submission", form_submission_path(@form_submission), class: "text-sm #{eyebrow_link_class}" %>
     <% end %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -2,7 +2,7 @@
 <div class="mx-auto max-w-2xl px-4 pt-4">
   <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>
-      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, **form_submission_carryover_params(params), return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, **form_submission_carryover_params(params), return_to: params[:origin].presence, anchor: form_submission_row_id(@form_submission), highlight: @form_submission.id), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif params[:return_to] == "form_answers" %>

--- a/app/views/shared/_column_toggle_switch.html.erb
+++ b/app/views/shared/_column_toggle_switch.html.erb
@@ -1,0 +1,14 @@
+<%# A single column-toggle slide switch (see column_toggle_controller.js). Shows/
+    hides every cell tagged data-column-toggle-col="<group>" under the nearest
+    [data-column-toggle-root]. Locals: group, label, on (default false). %>
+<% on = local_assigns.fetch(:on, false) %>
+<label class="inline-flex cursor-pointer items-center gap-2 select-none"
+       data-controller="column-toggle" data-column-toggle-group-value="<%= group %>">
+  <span class="text-sm text-gray-500"><%= label %></span>
+  <%= check_box_tag "column_toggle_#{group}", "1", on,
+        data: { column_toggle_target: "toggle", action: "column-toggle#toggle" }, class: "sr-only" %>
+  <span class="relative inline-block h-5 w-9">
+    <span data-column-toggle-target="track" class="absolute inset-0 rounded-full transition-colors <%= on ? "bg-blue-600" : "bg-gray-300" %>"></span>
+    <span data-column-toggle-target="knob" class="absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform" style="<%= "transform: translateX(16px)" if on %>"></span>
+  </span>
+</label>

--- a/config/features.yml
+++ b/config/features.yml
@@ -102,7 +102,7 @@
     "Clear filters" button appears once any is set. The chosen filters carry over when you
     open a submission and come back, so you land on the same filtered list.
   pro_tips:
-    - "The Organization filter matches submissions linked to an org through an event registration."
+    - "The Organization filter matches a submission whether the org was linked directly to it or reached through its event registration."
 - name: "On-demand training agreement"
   area: people
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -103,6 +103,7 @@
     open a submission and come back, so you land on the same filtered list.
   pro_tips:
     - "The Organization filter matches a submission whether the org was linked directly to it or reached through its event registration."
+    - "Set the organization-linking filter to \"Not linked to submission\" for a work queue of submissions that named an org but haven't been linked yet."
 - name: "On-demand training agreement"
   area: people
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -104,6 +104,7 @@
   pro_tips:
     - "The Organization filter matches a submission only when that organization is linked directly to it in the org-linking editor."
     - "Set the organization-linking filter to \"Pending\" for a work queue of submissions that named an org but haven't been linked yet."
+    - "Use the column toggles above the table to show or hide the Role, Event, Submitted date, and User account columns; your choices stick as you filter."
 - name: "On-demand training agreement"
   area: people
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -102,7 +102,7 @@
     "Clear filters" button appears once any is set. The chosen filters carry over when you
     open a submission and come back, so you land on the same filtered list.
   pro_tips:
-    - "The Organization filter matches a submission whether the org was linked directly to it or reached through its event registration."
+    - "The Organization filter matches a submission connected to the org by any route — a link on the submission or its event registration."
     - "Set the organization-linking filter to \"Not linked to submission\" for a work queue of submissions that named an org but haven't been linked yet."
 - name: "On-demand training agreement"
   area: people

--- a/config/features.yml
+++ b/config/features.yml
@@ -102,7 +102,7 @@
     "Clear filters" button appears once any is set. The chosen filters carry over when you
     open a submission and come back, so you land on the same filtered list.
   pro_tips:
-    - "The Organization filter matches a submission connected to the org by any route — a link on the submission or its event registration."
+    - "The Organization filter matches a submission only when that organization is linked directly to it in the org-linking editor."
     - "Set the organization-linking filter to \"Pending\" for a work queue of submissions that named an org but haven't been linked yet."
 - name: "On-demand training agreement"
   area: people

--- a/config/features.yml
+++ b/config/features.yml
@@ -103,7 +103,7 @@
     open a submission and come back, so you land on the same filtered list.
   pro_tips:
     - "The Organization filter matches a submission connected to the org by any route — a link on the submission or its event registration."
-    - "Set the organization-linking filter to \"Not linked to submission\" for a work queue of submissions that named an org but haven't been linked yet."
+    - "Set the organization-linking filter to \"Pending\" for a work queue of submissions that named an org but haven't been linked yet."
 - name: "On-demand training agreement"
   area: people
   display_status: admin_facing

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -103,16 +103,18 @@ RSpec.describe FormSubmission do
     end
 
     describe ".org_link_status" do
-      it "separates linked, pending, and unlinked by the direct submission link" do
+      it "separates linked, pending, none, and unlinked by the direct submission link" do
         linked = submission_with_org_answer("Harbor Family Shelter")
         linked.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
         pending = submission_with_org_answer("Lakeside College")
         no_answer = create(:form_submission)
 
         expect(described_class.org_link_status("linked")).to contain_exactly(linked)
-        # Pending is the actionable queue: named an org, nothing linked.
+        # Pending: gave an org answer, nothing linked yet — the actionable queue.
         expect(described_class.org_link_status("pending")).to contain_exactly(pending)
-        # Unlinked is broad: everything not linked, including the no-org-answer one.
+        # None: no organization answer provided.
+        expect(described_class.org_link_status("none")).to contain_exactly(no_answer)
+        # Unlinked is broad: pending + none (everything not linked).
         expect(described_class.org_link_status("unlinked")).to contain_exactly(pending, no_answer)
       end
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -36,13 +36,34 @@ RSpec.describe FormSubmission do
       expect(FormSubmission.search_by_params(end_date: "not-a-date")).to contain_exactly(old, recent)
     end
 
-    it "filters by organization through the registration link" do
+    it "filters by organization through the pinned registration link" do
       organization = create(:organization)
       linked = create(:form_submission)
       create(:form_submission)
       create(:event_registration_organization, organization: organization, form_submission: linked)
 
       expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(linked)
+    end
+
+    it "filters by organization linked directly on the submission's metadata" do
+      organization = create(:organization)
+      linked = create(:form_submission)
+      linked.link_organization!(organization.id)
+      create(:form_submission)
+
+      expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(linked)
+    end
+
+    it "filters by organization reached through the submission's event registration" do
+      organization = create(:organization)
+      event = create(:event)
+      person = create(:person)
+      submission = create(:form_submission, person: person, event: event)
+      registration = create(:event_registration, registrant: person, event: event)
+      create(:event_registration_organization, event_registration: registration, organization: organization)
+      create(:form_submission)
+
+      expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(submission)
     end
   end
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -113,25 +113,26 @@ RSpec.describe FormSubmission do
     end
 
     describe ".org_link_status" do
-      it "separates linked, unlinked, and answerless submissions by the direct submission link" do
+      it "separates linked, pending, and unlinked by the direct submission link" do
         linked = submission_with_org_answer("Harbor Family Shelter")
         linked.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
-        unlinked = submission_with_org_answer("Lakeside College")
+        pending = submission_with_org_answer("Lakeside College")
         no_answer = create(:form_submission)
 
         expect(described_class.org_link_status("linked")).to contain_exactly(linked)
-        expect(described_class.org_link_status("unlinked")).to contain_exactly(unlinked)
-        expect(described_class.org_link_status("none")).to include(no_answer)
-        expect(described_class.org_link_status("none")).not_to include(linked, unlinked)
+        # Pending is the actionable queue: named an org, nothing linked.
+        expect(described_class.org_link_status("pending")).to contain_exactly(pending)
+        # Unlinked is broad: everything not linked, including the no-org-answer one.
+        expect(described_class.org_link_status("unlinked")).to contain_exactly(pending, no_answer)
       end
 
       it "counts only a direct submission link, not a matching affiliation the person holds" do
         submission = submission_with_org_answer("Harbor Family Shelter")
         create(:affiliation, person: submission.person, organization: create(:organization, name: "Harbor Family Shelter"))
 
-        # The submission still needs processing — nothing has been linked to it.
+        # Still needs processing — nothing has been linked to the submission.
         expect(described_class.org_link_status("linked")).to be_empty
-        expect(described_class.org_link_status("unlinked")).to contain_exactly(submission)
+        expect(described_class.org_link_status("pending")).to contain_exactly(submission)
       end
 
       it "counts an explicitly linked org even when the submitted name doesn't match it" do
@@ -139,7 +140,7 @@ RSpec.describe FormSubmission do
         submission.link_organization!(create(:organization, name: "Acme Corporation").id)
 
         expect(described_class.org_link_status("linked")).to contain_exactly(submission)
-        expect(described_class.org_link_status("unlinked")).to be_empty
+        expect(described_class.org_link_status("pending")).to be_empty
       end
     end
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -36,16 +36,7 @@ RSpec.describe FormSubmission do
       expect(FormSubmission.search_by_params(end_date: "not-a-date")).to contain_exactly(old, recent)
     end
 
-    it "filters by organization through the pinned registration link" do
-      organization = create(:organization)
-      linked = create(:form_submission)
-      create(:form_submission)
-      create(:event_registration_organization, organization: organization, form_submission: linked)
-
-      expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(linked)
-    end
-
-    it "filters by organization linked directly on the submission's metadata" do
+    it "filters by the organization linked directly to the submission" do
       organization = create(:organization)
       linked = create(:form_submission)
       linked.link_organization!(organization.id)
@@ -54,16 +45,15 @@ RSpec.describe FormSubmission do
       expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(linked)
     end
 
-    it "filters by organization reached through the submission's event registration" do
+    it "ignores an org reached only through the submission's event registration" do
       organization = create(:organization)
       event = create(:event)
       person = create(:person)
-      submission = create(:form_submission, person: person, event: event)
+      create(:form_submission, person: person, event: event)
       registration = create(:event_registration, registrant: person, event: event)
       create(:event_registration_organization, event_registration: registration, organization: organization)
-      create(:form_submission)
 
-      expect(FormSubmission.search_by_params(organization_id: organization.id)).to contain_exactly(submission)
+      expect(FormSubmission.search_by_params(organization_id: organization.id)).to be_empty
     end
   end
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -113,9 +113,9 @@ RSpec.describe FormSubmission do
     end
 
     describe ".org_link_status" do
-      it "separates linked, unlinked, and answerless submissions" do
+      it "separates linked, unlinked, and answerless submissions by the direct submission link" do
         linked = submission_with_org_answer("Harbor Family Shelter")
-        create(:affiliation, person: linked.person, organization: create(:organization, name: "Harbor Family Shelter"))
+        linked.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
         unlinked = submission_with_org_answer("Lakeside College")
         no_answer = create(:form_submission)
 
@@ -125,11 +125,11 @@ RSpec.describe FormSubmission do
         expect(described_class.org_link_status("none")).not_to include(linked, unlinked)
       end
 
-      it "does not count an ended affiliation as linked" do
+      it "counts only a direct submission link, not a matching affiliation the person holds" do
         submission = submission_with_org_answer("Harbor Family Shelter")
-        create(:affiliation, person: submission.person, end_date: 1.year.ago,
-               organization: create(:organization, name: "Harbor Family Shelter"))
+        create(:affiliation, person: submission.person, organization: create(:organization, name: "Harbor Family Shelter"))
 
+        # The submission still needs processing — nothing has been linked to it.
         expect(described_class.org_link_status("linked")).to be_empty
         expect(described_class.org_link_status("unlinked")).to contain_exactly(submission)
       end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("Form submissions")
       end
 
+      it "offers a Clear filters link to the unfiltered index when a filter is active" do
+        form = create(:form)
+        get form_submissions_path(form_id: form.id)
+
+        expect(response.body).to include("Clear filters")
+        expect(response.body).to include(%(href="#{form_submissions_path}"))
+      end
+
+      it "omits the Clear filters link when no filter is active" do
+        get form_submissions_path
+
+        expect(response.body).not_to include("Clear filters")
+      end
+
       it "lists a person's submissions and links each to its detail page" do
         person = create(:person, first_name: "Priya", last_name: "Patel")
         other = create(:person)

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -201,6 +201,28 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include(CGI.escapeHTML(link_organization_form_submission_path(submission, return_to: "form_submissions")))
       end
 
+      it "offers column toggles and hides the user account column by default" do
+        create(:form_submission)
+
+        get form_submissions_path, headers: frame_headers
+
+        expect(response.body).to include('data-column-toggle-group-value="user_account"')
+        expect(response.body).to include('data-column-toggle-col="role"')
+        expect(response.body).to include('data-column-toggle-col="event"')
+        expect(response.body).to include('data-column-toggle-col="submitted"')
+        # User account column starts hidden.
+        expect(response.body).to include('class="px-4 py-3 hidden" data-column-toggle-col="user_account"')
+      end
+
+      it "highlights the submission row matching the highlight param" do
+        submission = create(:form_submission)
+
+        get form_submissions_path(highlight: submission.id), headers: frame_headers
+
+        expect(response.body).to include(%(id="form-submission-row-#{submission.id}"))
+        expect(response.body).to include("ring-yellow-500")
+      end
+
       it "filters by person name via the search box" do
         person = create(:person, user: nil, first_name: "Priya", last_name: "Patel")
         mine = create(:form_submission, person: person)
@@ -278,10 +300,13 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("AWBW")
       end
 
-      it "shows a back link to the form submissions index when arriving from it" do
+      it "shows a back link to the form submissions index, highlighting the row, when arriving from it" do
         get form_submission_path(submission, return_to: "form_submissions", person_id: submission.person_id)
 
-        expect(response.body).to include(form_submissions_path(person_id: submission.person_id))
+        expect(response.body).to include(
+          CGI.escapeHTML(form_submissions_path(person_id: submission.person_id, highlight: submission.id,
+                                               anchor: "form-submission-row-#{submission.id}"))
+        )
         expect(response.body).to include("Back to form submissions")
       end
 
@@ -298,7 +323,8 @@ RSpec.describe "FormSubmissions", type: :request do
                                  form_id: submission.form_id)
 
         expect(response.body).to include(
-          CGI.escapeHTML(form_submissions_path(form_id: submission.form_id, return_to: "forms"))
+          CGI.escapeHTML(form_submissions_path(form_id: submission.form_id, return_to: "forms",
+                                               highlight: submission.id, anchor: "form-submission-row-#{submission.id}"))
         )
       end
 

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -186,10 +186,13 @@ RSpec.describe "FormSubmissions", type: :request do
         get form_submissions_path, headers: frame_headers
         expect(response.body).to include("Pending")
 
-        submission.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
+        organization = create(:organization, name: "Harbor Family Shelter")
+        submission.link_organization!(organization.id)
         get form_submissions_path, headers: frame_headers
+        # Once linked, the org shows as its own chip (linking to the org) — no
+        # "Pending", matching the registrants roster.
         expect(response.body).not_to include("Pending")
-        expect(response.body).to include("Linked")
+        expect(response.body).to include(CGI.escapeHTML(organization_path(organization)))
       end
 
       it "shows a None chip linking to the editor when no organization was submitted" do
@@ -201,7 +204,7 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include(CGI.escapeHTML(link_organization_form_submission_path(submission, return_to: "form_submissions")))
       end
 
-      it "shows a Linked chip with the org name when linked directly, even with no submitted org" do
+      it "shows the linked org as a chip even when no org was submitted, instead of None" do
         submission = create(:form_submission)
         organization = create(:organization, name: "Harbor Family Shelter")
         submission.link_organization!(organization.id)
@@ -209,8 +212,7 @@ RSpec.describe "FormSubmissions", type: :request do
         get form_submissions_path, headers: frame_headers
 
         expect(response.body).to include("Harbor Family Shelter")
-        expect(response.body).to include("Linked")
-        expect(response.body).not_to include(">None<")
+        expect(response.body).to include(CGI.escapeHTML(organization_path(organization)))
       end
 
       it "offers column toggles and hides the user account column by default" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "FormSubmissions", type: :request do
         )
       end
 
-      it "shows the submitted organization with whether it is linked to the person" do
+      it "shows the submitted organization with whether it is linked to the submission" do
         submission = create(:form_submission)
         org_field = create(:form_field, form: submission.form, name: "Organization name",
                            field_identifier: "organization_name")
@@ -165,10 +165,16 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("Harbor Family Shelter")
         expect(response.body).to include("Not linked")
 
+        # A matching affiliation the person holds does not mark it linked — only a
+        # direct link made in the editor does, so it stays in the "to process" queue.
         create(:affiliation, person: submission.person,
                organization: create(:organization, name: "Harbor Family Shelter"))
         get form_submissions_path, headers: frame_headers
-        expect(response.body).to include("Linked")
+        expect(response.body).to include("Not linked")
+
+        submission.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
+        get form_submissions_path, headers: frame_headers
+        expect(response.body).not_to include("Not linked")
       end
 
       it "filters by person name via the search box" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -163,18 +163,19 @@ RSpec.describe "FormSubmissions", type: :request do
 
         get form_submissions_path, headers: frame_headers
         expect(response.body).to include("Harbor Family Shelter")
-        expect(response.body).to include("Not linked")
+        expect(response.body).to include("Pending")
 
         # A matching affiliation the person holds does not mark it linked — only a
-        # direct link made in the editor does, so it stays in the "to process" queue.
+        # direct link made in the editor does, so it stays Pending (the queue).
         create(:affiliation, person: submission.person,
                organization: create(:organization, name: "Harbor Family Shelter"))
         get form_submissions_path, headers: frame_headers
-        expect(response.body).to include("Not linked")
+        expect(response.body).to include("Pending")
 
         submission.link_organization!(create(:organization, name: "Harbor Family Shelter").id)
         get form_submissions_path, headers: frame_headers
-        expect(response.body).not_to include("Not linked")
+        expect(response.body).not_to include("Pending")
+        expect(response.body).to include("Linked")
       end
 
       it "filters by person name via the search box" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -192,6 +192,15 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include("Linked")
       end
 
+      it "shows a None chip linking to the editor when no organization was submitted" do
+        submission = create(:form_submission)
+
+        get form_submissions_path, headers: frame_headers
+
+        expect(response.body).to include("None")
+        expect(response.body).to include(CGI.escapeHTML(link_organization_form_submission_path(submission, return_to: "form_submissions")))
+      end
+
       it "filters by person name via the search box" do
         person = create(:person, user: nil, first_name: "Priya", last_name: "Patel")
         mine = create(:form_submission, person: person)

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -434,6 +434,15 @@ RSpec.describe "FormSubmissions", type: :request do
       before { travel_to Time.current.midday }
 
       describe "GET /form_submissions/:id/link_organization" do
+        it "eyebrows back to the index with the row highlighted when arriving from it" do
+          get link_organization_form_submission_path(submission, return_to: "form_submissions")
+
+          expect(response.body).to include("Back to form submissions")
+          expect(response.body).to include(
+            CGI.escapeHTML(form_submissions_path(highlight: submission.id, anchor: "form-submission-row-#{submission.id}"))
+          )
+        end
+
         it "offers a create-and-link row for a submitted org that isn't in the database" do
           add_answer("organization_name", "Lakeside Community College")
           add_answer("organization_position", "Counselor")

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "FormSubmissions", type: :request do
 
         expect(response.body).to include(
           CGI.escapeHTML(form_submission_path(submission, return_to: "form_submissions",
-                                              person_id: submission.person_id, event_id: event.id, role: "registration"))
+                                              event_id: event.id, role: "registration"))
         )
       end
 
@@ -141,7 +141,7 @@ RSpec.describe "FormSubmissions", type: :request do
 
         expect(response.body).to include(
           CGI.escapeHTML(form_submission_path(submission, return_to: "form_submissions", origin: "forms",
-                                              person_id: submission.person_id, form_id: form.id))
+                                              form_id: form.id))
         )
       end
 
@@ -152,8 +152,7 @@ RSpec.describe "FormSubmissions", type: :request do
         get form_submissions_path(form_id: form.id), headers: frame_headers
 
         expect(response.body).to include(
-          CGI.escapeHTML(form_submission_path(submission, return_to: "form_submissions",
-                                              person_id: submission.person_id, form_id: form.id))
+          CGI.escapeHTML(form_submission_path(submission, return_to: "form_submissions", form_id: form.id))
         )
       end
 

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).not_to include(form_submission_path(old))
       end
 
-      it "filters by organization through its registration link" do
+      it "filters by the organization linked directly to the submission" do
         organization = create(:organization)
         linked = create(:form_submission)
         other = create(:form_submission)
-        create(:event_registration_organization, organization: organization, form_submission: linked)
+        linked.link_organization!(organization.id)
 
         get form_submissions_path(organization_id: organization.id), headers: frame_headers
 

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -201,6 +201,18 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include(CGI.escapeHTML(link_organization_form_submission_path(submission, return_to: "form_submissions")))
       end
 
+      it "shows a Linked chip with the org name when linked directly, even with no submitted org" do
+        submission = create(:form_submission)
+        organization = create(:organization, name: "Harbor Family Shelter")
+        submission.link_organization!(organization.id)
+
+        get form_submissions_path, headers: frame_headers
+
+        expect(response.body).to include("Harbor Family Shelter")
+        expect(response.body).to include("Linked")
+        expect(response.body).not_to include(">None<")
+      end
+
       it "offers column toggles and hides the user account column by default" do
         create(:form_submission)
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -580,6 +580,15 @@ RSpec.describe "/users", type: :request do
         expect(flash[:notice]).to include("Invitation sent")
         expect(response).to redirect_to(users_path)
       end
+
+      it "returns to the form submissions index with the row highlighted when invited from there" do
+        submission = create(:form_submission)
+        post send_welcome_instructions_user_url(user, return_to: "form_submissions", form_submission_id: submission.id)
+
+        expect(response).to redirect_to(
+          form_submissions_path(highlight: submission.id, anchor: "form-submission-row-#{submission.id}")
+        )
+      end
     end
 
     context "as regular_user" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two org-filter scope changes on the form submissions index + specs; no schema, no new UI

## Context
Form-submission **org-linking** shipped on main via #2304 (metadata `linked_organization_ids` seam — an admin links an org to a submission in the editor). This branch makes both organization *filters* on the index agree that "linked" = **that direct link**, nothing else.

## 1. Organization picker → direct link only
`FormSubmission.for_organization` now matches a submission only when the chosen org is linked **directly** to it (the editor's metadata link). A matching affiliation, or an org on the submission's event registration, does not make it match.

## 2. Org-link status mirrors the registrants roster (Pending / Linked / Unlinked)
Keyed on the same direct submission link:
- **Pending** — named an org, nothing linked yet → the actionable queue.
- **Linked** — an org was linked.
- **Unlinked** — broad: not linked, whichever kind (includes no org answer).

Index chip's amber state renamed **Not linked → Pending** to match the roster.

## Not changed
The editor's "matched organization" display still surfaces an affiliation match (that's about showing the associated org, not the processing state).

## Tests
Model + request specs for the direct-link filter (and that a registration-only org is ignored), and the Pending/Linked/Unlinked status.