### PR TITLE
Fix intermittent CI: zone-fragile date specs + cold-start query-count guard

### DIFF
--- a/spec/requests/affiliations_spec.rb
+++ b/spec/requests/affiliations_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe "/affiliations", type: :request do
   end
 
   describe "POST /affiliations/:id/end" do
+    # The request runs in the user's (Pacific) zone while these assertions run in
+    # the default UTC zone; freeze to midday UTC so both land on the same calendar
+    # date and the today fallback doesn't drift by a day.
+    before { travel_to Time.current.midday }
+
     context "as an admin" do
       before { sign_in admin }
 

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -289,6 +289,10 @@ RSpec.describe "FormSubmissions", type: :request do
 
     context "processing panel for agreement scenario forms" do
       before { sign_in admin }
+      # The request runs in the user's (Pacific) zone while these assertions run
+      # in the default UTC zone; freeze to midday UTC so both land on the same
+      # calendar date and the submission-derived dates don't drift by a day.
+      before { travel_to Time.current.midday }
 
       let(:form) { create(:form, role: "new_job", name: "Collaboration agreement (new job)") }
       let(:person) { create(:person, user: nil) }
@@ -354,6 +358,10 @@ RSpec.describe "FormSubmissions", type: :request do
       end
 
       before { sign_in admin }
+      # The request runs in the user's (Pacific) zone while these assertions run
+      # in the default UTC zone; freeze to midday UTC so both land on the same
+      # calendar date and the submission-derived dates don't drift by a day.
+      before { travel_to Time.current.midday }
 
       describe "GET /form_submissions/:id/link_organization" do
         it "offers a create-and-link row for a submitted org that isn't in the database" do

--- a/spec/requests/organizations_index_preloading_spec.rb
+++ b/spec/requests/organizations_index_preloading_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe "Organizations index preloading", type: :request do
 
   it "does not issue more queries as more organizations are listed" do
     create_orgs(2)
+    # Warm process-level, once-per-boot memoization (survives Rails.cache.clear) so
+    # the baseline isn't inflated by a first-request query the comparison lacks —
+    # otherwise this flakes when the example runs cold early in a CI group.
+    queries_for_results_frame
     baseline = queries_for_results_frame
 
     create_orgs(6)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 spec-only, but the query-count fix needs the reasoning checked

Two independent, verified CI flakes — both spec-only, no production code changes.

## Timezone-fragile date specs (4 failures)

### Why
A request runs inside the user's zone (Pacific, via `ApplicationController#set_time_zone_from_user`), so `Date.current` / `submission.created_at.to_date` resolve to a Pacific calendar date. The matching assertions run *outside* the request, in the default UTC zone. When CI runs evening-Pacific / after midnight UTC, the two land on different days, the stored dates are off by one, and the specs fail. Verified in PR #2245 / #2348 CI (e.g. `expected Sun, 23 Aug 2026, got Sat, 22 Aug 2026`). App behavior is correct; only the specs were zone-fragile.

### Fix
Froze the clock to `Time.current.midday` (suite's existing `travel_to`, auto-reverted by `after { travel_back }`) in the three affected contexts. Midday UTC is ~5am Pacific, so both zones share a calendar date. Files: `affiliations_spec.rb`, `form_submissions_spec.rb`.

## Cold-start query-count guard (1 failure)

### Why
`organizations_index_preloading_spec.rb:38` guards the index against N+1s. It failed in PR #2245 CI with **baseline 19 vs 18** after adding orgs — the count *dropped* as data grew, so it is not an N+1. The first measured request pays a one-time, once-per-boot query that is memoized past `Rails.cache.clear`; when the example runs cold early in a CI group the baseline is inflated by 1.

### Fix
Added a throwaway frame render before the baseline so both measured requests are warm. The guard still trips on a genuine per-row query (that would raise the post-add count), just not on cold-start noise.

### Anything else to add?
No schema/app changes. All affected examples pass and rubocop is clean. (An earlier note flagged `events_spec.rb:3255` as possibly flaky — no CI run in #2245 or #2348 history actually shows it failing, so it's not included.)