### PR TITLE
Add opt-out for the "View ticket" button in bulk event emails

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -432,11 +432,13 @@ class EventsController < ApplicationController
     # hiding the box (its dates/times/cost describe nothing), but an explicit "0"
     # from a bounce-back means the admin unticked it and we respect that.
     @hide_event_card = params.key?(:hide_event_card) ? hide_event_card_param : @event.on_demand?
+    # The ticket button shows by default — only hidden when the admin explicitly ticks it.
+    @hide_ticket_button = hide_ticket_button_param
 
     if @sample_registration
       # Render in preview mode so the custom-message container is always present
       # in the markup for the live preview, even before any text is typed.
-      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card, preview: true)
+      mail = EventMailer.event_registration_reminder(@sample_registration, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card, hide_ticket_button: @hide_ticket_button, preview: true)
       @reminder_preview_html = mail.html_part&.body&.decoded
     end
   end
@@ -452,9 +454,10 @@ class EventsController < ApplicationController
     @custom_message = params[:custom_message].to_s
     @custom_subject = params[:custom_subject].to_s
     @hide_event_card = hide_event_card_param
+    @hide_ticket_button = hide_ticket_button_param
 
     if @event_registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: (hide_event_card_param ? "1" : "0")), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: (hide_event_card_param ? "1" : "0"), hide_ticket_button: (hide_ticket_button_param ? "1" : "0")), alert: "Please select at least one recipient."
       return
     end
 
@@ -464,7 +467,7 @@ class EventsController < ApplicationController
       return
     end
 
-    mail = EventMailer.event_registration_reminder(@event_registrations.first, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card)
+    mail = EventMailer.event_registration_reminder(@event_registrations.first, custom_message: @custom_message, custom_subject: @custom_subject, hide_event_card: @hide_event_card, hide_ticket_button: @hide_ticket_button)
     @reminder_subject = mail.subject
     @reminder_preview_html = mail.html_part&.body&.decoded
   end
@@ -474,7 +477,7 @@ class EventsController < ApplicationController
     registrations = selected_reminder_registrations
 
     if registrations.empty?
-      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s, hide_event_card: (hide_event_card_param ? "1" : "0")), alert: "Please select at least one recipient."
+      redirect_to preview_reminder_event_path(@event, mode: params[:mode].presence, custom_message: params[:custom_message].to_s, custom_subject: params[:custom_subject].to_s, hide_event_card: (hide_event_card_param ? "1" : "0"), hide_ticket_button: (hide_ticket_button_param ? "1" : "0")), alert: "Please select at least one recipient."
       return
     end
 
@@ -483,6 +486,7 @@ class EventsController < ApplicationController
     custom_message = params[:custom_message].to_s
     custom_subject = params[:custom_subject].to_s
     hide_event_card = hide_event_card_param
+    hide_ticket_button = hide_ticket_button_param
 
     # Record an individual notification per recipient (delivered + persisted via
     # NotificationMailerJob), so each reminder shows up in that person's
@@ -498,7 +502,8 @@ class EventsController < ApplicationController
         bulk: true,
         custom_message: custom_message.presence,
         custom_subject: custom_subject.presence,
-        hide_event_card: hide_event_card
+        hide_event_card: hide_event_card,
+        hide_ticket_button: hide_ticket_button
       )
     end
 
@@ -506,7 +511,7 @@ class EventsController < ApplicationController
     # was sent. Roster passed as plain "Name <email>" labels so the delivery job
     # needs no record lookups.
     recipient_labels = registrations.map { |r| "#{r.registrant.full_name} <#{r.registrant.preferred_email}>" }
-    EventMailer.event_registration_reminder_fyi(@event, recipient_labels, custom_message: custom_message.presence, hide_event_card: hide_event_card).deliver_later
+    EventMailer.event_registration_reminder_fyi(@event, recipient_labels, custom_message: custom_message.presence, hide_event_card: hide_event_card, hide_ticket_button: hide_ticket_button).deliver_later
 
     track_view("events.send_reminder", { event_id: @event.id, recipient_count: registrations.size })
     redirect_to registrants_event_path(@event), notice: "Reminder emails are being sent to #{registrations.size} registrant#{'s' if registrations.size != 1}."
