### PR TITLE
Tighten "boomerang" facilitator filter to true returnees

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -216,11 +216,20 @@ class Person < ApplicationRecord
     ended = Affiliation.facilitators.where.not(end_date: nil)
       .where("affiliations.end_date < ?", Date.current).select(:person_id)
     where(id: ended).where.not(id: Affiliation.facilitators.active.select(:person_id)) }
-  # Facilitators tied to 2+ facilitator affiliations with at least one still active
-  # (e.g. moved between partner orgs, or serve more than one at once).
+  # True returnees: a currently-active facilitator term that began after an earlier
+  # facilitator term had genuinely ended — "left and came back", not merely serving
+  # two orgs at once (both of which the old count-based definition matched;
+  # rubyforgood/awbw#2327). The self-join pairs each active term with a prior term of
+  # the same person that ended before the active one started.
   scope :boomerang_facilitators, -> {
-    multiple = Affiliation.facilitators.group(:person_id).having("COUNT(affiliations.id) >= 2").select(:person_id)
-    where(id: multiple).where(id: Affiliation.facilitators.active.select(:person_id)) }
+    returnees = Affiliation.facilitators.active.where.not(start_date: nil)
+      .joins("INNER JOIN affiliations prior_terms " \
+             "ON prior_terms.person_id = affiliations.person_id " \
+             "AND prior_terms.title = BINARY '#{Affiliation::FACILITATOR_TITLE}' " \
+             "AND prior_terms.end_date IS NOT NULL " \
+             "AND prior_terms.end_date < affiliations.start_date")
+      .select(:person_id)
+    where(id: returnees) }
   scope :by_facilitator_status, ->(status) {
     case status
     when "active" then facilitators_active
@@ -291,7 +300,7 @@ class Person < ApplicationRecord
   FACILITATOR_STATUS_FILTER_OPTIONS = [
     [ "Active", "active" ],
     [ "Inactive", "inactive" ],
-    [ "Boomerang (2+ affiliations, 1+ active)", "boomerang" ],
+    [ "Boomerang (left, then active again)", "boomerang" ],
     [ "Formerly active", "formerly_active" ]
   ].freeze
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -1944,22 +1944,82 @@
   action_path: "/people"
   pr_number: 2312
   summary: >-
-    New dropdowns filter the people directory by age range, by what a person
-    creates (story, blog, workshop, variation, and log authors, plus sector
-    leaders), by facilitator status, by membership status, by topic subscription,
-    and by staff tag. The admin-only filters sit together in a blue panel.
+    The people directory gains a row of dropdown filters — role, facilitator
+    status, membership status, age range, topic subscription, and staff tag —
+    together in a blue admin panel. Each filter's values are explained in its own
+    entry below.
+
+- name: "People filter: role"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by what they create or lead: story authors, blog contributors,
+    workshop authors, workshop variation authors, workshop log authors, and sector
+    leaders.
   pro_tips:
     - The role dropdown replaces the old "Sector leaders only" checkbox; pick
       "Sector leaders" there to get the same list.
-    - "Facilitator status: \"boomerang\" means someone who left and came back — an
-      active term that began after an earlier facilitator term had ended; \"formerly
-      active\" means a past term ended and none is active now."
-    - "Membership status reads the current invoice: \"due\" still owes but is within
-      the grace period, \"overdue\" has passed it."
-    - The topic and staff tag dropdowns sit in the same blue admin panel; topic
-      matches people still subscribed, staff tag matches people carrying that tag.
-    - The age range dropdown lists your published age ranges and matches anyone
-      tagged with that range.
+
+- name: "People filter: facilitator status"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by their facilitator standing: active, inactive, boomerang (left
+    and came back), or formerly active.
+  description: >-
+    Active — a current facilitator term. Inactive — has facilitator terms but none
+    current. Boomerang — left and came back: a current term that began after an
+    earlier facilitator term had ended. Formerly active — a past term genuinely
+    ended and none is current.
+
+- name: "People filter: membership status"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by membership standing, read from their current invoice: active,
+    inactive, paid, due, or overdue.
+  description: >-
+    Active — membership not cancelled. Inactive — has a membership but it's
+    cancelled. Paid — the current invoice is covered. Due — still owes but within
+    the grace period. Overdue — past the grace period.
+
+- name: "People filter: age range"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by age range. The dropdown lists your published age ranges and
+    matches anyone tagged with the one you pick.
+
+- name: "People filter: topic subscription"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by topic subscription. Pick a topic to see everyone still
+    subscribed to it; anyone who unsubscribed is left out.
+
+- name: "People filter: staff tag"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/people"
+  pr_number: 2312
+  summary: >-
+    Filter people by staff tag. Pick a tag to see everyone carrying it.
 
 - name: "People filters: staff tag dropdown always shows, with manage links"
   area: people

--- a/config/features.yml
+++ b/config/features.yml
@@ -1951,9 +1951,9 @@
   pro_tips:
     - The role dropdown replaces the old "Sector leaders only" checkbox; pick
       "Sector leaders" there to get the same list.
-    - "Facilitator status: \"boomerang\" means two or more facilitator affiliations
-      with at least one still active; \"formerly active\" means a past term ended
-      and none is active now."
+    - "Facilitator status: \"boomerang\" means someone who left and came back — an
+      active term that began after an earlier facilitator term had ended; \"formerly
+      active\" means a past term ended and none is active now."
     - "Membership status reads the current invoice: \"due\" still owes but is within
       the grace period, \"overdue\" has passed it."
     - The topic and staff tag dropdowns sit in the same blue admin panel; topic

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -651,14 +651,38 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_alice)
       end
 
