### PR TITLE
Serve thumbnail variant in tiny people/tagging cards + gate taggings people group (PR #2342 follow-up)

### DIFF
--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -8,10 +8,6 @@ class PersonDecorator < ApplicationDecorator
     length ? text&.truncate(length) : text
   end
 
-  def default_display_image
-    "missing.png"
-  end
-
   def primary_asset
     avatar
   end

--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -22,7 +22,7 @@ class DisplayImagePresenter
   end
 
   def initialize(resource: nil, item: nil, file: nil, field_name: :primary_asset,
-                 variant: :gallery, width: "32", height: nil,
+                 variant: :gallery, width: "32", height: nil, prefer_thumbnail: false,
                  link: nil, link_to_object: false, display_open_pdf_link: false,
                  idx: 0, item_type: "PrimaryAsset", extra_image_classes: "",
                  view_context:)
@@ -32,6 +32,7 @@ class DisplayImagePresenter
     @variant = variant
     @width = width.to_s
     @height = (height || width).to_s
+    @prefer_thumbnail = prefer_thumbnail
     @link_to_object = link_to_object
     @link = link.nil? ? link_to_object : link
     @display_open_pdf_link = display_open_pdf_link
@@ -89,9 +90,9 @@ class DisplayImagePresenter
       resolve_previewable
     elsif @variant == :hero
       @file
-    elsif large_display? && variant_defined?(:card)
+    elsif large_display? && !@prefer_thumbnail && variant_defined?(:card)
       @file.variant(:card)
-    elsif use_thumbnail? && variant_defined?(:thumbnail)
+    elsif (use_thumbnail? || @prefer_thumbnail) && variant_defined?(:thumbnail)
       @file.variant(:thumbnail)
     else
       @file

--- a/app/services/display_image_presenter.rb
+++ b/app/services/display_image_presenter.rb
@@ -22,7 +22,7 @@ class DisplayImagePresenter
   end
 
   def initialize(resource: nil, item: nil, file: nil, field_name: :primary_asset,
-                 variant: :gallery, width: "32", height: nil, prefer_thumbnail: false,
+                 variant: :gallery, width: "32", height: nil, image_variant: nil,
                  link: nil, link_to_object: false, display_open_pdf_link: false,
                  idx: 0, item_type: "PrimaryAsset", extra_image_classes: "",
                  view_context:)
@@ -32,7 +32,7 @@ class DisplayImagePresenter
     @variant = variant
     @width = width.to_s
     @height = (height || width).to_s
-    @prefer_thumbnail = prefer_thumbnail
+    @image_variant = image_variant
     @link_to_object = link_to_object
     @link = link.nil? ? link_to_object : link
     @display_open_pdf_link = display_open_pdf_link
@@ -90,9 +90,11 @@ class DisplayImagePresenter
       resolve_previewable
     elsif @variant == :hero
       @file
-    elsif large_display? && !@prefer_thumbnail && variant_defined?(:card)
+    elsif @image_variant && variant_defined?(@image_variant)
+      @file.variant(@image_variant)
+    elsif large_display? && variant_defined?(:card)
       @file.variant(:card)
-    elsif (use_thumbnail? || @prefer_thumbnail) && variant_defined?(:thumbnail)
+    elsif use_thumbnail? && variant_defined?(:thumbnail)
       @file.variant(:thumbnail)
     else
       @file

--- a/app/services/tagging_search_service.rb
+++ b/app/services/tagging_search_service.rb
@@ -55,13 +55,19 @@ class TaggingSearchService
                  .paginate(page: pages[:stories] || 1, per_page: number_of_items_per_page)
                  .decorate,
 
-      people: authorized_scope(Person.all)
-                .includes(:sectors)
-                .sector_names_all(sector_names_all)
-                .category_names_all(category_names_all)
-                .order(:first_name, :last_name)
-                .paginate(page: pages[:people] || 1, per_page: number_of_items_per_page)
-                .decorate,
+      # People surface here only for viewers who may see the People index
+      # (admins); otherwise the group is empty so no avatar/name is exposed.
+      people: if allowed_to?(:index?, Person)
+                authorized_scope(Person.all)
+                  .includes(:sectors)
+                  .sector_names_all(sector_names_all)
+                  .category_names_all(category_names_all)
+                  .order(:first_name, :last_name)
+                  .paginate(page: pages[:people] || 1, per_page: number_of_items_per_page)
+                  .decorate
+              else
+                empty_page(number_of_items_per_page)
+              end,
 
       organizations: authorized_scope(Organization.all)
                   .includes(:sectors)
@@ -103,5 +109,11 @@ class TaggingSearchService
     Tag::TAGGABLE_META.keys.index_with do
       WillPaginate::Collection.create(1, per_page || 9, 0) { |pager| pager.replace([]) }
     end
+  end
+
+  private
+
+  def empty_page(per_page)
+    WillPaginate::Collection.create(1, per_page || 9, 0) { |pager| pager.replace([]) }
   end
 end

--- a/app/views/people/_show_card.html.erb
+++ b/app/views/people/_show_card.html.erb
@@ -28,6 +28,7 @@
           <%= render "assets/display_image",
                      resource: record.object,
                      width: "full", height: "full",
+                     prefer_thumbnail: true,
                      link: false,
                      link_to_object: false,
                      file: record.display_image %>

--- a/app/views/people/_show_card.html.erb
+++ b/app/views/people/_show_card.html.erb
@@ -28,7 +28,7 @@
           <%= render "assets/display_image",
                      resource: record.object,
                      width: "full", height: "full",
-                     prefer_thumbnail: true,
+                     image_variant: :thumbnail,
                      link: false,
                      link_to_object: false,
                      file: record.display_image %>

--- a/app/views/taggings/_tagged_item_card.html.erb
+++ b/app/views/taggings/_tagged_item_card.html.erb
@@ -37,6 +37,7 @@
           <%= render "assets/display_image",
                      resource: item.object,
                      width: "full", height: "full",
+                     prefer_thumbnail: true,
                      link: false,
                      link_to_object: false,
                      file: item.display_image %>

--- a/app/views/taggings/_tagged_item_card.html.erb
+++ b/app/views/taggings/_tagged_item_card.html.erb
@@ -37,7 +37,7 @@
           <%= render "assets/display_image",
                      resource: item.object,
                      width: "full", height: "full",
-                     prefer_thumbnail: true,
+                     image_variant: :thumbnail,
                      link: false,
                      link_to_object: false,
                      file: item.display_image %>

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe DisplayImagePresenter do
         expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 1200, 1200 ])
       end
 