@@ -1053,6 +1058,11 @@ class EventsController < ApplicationController
   # Whether the admin ticked "hide the event details box" on the compose page.
   def hide_event_card_param
     ActiveModel::Type::Boolean.new.cast(params[:hide_event_card]) || false
+  end
+
+  # Whether the admin ticked "hide the View ticket button" on the compose page.
+  def hide_ticket_button_param
+    ActiveModel::Type::Boolean.new.cast(params[:hide_ticket_button]) || false
   end
 
   # The registrations the admin checked on the recipient picker, narrowed to those

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -85,6 +85,7 @@ class NotificationsController < ApplicationController
       custom_message: @notification.custom_message,
       custom_subject: @notification.custom_subject,
       hide_event_card: @notification.hide_event_card,
+      hide_ticket_button: @notification.hide_ticket_button,
       sender: current_user, # a resend is an admin action — attribute it to them
       deliver: true,
       persist_delivered_email: true

--- a/app/frontend/javascript/controllers/reminder_preview_controller.js
+++ b/app/frontend/javascript/controllers/reminder_preview_controller.js
@@ -7,7 +7,7 @@ import { Controller } from "@hotwired/stimulus"
 // above the rendered email. The actual send re-sanitizes the message server-side,
 // so injecting the raw values here is only for the on-page preview.
 export default class extends Controller {
-  static targets = ["input", "message", "subjectInput", "subjectPreview", "eventCard", "eventCardToggle", "cardStatus"]
+  static targets = ["input", "message", "subjectInput", "subjectPreview", "eventCard", "eventCardToggle", "cardStatus", "ticketButton", "ticketButtonToggle", "ticketStatus"]
 
   inputTargetConnected() {
     this.update()
@@ -31,6 +31,14 @@ export default class extends Controller {
 
   eventCardToggleTargetConnected() {
     this.syncEventCard()
+  }
+
+  ticketButtonTargetConnected() {
+    this.syncTicketButton()
+  }
+
+  ticketButtonToggleTargetConnected() {
+    this.syncTicketButton()
   }
 
   update() {
@@ -63,5 +71,23 @@ export default class extends Controller {
     if (!this.hasEventCardTarget || !this.hasEventCardToggleTarget) return
 
     this.eventCardTarget.style.display = this.eventCardToggleTarget.checked ? "none" : ""
+  }
+
+  // Action handler. Announces as well as syncing — the connect callbacks use
+  // syncTicketButton directly so the live region stays silent on page load.
+  toggleTicketButton() {
+    this.syncTicketButton()
+
+    if (!this.hasTicketStatusTarget || !this.hasTicketButtonToggleTarget) return
+
+    this.ticketStatusTarget.textContent = this.ticketButtonToggleTarget.checked
+      ? "View ticket button hidden from the email."
+      : "View ticket button shown in the email."
+  }
+
+  syncTicketButton() {
+    if (!this.hasTicketButtonTarget || !this.hasTicketButtonToggleTarget) return
+
+    this.ticketButtonTarget.style.display = this.ticketButtonToggleTarget.checked ? "none" : ""
   }
 }

--- a/app/jobs/notification_mailer_job.rb
+++ b/app/jobs/notification_mailer_job.rb
@@ -17,7 +17,7 @@ class NotificationMailerJob < ApplicationJob
       "event_registration_confirmation_fyi" => ->(n) { NotificationMailer.event_registration_confirmation_fyi(n) },
       "event_registration_cancelled" => ->(n) { EventMailer.event_registration_cancelled(n.noticeable) },
       "event_registration_cancelled_fyi" => ->(n) { NotificationMailer.event_registration_cancelled_fyi(n) },
-      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message, custom_subject: n.custom_subject, hide_event_card: n.hide_event_card) },
+      "event_registration_reminder" => ->(n) { EventMailer.event_registration_reminder(n.noticeable, custom_message: n.custom_message, custom_subject: n.custom_subject, hide_event_card: n.hide_event_card, hide_ticket_button: n.hide_ticket_button) },
       "bulk_payment_confirmation" => ->(n) { EventMailer.bulk_payment_confirmation(n.noticeable) },
       "bulk_payment_confirmation_fyi" => ->(n) { NotificationMailer.bulk_payment_confirmation_fyi(n) },
       "form_submission_confirmation" => ->(n) { NotificationMailer.form_submission_confirmation(n) },

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -44,7 +44,7 @@ class EventMailer < ApplicationMailer
     )
   end
 