-      it "boomerang: includes people with 2+ facilitator affiliations and at least one active" do
-        multi = create(:person, first_name: "Multi", last_name: "Fac")
-        create(:affiliation, person: multi, title: "Facilitator", end_date: nil)
-        create(:affiliation, person: multi, title: "Facilitator", end_date: 1.year.from_now)
+      it "boomerang: includes people whose active term began after an earlier term ended" do
+        returnee = create(:person, first_name: "Returnee", last_name: "Fac")
+        create(:affiliation, person: returnee, title: "Facilitator",
+                             start_date: 5.years.ago, end_date: 3.years.ago)
+        create(:affiliation, person: returnee, title: "Facilitator",
+                             start_date: 1.year.ago, end_date: nil)
 
         results = Person.search_by_params(facilitator_status: "boomerang")
-        expect(results).to include(multi)
+        expect(results).to include(returnee)
         expect(results).not_to include(person_alice)
+      end
+
+      it "boomerang: excludes people serving two orgs concurrently who never left" do
+        concurrent = create(:person, first_name: "Concurrent", last_name: "Fac")
+        create(:affiliation, person: concurrent, title: "Facilitator",
+                             start_date: 5.years.ago, end_date: nil)
+        create(:affiliation, person: concurrent, title: "Facilitator",
+                             start_date: 1.year.ago, end_date: nil)
+
+        results = Person.search_by_params(facilitator_status: "boomerang")
+        expect(results).not_to include(concurrent)
+      end
+
+      it "boomerang: excludes a continuous term overlapping a since-ended second org" do
+        overlapper = create(:person, first_name: "Overlap", last_name: "Fac")
+        create(:affiliation, person: overlapper, title: "Facilitator",
+                             start_date: 5.years.ago, end_date: nil)
+        create(:affiliation, person: overlapper, title: "Facilitator",
+                             start_date: 3.years.ago, end_date: 1.year.ago)
+
+        results = Person.search_by_params(facilitator_status: "boomerang")
+        expect(results).not_to include(overlapper)
       end
 
       it "formerly_active: includes people whose facilitator term ended and none is active" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one model scope reworked with a self-join, plus /features seed copy

Closes #2327

## Why
- "Boomerang" facilitator status matched anyone with 2+ facilitator affiliations and 1+ active.
- That also swept up facilitators serving two orgs **concurrently** who never left — not the intended "left and came back."

## Change
- `Person.boomerang_facilitators` now requires an active facilitator term that **began after an earlier facilitator term had genuinely ended** (self-join on the same person).
- Excludes pure-concurrent and "continuous term overlapping a since-ended second org" cases.
- Updated the filter label to "Boomerang (left, then active again)".

## `/features` seed
- Broke the umbrella people-directory filter entry into **one entry per filter** (role, facilitator status, membership status, age range, topic, staff tag), each documenting its values.
- Slimmed the umbrella entry to just note the filters are surfaced on the people index.

## Tests
- New model specs: returnee included; concurrent-never-left excluded; continuous-overlap excluded.
- Feature-catalog seed spec passes.