### PR TITLE
Add optional organization reference to topic subscriptions

### DIFF
--- a/app/controllers/topic_subscriptions_controller.rb
+++ b/app/controllers/topic_subscriptions_controller.rb
@@ -8,7 +8,7 @@ class TopicSubscriptionsController < ApplicationController
     # active), so exclude status from the shared filter and apply it here.
     base = TopicSubscription
       .search_by_params(params.except(:status))
-      .includes(:topic_subscription_type, :interested_event, person: [ :user, { event_registrations: :event } ])
+      .includes(:topic_subscription_type, :interested_event, :organization, person: [ :user, { event_registrations: :event } ])
 
     @active_count = base.active.count
     @unsubscribed_count = base.unsubscribed.count
@@ -50,6 +50,7 @@ class TopicSubscriptionsController < ApplicationController
     @topic_subscription = TopicSubscription.new(
       topic_subscription_type_id: new_topic_type_id,
       interested_event_id: params[:interested_event_id],
+      organization_id: params[:organization_id],
       person_id: params[:person_id]
     )
   end
@@ -122,7 +123,7 @@ class TopicSubscriptionsController < ApplicationController
   end
 
   def topic_subscription_params
-    permitted = params.require(:topic_subscription).permit(:person_id, :topic_subscription_type_id, :interested_event_id, :source,
+    permitted = params.require(:topic_subscription).permit(:person_id, :topic_subscription_type_id, :interested_event_id, :organization_id, :source,
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
       person_attributes: [ :first_name, :last_name, :email ])
 

--- a/app/decorators/topic_subscription_decorator.rb
+++ b/app/decorators/topic_subscription_decorator.rb
@@ -23,11 +23,12 @@ class TopicSubscriptionDecorator < ApplicationDecorator
     h.render "shared/badge", label: label, classes: classes, icon: icon, icon_html: icon_html, href: href
   end
 
-  # The specific event this subscription narrows to, "Any — <topic>" for a broad
-  # subscription to an event-oriented topic, or "N/A" for topics with no event
-  # dimension (e.g. News).
+  # The specific event this subscription narrows to — its abbreviation when set,
+  # else the full title (via the event's compact label) — "Any — <topic>" for a
+  # broad subscription to an event-oriented topic, or "N/A" for topics with no
+  # event dimension (e.g. News).
   def event_label
-    return interested_event.title if interested_event
+    return interested_event.decorate.compact_label if interested_event
     topic_subscription_type&.event_selector? ? "Any — #{topic_label.downcase}" : "N/A"
   end
 

--- a/app/decorators/topic_subscription_decorator.rb
+++ b/app/decorators/topic_subscription_decorator.rb
@@ -37,10 +37,4 @@ class TopicSubscriptionDecorator < ApplicationDecorator
   def general_event_scope?
     general? && topic_subscription_type&.event_selector?
   end
-
-  # The organization this subscription is narrowed to, or nil when it isn't tied
-  # to one.
-  def organization_label
-    organization&.name
-  end
 end

--- a/app/decorators/topic_subscription_decorator.rb
+++ b/app/decorators/topic_subscription_decorator.rb
@@ -36,4 +36,10 @@ class TopicSubscriptionDecorator < ApplicationDecorator
   def general_event_scope?
     general? && topic_subscription_type&.event_selector?
   end
+
+  # The organization this subscription is narrowed to, or nil when it isn't tied
+  # to one.
+  def organization_label
+    organization&.name
+  end
 end

--- a/app/decorators/topic_subscription_decorator.rb
+++ b/app/decorators/topic_subscription_decorator.rb
@@ -25,11 +25,11 @@ class TopicSubscriptionDecorator < ApplicationDecorator
 
   # The specific event this subscription narrows to — its abbreviation when set,
   # else the full title (via the event's compact label) — "Any — <topic>" for a
-  # broad subscription to an event-oriented topic, or "N/A" for topics with no
-  # event dimension (e.g. News).
+  # broad subscription to an event-oriented topic, or nil for topics with no event
+  # dimension (e.g. News), so callers render nothing rather than an "N/A".
   def event_label
     return interested_event.decorate.compact_label if interested_event
-    topic_subscription_type&.event_selector? ? "Any — #{topic_label.downcase}" : "N/A"
+    "Any — #{topic_label.downcase}" if topic_subscription_type&.event_selector?
   end
 
   # A broad ("Any") subscription to an event-oriented topic — the case the index

--- a/app/helpers/topic_subscription_helper.rb
+++ b/app/helpers/topic_subscription_helper.rb
@@ -2,7 +2,7 @@ module TopicSubscriptionHelper
   # The filters the subscriptions index applies. They ride along on links off the
   # index and back through the form so a return trip lands on the same filtered
   # list rather than the bare index.
-  INDEX_FILTER_KEYS = %w[person_id organization_id topic_subscription_type_id status page].freeze
+  INDEX_FILTER_KEYS = %w[person_id organization_name topic_subscription_type_id status page].freeze
 
   # Where a subscription form came from, keyed by the `return_to` param its
   # originating link set (the subscriptions index, an event's Forms menu, or a
@@ -56,10 +56,7 @@ module TopicSubscriptionHelper
       filters << [ "Person", person&.full_name || "Unknown" ]
     end
 
-    if params[:organization_id].present?
-      organization = Organization.find_by(id: params[:organization_id])
-      filters << [ "Organization", organization&.name || "Unknown" ]
-    end
+    filters << [ "Organization", params[:organization_name] ] if params[:organization_name].present?
 
     if params[:topic_subscription_type_id].present?
       topic = TopicSubscriptionType.find_by(id: params[:topic_subscription_type_id])

--- a/app/helpers/topic_subscription_helper.rb
+++ b/app/helpers/topic_subscription_helper.rb
@@ -2,7 +2,7 @@ module TopicSubscriptionHelper
   # The filters the subscriptions index applies. They ride along on links off the
   # index and back through the form so a return trip lands on the same filtered
   # list rather than the bare index.
-  INDEX_FILTER_KEYS = %w[person_id topic_subscription_type_id status page].freeze
+  INDEX_FILTER_KEYS = %w[person_id organization_id topic_subscription_type_id status page].freeze
 
   # Where a subscription form came from, keyed by the `return_to` param its
   # originating link set (the subscriptions index, an event's Forms menu, or a
@@ -54,6 +54,11 @@ module TopicSubscriptionHelper
     if params[:person_id].present?
       person = Person.find_by(id: params[:person_id])
       filters << [ "Person", person&.full_name || "Unknown" ]
+    end
+
+    if params[:organization_id].present?
+      organization = Organization.find_by(id: params[:organization_id])
+      filters << [ "Organization", organization&.name || "Unknown" ]
     end
 
     if params[:topic_subscription_type_id].present?

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -26,6 +26,10 @@ class TopicSubscription < ApplicationRecord
   scope :active, -> { where(unsubscribed_at: nil) }
   scope :unsubscribed, -> { where.not(unsubscribed_at: nil) }
   scope :for_topic_type, ->(type) { where(topic_subscription_type: type) }
+  scope :by_organization_name, ->(name) {
+    next all if name.blank?
+    joins(:organization).where("organizations.name LIKE ?", "%#{sanitize_sql_like(name)}%")
+  }
   scope :newest_first, -> { order(subscribed_at: :desc) }
   scope :comment_status, ->(value) {
     commented = Comment.where(commentable_type: "TopicSubscription").select(:commentable_id)
@@ -39,12 +43,12 @@ class TopicSubscription < ApplicationRecord
 
   # Drives the subscriptions index filters: person, organization, topic type, and
   # status ("active"/"unsubscribed" — the two the segmented toggle emits). The
-  # person and organization filters are exact ids — the index picks both through
-  # the remote-select search, so there's no free-text name matching to do here.
+  # person filter is an exact id (picked through the remote-select search), while
+  # organization is a free-text name match against the linked org.
   def self.search_by_params(params)
     scope = all
     scope = scope.where(person_id: params[:person_id]) if params[:person_id].present?
-    scope = scope.where(organization_id: params[:organization_id]) if params[:organization_id].present?
+    scope = scope.by_organization_name(params[:organization_name]) if params[:organization_name].present?
     scope = scope.for_topic_type(params[:topic_subscription_type_id]) if params[:topic_subscription_type_id].present?
     scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
 

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -4,6 +4,9 @@ class TopicSubscription < ApplicationRecord
   # Optional narrowing to a specific event (e.g. one training). Null = the topic
   # broadly.
   belongs_to :interested_event, class_name: "Event", optional: true
+  # Optional narrowing to a specific organization. Null = the topic isn't tied
+  # to any organization.
+  belongs_to :organization, optional: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -37,13 +37,14 @@ class TopicSubscription < ApplicationRecord
     end
   }
 
-  # Drives the subscriptions index filters: person, topic type, and status
-  # ("active"/"unsubscribed" — the two the segmented toggle emits). The person
-  # filter is an exact id — the index picks people through the remote-select
-  # search, so there's no free-text name matching to do here.
+  # Drives the subscriptions index filters: person, organization, topic type, and
+  # status ("active"/"unsubscribed" — the two the segmented toggle emits). The
+  # person and organization filters are exact ids — the index picks both through
+  # the remote-select search, so there's no free-text name matching to do here.
   def self.search_by_params(params)
     scope = all
     scope = scope.where(person_id: params[:person_id]) if params[:person_id].present?
+    scope = scope.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     scope = scope.for_topic_type(params[:topic_subscription_type_id]) if params[:topic_subscription_type_id].present?
     scope = scope.comment_status(params[:comment_status]) if params[:comment_status].present?
 

--- a/app/views/topic_subscriptions/_form.html.erb
+++ b/app/views/topic_subscriptions/_form.html.erb
@@ -130,6 +130,18 @@
     <p class="mt-1 text-xs text-gray-500">Choose a specific upcoming event, or “All upcoming events”.</p>
   </div>
 
+  <%# Organization — optional narrowing to a specific org, unrelated to the topic's
+      event dimension, so it's always shown (not gated on the topic like Event). %>
+  <div>
+    <%= f.label :organization_id, "Organization", class: label_class %>
+    <%= f.select :organization_id,
+      options_for_select(Organization.where(id: @topic_subscription.organization_id).map { |o| [ o.name, o.id ] }, @topic_subscription.organization_id),
+      { include_blank: true, prompt: "Search for an organization" },
+      class: field_class,
+      data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+    <p class="mt-1 text-xs text-gray-500">Optional — narrow this subscription to a specific organization.</p>
+  </div>
+
   <div>
     <%= f.label :source, class: label_class %>
     <%= f.text_field :source, class: field_class, placeholder: "e.g. Facilitator Training registration, admin" %>

--- a/app/views/topic_subscriptions/_search_boxes.html.erb
+++ b/app/views/topic_subscriptions/_search_boxes.html.erb
@@ -19,6 +19,16 @@
               onchange: "this.form.requestSubmit()",
               data: { controller: "remote-select", remote_select_model_value: "person" } %>
       </div>
+      <div class="flex-1 min-w-[200px]">
+        <%= f.label :organization_id, "Organization", class: label_class %>
+        <%= select_tag :organization_id,
+              options_for_select(Organization.where(id: params[:organization_id]).map { |organization| [ organization.name, organization.id ] }, params[:organization_id]),
+              include_blank: true,
+              prompt: "Search for an organization",
+              class: field_class,
+              onchange: "this.form.requestSubmit()",
+              data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+      </div>
       <div class="min-w-[180px]">
         <%= f.label :topic_subscription_type_id, "Topic", class: label_class %>
         <%= f.select :topic_subscription_type_id,

--- a/app/views/topic_subscriptions/_search_boxes.html.erb
+++ b/app/views/topic_subscriptions/_search_boxes.html.erb
@@ -20,14 +20,13 @@
               data: { controller: "remote-select", remote_select_model_value: "person" } %>
       </div>
       <div class="flex-1 min-w-[200px]">
-        <%= f.label :organization_id, "Organization", class: label_class %>
-        <%= select_tag :organization_id,
-              options_for_select(Organization.where(id: params[:organization_id]).map { |organization| [ organization.name, organization.id ] }, params[:organization_id]),
-              include_blank: true,
-              prompt: "Search for an organization",
-              class: field_class,
-              onchange: "this.form.requestSubmit()",
-              data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+        <%= f.label :organization_name, "Organization", class: label_class %>
+        <div class="relative">
+          <%= text_field_tag :organization_name, params[:organization_name],
+                class: search_field_class(extra: "bg-white pr-10"),
+                placeholder: "Search by organization name" %>
+          <%= render "shared/search_submit" %>
+        </div>
       </div>
       <div class="min-w-[180px]">
         <%= f.label :topic_subscription_type_id, "Topic", class: label_class %>

--- a/app/views/topic_subscriptions/index.html.erb
+++ b/app/views/topic_subscriptions/index.html.erb
@@ -15,7 +15,7 @@
         <i class="fa-solid fa-envelope-open-text <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
         Subscriptions
       </h1>
-      <p class="text-gray-600 mt-1">People subscribed to hear about a topic.</p>
+      <p class="text-gray-600 mt-1">People with whom we are corresponding about a topic.</p>
     </div>
     <div class="flex items-center gap-2">
       <%# Carry the index's filters so the form prefills from them (person, topic)

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -74,7 +74,7 @@
                     <%# Org the subscription is narrowed to, linked to its profile; outside the
                         person card so it isn't a link nested in a link. %>
                     <%= link_to organization_path(subscription.organization),
-                                class: "mt-1 inline-flex max-w-56 items-center gap-1 text-xs text-gray-400 hover:text-gray-600 hover:underline",
+                                class: "mt-1 inline-flex max-w-56 items-center gap-1 pl-2 text-xs text-gray-400 hover:text-gray-600 hover:underline",
                                 data: { turbo_frame: "_top" } do %>
                       <i class="fa-solid fa-building flex-shrink-0 text-2xs"></i>
                       <span class="truncate"><%= subscription.organization.name %></span>
@@ -84,19 +84,19 @@
 
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <div class="font-medium"><%= subscription.topic_label %></div>
-                  <div class="mt-0.5 text-xs text-gray-500">
-                    <% if subscription.general_event_scope? %>
+                  <% if subscription.general_event_scope? %>
+                    <div class="mt-0.5 text-xs text-gray-500">
                       <span class="inline-flex items-center gap-1">
                         <i class="fa-solid fa-layer-group text-2xs"></i>
                         <%= subscription.event_label %>
                       </span>
-                    <% elsif subscription.interested_event %>
-                      <%# The label may be a terse abbreviation, so carry the full title as a tooltip. %>
+                    </div>
+                  <% elsif subscription.interested_event %>
+                    <%# The label may be a terse abbreviation, so carry the full title as a tooltip. %>
+                    <div class="mt-0.5 text-xs text-gray-500">
                       <span title="<%= subscription.interested_event.title %>"><%= subscription.event_label %></span>
-                    <% else %>
-                      <%= subscription.event_label %>
-                    <% end %>
-                  </div>
+                    </div>
+                  <% end %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -74,7 +74,7 @@
                     <%# Org the subscription is narrowed to, linked to its profile; outside the
                         person card so it isn't a link nested in a link. %>
                     <%= link_to organization_path(subscription.organization),
-                                class: "mt-1 inline-flex max-w-56 items-center gap-1 text-xs #{DomainTheme.text_class_for(:organizations, intensity: 700)} #{DomainTheme.text_class_for(:organizations, intensity: 800, hover: true)} hover:underline",
+                                class: "mt-1 inline-flex max-w-56 items-center gap-1 text-xs text-gray-400 hover:text-gray-600 hover:underline",
                                 data: { turbo_frame: "_top" } do %>
                       <i class="fa-solid fa-building flex-shrink-0 text-2xs"></i>
                       <span class="truncate"><%= subscription.organization.name %></span>

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -29,7 +29,6 @@
             <tr>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Person</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Topic</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Training registrations</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Subscribed</th>
             </tr>
@@ -71,6 +70,16 @@
                     <% end %>
                     <%= subscription.status_badge %>
                   </div>
+                  <% if subscription.organization %>
+                    <%# Org the subscription is narrowed to, linked to its profile; outside the
+                        person card so it isn't a link nested in a link. %>
+                    <%= link_to organization_path(subscription.organization),
+                                class: "mt-1 inline-flex max-w-56 items-center gap-1 text-xs #{DomainTheme.text_class_for(:organizations, intensity: 700)} #{DomainTheme.text_class_for(:organizations, intensity: 800, hover: true)} hover:underline",
+                                data: { turbo_frame: "_top" } do %>
+                      <i class="fa-solid fa-building flex-shrink-0 text-2xs"></i>
+                      <span class="truncate"><%= subscription.organization.name %></span>
+                    <% end %>
+                  <% end %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">
@@ -88,10 +97,6 @@
                       <%= subscription.event_label %>
                     <% end %>
                   </div>
-                </td>
-
-                <td class="px-4 py-2 text-sm text-gray-800">
-                  <%= subscription.organization_label || content_tag(:span, "—", class: "text-gray-400") %>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -29,11 +29,8 @@
             <tr>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Person</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Topic</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Event</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Status</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Training registrations</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Source</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Subscribed</th>
             </tr>
           </thead>
@@ -57,38 +54,45 @@
                     <% icon_classes = "text-gray-300" %>
                     <% email_classes = "text-gray-300" %>
                   <% end %>
-                  <%= link_to edit_topic_subscription_path(subscription, topic_subscription_index_filters.merge(return_to: "index")),
-                              title: [ person.name, person.preferred_email ].compact_blank.join(" — "),
-                              class: "group flex items-center gap-2 w-56 max-w-full px-2 py-1 rounded-lg border shadow-sm leading-tight transition-colors duration-200 overflow-hidden #{card_classes}",
-                              data: { turbo_frame: "_top", turbo_prefetch: false } do %>
-                    <i class="fa-solid fa-envelope-open-text flex-shrink-0 <%= icon_classes %>"></i>
-                    <div class="flex min-w-0 flex-col justify-center">
-                      <span class="truncate text-xs font-semibold"><%= truncate(person.name.to_s, length: 30) %></span>
-                      <% if person.preferred_email.present? %>
-                        <!--email_off--><span class="truncate text-xs font-normal <%= email_classes %>"><%= person.preferred_email %></span><!--email_on-->
-                      <% end %>
-                    </div>
-                  <% end %>
+                  <%# Status sits right of the person card — the card is already a link to
+                      edit, so the badge is a plain pill (no nested link). %>
+                  <div class="flex items-center gap-2">
+                    <%= link_to edit_topic_subscription_path(subscription, topic_subscription_index_filters.merge(return_to: "index")),
+                                title: [ person.name, person.preferred_email ].compact_blank.join(" — "),
+                                class: "group flex items-center gap-2 w-56 max-w-full px-2 py-1 rounded-lg border shadow-sm leading-tight transition-colors duration-200 overflow-hidden #{card_classes}",
+                                data: { turbo_frame: "_top", turbo_prefetch: false } do %>
+                      <i class="fa-solid fa-envelope-open-text flex-shrink-0 <%= icon_classes %>"></i>
+                      <div class="flex min-w-0 flex-col justify-center">
+                        <span class="truncate text-xs font-semibold"><%= truncate(person.name.to_s, length: 30) %></span>
+                        <% if person.preferred_email.present? %>
+                          <!--email_off--><span class="truncate text-xs font-normal <%= email_classes %>"><%= person.preferred_email %></span><!--email_on-->
+                        <% end %>
+                      </div>
+                    <% end %>
+                    <%= subscription.status_badge %>
+                  </div>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-gray-800"><%= subscription.topic_label %></td>
-
                 <td class="px-4 py-2 text-sm text-gray-800">
-                  <% if subscription.general_event_scope? %>
-                    <span class="inline-flex items-center gap-1.5 text-gray-500">
-                      <i class="fa-solid fa-layer-group text-xs"></i>
+                  <div class="font-medium"><%= subscription.topic_label %></div>
+                  <div class="mt-0.5 text-xs text-gray-500">
+                    <% if subscription.general_event_scope? %>
+                      <span class="inline-flex items-center gap-1">
+                        <i class="fa-solid fa-layer-group text-2xs"></i>
+                        <%= subscription.event_label %>
+                      </span>
+                    <% elsif subscription.interested_event %>
+                      <%# The label may be a terse abbreviation, so carry the full title as a tooltip. %>
+                      <span title="<%= subscription.interested_event.title %>"><%= subscription.event_label %></span>
+                    <% else %>
                       <%= subscription.event_label %>
-                    </span>
-                  <% else %>
-                    <%= subscription.event_label %>
-                  <% end %>
+                    <% end %>
+                  </div>
                 </td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <%= subscription.organization_label || content_tag(:span, "—", class: "text-gray-400") %>
                 </td>
-
-                <td class="px-4 py-2 text-sm"><%= subscription.status_badge(href: edit_topic_subscription_path(subscription, topic_subscription_index_filters.merge(return_to: "index"))) %></td>
 
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <% registrations = subscription.person_facilitator_training_registrations %>
@@ -106,9 +110,10 @@
                   <% end %>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-gray-500"><%= subscription.source.presence || "—" %></td>
-
-                <td class="px-4 py-2 text-sm text-nowrap text-gray-500"><%= subscription.subscribed_at.strftime("%B %d, %Y") %></td>
+                <td class="px-4 py-2 text-sm text-gray-500">
+                  <div class="text-nowrap"><%= subscription.subscribed_at.strftime("%B %d, %Y") %></div>
+                  <div class="mt-0.5 text-xs text-gray-400"><%= subscription.source.presence || "—" %></div>
+                </td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -1,12 +1,12 @@
 <%= turbo_frame_tag :topic_subscriptions_results do %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit">
+  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
     <%# Outside the empty check: with nothing to list, the toggle is the only way
         back to the other status. It navigates the whole page rather than this
         frame so the filter form — which lives outside the frame and carries the
         status through every other filter change — is re-rendered with it. %>
     <% total = @topic_subscriptions.respond_to?(:total_entries) ? @topic_subscriptions.total_entries : @topic_subscriptions.size %>
     <% toggle_params = request.query_parameters.except("page") %>
-    <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+    <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Status filter">
         <%= link_to topic_subscriptions_path(toggle_params.merge(status: "active")),
               data: { turbo_frame: "_top" },
@@ -23,13 +23,14 @@
     </div>
 
     <% if @topic_subscriptions.any? %>
-      <div class="overflow-x-auto animate-fade">
+      <div class="animate-fade overflow-x-auto">
         <table class="w-full border-collapse border border-gray-200">
           <thead class="bg-gray-100">
             <tr>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Person</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Topic</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Event</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Status</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Training registrations</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Source</th>
@@ -40,7 +41,7 @@
           <tbody class="divide-y divide-gray-200">
             <% @topic_subscriptions.each do |subscription| %>
               <% subscription = subscription.decorate %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150 align-middle <%= "text-gray-500" unless subscription.active? %>">
+              <tr class="align-middle transition-colors duration-150 hover:bg-gray-50 <%= "text-gray-500" unless subscription.active? %>">
                 <td class="px-4 py-2 text-sm">
                   <% person = subscription.person %>
                   <%# Active is a light card with the page's stone tone; unsubscribed keeps a
@@ -61,10 +62,10 @@
                               class: "group flex items-center gap-2 w-56 max-w-full px-2 py-1 rounded-lg border shadow-sm leading-tight transition-colors duration-200 overflow-hidden #{card_classes}",
                               data: { turbo_frame: "_top", turbo_prefetch: false } do %>
                     <i class="fa-solid fa-envelope-open-text flex-shrink-0 <%= icon_classes %>"></i>
-                    <div class="flex flex-col justify-center min-w-0">
-                      <span class="font-semibold text-xs truncate"><%= truncate(person.name.to_s, length: 30) %></span>
+                    <div class="flex min-w-0 flex-col justify-center">
+                      <span class="truncate text-xs font-semibold"><%= truncate(person.name.to_s, length: 30) %></span>
                       <% if person.preferred_email.present? %>
-                        <!--email_off--><span class="text-xs font-normal truncate <%= email_classes %>"><%= person.preferred_email %></span><!--email_on-->
+                        <!--email_off--><span class="truncate text-xs font-normal <%= email_classes %>"><%= person.preferred_email %></span><!--email_on-->
                       <% end %>
                     </div>
                   <% end %>
@@ -81,6 +82,10 @@
                   <% else %>
                     <%= subscription.event_label %>
                   <% end %>
+                </td>
+
+                <td class="px-4 py-2 text-sm text-gray-800">
+                  <%= subscription.organization_label || content_tag(:span, "—", class: "text-gray-400") %>
                 </td>
 
                 <td class="px-4 py-2 text-sm"><%= subscription.status_badge(href: edit_topic_subscription_path(subscription, topic_subscription_index_filters.merge(return_to: "index"))) %></td>
@@ -103,18 +108,18 @@
 
                 <td class="px-4 py-2 text-sm text-gray-500"><%= subscription.source.presence || "—" %></td>
 
-                <td class="px-4 py-2 text-sm text-gray-500 text-nowrap"><%= subscription.subscribed_at.strftime("%B %d, %Y") %></td>
+                <td class="px-4 py-2 text-sm text-nowrap text-gray-500"><%= subscription.subscribed_at.strftime("%B %d, %Y") %></td>
               </tr>
             <% end %>
           </tbody>
         </table>
       </div>
     <% else %>
-      <p class="text-gray-500 text-center py-8">No subscriptions match your search.</p>
+      <p class="py-8 text-center text-gray-500">No subscriptions match your search.</p>
     <% end %>
   </div>
 
   <% if @topic_subscriptions.respond_to?(:total_pages) && @topic_subscriptions.total_pages > 1 %>
-    <div class="pagination flex justify-center mt-6"><%= tailwind_paginate @topic_subscriptions %></div>
+    <div class="pagination mt-6 flex justify-center"><%= tailwind_paginate @topic_subscriptions %></div>
   <% end %>
 <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2091,3 +2091,15 @@
     Admins can now check "Blog contributor" on a person's edit page to add the
     orange Blog Contributor badge to their profile. Previously the flag could
     only be set outside the app.
+
+- name: "Tie a topic subscription to an organization"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-08-23
+  action_path: "/topic_subscriptions"
+  pr_number: 2360
+  summary: >-
+    A topic subscription can now name a specific organization. Set it on the
+    subscription form, filter the subscriptions list by organization, and see it
+    in the new Organization column. It's optional — leave it blank for a topic
+    that isn't tied to any organization.

--- a/db/migrate/20260823184624_add_organization_to_topic_subscriptions.rb
+++ b/db/migrate/20260823184624_add_organization_to_topic_subscriptions.rb
@@ -1,0 +1,13 @@
+class AddOrganizationToTopicSubscriptions < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:topic_subscriptions, :organization_id)
+
+    # Optional narrowing: an organization the subscription is about. Null = the
+    # topic broadly, not tied to any organization.
+    add_reference :topic_subscriptions, :organization, null: true, foreign_key: true, type: :integer
+  end
+
+  def down
+    remove_reference :topic_subscriptions, :organization, foreign_key: true, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1449,6 +1449,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.bigint "interested_event_id"
+    t.integer "organization_id"
     t.bigint "person_id", null: false
     t.string "source"
     t.datetime "subscribed_at", null: false