-  def event_registration_reminder(event_registration, custom_message: nil, custom_subject: nil, hide_event_card: false, preview: false)
+  def event_registration_reminder(event_registration, custom_message: nil, custom_subject: nil, hide_event_card: false, hide_ticket_button: false, preview: false)
     @event_registration = event_registration
     @event = event_registration.event.decorate
     @person = event_registration.registrant
@@ -53,6 +53,9 @@ class EventMailer < ApplicationMailer
     # When true, the grey event-details card is dropped from the email — the admin
     # chose to send a plainer message on the bulk-reminder page.
     @hide_event_card = hide_event_card
+    # When true, the "View ticket" button (and its lead-in line) is dropped — the
+    # admin chose a plain informational email with no link to the registrant's ticket.
+    @hide_ticket_button = hide_ticket_button
     # When true, the HTML body always renders the custom-message container (even
     # when blank) with hooks the on-page preview's Stimulus controller fills in
     # live. Never set on a real send.
@@ -80,12 +83,14 @@ class EventMailer < ApplicationMailer
   # is passed as "Name <email>" labels (not records), so the job that delivers
   # this needs no extra lookups. The per-recipient reminders are tracked
   # notifications; this is just an at-a-glance heads-up for the team.
-  def event_registration_reminder_fyi(event, recipient_labels, custom_message: nil, hide_event_card: false)
+  def event_registration_reminder_fyi(event, recipient_labels, custom_message: nil, hide_event_card: false, hide_ticket_button: false)
     @event = event.decorate
     @recipient_labels = Array(recipient_labels)
     @custom_message = custom_message.presence
     # Mirror what registrants received: drop the card from the admin copy too.
     @hide_event_card = hide_event_card
+    # Mirror what registrants received: note the ticket link only when it was sent.
+    @hide_ticket_button = hide_ticket_button
     @notification_type = "Event registration reminder"
     @time_zone = Time.zone.name
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")

--- a/app/services/notification_services/create_notification.rb
+++ b/app/services/notification_services/create_notification.rb
@@ -9,6 +9,7 @@ module NotificationServices
       custom_message: nil,
       custom_subject: nil,
       hide_event_card: false,
+      hide_ticket_button: false,
       sender: nil,
       bulk: false,
       deliver: true,
@@ -24,6 +25,7 @@ module NotificationServices
         custom_message: custom_message,
         custom_subject: custom_subject,
         hide_event_card: hide_event_card,
+        hide_ticket_button: hide_ticket_button,
         sender: sender,
         bulk: bulk
       )

--- a/app/views/event_mailer/_ticket_button.html.erb
+++ b/app/views/event_mailer/_ticket_button.html.erb
@@ -1,0 +1,7 @@
+<%# The "View ticket" call to action. Rendered from both branches of the
+    reminder's preview/real-send split, so the copy lives in one place.
+    Locals: event_registration. %>
+<p>
+  View your ticket for everything you need to attend, plus a calendar link:
+</p>
+<p><a href="<%= registration_ticket_url(event_registration.slug) %>" class="button">View ticket</a></p>

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -42,16 +42,10 @@
 <% if @event_registration.persisted? && @event_registration.slug.present? %>
   <% if @preview %>
     <div id="reminder-ticket-button" data-reminder-preview-target="ticketButton" style="<%= "display: none;" if @hide_ticket_button %>">
-      <p>
-        View your ticket for everything you need to attend, plus a calendar link:
-      </p>
-      <p><a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a></p>
+      <%= render "ticket_button", event_registration: @event_registration %>
     </div>
   <% elsif !@hide_ticket_button %>
-    <p>
-      View your ticket for everything you need to attend, plus a calendar link:
-    </p>
-    <p><a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a></p>
+    <%= render "ticket_button", event_registration: @event_registration %>
   <% end %>
 <% end %>
 

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -34,11 +34,25 @@
   <%= render "ce_deadlines", event: @event %>
 </div>
 
+<%#
+  The "View ticket" button. In preview the wrapper always renders (hidden when
+  the admin ticked "hide") so the reminder-preview controller can toggle it live;
+  a real send just omits it when hidden.
+%>
 <% if @event_registration.persisted? && @event_registration.slug.present? %>
