### PR TITLE
Reach the person history through records that hang off a person

### DIFF
--- a/app/services/analytics/person_activity_events.rb
+++ b/app/services/analytics/person_activity_events.rb
@@ -2,8 +2,10 @@ module Analytics
   # Collects every Ahoy event that belongs to a person's history: events about
   # the person record itself, about their user account (both lifecycle and
   # `auth.*` events), and about the associated records surfaced on the person's
-  # "Associated records" panel. Powers the person edit "History" card and the
-  # `person_id` filter on the admin Ahoy activities index.
+  # "Associated records" panel — plus the records that only reach a person
+  # through a parent (registration children, the money ledger, form answers and
+  # their uploads, agreement responses). Powers the person edit "History" card
+  # and the `person_id` filter on the admin Ahoy activities index.
   class PersonActivityEvents
     def initialize(person)
       @person = person
@@ -41,12 +43,23 @@ module Analytics
         # Every comment connected to the person, not just profile comments —
         # reuses PersonCommentAggregator so History and the comments page agree.
         "Comment" => PersonCommentAggregator.new(@person).comments.reorder(nil).select(:id),
-        "EventRegistration" => @person.event_registrations.select(:id),
-        "ContinuingEducationRegistration" => ContinuingEducationRegistration.where(event_registration_id: @person.event_registrations.select(:id)).select(:id),
-        "FormSubmission" => @person.form_submissions.select(:id),
+        "EventRegistration" => registration_ids,
+        "ContinuingEducationRegistration" => ce_registration_ids,
+        "EventRegistrationChecklistCompletion" => EventRegistrationChecklistCompletion.where(event_registration_id: registration_ids).select(:id),
+        "EventRegistrationOrganization" => EventRegistrationOrganization.where(event_registration_id: registration_ids).select(:id),
+        "EventAttendanceTimeEntry" => EventAttendanceTimeEntry.where(event_registration_id: registration_ids).select(:id),
+        "EventStaff" => @person.event_staffs.select(:id),
+        "FormSubmission" => submission_ids,
+        "FormAnswer" => answer_ids,
+        # Uploads only reach a person through the form answer that owns them.
+        "Asset" => Asset.where(owner_type: "FormAnswer", owner_id: answer_ids).select(:id),
         "Grant" => @person.grants.select(:id),
-        "Payment" => Payment.where(person_id: @person.id).select(:id),
-        "Scholarship" => @person.scholarships.select(:id),
+        "Payment" => payment_ids,
+        "Allocation" => allocation_ids,
+        "Refund" => refund_ids,
+        "MembershipInvoice" => @person.membership_invoices.select(:id),
+        "Scholarship" => scholarship_ids,
+        "ScholarshipAgreementResponse" => ScholarshipAgreementResponse.where(scholarship_id: scholarship_ids).select(:id),
         "TopicSubscription" => @person.topic_subscriptions.select(:id),
         "CommunityNews" => @person.community_news_as_author.select(:id),
         "Resource" => @person.resources_as_author.select(:id),
@@ -62,6 +75,46 @@ module Analytics
         map["WorkshopLog"] = user.workshop_logs.select(:id)
       end
       map
+    end
+
+    def registration_ids
+      @registration_ids ||= @person.event_registrations.select(:id)
+    end
+
+    def ce_registration_ids
+      @ce_registration_ids ||= ContinuingEducationRegistration.where(event_registration_id: registration_ids).select(:id)
+    end
+
+    def submission_ids
+      @submission_ids ||= @person.form_submissions.select(:id)
+    end
+
+    def answer_ids
+      @answer_ids ||= FormAnswer.where(form_submission_id: submission_ids).select(:id)
+    end
+
+    def payment_ids
+      @payment_ids ||= Payment.where(person_id: @person.id).select(:id)
+    end
+
+    def scholarship_ids
+      @scholarship_ids ||= @person.scholarships.select(:id)
+    end
+
+    # An allocation is money moving against something this person owes: their
+    # registration, its CE add-on, or a membership invoice.
+    def allocation_ids
+      Allocation.where(allocatable_type: "EventRegistration", allocatable_id: registration_ids)
+        .or(Allocation.where(allocatable_type: "ContinuingEducationRegistration", allocatable_id: ce_registration_ids))
+        .or(Allocation.where(allocatable_type: "MembershipInvoice", allocatable_id: @person.membership_invoices.select(:id)))
+        .select(:id)
+    end
+
+    # Theirs when they receive it, or when it reverses a payment they made.
+    def refund_ids
+      Refund.where(recipient_type: "Person", recipient_id: @person.id)
+        .or(Refund.where(refundable_type: "Payment", refundable_id: payment_ids))
+        .select(:id)
     end
 
     # Auth events store the user under properties.record_id/record_type rather

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -145,6 +145,19 @@ RSpec.describe Analytics::PersonActivityEvents do
       end
     end
 
