### PR TITLE
Guard DisplayImagePresenter against undeclared image variants

### DIFF
--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -89,9 +89,9 @@ class DisplayImagePresenter
       resolve_previewable
     elsif @variant == :hero
       @file
-    elsif large_display?
+    elsif large_display? && variant_defined?(:card)
       @file.variant(:card)
-    elsif use_thumbnail?
+    elsif use_thumbnail? && variant_defined?(:thumbnail)
       @file.variant(:thumbnail)
     else
       @file
@@ -102,11 +102,21 @@ class DisplayImagePresenter
     @width == "full" && @file.variable?
   end
 
+  # Attachments declare their named variants in the model (e.g. Asset#file has
+  # :thumbnail and :card, Person#avatar has only :thumbnail). Asking for an
+  # undeclared variant raises, so degrade to the original file instead.
+  def variant_defined?(name)
+    return false unless @file.respond_to?(:record) && @file.respond_to?(:name)
+
+    reflection = @file.record.class.reflect_on_attachment(@file.name)
+    reflection&.named_variants&.key?(name) || false
+  end
+
   def resolve_previewable
     if pdf?
       preview_size = PDF_PREVIEW_SIZES.fetch(@variant, [ 300, 300 ])
       @file.preview(resize_to_limit: preview_size)
-    elsif use_thumbnail?
+    elsif use_thumbnail? && variant_defined?(:thumbnail)
       @file.variant(:thumbnail)
     else
       @file.preview(resize_to_limit: PDF_PREVIEW_SIZES.fetch(@variant, [ 300, 300 ]))

--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -102,9 +102,7 @@ class DisplayImagePresenter
     @width == "full" && @file.variable?
   end
 
-  # Attachments declare their named variants in the model (e.g. Asset#file has
-  # :thumbnail and :card, Person#avatar has only :thumbnail). Asking for an
-  # undeclared variant raises, so degrade to the original file instead.
+  # Asking an attachment for a variant its model doesn't declare raises.
   def variant_defined?(name)
     return false unless @file.respond_to?(:record) && @file.respond_to?(:name)
 

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe DisplayImagePresenter do
       end
     end
 
+    context "when the attachment has no :card variant (e.g. Person#avatar)" do
+      let(:person) do
+        create(:person).tap do |p|
+          p.avatar.attach(
+            io: File.open(Rails.root.join("app", "assets", "images", "missing.png")),
+            filename: "missing.png",
+            content_type: "image/png"
+          )
+        end
+      end
+
+      it "degrades to a declared variant for a full-width display instead of raising" do
+        result = described_class.call(file: person.avatar, variant: :index, width: "full", height: "full", view_context: view_context)
+        expect(result.display_type).to eq(:active_storage)
+        expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
+        expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 256, 256 ])
+      end
+
+      it "uses the original file when no usable variant is declared" do
+        allow_any_instance_of(described_class).to receive(:variant_defined?).and_return(false)
+        result = described_class.call(file: person.avatar, variant: :index, width: "full", height: "full", view_context: view_context)
+        expect(result.renderable).to eq(person.avatar)
+      end
+    end
+
     context "CSS classes" do
       it "builds hero image classes" do
         result = described_class.call(file: "test.jpg", variant: :hero, view_context: view_context)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained guard in one service, covered by specs

### What is the goal of this PR and why is this important?
`Person#avatar` declares only a `:thumbnail` variant, so rendering a person avatar at full width through the shared `display_image` partial asked ActiveStorage for the undeclared `:card` variant and raised `ArgumentError: Cannot find variant :card` (seen on staging via `people/_show_card`).

### How did you approach the change?
Added a `variant_defined?` guard in `DisplayImagePresenter` that checks the attachment's declared named variants before requesting `:card`/`:thumbnail`, degrading to a declared variant or the original file instead of raising. Wrote a failing spec reproducing the crash first, then the fix; the avatar now serves its `:thumbnail` (appropriate for its small display).

### UI Testing Checklist
- [ ] Person show card / list renders avatars without error at all sizes

### Anything else to add?
Fix lives in the generic presenter rather than adding a wasteful large `:card` variant to avatars, so any attachment lacking a variant degrades gracefully.