-  <p>
-    View your ticket for everything you need to attend, plus a calendar link:
-  </p>
-  <p><a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a></p>
+  <% if @preview %>
+    <div id="reminder-ticket-button" data-reminder-preview-target="ticketButton" style="<%= "display: none;" if @hide_ticket_button %>">
+      <p>
+        View your ticket for everything you need to attend, plus a calendar link:
+      </p>
+      <p><a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a></p>
+    </div>
+  <% elsif !@hide_ticket_button %>
+    <p>
+      View your ticket for everything you need to attend, plus a calendar link:
+    </p>
+    <p><a href="<%= registration_ticket_url(@event_registration.slug) %>" class="button">View ticket</a></p>
+  <% end %>
 <% end %>
 
 <p style="margin-top: 24px; font-size: 12px; color: #6b7280;">This is an automated reminder from <%= @organization_name %>.</p>

--- a/app/views/event_mailer/event_registration_reminder.text.erb
+++ b/app/views/event_mailer/event_registration_reminder.text.erb
@@ -29,7 +29,7 @@ Event reminder Hello<%= @person.full_name %>,
 <% end %>
 <% end %>
 <%= render "ce_deadlines", event: @event %>
-<% if @event_registration.slug.present? %>
+<% if @event_registration.slug.present? && !@hide_ticket_button %>
   View your ticket for everything you need to attend, plus a calendar link:
   <%= registration_ticket_url(@event_registration.slug) %>
 <% end %>

--- a/app/views/event_mailer/event_registration_reminder_fyi.html.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.html.erb
@@ -31,7 +31,9 @@
     <%= render "event_details_card", event: @event, time_zone: @time_zone %>
   <% end %>
 
-  <p style="font-size: 12px; color: #6b7280; margin: 8px 0 0;">
-    Each registrant also received a personalized "View ticket" link.
-  </p>
+  <% unless @hide_ticket_button %>
+    <p style="font-size: 12px; color: #6b7280; margin: 8px 0 0;">
+      Each registrant also received a personalized "View ticket" link.
+    </p>
+  <% end %>
 </div>

--- a/app/views/event_mailer/event_registration_reminder_fyi.text.erb
+++ b/app/views/event_mailer/event_registration_reminder_fyi.text.erb
@@ -19,5 +19,6 @@ Location: <%= event_location_label(@event.object) %>
 <% end %><% if event_platform_label(@event.object).present? %>
 <%= event_platform_label(@event.object) %>
 <% end %><% end %>
-
+<% unless @hide_ticket_button %>
 Each registrant also received a personalized "View ticket" link.
+<% end %>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -3,7 +3,7 @@
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0"), hide_ticket_button: (@hide_ticket_button ? "1" : "0")), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
@@ -66,6 +66,12 @@
           Event details box hidden — the date, time, cost, and location won't be in this email.
         </p>
       <% end %>
+      <% if @hide_ticket_button && !@invite_mode %>
+        <p class="text-xs text-gray-500 mt-1.5">
+          <i class="fa-solid fa-eye-slash text-gray-400"></i>
+          "View ticket" button hidden — this email won't link to the registrant's ticket.
+        </p>
+      <% end %>
     </div>
     <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
       <%= raw @reminder_preview_html %>
@@ -79,13 +85,14 @@
     <% if @invite_mode %>
       <%= hidden_field_tag :mode, "invite" %>
     <% else %>
-      <%# Carry the composed subject/message and the hide-card choice through to the send untouched. %>
+      <%# Carry the composed subject/message and the hide choices through to the send untouched. %>
       <%= hidden_field_tag :custom_subject, @custom_subject %>
       <%= hidden_field_tag :custom_message, @custom_message %>
       <%= hidden_field_tag :hide_event_card, (@hide_event_card ? "1" : "0") %>
+      <%= hidden_field_tag :hide_ticket_button, (@hide_ticket_button ? "1" : "0") %>
     <% end %>
     <div class="flex justify-center gap-3">