@@ -1458,6 +1459,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
     t.bigint "updated_by_id"
     t.index ["created_by_id"], name: "index_topic_subscriptions_on_created_by_id"
     t.index ["interested_event_id"], name: "index_topic_subscriptions_on_interested_event_id"
+    t.index ["organization_id"], name: "index_topic_subscriptions_on_organization_id"
     t.index ["person_id"], name: "index_topic_subscriptions_on_person_id"
     t.index ["topic_subscription_type_id"], name: "index_topic_subscriptions_on_topic_subscription_type_id"
     t.index ["unsubscribed_at"], name: "index_topic_subscriptions_on_unsubscribed_at"
@@ -1990,6 +1992,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_154252) do
   add_foreign_key "story_ideas", "windows_types"
   add_foreign_key "story_ideas", "workshops"
   add_foreign_key "topic_subscriptions", "events", column: "interested_event_id"
+  add_foreign_key "topic_subscriptions", "organizations"
   add_foreign_key "topic_subscriptions", "people"
   add_foreign_key "topic_subscriptions", "topic_subscription_types"
   add_foreign_key "user_form_form_fields", "form_fields"

--- a/spec/decorators/topic_subscription_decorator_spec.rb
+++ b/spec/decorators/topic_subscription_decorator_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe TopicSubscriptionDecorator do
   let(:news) { create(:topic_subscription_type, :news) }
 
   describe "#event_label" do
