### PR TITLE
Enable the Form submissions card on the admin home

### DIFF
--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -82,7 +82,7 @@ module AdminCardsHelper
       custom_card("Features & tips", features_path, icon: "⭐", color: :sky, intensity: 100),
       custom_card("Forms", forms_path, icon: "📋", color: :sky, intensity: 100),
       custom_card("Licenses", professional_licenses_path, icon: "🪪", color: :sky, intensity: 100),
-      disabled_card("Form submissions", icon: "📨"),
+      custom_card("Form submissions", form_submissions_path, icon: "📨", color: :sky, intensity: 100),
       custom_card("Form answers", form_answers_path, icon: "✅", color: :sky, intensity: 100),
       custom_card("Monthly reports", monthly_reports_path, icon: "📈", color: :sky, intensity: 100),
       custom_card("Payments", payments_path, icon: "💳", color: :sky, intensity: 100),

--- a/spec/requests/admin/home_spec.rb
+++ b/spec/requests/admin/home_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe "Admin home", type: :request do
     expect(response.body).to include("Actions")
     expect(response.body).to include("Sync features")
   end
+
+  it "links to the form submissions index" do
+    get "/admin"
+
+    expect(response.body).to include("Form submissions")
+    expect(response.body).to include(%(href="#{form_submissions_path}"))
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 flips one disabled admin-home card to a live link

## What
The admin home (`/admin`) had a **disabled** "Form submissions" placeholder card. Wired it to `/form_submissions`, matching the sibling "Forms" and "Form answers" cards (same sky styling, 📨 icon).

- The page is already admin-gated, and `FormSubmissionPolicy#index?` is admin-only, so no per-card gating needed.
- Added an admin-home spec assertion for the card + href.