+      it "serves the smaller thumbnail variant when prefer_thumbnail is set for a full-width display" do
+        result = described_class.call(file: file, variant: :gallery, width: "full", height: "full", prefer_thumbnail: true, view_context: view_context)
+        expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
+        expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 256, 256 ])
+      end
+
       it "builds alt text with filename" do
         result = described_class.call(file: file, idx: 0, item_type: "Main", view_context: view_context)
         expect(result.alt_text).to include("missing.png")

--- a/spec/services/display_image_presenter_spec.rb
+++ b/spec/services/display_image_presenter_spec.rb
@@ -77,10 +77,15 @@ RSpec.describe DisplayImagePresenter do
         expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 1200, 1200 ])
       end
 
-      it "serves the smaller thumbnail variant when prefer_thumbnail is set for a full-width display" do
-        result = described_class.call(file: file, variant: :gallery, width: "full", height: "full", prefer_thumbnail: true, view_context: view_context)
+      it "serves the named image_variant, overriding the width-based size inference" do
+        result = described_class.call(file: file, variant: :gallery, width: "full", height: "full", image_variant: :thumbnail, view_context: view_context)
         expect(result.renderable).to be_a(ActiveStorage::VariantWithRecord)
         expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 256, 256 ])
+      end
+
+      it "ignores an image_variant the attachment does not declare and falls back to inference" do
+        result = described_class.call(file: file, variant: :index, width: "full", height: "full", image_variant: :nonexistent, view_context: view_context)
+        expect(result.renderable.variation.transformations[:resize_to_limit]).to eq([ 1200, 1200 ])
       end
 
       it "builds alt text with filename" do