-      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0")), class: "btn btn-secondary-outline" %>
+      <%= link_to "Cancel", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0"), hide_ticket_button: (@hide_ticket_button ? "1" : "0")), class: "btn btn-secondary-outline" %>
       <%= f.submit(@invite_mode ? "Send invites" : "Send reminder", class: "btn btn-primary") %>
     </div>
   <% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -126,6 +126,18 @@
                   reader never sees change. Announce it instead. %>
               <p class="sr-only" role="status" aria-live="polite" data-reminder-preview-target="cardStatus"></p>
             </div>
+            <div>
+              <label class="flex items-center gap-2 text-sm font-semibold text-gray-700">
+                <%= check_box_tag :hide_ticket_button, "1", @hide_ticket_button,
+                      class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500",
+                      data: { reminder_preview_target: "ticketButtonToggle", action: "reminder-preview#toggleTicketButton" } %>
+                Hide the "View ticket" button
+              </label>
+              <p class="text-xs text-gray-400 mt-1.5 ml-6">
+                Leaves out the "View ticket" button and its lead-in line — send a plain informational email with no link to the registrant's ticket.
+              </p>
+              <p class="sr-only" role="status" aria-live="polite" data-reminder-preview-target="ticketStatus"></p>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -120,7 +120,7 @@
                 Hide the event details box
               </label>
               <p class="text-xs text-gray-400 mt-1.5 ml-6">
-                Leaves out the grey box with the event's date, time, cost, and location — send just your message and the "View ticket" button.
+                Leaves out the grey box with the event's date, time, cost, and location.
               </p>
               <%# The toggle's only feedback is the preview below, which a screen
                   reader never sees change. Announce it instead. %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -37,13 +37,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "c0a7785bbcfe39ba0b0ec792dacfbf3b12596ef585e9eba974b6ed85ab106d30",
+      "fingerprint": "5a2e0de7fa57aff912268465df53bfe1aadbec3115b4a59ac3c43bb9b665dfb0",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
       "file": "app/views/events/confirm_reminder.html.erb",
