### PR TITLE
Always show the people staff-tag filter; add manage links to filters

### DIFF
--- a/app/views/events/_filter_select.html.erb
+++ b/app/views/events/_filter_select.html.erb
@@ -12,7 +12,9 @@
       clear_to     – optional value "Clear filters" resets this select to. Only
                      needed when the select renders pre-selected (blank: nil), so
                      its first option is a real value rather than a neutral
-                     placeholder — see collection#clearAndSubmit. %>
+                     placeholder — see collection#clearAndSubmit.
+      hint         – optional HTML rendered as muted help text under the select
+                     (e.g. a link to manage the underlying records). %>
 <div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-44") %>">
   <%= label_tag param, label, class: search_label_class %>
   <%= select_tag param,
@@ -20,4 +22,7 @@
                  include_blank: blank,
                  data: { clear_to: local_assigns[:clear_to] },
                  class: "#{field_class} search-select-placeholder" %>
+  <% if local_assigns[:hint].present? %>
+    <p class="mt-1 text-xs text-gray-500"><%= local_assigns[:hint] %></p>
+  <% end %>
 </div>

--- a/app/views/people/_search_boxes.html.erb
+++ b/app/views/people/_search_boxes.html.erb
@@ -71,20 +71,19 @@
 
         <!-- Staff tag -->
         <% if allowed_to?(:index?, StaffTag) %>
-          <% staff_tags = StaffTag.published.ordered %>
-          <% if staff_tags.any? %>
-            <%= render "events/filter_select", param: :staff_tag_ids, label: "Staff tag",
-                  options: staff_tags.map { |t| [ t.name, t.id ] },
-                  selected: params[:staff_tag_ids], blank: "Any",
-                  field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
-          <% end %>
+          <%= render "events/filter_select", param: :staff_tag_ids, label: "Staff tag",
+                options: StaffTag.published.ordered.map { |t| [ t.name, t.id ] },
+                selected: params[:staff_tag_ids], blank: "Any",
+                field_class: search_field_class, wrapper_class: "w-full md:w-56",
+                hint: link_to("Manage staff tags", staff_tags_path, class: eyebrow_link_class, target: "_blank", rel: "noopener") %>
         <% end %>
 
         <!-- Topic subscription -->
         <%= render "events/filter_select", param: :topic_subscription_type_id, label: "Topic subscription",
               options: TopicSubscriptionType.active.ordered.pluck(:name, :id),
               selected: params[:topic_subscription_type_id], blank: "Any topic",
-              field_class: search_field_class, wrapper_class: "w-full md:w-56" %>
+              field_class: search_field_class, wrapper_class: "w-full md:w-56",
+              hint: link_to("Manage topics", topic_subscription_types_path, class: eyebrow_link_class, target: "_blank", rel: "noopener") %>
       </div>
     </div>
   <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -1938,6 +1938,18 @@
     - The age range dropdown lists your published age ranges and matches anyone
       tagged with that range.
 
+- name: "People filters: staff tag dropdown always shows, with manage links"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2328
+  summary: >-
+    The staff tag filter in the people directory now always appears, even before
+    you've published any staff tags. Both it and the topic subscription filter
+    carry a small "Manage staff tags" / "Manage topics" link so you can add or
+    edit the underlying records in one hop.
+
 - name: "Flag blog contributors from the person edit form"
   area: people
   display_status: admin_facing

--- a/spec/requests/people_search_spec.rb
+++ b/spec/requests/people_search_spec.rb
@@ -79,6 +79,26 @@ RSpec.describe "People search", type: :request do
     end
   end
 
+  describe "GET /people (full page) admin filters" do
+    it "always renders the staff tag filter with a manage link, even when none are published" do
+      expect(StaffTag.published).to be_empty
+
+      get people_path
+      page = Capybara.string(response.body)
+      expect(page).to have_css("select[name=staff_tag_ids]")
+      expect(page).to have_link("Manage staff tags", href: staff_tags_path)
+    end
+
+    it "always renders the topic subscription filter with a manage link, even when none exist" do
+      expect(TopicSubscriptionType.active).to be_empty
+
+      get people_path
+      page = Capybara.string(response.body)
+      expect(page).to have_css("select[name=topic_subscription_type_id]")
+      expect(page).to have_link("Manage topics", href: topic_subscription_types_path)
+    end
+  end
+
   describe "GET /people?organization_id=X (full page)" do
     let!(:org) { create(:organization, name: "Scoped Org") }
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view change to one shared partial + one filter view, plus a spec

Closes #2328

## What
- Staff-tag filter in the people directory now **always renders**, even with no published tags.
- Both the staff-tag and topic-subscription filters get a muted hint link — **Manage staff tags** / **Manage topics** — opening the respective manager in a new tab.

## Why
- Empty-hidden dropdown left admins with no control and no path to create tags.
- The hint link gives a one-hop route to add/edit the underlying records whether or not any exist yet.

## Notes
- Added an optional `hint` local to the shared `events/_filter_select` partial (renders muted help text under the select); existing callers unaffected.