### PR TITLE
Fix 500 when linking an org without choosing one

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -400,7 +400,11 @@ class EventRegistrationsController < ApplicationController
     authorize! @event_registration, to: :select_organization?
     return deny_locked_org_edit if @event_registration.editing_locked?
     @person = @event_registration.registrant
-    organization = Organization.find(params[:organization_id])
+    organization = Organization.find_by(id: params[:organization_id])
+    if organization.nil?
+      redirect_to link_organization_event_registration_path(@event_registration, return_to: params[:return_to].presence), alert: "Choose an organization to link."
+      return
+    end
 
     notice = link_and_report(organization, verb: "linked", record_fills: true)
 

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -53,7 +53,11 @@ class FormSubmissionsController < ApplicationController
 
   def select_organization
     authorize! @form_submission
-    organization = Organization.find(params[:organization_id])
+    organization = Organization.find_by(id: params[:organization_id])
+    if organization.nil?
+      redirect_to link_organization_form_submission_path(@form_submission, return_to: params[:return_to].presence), alert: "Choose an organization to link."
+      return
+    end
 
     notice = link_and_report(organization, verb: "linked")
 

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -1608,6 +1608,13 @@ RSpec.describe "EventRegistrations", type: :request do
         # off a facilitator-training event.
         let(:event) { create(:event, title: "Test Event", facilitator_training: true) }
 
+        it "redirects with an alert when submitted without choosing an organization" do
+          post select_organization_event_registration_path(existing_registration), params: { organization_id: "" }
+
+          expect(response).to redirect_to(link_organization_event_registration_path(existing_registration))
+          expect(flash[:alert]).to be_present
+        end
+
         it "links the org to the registration and the person, then returns to the edit page" do
           expect {
             post select_organization_event_registration_path(existing_registration),

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -403,6 +403,13 @@ RSpec.describe "FormSubmissions", type: :request do
       end
 
       describe "POST /form_submissions/:id/select_organization" do
+        it "redirects with an alert when submitted without choosing an organization" do
+          post select_organization_form_submission_path(submission, organization_id: "")
+
+          expect(response).to redirect_to(link_organization_form_submission_path(submission))
+          expect(flash[:alert]).to be_present
+        end
+
         it "creates the job and Facilitator affiliations, both dated to the submission (new job)" do
           add_answer("organization_name", "Harbor Family Shelter")
           add_answer("organization_position", "Counselor")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two-line guard on a crash path + specs

## Bug
On the org-linking editor, clicking **Link organization** in the search picker without selecting an org posts a blank `organization_id`. `select_organization` did `Organization.find("")` → `ActiveRecord::RecordNotFound` (500).

## Fix
Look the org up with `find_by(id:)` and, when nil, redirect back to the editor with an alert ("Choose an organization to link.").

Both the **form-submission** and **event-registration** editors share the picker partial and had the same crash — fixed in both `select_organization` actions.

## Tests
Failing-first request specs for each controller (blank `organization_id` → redirect + alert, no 500).