-    it "is the event title for an event-specific subscription" do
-      event = create(:event, title: "Spring Training")
+    it "is the event abbreviation for an event-specific subscription when set" do
+      event = create(:event, title: "Spring Training", abbreviation: "TOS205")
+      subscription = create(:topic_subscription, topic_subscription_type: trainings, interested_event: event)
+      expect(subscription.decorate.event_label).to eq("TOS205")
+    end
+
+    it "falls back to the event title when there's no abbreviation" do
+      event = create(:event, title: "Spring Training", abbreviation: nil)
       subscription = create(:topic_subscription, topic_subscription_type: trainings, interested_event: event)
       expect(subscription.decorate.event_label).to eq("Spring Training")
     end

--- a/spec/decorators/topic_subscription_decorator_spec.rb
+++ b/spec/decorators/topic_subscription_decorator_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe TopicSubscriptionDecorator do
       expect(subscription.decorate.event_label).to eq("Any — facilitator trainings")
     end
 
-    it "is 'N/A' for a topic with no event dimension" do
+    it "is nil for a topic with no event dimension" do
       subscription = create(:topic_subscription, topic_subscription_type: news)
-      expect(subscription.decorate.event_label).to eq("N/A")
+      expect(subscription.decorate.event_label).to be_nil
     end
   end
 

