### PR TITLE
Harden responded-flag spec against cocoon insertion race

### DIFF
--- a/spec/system/event_registration_edit_spec.rb
+++ b/spec/system/event_registration_edit_spec.rb
@@ -307,8 +307,14 @@ RSpec.describe "Event registration edit page", type: :system do
 
       within("section", text: "Registration communications") do
         click_on "Add communication"
+        # Wait for cocoon to insert the field and the paginated-fields controller
+        # to finish its re-render before typing, so the input node isn't swapped
+        # mid-fill (which raced as a stale-node error).
         expect(page).to have_field("Subject")
         fill_in "Subject", with: "They emailed us"
+        # Confirm the field registered its value before touching the direction
+        # toggle, so the DOM has settled and the label/checkbox nodes are stable.
+        expect(page).to have_field("Subject", with: "They emailed us")
 
         expect(page).not_to have_field("Already responded")
         find("label", text: "Incoming").click


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 test-only hardening, one spec, mirrors an existing fix

### What is the goal of this PR and why is this important?
`event_registration_edit_spec.rb:304` ("reveals and saves the responded flag once a logged communication is incoming") flaked on loaded CI runners with `Node with given id does not belong to the document` — the classic Capybara detached-node race.

### How did you approach the change?
The example touched the "Incoming" label and "Already responded" checkbox immediately after `fill_in "Subject"`, before the cocoon insert + paginated-fields re-render had settled. Mirrored the sibling example's existing fix (#2223): assert the field registered its value (`have_field("Subject", with: …)`) so the DOM stabilizes before the next interactions.

### Anything else to add?
Test-only; no app code changed. Ran the example 10× locally under headless Chrome, all green.