-      "line": 63,
+      "line": 77,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "EventMailer.event_registration_reminder(selected_reminder_registrations.first, :custom_message => params[:custom_message].to_s, :custom_subject => params[:custom_subject].to_s, :hide_event_card => hide_event_card_param).html_part.body.decoded",
+      "code": "EventMailer.event_registration_reminder(selected_reminder_registrations.first, :custom_message => params[:custom_message].to_s, :custom_subject => params[:custom_subject].to_s, :hide_event_card => hide_event_card_param, :hide_ticket_button => hide_ticket_button_param).html_part.body.decoded",
       "render_path": [
         {
           "type": "controller",

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,16 @@
   pro_tips:
     - "Filter the people list first — the email list always matches whatever the list is showing."
 
+- name: "Hide the View ticket button in a bulk email"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-08-22
+  action_path: "/events/1/preview_reminder"
+  summary: >-
+    When composing a bulk email, tick "Hide the View ticket button" to send a plain
+    informational message with no link to a registrant's ticket — the same way you can
+    already hide the event details box.
+
 - name: "Affiliation editor: FileMaker code"
   area: people
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -43,6 +43,7 @@
   display_status: admin_facing
   released_on: 2026-08-22
   action_path: "/events/1/preview_reminder"
+  pr_number: 2344
   summary: >-
     When composing a bulk email, tick "Hide the View ticket button" to send a plain
     informational message with no link to a registrant's ticket — the same way you can

--- a/db/migrate/20260822164529_add_hide_ticket_button_to_notifications.rb
+++ b/db/migrate/20260822164529_add_hide_ticket_button_to_notifications.rb
@@ -1,0 +1,9 @@
+class AddHideTicketButtonToNotifications < ActiveRecord::Migration[8.1]
+  def up
+    add_column :notifications, :hide_ticket_button, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :notifications, :hide_ticket_button, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -835,6 +835,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
     t.string "error_class"
     t.text "error_message"
     t.boolean "hide_event_card", default: false, null: false
+    t.boolean "hide_ticket_button", default: false, null: false
     t.string "kind", null: false
     t.integer "noticeable_id"
     t.string "noticeable_type"

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -333,6 +333,41 @@ RSpec.describe EventMailer, type: :mailer do
         end
       end
     end
+
+    context "by default" do
+      it "includes the View ticket button in the HTML body" do
+        expect(mail.html_part.body.encoded).to include("View ticket")
+      end
+
+      it "includes the ticket link in the plain-text body" do
+        expect(mail.text_part.body.encoded).to include("View your ticket")
+      end
+    end
+
+    context "with the ticket button hidden" do
+      let(:mail) { described_class.event_registration_reminder(event_registration, hide_ticket_button: true) }
+
+      it "renders without raising" do
+        expect { mail.deliver_now }.not_to raise_error
+      end
+
+      it "omits the View ticket button from the HTML body" do
+        expect(mail.html_part.body.encoded).not_to include("View ticket")
+      end
+
+      it "omits the ticket link from the plain-text body" do
+        expect(mail.text_part.body.encoded).not_to include("View your ticket")
+      end
+
+      context "in preview mode" do
+        let(:mail) { described_class.event_registration_reminder(event_registration, hide_ticket_button: true, preview: true) }
+
+        it "still renders the button markup (hidden), so the live toggle can reveal it" do
+          expect(mail.html_part.body.encoded).to include("reminder-ticket-button")
+          expect(mail.html_part.body.encoded).to include("View ticket")
+        end
+      end
+    end
   end
 
   describe "#event_registration_reminder_fyi" do
@@ -395,6 +430,22 @@ RSpec.describe EventMailer, type: :mailer do
       it "still names the event and lists recipients in the plain-text body" do
         expect(mail.text_part.body.encoded).to include("Art Workshop")
         expect(mail.text_part.body.encoded).to include("Alex Rivera <alex@example.org>")
+      end
+    end
+
+    context "with the ticket button hidden" do
+      let(:mail) { described_class.event_registration_reminder_fyi(event, recipient_labels, hide_ticket_button: true) }
+
+      it "omits the View ticket link note, matching what registrants received" do
+        expect(mail.html_part.body.encoded).not_to include("View ticket")
+        expect(mail.text_part.body.encoded).not_to include("View ticket")
+      end
+    end
+
+    context "by default" do
+      it "notes each registrant received a View ticket link" do
+        expect(mail.html_part.body.encoded).to include("View ticket")
+        expect(mail.text_part.body.encoded).to include("View ticket")
       end
     end
   end

--- a/spec/requests/events/bulk_invites_spec.rb
+++ b/spec/requests/events/bulk_invites_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Events::BulkInvites", type: :request do
     it "redirects back to the picker when nothing is selected" do
       post send_reminder_event_path(event), params: { mode: "invite", registration_ids: [] }
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, mode: "invite", custom_message: "", custom_subject: "", hide_event_card: "0"))
+      expect(response).to redirect_to(preview_reminder_event_path(event, mode: "invite", custom_message: "", custom_subject: "", hide_event_card: "0", hide_ticket_button: "0"))
       expect(flash[:alert]).to be_present
     end
   end

--- a/spec/requests/events/bulk_reminders_spec.rb
+++ b/spec/requests/events/bulk_reminders_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Events::BulkReminders", type: :request do
     it "redirects back to the picker when nothing is selected" do
       post confirm_reminder_event_path(event), params: { registration_ids: [] }
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0"))
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0", hide_ticket_button: "0"))
       expect(flash[:alert]).to be_present
     end
 
@@ -183,6 +183,32 @@ RSpec.describe "Events::BulkReminders", type: :request do
       reminder = ActionMailer::Base.deliveries.find { |m| m.to == [ jane.registrant.preferred_email ] }
       expect(reminder.html_part.body.encoded).to include("#166534")
     end
+
+    it "records the hide-ticket-button choice on each reminder when checked" do
+      post send_reminder_event_path(event), params: { registration_ids: [ jane.id, sam.id ], hide_ticket_button: "1" }
+
+      reminders = Notification.where(kind: "event_registration_reminder")
+      expect(reminders.count).to eq(2)
+      expect(reminders.map(&:hide_ticket_button)).to all(be(true))
+    end
+
+    it "defaults hide_ticket_button to false when the box is left unchecked" do
+      post send_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+
+      expect(Notification.where(kind: "event_registration_reminder").map(&:hide_ticket_button)).to all(be(false))
+    end
+
+    # End-to-end: checking the box on the page must carry through the async delivery
+    # job into the email that actually lands in the registrant's inbox.
+    it "hides the View ticket button in the delivered email when the box is checked" do
+      perform_enqueued_jobs do
+        post send_reminder_event_path(event), params: { registration_ids: [ jane.id ], hide_ticket_button: "1" }
+      end
+
+      reminder = ActionMailer::Base.deliveries.find { |m| m.to == [ jane.registrant.preferred_email ] }
+      expect(reminder).to be_present
+      expect(reminder.html_part.body.encoded).not_to include("View ticket")
+    end
   end
 
   describe "the compose page" do
