### PR TITLE
Allow anonymous public form submissions

### DIFF
--- a/app/controllers/public_forms_controller.rb
+++ b/app/controllers/public_forms_controller.rb
@@ -73,6 +73,13 @@ class PublicFormsController < ApplicationController
     fields = @form_fields.reject(&:group_header?)
     errors = FormAnswerValidator.call(fields, form_params)
 
+    # A registration-role form mints an event registration, so it must collect
+    # the full identity even when its name/email questions are flagged optional.
+    fields.each do |field|
+      next if field.required? || !@form.requires_answer?(field)
+      errors[field.id] ||= "can't be blank" if form_params[field.id.to_s].blank?
+    end
+
     fields_by_identifier = fields.select { |f| f.field_identifier.present? }.index_by(&:field_identifier)
     confirm_field = fields_by_identifier["confirm_email"]
     email_field = fields_by_identifier["primary_email"]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -401,7 +401,7 @@ module ApplicationHelper
   # show page.
   def form_submission_link_path(submission)
     event = submission.resolved_event
-    registration = event && submission.person.event_registrations.find_by(event: event)
+    registration = event && submission.person&.event_registrations&.find_by(event: event)
     return event_public_registration_path(event, reg: registration.slug) if registration&.slug.present?
     form_submission_path(submission)
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -199,8 +199,9 @@ class NotificationMailer < ApplicationMailer
     @person = @submission.person
     @answers = @submission.form_answers.includes(:form_field)
 
+    submitter = @person&.full_name || "an anonymous respondent"
     mail(
-      subject: "#{FYI_PREFIX} New form submission: #{@form.display_name} by #{@person.full_name}"
+      subject: "#{FYI_PREFIX} New form submission: #{@form.display_name} by #{submitter}"
     )
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -12,6 +12,9 @@ class Form < ApplicationRecord
   # submissions index scenario filter.
   AGREEMENT_ROLES = %w[registration new_job reinstatement].freeze
 
+  # The questions that identify a public respondent (used to build their Person).
+  IDENTITY_IDENTIFIERS = %w[first_name last_name primary_email].freeze
+
   belongs_to :owner, polymorphic: true, optional: true
   has_many :form_fields, dependent: :destroy, inverse_of: :form
   has_many :event_forms, dependent: :destroy
@@ -56,6 +59,31 @@ class Form < ApplicationRecord
   # event-connected form stays tied to its event and is never offered publicly.
   def publicly_fillable?
     standalone? && !event_connected? && published? && slug.present?
+  end
+
+  # An agreement form (registration / new job / reinstatement) processes its
+  # submission against a Person — minting a registration, reconciling
+  # affiliations — so it always requires the full name/email identity and never
+  # accepts anonymous responses, however its identity questions are flagged.
+  def requires_identity?
+    role.in?(AGREEMENT_ROLES)
+  end
+
+  # Derived, not stored: a public form invites anonymous responses when it asks
+  # for name/email but requires none of them, so a respondent can skip
+  # identifying themselves and still submit (see PublicFormSubmission). A form
+  # with required identity questions forces an identified submission instead.
+  def accepts_anonymous_submissions?
+    return false if requires_identity?
+
+    identity_fields = form_fields.select { |field| field.field_identifier.in?(IDENTITY_IDENTIFIERS) }
+    identity_fields.any? && identity_fields.none?(&:required?)
+  end
+
+  # Whether a submission must carry an answer for this field: the field's own
+  # required flag, plus the identity questions a registration form always needs.
+  def requires_answer?(field)
+    field.required? || (requires_identity? && field.field_identifier.in?(IDENTITY_IDENTIFIERS))
   end
 
   private

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -1,5 +1,7 @@
 class FormSubmission < ApplicationRecord
-  belongs_to :person
+  # Optional so a public form whose name/email questions are not required can
+  # record an anonymous submission with no identity (see PublicFormSubmission).
+  belongs_to :person, optional: true
   belongs_to :form
   belongs_to :event, optional: true
   has_many :form_answers, dependent: :destroy