+    # Most mapped types have no dedicated inclusion example above, so a typo or
+    # model rename in a key would silently drop that type from the history. This
+    # guard derives from the map itself and fails loudly instead.
+    it "keys the map only on real trackable model classes" do
+      map = described_class.new(person).send(:resource_ids_by_type)
+
+      map.each_key do |resource_type|
+        klass = resource_type.safe_constantize
+        expect(klass).to be_present, "#{resource_type} is not a real constant"
+        expect(klass).to be < ApplicationRecord
+      end
+    end
+
     it "excludes events unrelated to the person" do
       unrelated_person = create(:person)
       other = event(resource_type: "Person", resource_id: unrelated_person.id, name: "update.person")

--- a/spec/services/analytics/person_activity_events_spec.rb
+++ b/spec/services/analytics/person_activity_events_spec.rb
@@ -59,6 +59,92 @@ RSpec.describe Analytics::PersonActivityEvents do
       expect(described_class.new(person).relation).to include(target)
     end
 
+    # These records only reach a person through a parent, so the mapping is the
+    # only thing putting them on the history — one example per hop.
+    describe "records that reach the person through a parent" do
+      let(:registration) { create(:event_registration, registrant: person) }
+
+      it "includes the registration's checklist completions, org links, and attendance entries" do
+        completion = create(:event_registration_checklist_completion, event_registration: registration)
+        org_link = create(:event_registration_organization, event_registration: registration)
+        entry = create(:event_attendance_time_entry, event_registration: registration)
+
+        relation = described_class.new(person).relation
+
+        expect(relation).to include(event(resource_type: "EventRegistrationChecklistCompletion", resource_id: completion.id))
+        expect(relation).to include(event(resource_type: "EventRegistrationOrganization", resource_id: org_link.id))
+        expect(relation).to include(event(resource_type: "EventAttendanceTimeEntry", resource_id: entry.id))
+      end
+
+      it "includes the events they staff" do
+        staffing = create(:event_staff, person: person)
+
+        expect(described_class.new(person).relation)
+          .to include(event(resource_type: "EventStaff", resource_id: staffing.id))
+      end
+
+      it "includes their membership invoices" do
+        invoice = create(:membership_invoice, membership: create(:membership, person: person))
+
+        expect(described_class.new(person).relation)
+          .to include(event(resource_type: "MembershipInvoice", resource_id: invoice.id))
+      end
+
+      it "includes allocations against anything they owe" do
+        payment = create(:payment, person: person)
+        invoice = create(:membership_invoice, membership: create(:membership, person: person))
+        ce = create(:continuing_education_registration, event_registration: registration)
+        targets = [ registration, invoice, ce ].map do |allocatable|
+          allocation = create(:allocation, source: payment, allocatable: allocatable)
+          [ allocatable.class.name, event(resource_type: "Allocation", resource_id: allocation.id) ]
+        end
+
+        relation = described_class.new(person).relation
+
+        targets.each do |allocatable_type, target|
+          expect(relation).to include(target), "expected the #{allocatable_type} allocation on the history"
+        end
+      end
+
+      it "includes refunds they receive and refunds reversing their payments" do
+        theirs = create(:refund, recipient: person, refundable: create(:payment, person: person))
+        on_their_payment = create(:refund, recipient: create(:organization), refundable: create(:payment, person: person))
+
+        relation = described_class.new(person).relation
+
+        expect(relation).to include(event(resource_type: "Refund", resource_id: theirs.id))
+        expect(relation).to include(event(resource_type: "Refund", resource_id: on_their_payment.id))
+      end
+
+      it "includes their form answers and the uploads attached to them" do
+        answer = create(:form_answer, form_submission: create(:form_submission, person: person))
+        asset = create(:asset, owner: answer)
+
+        relation = described_class.new(person).relation
+
+        expect(relation).to include(event(resource_type: "FormAnswer", resource_id: answer.id))
+        expect(relation).to include(event(resource_type: "Asset", resource_id: asset.id))
+      end
+
+      it "includes responses to their scholarship agreements" do
+        response = create(:scholarship_agreement_response, scholarship: create(:scholarship, recipient: person))
+
+        expect(described_class.new(person).relation)
+          .to include(event(resource_type: "ScholarshipAgreementResponse", resource_id: response.id))
+      end
+
+      it "excludes the same record types when they belong to someone else" do
+        other_registration = create(:event_registration)
+        completion = create(:event_registration_checklist_completion, event_registration: other_registration)
+        allocation = create(:allocation, allocatable: other_registration)
+
+        relation = described_class.new(person).relation
+
+        expect(relation).not_to include(event(resource_type: "EventRegistrationChecklistCompletion", resource_id: completion.id))
+        expect(relation).not_to include(event(resource_type: "Allocation", resource_id: allocation.id))
+      end
+    end
+
     it "excludes events unrelated to the person" do
       unrelated_person = create(:person)
       other = event(resource_type: "Person", resource_id: unrelated_person.id, name: "update.person")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained: ten resource types added to one query service, no schema change