--- a/spec/factories/topic_subscriptions.rb
+++ b/spec/factories/topic_subscriptions.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :person
     topic_subscription_type
     interested_event { nil }
+    organization { nil }
     source { "Facilitator Training registration" }
 
     trait :for_event do

--- a/spec/models/topic_subscription_spec.rb
+++ b/spec/models/topic_subscription_spec.rb
@@ -139,6 +139,18 @@ RSpec.describe TopicSubscription, type: :model do
     end
   end
 
+  describe "organization" do
+    it "is optional" do
+      expect(build(:topic_subscription, topic_subscription_type: trainings, organization: nil)).to be_valid
+    end
+
+    it "links an organization when given one" do
+      organization = create(:organization)
+      subscription = create(:topic_subscription, topic_subscription_type: trainings, organization: organization)
+      expect(subscription.organization).to eq(organization)
+    end
+  end
+
   describe "#general?" do
     it "is true without an event and false with one" do
       expect(build(:topic_subscription, interested_event: nil)).to be_general

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe "TopicSubscriptions", type: :request do
       expect(response.body).not_to include("Tara Trainings")
     end
 
+    it "filters by organization via the frame request" do
+      acme = create(:organization, name: "Acme Shelter")
+      create(:topic_subscription, person: create(:person, first_name: "Orla", last_name: "Acme"), topic_subscription_type: trainings, organization: acme)
+      create(:topic_subscription, person: create(:person, first_name: "Nadia", last_name: "Noorg"), topic_subscription_type: trainings, organization: nil)
+
+      get topic_subscriptions_path(organization_id: acme.id), headers: { "Turbo-Frame" => "topic_subscriptions_results" }
+
+      expect(response.body).to include("Orla Acme")
+      expect(response.body).not_to include("Nadia Noorg")
+    end
+
     it "eager loads each subscriber's user so the row count doesn't drive the query count" do
       5.times { create(:topic_subscription, person: create(:person), topic_subscription_type: trainings) }
 