@@ -212,6 +214,10 @@ class FormSubmission < ApplicationRecord
 
   def bulk_payment?
     role == "bulk_payment"
+  end
+
+  def anonymous?
+    person_id.nil?
   end
 
   # The event this submission belongs to: the directly stored one, or — for

--- a/app/services/other_responses/capture_from_submission.rb
+++ b/app/services/other_responses/capture_from_submission.rb
@@ -23,6 +23,9 @@ module OtherResponses
     end
 
     def call
+      # "Other" responses are person-owned; an anonymous submission has no owner.
+      return unless @submission.person
+
       answers.each do |answer|
         field_identifier = answer.form_field&.field_identifier
         next unless capturable?(field_identifier)

--- a/app/services/public_form_submission.rb
+++ b/app/services/public_form_submission.rb
@@ -1,15 +1,20 @@
 # Records a submission to a standalone, published form filled out at its public
 # pretty URL (see PublicFormsController). Unlike event registration there is no
 # event, role, or account — the respondent is find-or-created as a Person from
-# the form's name/email answers. Answers persist via FormSubmission#persist_answer.
+# the form's name/email answers. When those questions are optional and left
+# blank the submission stands anonymously (person: nil); a required-but-blank
+# identity question is already blocked upstream by the form's field validation.
+# Answers persist via FormSubmission#persist_answer.
 class PublicFormSubmission
   Result = Struct.new(:success?, :form_submission, :person, :errors, keyword_init: true)
 
   ROLE = "public".freeze
 
-  # Shown when the form lacks the name/email questions needed to build a Person.
-  IDENTITY_MISSING_MESSAGE =
-    "This form can't accept submissions yet — it needs a name and email question. Please contact us.".freeze
+  # An agreement form (registration / new job / reinstatement) can't do its job
+  # — process the submission against a Person — without one, so it's rejected
+  # rather than recorded anonymously.
+  IDENTITY_REQUIRED_MESSAGE =
+    "This form needs your name and email to complete your submission.".freeze
 
   def self.call(form:, form_params:)
     new(form:, form_params:).call
@@ -23,9 +28,9 @@ class PublicFormSubmission
   def call
     ActiveRecord::Base.transaction do
       person = find_or_create_person
-      return Result.new(success?: false, errors: [ IDENTITY_MISSING_MESSAGE ]) unless person
+      return Result.new(success?: false, errors: [ IDENTITY_REQUIRED_MESSAGE ]) if @form.requires_identity? && person.nil?
 
-      record_news_subscription(person)
+      record_news_subscription(person) if person
 
       submission = FormSubmission.create!(person: person, form: @form, role: ROLE)
       save_form_answers(submission)
@@ -53,6 +58,9 @@ class PublicFormSubmission
   # no-op when no current on-demand training exists.
   def register_for_on_demand_training(submission)
     return unless @form.role == "registration"
+    # Registration mints a facilitator event registration — impossible without an
+    # identified person, so an anonymous submission skips it.
+    return unless submission.person
 
     event = Event.current_on_demand_facilitator_training
     return unless event
@@ -115,13 +123,16 @@ class PublicFormSubmission
   # A confirmation to the submitter and an FYI to the AWBW team, mirroring the
   # event-registration flow.
   def send_notifications(submission)
