### PR TITLE
Show events by date + title (no start time) in form submissions filter

### DIFF
--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -10,7 +10,6 @@ class FormAnswersController < ApplicationController
       render :form_answers_results
     else
       @forms = Form.order(:name)
-      @events = Event.order(start_date: :desc)
       render :index
     end
   end

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -63,9 +63,11 @@
         <div class="w-56">
           <%= label_tag :event_id, "Event", class: search_label_class %>
           <%= select_tag :event_id,
-                options_from_collection_for_select(@events, :id, :time_title, params[:event_id].to_i),
-                include_blank: "All events",
-                class: search_field_class(extra: "search-select-placeholder") %>
+                options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.remote_search_label[:label], event.id ] }, params[:event_id]),
+                include_blank: true,
+                prompt: "Search for an event",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "event" } %>
         </div>
         <div class="flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/controller change to one filter dropdown

### What is the goal of this PR and why is this important?
The event filter dropdown on the form submissions index (`/form_answers`) labeled each event with its start time (`(2026-09-14 @ 02:09 PM) Title`), which is noise for picking an event to filter by — date + title is enough.

### How did you approach the change?
Switched the dropdown to the `remote-select` autocomplete already used on the form submissions index, so events read as `Title (August 22, 2026)` (date, no time) and are searched server-side instead of rendering every event up front. Dropped the now-unused `@events` load from the controller.

### UI Testing Checklist
- [ ] On `/form_answers`, the Event filter is a type-to-search box; results show `Title (date)` with no start time.
- [ ] Selecting an event filters the results; the selected event stays shown with its date + title.

### Anything else to add?
Behavior change: the filter is now type-to-search autocomplete rather than a full scrollable list.