### PR TITLE
Reword blog-contributor and mailing-list consent hints

### DIFF
--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -474,7 +474,7 @@
                       label: "Consented to mailing list",
                       hint: f.object.mailing_list_consent_at.present? ?
                               "Consented #{f.object.mailing_list_consent_at.to_date.to_fs(:long)} (#{f.object.mailing_list_consent_source}). Uncheck to withdraw." :
-                              "No consent on file. Check to record consent.",
+                              "Has agreed through form or email.",
                       wrapper_html: { class: "w-full sm:flex-1" } %>
 
           <%= f.input :blog_contributor,

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -480,7 +480,7 @@
           <%= f.input :blog_contributor,
                       as: :boolean,
                       label: "Blog contributor",
-                      hint: "Adds a blog contributor badge to this person's profile.",
+                      hint: "Adds a badge to their profile.",
                       wrapper_html: { class: "w-full sm:w-auto sm:text-right" } %>
         </div>
       </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -481,7 +481,7 @@
                       as: :boolean,
                       label: "Blog contributor",
                       hint: "Adds a badge to their profile.",
-                      wrapper_html: { class: "w-full sm:w-auto sm:text-right" } %>
+                      wrapper_html: { class: "w-full sm:flex-1" } %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only copy + alignment tweaks to two form hints

## Why
- The admin panel (`lg:w-auto`) is sized to its widest content; the long blog-contributor hint forced it wide and squeezed the adjacent timezone card (`lg:flex-1`). A terser hint lets the blue panel narrow and the timezone card grow back.

## Changes
- Blog-contributor hint: "Adds a blog contributor badge to this person's profile." → "Adds a badge to their profile."
- Mailing-list no-consent hint: "No consent on file. Check to record consent." → "Has agreed through form or email."
- Left-align the blog-contributor column (`sm:flex-1`) to match its mailing-list neighbor instead of right-aligning it.