@@ -192,6 +218,25 @@ RSpec.describe "Events::BulkReminders", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("hide_event_card")
       expect(response.body).to include("Hide the event details")
+    end
+
+    it "offers a checkbox to hide the View ticket button" do
+      get preview_reminder_event_path(event)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("hide_ticket_button")
+      expect(response.body).to include("Hide the \"View ticket\" button")
+    end
+
+    it "reflects a carried-over hidden ticket-button choice: checkbox ticked and the button pre-hidden in the live preview" do
+      get preview_reminder_event_path(event, hide_ticket_button: "1")
+
+      expect(response).to have_http_status(:ok)
+      html = Nokogiri::HTML(response.body)
+      expect(html.at_css("#hide_ticket_button")["checked"]).to be_present
+      button = html.at_css("#reminder-ticket-button")
+      expect(button).to be_present
+      expect(button["style"]).to include("display: none")
     end
 
     it "reflects a carried-over hidden choice: checkbox ticked and the card pre-hidden in the live preview" do
@@ -217,6 +262,18 @@ RSpec.describe "Events::BulkReminders", type: :request do
       post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
 
       expect(response.body).not_to include("Event details box hidden")
+    end
+
+    it "says on the confirm page when the View ticket button is hidden" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ], hide_ticket_button: "1" }
+
+      expect(response.body).to include("\"View ticket\" button hidden")
+    end
+
+    it "says nothing about the ticket button on the confirm page when it is shown" do
+      post confirm_reminder_event_path(event), params: { registration_ids: [ jane.id ] }
+
+      expect(response.body).not_to include("button hidden")
     end
 
     # Gated on the event carrying a deadline, not on it being on-demand.

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -4034,7 +4034,7 @@ RSpec.describe "Events", type: :request do
         post send_reminder_event_path(event), params: { registration_ids: [] }
       }.not_to change(Notification, :count)
 
-      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0"))
+      expect(response).to redirect_to(preview_reminder_event_path(event, custom_message: "", custom_subject: "", hide_event_card: "0", hide_ticket_button: "0"))
     end
 
     it "logs an Ahoy event with the recipient count on a successful send" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -499,16 +499,18 @@ RSpec.describe "Notifications", type: :request do
                  recipient_role: :person,
                  custom_message: "See you tomorrow!",
                  custom_subject: "Reminder: see you tomorrow",
-                 hide_event_card: true)
+                 hide_event_card: true,
+                 hide_ticket_button: true)
         end
 
-        it "carries the composed message, subject, and hide-card choice onto the resent copy" do
+        it "carries the composed message, subject, and hide choices onto the resent copy" do
           post resend_notification_path(reminder)
 
           resent = Notification.last
           expect(resent.custom_message).to eq("See you tomorrow!")
           expect(resent.custom_subject).to eq("Reminder: see you tomorrow")
           expect(resent.hide_event_card).to be(true)
+          expect(resent.hide_ticket_button).to be(true)
         end
 
         it "delivers the same email the registrant originally received" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic mirroring the existing hide-event-card opt-out across the reminder flow

## What
- Adds a "Hide the View ticket button" checkbox to the bulk-email compose page, mirroring the existing "Hide the event details box" opt-out.
- When ticked, the reminder email (and the admin FYI) drops the "View ticket" button and its lead-in line — a plain informational email with no link to the registrant's ticket.

## How
- New `hide_ticket_button` boolean on `notifications` (default false) so the choice survives the async delivery job and resends — same seam as `hide_event_card`.
- Threaded through compose → confirm → send → `NotificationMailerJob` → resend, plus the live Stimulus preview toggle.

## Notes
- Brakeman ignore fingerprint for the admin-only confirm-page preview `raw` updated (the mailer-call code changed; the warning is unchanged and already reviewed).