### PR TITLE
Fix organizations index skeleton to match lazy-loaded columns

### DIFF
--- a/app/views/organizations/_results_skeleton.html.erb
+++ b/app/views/organizations/_results_skeleton.html.erb
@@ -3,13 +3,10 @@
     <table class="min-w-full border border-gray-200 rounded divide-y divide-gray-200 animate-pulse">
       <thead class="bg-gray-100">
         <tr>
-          <% if allowed_to?(:manage?, Organization) %>
-            <th class="admin-only bg-blue-100 px-4 py-2 text-center text-sm font-semibold text-gray-700">Program</th>
-          <% end %>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Designations</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Sectors</th>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Age group(s)</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Affiliated since</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Facilitators since</th>
           <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">People</th>
           <% if allowed_to?(:manage?, Organization) %>
             <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
@@ -20,9 +17,6 @@
       <tbody class="divide-y divide-gray-100">
         <% 8.times do %>
           <tr>
-            <% if allowed_to?(:manage?, Organization) %>
-              <td class="admin-only bg-blue-100 px-4 py-3 text-center"><div class="h-4 w-6 bg-gray-200 rounded mx-auto"></div></td>
-            <% end %>
             <td class="px-4 py-3"><div class="h-4 w-40 bg-gray-200 rounded"></div></td>
             <td class="px-4 py-3"><div class="h-4 w-24 bg-gray-200 rounded"></div></td>
             <td class="px-4 py-3"><div class="h-4 w-24 bg-gray-200 rounded"></div></td>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 skeleton-only markup change, no logic

## Why
The organizations index skeleton didn't match the rendered results table, causing a layout shift on load.

## Changes
- Drop the stale **Programs** column (removed from results).
- Rename headers to match results: **Designations → Sectors**, **Affiliated since → Facilitators since**.

Closes #2272