@@ -360,6 +371,17 @@ RSpec.describe "TopicSubscriptions", type: :request do
       expect(subscription.created_by).to eq(admin)
       expect(subscription).to be_general
       expect(subscription).to be_active
+    end
+
+    it "links the chosen organization to the subscription" do
+      person = create(:person)
+      organization = create(:organization)
+
+      post topic_subscriptions_path, params: {
+        topic_subscription: { person_id: person.id, topic_subscription_type_id: trainings.id, organization_id: organization.id, source: "admin" }
+      }
+
+      expect(TopicSubscription.last.organization).to eq(organization)
     end
 
     it "creates a new person inline and links them to the subscription" do

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe "TopicSubscriptions", type: :request do
       expect(response.body).not_to include("Tara Trainings")
     end
 
-    it "filters by organization via the frame request" do
+    it "filters by organization name via the frame request" do
       acme = create(:organization, name: "Acme Shelter")
       create(:topic_subscription, person: create(:person, first_name: "Orla", last_name: "Acme"), topic_subscription_type: trainings, organization: acme)
       create(:topic_subscription, person: create(:person, first_name: "Nadia", last_name: "Noorg"), topic_subscription_type: trainings, organization: nil)
 
-      get topic_subscriptions_path(organization_id: acme.id), headers: { "Turbo-Frame" => "topic_subscriptions_results" }
+      get topic_subscriptions_path(organization_name: "acme"), headers: { "Turbo-Frame" => "topic_subscriptions_results" }
 
       expect(response.body).to include("Orla Acme")
       expect(response.body).not_to include("Nadia Noorg")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 model + migration plus index/form wiring and a table-layout rework

## What
- Adds an optional `organization` reference to `TopicSubscription`, wires it through the admin UI, and compacts the subscriptions index.
- Mirrors the existing optional `interested_event` narrowing — null means the topic isn't tied to any organization.

## Why
- Handles FM needs — lets a subscription be attributed to a specific organization.

## Data model
- Migration adds nullable `organization_id` + FK, typed `:integer` (the `organizations` table has an int PK, not bigint).
- `belongs_to :organization, optional: true`; factory default + specs.

## UI wiring
- Form: remote-select organization picker (always shown — org is independent of the topic's event dimension).
- Index: free-text organization-name filter (matches the linked org, like the people directory), carried through the lazy frame + applied-filter chip.
- Controller: permits `organization_id`, eager-loads `:organization`, prefills it on `new`.

## Index compaction
- Four columns instead of eight: event folds under topic, status sits beside the person card, source folds under the subscribed date, and the organization reads as an emerald linked line under the person card (linked to its profile).
- Event line shows the admin-set abbreviation when present (full title as tooltip), else the title.

## Notes
- Dedup key (`no_duplicate_active_subscription`) is unchanged — still keys off person/topic/event, not organization. Left deliberately.
- Added a Features & tips entry (`config/features.yml`).