--- a/spec/services/tagging_search_service_spec.rb
+++ b/spec/services/tagging_search_service_spec.rb
@@ -138,6 +138,37 @@ RSpec.describe TaggingSearchService do
       end
     end
 
+    context "with people (People-index-only)" do
+      let!(:admin) { create(:user, :admin) }
+      let!(:person) { create(:person, first_name: "Tagged", last_name: "Facilitator") }
+
+      before { create(:sectorable_item, sector: sector, sectorable: person) }
+
+      it "returns matching people for a viewer allowed to see the People index" do
+        results = described_class.new(user: admin).call(
+          sector_names_all: "Youth", category_names_all: nil, pages: {}, number_of_items_per_page: 9
+        )
+
+        expect(results[:people].map(&:title)).to include("Tagged Facilitator")
+      end
+
+      it "hides people from viewers who cannot see the People index" do
+        results = described_class.new(user: user).call(
+          sector_names_all: "Youth", category_names_all: nil, pages: {}, number_of_items_per_page: 9
+        )
+
+        expect(results[:people]).to be_empty
+      end
+
+      it "hides people from guests" do
+        results = described_class.new(user: nil).call(
+          sector_names_all: "Youth", category_names_all: nil, pages: {}, number_of_items_per_page: 9
+        )
+
+        expect(results[:people]).to be_empty
+      end
+    end
+
     context "as a guest (nil user)" do
       it "returns only publicly visible results" do
         results = described_class.new(user: nil).call(


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 image-variant param across two card partials + a policy gate on one search group, covered by specs

Follow-up to #2342 (which added the `variant_defined?` guard). Related: #1204 introduced the person `:thumbnail` variant.

## Review comments addressed
| Comment | Resolved by this PR? |
|---|---|
| [#2349 — "why not specify `thumbnail` at the source instead of more fallback?"](https://github.com/rubyforgood/awbw/pull/2349#issuecomment-5385783997) | ✅ Yes — added an explicit `image_variant:` selector; both cards now declare `image_variant: :thumbnail`. [Reply](https://github.com/rubyforgood/awbw/pull/2349#issuecomment-5387897000) |
| [#2342 — "what actually requested `:card`? if a view wants card and gets thumbnail it'll look bad"](https://github.com/rubyforgood/awbw/pull/2342#issuecomment-5381368081) | ✅ Yes — the requesters were `people/_show_card` + `taggings/_tagged_item_card` via `width: "full"`; their boxes are 48–72px, so thumbnail is correct (not a downgrade). |
| [#2342 — "what view rendered the avatar at card size? there's more here than just guarding"](https://github.com/rubyforgood/awbw/pull/2342#issuecomment-5381567487) | ✅ Yes — #2342 guarded the symptom; this fixes the source by not requesting `:card` in tiny boxes. |

## Image sizing
- `people/_show_card` (~48–64px box) and `taggings/_tagged_item_card` (~72px box) passed `width: "full"`, so `DisplayImagePresenter` treated them as a large display and fetched the **1200×1200 `:card`** variant into a tiny box.
- The presenter's `variant:` is a *layout* mode (`:hero`/`:gallery`/`:index`), not the image variant — size was inferred from `width`. Added an explicit **`image_variant:`** selector so a caller names the variant at the source.
- Both cards now pass `image_variant: :thumbnail` → **256px** across the board. The `large_display?`/`use_thumbnail?` inference only runs when size is unspecified. Guarded by `variant_defined?` (handles missing-png strings / PDFs). Views that genuinely want card (workshop banner, hero) are untouched.

## Public exposure of person avatar + name
- The public `taggings#index` rendered a **people group** (avatar + name) to logged-out visitors: `TaggingPolicy#index?` is public and `PersonPolicy`'s `relation_scope` exposes searchable people (that scope is for the pending public-profile feature, not this browse page).
- Now the people group renders **only for viewers allowed to see the People index** (admins); everyone else gets an empty group, mirroring how `grants` already behaves here. `PersonPolicy#relation_scope` is left untouched.
- Event "meet the staff" pages (`events#staff`) stay intentionally public — unchanged.

## Cleanup
- Dropped the **shadowed** first `PersonDecorator#default_display_image` (a second definition of the same method — returning the avatar — always won, so the first was dead code).