Part of #2251.

## Reach, not tracking

`AhoyTrackable` already covers every model, so a person's history isn't missing events — it's missing **routes to them**. `Analytics::PersonActivityEvents` maps `person → ids` per `resource_type`, and records that connect to a person only through a parent were absent from that map.

Nothing needs backfilling: the mapping is read-time, so it covers everything already recorded.

## Ten types added

- **Registration children** — `EventRegistrationChecklistCompletion`, `EventRegistrationOrganization`, `EventAttendanceTimeEntry`
- **Staffing** — `EventStaff`
- **Money** — `Allocation` (through registration / CE registration / membership invoice), `Refund` (recipient, or reversing one of their payments), `MembershipInvoice`
- **Forms** — `FormAnswer`, plus the `Asset` uploads those answers own
- **Scholarships** — `ScholarshipAgreementResponse`

Repeated subqueries (registration / submission / payment / scholarship ids) are memoized rather than rebuilt inline.

## How to test

1. `ai/server`, sign in as an admin.
2. Act on something that reaches a person through a registration — add a payment/allocation, tick an onboarding checklist step, upload a form answer file.
3. Open `/people/:id/edit` → *Associated records* → **History**, or `/admin/activities/events?person_id=:id&time_period=all_time&audience[]=visitors&audience[]=users&audience[]=staff`.
4. Look at the **Activity** column for `create.allocation`, `update.event_registration_checklist_completion`, `create.form_answer`, `create.asset`. On `main` none of those can reach a person's history no matter how many exist.

## Scope: all ten, decided

Keeping the full set, including the mechanical ones (`create.allocation`, `update.event_registration_checklist_completion`, `update.event_attendance_time_entry`). The history is meant to be complete; filtering for readability belongs in the UI, not in what reaches the page.

## Note on the approach

This reaches the records at read time — the relation is an OR of ~33 subqueries, bounded per person. #2251 sketches a denormalized tag table instead; that's a different mechanism for a wider problem (event and organization timelines), and not a blocker here.

## Test guard

- Added a spec asserting every `resource_type` key in the map resolves to a real `ApplicationRecord` — most mapped types have no inclusion example, so a rename/typo would otherwise drop that type from the history silently.
