### PR TITLE
Save org removal when unchecking the last chip on registration edit

### DIFF
--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -257,6 +257,9 @@
           </div>
 
           <div class="flex flex-1 flex-col p-4">
+            <%# Fallback so unchecking every org chip still submits an empty organization_ids
+                array — otherwise no key is sent and the removal is silently dropped. %>
+            <input type="hidden" name="event_registration[organization_ids][]" value="">
             <div data-org-toggle-target="section" <%= "hidden" unless f.object.organizations.any? %>>
               <div class="flex flex-wrap gap-1.5" data-org-toggle-target="chips">
                 <%# Matched pair (like the registrants roster): the org name as a grey

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -451,6 +451,17 @@ RSpec.describe "EventRegistrations", type: :request do
         expect(response.body).to include("A Window Between Worlds")
       end
 
+      it "renders a hidden fallback so unchecking the last org still submits an empty set" do
+        organization = create(:organization, name: "A Window Between Worlds")
+        existing_registration.organizations << organization
+
+        get edit_event_registration_path(existing_registration)
+
+        expect(response.body).to include(
+          "<input type=\"hidden\" name=\"event_registration[organization_ids][]\" value=\"\""
+        )
+      end
+
       it "shows a Delete button for a deletable registration" do
         get edit_event_registration_path(existing_registration)
 
@@ -643,6 +654,16 @@ RSpec.describe "EventRegistrations", type: :request do
           registrants_event_path(new_event, anchor: "registrant-row-#{existing_registration.id}", highlight: existing_registration.id)
         )
         expect(existing_registration.reload.event_id).to eq(new_event.id)
+      end
+
+      it "removes a linked organization when the last chip is unchecked" do
+        organization = create(:organization)
+        existing_registration.organizations << organization
+
+        patch event_registration_path(existing_registration),
+              params: { event_registration: { organization_ids: [ "" ] } }
+
+        expect(existing_registration.reload.organizations).to be_empty
       end
 
       it "returns to the attendance report after saving when opened from it" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line view fix for a dropped-param bug, covered by two request specs

## Why
Unchecking the only (or last) linked-organization chip on the event registration edit form didn't save the removal.

- The chips are hand-rolled checkboxes with no hidden fallback field.
- An all-unchecked collection sends no `organization_ids` param, so strong params drops it and `organization_ids=` never runs — the join rows survive.

## Fix
- Add the hidden empty-value input Rails' own `collection_check_boxes` emits, so an all-unchecked collection still POSTs an empty array and the removal clears the rows.

## Tests
- Edit form renders the hidden fallback field.
- PATCH with the (post-fix) empty array removes the last linked org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)