### PR TITLE
Move person_id submission-view authorization into EventPolicy

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -99,9 +99,9 @@ module Events
         # Unlike the registration slug — an unguessable token handed to the
         # registrant — person ids are sequential, so this branch is not a
         # capability. It exists as the admin-side fallback for registrations with
-        # no slug, so gate it on the same access as the event's other submission
-        # views (or on the viewer being that person).
-        authorize! @event, to: :form_submissions? unless current_user&.person_id == person.id
+        # no slug, so the policy gates it on the same access as the event's other
+        # submission views (or on the viewer being that person).
+        authorize! @event, to: :person_form_submission?, context: { person: person }
         registration = @event.event_registrations.find_by(registrant: person)
       else
         redirect_to event_path(@event), alert: "Registration not found."

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -2,6 +2,7 @@ class EventPolicy < ApplicationPolicy
   # See https://actionpolicy.evilmartians.io/#/writing_policies
   #
   # override or add new rules here that are not defined in ApplicationPolicy
+  authorize :person, optional: true, allow_nil: true
 
   def index?
     true
@@ -126,6 +127,14 @@ class EventPolicy < ApplicationPolicy
   # Who can view a person's form submissions for this event
   def form_submissions?
     manage?
+  end
+
+  # Who can view one specific person's registration submission for this event:
+  # the event's submission managers, or that person viewing their own. The person
+  # is passed as context because the admin-side person_id fallback authorizes
+  # against the event while still allowing the registrant themselves through.
+  def person_form_submission?
+    form_submissions? || (person.present? && user&.person_id == person.id)
   end
 
   def preview_reminder?

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -230,6 +230,47 @@ RSpec.describe EventPolicy, type: :policy do
     end
   end
 
+  describe "#person_form_submission?" do
+    let(:owned_event) { build_stubbed :event, created_by: regular_user }
+    let(:person) { build_stubbed :person }
+
+    def policy_for_person(record:, user:, person: nil)
+      described_class.new(record, user: user, person: person)
+    end
+
+    context "with admin user" do
+      subject { policy_for_person(record: published_event, user: admin_user, person: person) }
+
+      it { is_expected.to be_allowed_to(:person_form_submission?) }
+    end
+
+    context "with owner" do
+      subject { policy_for_person(record: owned_event, user: regular_user, person: person) }
+
+      it { is_expected.to be_allowed_to(:person_form_submission?) }
+    end
+
+    context "when the viewer is that person" do
+      let(:viewer) { build_stubbed :user, person: person }
+
+      subject { policy_for_person(record: published_event, user: viewer, person: person) }
+
+      it { is_expected.to be_allowed_to(:person_form_submission?) }
+    end
+
+    context "with a non-owner regular user viewing someone else" do
+      subject { policy_for_person(record: published_event, user: regular_user, person: person) }
+
+      it { is_expected.not_to be_allowed_to(:person_form_submission?) }
+    end
+
+    context "with no user" do
+      subject { policy_for_person(record: published_event, user: nil, person: person) }
+
+      it { is_expected.not_to be_allowed_to(:person_form_submission?) }
+    end
+  end
+
   describe "#registrants?" do
     let(:owned_event) { build_stubbed :event, created_by: regular_user }
 

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -705,6 +705,36 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       end
     end
 
+    context "when a signed-in user who is neither the registrant nor staff looks it up by person id" do
+      let(:other_user) { create(:user, :with_person) }
+
+      before do
+        sign_out admin
+        sign_in other_user
+      end
+
+      it "does not serve another person's registration" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the registrant views their own submission by person id" do
+      let(:registrant_user) { create(:user, person: person) }
+
+      before do
+        sign_out admin
+        sign_in registrant_user
+      end
+
+      it "serves the submission" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
     it "renders header and field-label HTML unescaped on the response page" do
       create(:form_field, form: form, answer_type: :group_header, name: "<strong>Your details</strong>")
       create(:form_field, form: form, answer_type: :free_form_input_one_line, name: "<em>Name</em>", required: false)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small authz refactor moving one inline controller check into the policy, no behavior change

### What is the goal of this PR and why is this important?

Follow-up to #2217, addressing [Justin's review comment](https://github.com/rubyforgood/awbw/pull/2217#discussion_r3792637502). The public registration `show` action gated its `person_id` fallback with an inline exception in the controller (`authorize! @event, to: :form_submissions? unless current_user&.person_id == person.id`) — authorization logic that belongs in the policy.

### How did you approach the change?

Added `EventPolicy#person_form_submission?`, which captures the whole rule (event submission managers, or the viewer being that person), and pass the person as authorization context — mirroring the existing `authorize :slug` pattern in `FormSubmissionPolicy`. Behavior is unchanged; policy and request specs pin the manager, self-view, other-person, and signed-out cases.

### Anything else to add?

Purely a refactor prompted by review feedback — no user-facing change.