-    NotificationServices::CreateNotification.call(
-      noticeable: submission,
-      kind: :form_submission_confirmation,
-      recipient_role: :person,
-      recipient_email: submission.person.preferred_email,
-      notification_type: 0
-    )
+    # An anonymous submission has no submitter to confirm to; only the team FYI goes out.
+    if submission.person
+      NotificationServices::CreateNotification.call(
+        noticeable: submission,
+        kind: :form_submission_confirmation,
+        recipient_role: :person,
+        recipient_email: submission.person.preferred_email,
+        notification_type: 0
+      )
+    end
 
     NotificationServices::CreateNotification.call(
       noticeable: submission,

--- a/app/views/events/public_registrations/_form_field.html.erb
+++ b/app/views/events/public_registrations/_form_field.html.erb
@@ -1,6 +1,8 @@
-<%# locals: (field:, value: nil, label: nil, show_option_source: false, show_dropdown_warning: false, param_scope: "public_registration") %>
+<%# locals: (field:, value: nil, label: nil, show_option_source: false, show_dropdown_warning: false, param_scope: "public_registration", required: nil) %>
 <% param_scope = local_assigns.fetch(:param_scope, "public_registration") %>
 <% return if field.group_header? %>
+<%# Callers can force a field required (e.g. identity on a registration form); defaults to the field's own setting. %>
+<% required = local_assigns.fetch(:required, field.required) %>
 
 <% error = @field_errors&.dig(field.id) %>
 <% error_border = error ? "border-red-400 focus:border-red-500 focus:ring-red-500/30" : "border-gray-300 hover:border-gray-400 focus:border-blue-500 focus:ring-blue-500/30" %>
@@ -10,7 +12,7 @@
   <div class="flex flex-wrap items-center gap-2 mb-1.5">
     <label class="rich-label text-sm font-semibold text-gray-700" for="<%= param_scope %>_form_fields_<%= field.id %>">
       <%= form_label_html(label || field.name) %>
-      <% if field.required %>
+      <% if required %>
         <span class="text-red-500">*</span>
       <% end %>
     </label>
@@ -38,7 +40,7 @@
       <select name="<%= field_name %>"
               id="<%= field_id %>"
               class="<%= input_classes %>"
-              <%= "required" if field.required %>>
+              <%= "required" if required %>>
         <option value="">Select a state</option>
         <% us_states.each do |name, abbr| %>
           <option value="<%= abbr %>" <%= "selected" if value == abbr %>><%= name %> (<%= abbr %>)</option>
@@ -66,7 +68,7 @@
              id="<%= field_id %>"
              value="<%= value %>"
              class="<%= input_classes %>"
-             <%= "required" if field.required %>
+             <%= "required" if required %>
              <%= raw(extra_attrs.join(" ")) %>>
     <% end %>
 
@@ -76,7 +78,7 @@
               rows="4"
               class="<%= input_classes %>"
               <%= "maxlength=\"#{field.effective_max_characters}\"".html_safe if field.effective_max_characters %>
-              <%= "required" if field.required %>><%= value %></textarea>
+              <%= "required" if required %>><%= value %></textarea>
 
   <% when "single_select_radio" %>
     <%# Dynamic fields (e.g. additional_sectors) source options from Sector/Category
@@ -96,7 +98,7 @@
                    class="text-blue-600 focus:ring-blue-500"
                    <%= "data-specify-option-target=\"control\"".html_safe if is_specify %>
                    <%= "checked" if (is_specify ? specify_option_selected?(option_label, value) : value == option_value) || (value.blank? && field.field_identifier == "interested_in_more" && option_value == "Yes") %>
-                   <%= "required" if field.required %>>
+                   <%= "required" if required %>>
             <%= option_label %>
           </span>
           <% if option_description.present? %>
@@ -125,7 +127,7 @@
     <select name="<%= field_name %>"
             id="<%= field_id %>"
             class="<%= input_classes %>"
-            <%= "required" if field.required %>>
+            <%= "required" if required %>>
       <option value="">Select one</option>
       <%# A dropdown can't show subtext, so an option's description is folded into
           the label as "Name (description)". %>
@@ -203,7 +205,7 @@
              data-file-preview-target="input"
              data-action="change->file-preview#update"
              class="block w-full text-sm text-gray-700 file:mr-3 file:rounded-md file:border-0 file:bg-blue-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 rounded-lg border <%= error_border %> bg-white px-2 py-2"
-             <%= "required" if field.required && retained_upload.nil? %>>
+             <%= "required" if required && retained_upload.nil? %>>
       <p data-file-preview-target="filename" class="mt-1.5 text-xs font-medium text-gray-600"></p>
       <p class="mt-1 text-xs text-gray-400">Accepted: <%= FormUploadAsset.accepted_types_label %> (max <%= FormUploadAsset.max_file_size_label %>)</p>
       <img data-file-preview-target="preview"

--- a/app/views/form_submissions/_submission.html.erb
+++ b/app/views/form_submissions/_submission.html.erb
@@ -28,14 +28,16 @@
       </div>
     <% end %>
   <% end %>
-  <% if submission.person.present? %>
-    <div class="py-2">
-      <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Submitted by</dt>
-      <dd class="mt-1 text-sm text-gray-900">
+  <div class="py-2">
+    <dt class="text-xs font-medium text-gray-500 uppercase tracking-wide">Submitted by</dt>
+    <dd class="mt-1 text-sm text-gray-900">
+      <% if submission.person.present? %>
         <%= submission.person.name %> &lt;<%= submission.person.email %>&gt;
-      </dd>
-    </div>
-  <% end %>
+      <% else %>
+        <span class="text-gray-400 italic">Anonymous</span>
+      <% end %>
+    </dd>
+  </div>
   <% if attendees.any? %>
     <div class="pt-6 pb-2 border-b border-gray-200 mb-4">
       <h3 class="text-lg font-semibold text-gray-800">Attendees</h3>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -62,7 +62,7 @@
                   <span class="text-gray-300">—</span>
                 <% end %>
               </td>
-              <% unless @person %><td class="px-4 py-3"><%= submission.person&.name %></td><% end %>
+              <% unless @person %><td class="px-4 py-3"><%= submission.person&.name || content_tag(:span, "Anonymous", class: "text-gray-400 italic") %></td><% end %>
               <td class="px-4 py-3">
                 <%# The submitted organization answer, with whether an org has been
                     directly linked to this submission yet — the "to process" signal.

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -136,6 +136,7 @@
             <span class="text-sm text-gray-800">Publish this form at a public link (anyone can fill it out, no account needed)</span>
           </label>
           <p class="text-xs text-gray-500">Publishes the form at the public link below. A form connected to an event can't be published — event forms are filled out through their event.</p>
+          <p class="text-xs text-gray-500">To accept anonymous submissions, make the name and email questions optional (uncheck "Required" on those fields). A respondent who fills them is still identified; one who skips them submits anonymously. Agreement forms (registration, new job, reinstatement) always require name and email, since each submission is processed against a person.</p>
 
           <div>
             <label class="mb-1 block text-sm font-medium text-gray-700">Public link address</label>
@@ -144,7 +145,7 @@
               <%= f.text_field :slug, placeholder: "volunteer-interest",
                     class: "flex-1 border-0 px-3 py-2 text-sm focus:ring-0" %>
             </div>
-            <p class="mt-1 text-xs text-gray-500">Lowercase letters, numbers, and hyphens. Required to publish. Must include name and email questions to identify who submitted.</p>
+            <p class="mt-1 text-xs text-gray-500">Lowercase letters, numbers, and hyphens. Required to publish. Include name and email questions to identify who submitted — unless anonymous submissions are allowed.</p>
           </div>
 
           <% if @form.publicly_fillable? %>

--- a/app/views/notification_mailer/form_submission_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/form_submission_confirmation_fyi.html.erb
@@ -1,12 +1,14 @@
-<% profile_url = person_url(@person) %>
-
 <p style="margin-bottom: 6px;">
   New form submission
 </p>
 
 <h1 style="margin: 0;">
-  <strong><%= @person.full_name %></strong>
-  (<%= @person.preferred_email %>)
+  <% if @person %>
+    <strong><%= @person.full_name %></strong>
+    (<%= @person.preferred_email %>)
+  <% else %>
+    <strong>Anonymous respondent</strong>
+  <% end %>
 </h1>
 
 <p style="margin: 4px 0 16px; font-size: 13px; color: #6b7280;">
@@ -32,8 +34,10 @@
     View submission
   </a>
 
-  <a href="<%= profile_url %>"
-     style="display:inline-block;background:#e5e7eb;color:#111827;text-decoration:none;padding:10px 16px;border-radius:6px;font-weight:bold;">
-    View profile
-  </a>
+  <% if @person %>
+    <a href="<%= person_url(@person) %>"
+       style="display:inline-block;background:#e5e7eb;color:#111827;text-decoration:none;padding:10px 16px;border-radius:6px;font-weight:bold;">
+      View profile
+    </a>
+  <% end %>
 </p>

--- a/app/views/notification_mailer/form_submission_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/form_submission_confirmation_fyi.text.erb
@@ -1,6 +1,6 @@
 New form submission
 
-<%= @person.full_name %> (<%= @person.preferred_email %>)
+<%= @person ? "#{@person.full_name} (#{@person.preferred_email})" : "Anonymous respondent" %>
 <%= @form.display_name %> · submitted on <%= @submission.created_at
                  .in_time_zone("Pacific Time (US & Canada)")
                  .strftime("%B %-d, %Y at %-l:%M %p %Z") %>
@@ -8,4 +8,4 @@ New form submission
 <% @answers.each do |answer| %><% next if answer.submitted_answer.blank? %><%= answer.question_name_when_answered.presence || answer.form_field&.name %>: <%= answer.submitted_answer %>
 <% end %>
 View submission: <%= form_submission_url(@submission) %>
-View profile: <%= person_url(@person) %>
+<% if @person %>View profile: <%= person_url(@person) %><% end %>

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -21,6 +21,13 @@
     <div class="px-6 py-7 sm:px-8">
       <%= render "forms/header", form: @form %>
 
+      <% if @form.accepts_anonymous_submissions? %>
+        <p class="mb-6 flex items-start gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+          <i class="fa-solid fa-user-secret mt-0.5 text-gray-400"></i>
+          <span>You can submit this form anonymously — name and email are optional.</span>
+        </p>
+      <% end %>
+
       <% if flash[:alert] %>
         <div role="alert" class="mb-6 flex scroll-mt-24 items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800" data-controller="form-errors">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
@@ -41,7 +48,7 @@
             <% else %>
               <% submitted_value = params.dig(:public_registration, :form_fields, field.id.to_s) %>
               <div class="<%= field.grid_span_class %>">
-                <%= render "events/public_registrations/form_field", field: field, value: submitted_value %>
+                <%= render "events/public_registrations/form_field", field: field, value: submitted_value, required: @form.requires_answer?(field) %>
               </div>
             <% end %>
           <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2625,3 +2625,26 @@
     email. Bulk payment now uses the same field names as every other form.
   pro_tips:
     - "Older bulk payment forms keep working — the payer, phone and organization fields are recognised whichever naming they were built with."
+
+- name: "Anonymous form submissions"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-29
+  action_path: "/forms"
+  pr_number: 2350
+  summary: >-
+    Public forms can now be submitted anonymously. Make the name and email
+    questions optional (uncheck "Required") and a respondent who skips them
+    submits without identifying themselves — shown as "Anonymous" in the
+    submissions index.
+  pro_tips:
+    - There's no separate setting — anonymity follows the required status of the
+      name and email questions. Required means everyone identifies; optional lets
+      them skip.
+    - A respondent who does fill name and email is still matched to a person as
+      before; only a skipped identity is anonymous.
+    - Agreement forms (registration, new job, reinstatement) are the exception —
+      they always require name and email, because every submission is processed
+      against a person.
+    - Anonymous responses send the team the usual FYI email but no confirmation
+      goes back (there's no email to send it to).

--- a/db/migrate/20260823003323_add_anonymous_form_submissions.rb
+++ b/db/migrate/20260823003323_add_anonymous_form_submissions.rb
@@ -1,0 +1,15 @@
+class AddAnonymousFormSubmissions < ActiveRecord::Migration[8.0]
+  # Anonymity is a per-form property derived from whether the name/email
+  # questions are required (see PublicFormSubmission) — no stored flag. All this
+  # migration needs is to let a submission stand without a person.
+  def up
+    change_column_null :form_submissions, :person_id, true
+  end
+
+  def down
+    # Can't restore NOT NULL while anonymous (person-less) submissions exist; the
+    # feature that created them is being removed, so drop those rows first.
+    execute "DELETE FROM form_submissions WHERE person_id IS NULL"
+    change_column_null :form_submissions, :person_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -858,7 +858,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_28_160913) do
     t.bigint "event_id"
     t.integer "form_id", null: false
     t.json "metadata"
-    t.bigint "person_id", null: false
+    t.bigint "person_id"
     t.string "role"
     t.string "slug"
     t.datetime "updated_at", null: false

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -56,6 +56,62 @@ RSpec.describe Form do
     end
   end
 
+  describe "#accepts_anonymous_submissions?" do
+    let(:form) { create(:form) }
+
+    it "is true when the name/email questions are all optional" do
+      create(:form_field, form: form, field_identifier: "first_name", required: false)
+      create(:form_field, form: form, field_identifier: "last_name", required: false)
+      create(:form_field, form: form, field_identifier: "primary_email", required: false)
+
+      expect(form.reload.accepts_anonymous_submissions?).to be(true)
+    end
+
+    it "is false when any identity question is required" do
+      create(:form_field, form: form, field_identifier: "first_name", required: false)
+      create(:form_field, form: form, field_identifier: "primary_email", required: true)
+
+      expect(form.reload.accepts_anonymous_submissions?).to be(false)
+    end
+
+    it "is false when the form asks for no identity questions at all" do
+      create(:form_field, form: form, field_identifier: "why_volunteer", required: false)
+
+      expect(form.reload.accepts_anonymous_submissions?).to be(false)
+    end
+
+    Form::AGREEMENT_ROLES.each do |role|
+      it "is false for a #{role} agreement form even when its identity questions are optional" do
+        agreement = create(:form, role: role)
+        create(:form_field, form: agreement, field_identifier: "first_name", required: false)
+        create(:form_field, form: agreement, field_identifier: "last_name", required: false)
+        create(:form_field, form: agreement, field_identifier: "primary_email", required: false)
+
+        expect(agreement.reload.accepts_anonymous_submissions?).to be(false)
+      end
+    end
+  end
+
+  describe "#requires_answer?" do
+    Form::AGREEMENT_ROLES.each do |role|
+      it "forces identity questions on a #{role} agreement form even when flagged optional" do
+        agreement = create(:form, role: role)
+        email = create(:form_field, form: agreement, field_identifier: "primary_email", required: false)
+        other = create(:form_field, form: agreement, field_identifier: "why_volunteer", required: false)
+
+        expect(agreement.requires_answer?(email)).to be(true)
+        expect(agreement.requires_answer?(other)).to be(false)
+      end
+    end
+
+    it "defers to the field's own required flag on a non-agreement form" do
+      general = create(:form)
+      email = create(:form_field, form: general, field_identifier: "primary_email", required: false)
+
+      expect(general.requires_answer?(email)).to be(false)
+    end
+  end
+
   describe '#display_name' do
     let(:user_owner) do
       create(:user)

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe FormSubmission do
   describe "associations" do
-    it { should belong_to(:person) }
+    it { should belong_to(:person).optional }
     it { should belong_to(:form) }
     it { should belong_to(:event).optional }
     it { should have_many(:form_answers).dependent(:destroy) }
@@ -87,6 +87,16 @@ RSpec.describe FormSubmission do
       submission = create(:form_submission, role: "registration")
 
       expect(submission.slug).to be_nil
+    end
+  end
+
+  describe "#anonymous?" do
+    it "is true when there is no person" do
+      expect(build(:form_submission, person: nil)).to be_anonymous
+    end
+
+    it "is false when a person is attached" do
+      expect(build(:form_submission, person: create(:person))).not_to be_anonymous
     end
   end
 

--- a/spec/requests/public_forms_spec.rb
+++ b/spec/requests/public_forms_spec.rb
@@ -79,6 +79,47 @@ RSpec.describe "PublicForms", type: :request do
     end
   end
 
+  describe "anonymous submissions" do
+    before { [ first_name_field, last_name_field, email_field ].each { |field| field.update!(required: false) } }
+
+    it "tells respondents the form can be submitted anonymously" do
+      get public_form_path(form.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("submit this form anonymously")
+    end
+
+    it "records a person-less submission when identity is left blank" do
+      expect { post public_form_path(form.slug), params: submission_params(first: "", last: "", email: "") }
+        .to change(FormSubmission, :count).by(1)
+        .and change(Person, :count).by(0)
+
+      expect(response).to redirect_to(thank_you_public_form_path(form.slug))
+      expect(FormSubmission.last.person).to be_nil
+    end
+
+    it "still builds a person when the respondent fills in name and email" do
+      expect { post public_form_path(form.slug), params: submission_params }
+        .to change(Person, :count).by(1)
+    end
+  end
+
+  describe "agreement-role forms always require identity" do
+    let(:form) { create(:form, name: "On-demand agreement", slug: "collab", published: true, role: "registration") }
+
+    before { [ first_name_field, last_name_field, email_field ].each { |field| field.update!(required: false) } }
+
+    it "does not offer anonymous submission and blocks a blank-identity submission" do
+      get public_form_path(form.slug)
+      expect(response.body).not_to include("submit this form anonymously")
+
+      expect { post public_form_path(form.slug), params: submission_params(first: "", last: "", email: "") }
+        .not_to change(FormSubmission, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
   describe "GET /f/:slug/thank-you" do
     it "renders a confirmation" do
       get thank_you_public_form_path(form.slug)

--- a/spec/services/public_form_submission_spec.rb
+++ b/spec/services/public_form_submission_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe PublicFormSubmission do
         .not_to change(EventRegistration, :count)
     end
 
+    it "rejects a blank-identity submission rather than recording it anonymously" do
+      result = nil
+      expect { result = described_class.call(form: form, form_params: params_for(first: "", last: "", email: "")) }
+        .to change(FormSubmission, :count).by(0)
+        .and change(EventRegistration, :count).by(0)
+
+      expect(result.success?).to be(false)
+      expect(result.errors).to include(PublicFormSubmission::IDENTITY_REQUIRED_MESSAGE)
+    end
+
     it "does not register submissions to non-registration forms" do
       plain = create(:form, slug: "plain", published: true)
       field = create(:form_field, form: plain, field_identifier: "first_name")
@@ -92,14 +102,6 @@ RSpec.describe PublicFormSubmission do
     expect(FormSubmission.last.person).to eq(existing)
   end
 
-  it "fails with a friendly error when the form can't identify the respondent" do
-    result = described_class.call(form: form, form_params: params_for(email: ""))
-
-    expect(result.success?).to be(false)
-    expect(result.errors).to include(PublicFormSubmission::IDENTITY_MISSING_MESSAGE)
-    expect(FormSubmission.count).to eq(0)
-  end
-
   it "sends a confirmation to the submitter and an FYI to admin" do
     expect { described_class.call(form: form, form_params: params_for) }
       .to change { Notification.where(kind: "form_submission_confirmation").count }.by(1)
@@ -108,6 +110,34 @@ RSpec.describe PublicFormSubmission do
     confirmation = Notification.find_by(kind: "form_submission_confirmation")
     expect(confirmation.recipient_email).to eq("sam@example.com")
     expect(confirmation.recipient_role).to eq("person")
+  end
+
+  context "when identity is left blank (optional name/email questions)" do
+    it "records a person-less submission when identity is blank" do
+      result = nil
+      expect { result = described_class.call(form: form, form_params: params_for(first: "", last: "", email: "")) }
+        .to change(FormSubmission, :count).by(1)
+        .and change(Person, :count).by(0)
+
+      expect(result.success?).to be(true)
+      expect(result.form_submission.person).to be_nil
+      expect(result.form_submission).to be_anonymous
+      expect(result.form_submission.form_answers.find_by(form_field: question_field).submitted_answer).to eq("I care.")
+    end
+
+    it "still builds a person when the respondent chooses to identify" do
+      result = nil
+      expect { result = described_class.call(form: form, form_params: params_for) }
+        .to change(Person, :count).by(1)
+
+      expect(result.form_submission.person.email).to eq("sam@example.com")
+    end
+
+    it "skips the submitter confirmation but still sends the admin FYI for an anonymous submission" do
+      expect { described_class.call(form: form, form_params: params_for(first: "", last: "", email: "")) }
+        .to change { Notification.where(kind: "form_submission_confirmation").count }.by(0)
+        .and change { Notification.where(kind: "form_submission_confirmation_fyi").count }.by(1)
+    end
   end
 
   it "subscribes the submitter to News, sourced to the form, when the consent question is answered" do

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -106,6 +106,21 @@ class NotificationMailerPreview < ActionMailer::Preview
     NotificationMailer.form_link_request(notification)
   end
 
+  def form_submission_confirmation_fyi_anonymous
+    submission = FormSubmission.where(role: "public", person_id: nil).order(id: :desc).first ||
+      raise("Need an anonymous (person-less) public FormSubmission to preview")
+
+    notification = Notification.new(
+      noticeable: submission,
+      notification_type: 0,
+      kind: "form_submission_confirmation_fyi",
+      recipient_role: "admin",
+      recipient_email: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+    )
+
+    NotificationMailer.form_submission_confirmation_fyi(notification)
+  end
+
   def idea_submitted
     noticeable = StoryIdea.first || WorkshopVariationIdea.first
     user = noticeable&.created_by || User.first


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 nullable FK + person-optional model change with wide nil-person blast radius

## Why
Public standalone forms required name + email to build a `Person`, so a form meant for anonymous feedback couldn't accept a response (it errored with "needs a name and email question").

## What
A public form now accepts anonymous responses **when its name/email questions aren't required** — no separate setting. Anonymity is derived at read time from the identity questions' required status, not stored on a column.

- Make the name/email questions optional (uncheck "Required") → a respondent who skips them submits with **no `Person`**.
- A respondent who fills them is matched to a `Person` as before.
- Required identity questions still force an identified submission (the field validator enforces it upstream).

### Data / model
- `form_submissions.person_id` is now **nullable**; `FormSubmission belongs_to :person, optional: true`.
- Migration is not a backfill — existing rows keep their `person_id`.

### Derived seam (no stored flag)
- `Form#accepts_anonymous_submissions?` — true when the form asks for name/email but requires none of them. Drives the respondent-facing "you can submit anonymously" note.
- `PublicFormSubmission` records a person-less submission whenever it can't build a `Person`; the "needs a name and email" hard error is gone.

### Nil-person handling
- Skips the submitter confirmation email (no address); team FYI still sends, showing "Anonymous respondent".
- Admin submission index/detail show "Anonymous".
- `OtherResponses::CaptureFromSubmission` no-ops (responses are person-owned); `register_for_on_demand_training` and quote capture guard on person presence.

## Notes
- Pre-existing bulk-payment flows already tolerate a nil person via `current_user&.person`; left untouched (out of scope).