### PR TITLE
Role-agnostic form sections + de-dup nested-form questions

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -17,6 +17,7 @@ module Events
       @scholarship = scholarship_mode?
       @scholarship_form = @event.scholarship_form if @scholarship
       @continuing_education_form = @event.continuing_education_form
+      assign_nested_form_fields
       @event = @event.decorate
     end
 
@@ -38,16 +39,20 @@ module Events
 
       @field_errors = validate_required_fields(registration_params)
       if @scholarship_form
-        scholarship_fields = @scholarship_form.form_fields.where.not(answer_type: :group_header).to_a
+        # Validate only the fields actually shown — questions suppressed as
+        # registration-form duplicates are never submitted, so requiring them
+        # would wrongly block the registration.
+        scholarship_fields = nested_visible_fields(@scholarship_form).reject(&:group_header?)
         @field_errors = @field_errors.merge(FormAnswerValidator.call(scholarship_fields, scholarship_params))
       end
       if @continuing_education_form
-        ce_fields = @continuing_education_form.form_fields.where.not(answer_type: :group_header).to_a
+        ce_fields = nested_visible_fields(@continuing_education_form).reject(&:group_header?)
         @field_errors = @field_errors.merge(FormAnswerValidator.call(ce_fields, continuing_education_params))
       end
       if @field_errors.any?
         @form_fields = visible_form_fields
         @continuing_education_form = @event.continuing_education_form
+        assign_nested_form_fields
         @event = @event.decorate
         flash.now[:alert] = "Your registration is not complete yet. Scroll down to check for any errors or missing information."
         render :new, status: :unprocessable_content
@@ -81,6 +86,7 @@ module Events
       else
         @form_fields = visible_form_fields
         @continuing_education_form = @event.continuing_education_form
+        assign_nested_form_fields
         @event = @event.decorate
         flash.now[:error] = result.errors.join(", ")
         flash.now[:alert] = "Your registration is not complete yet. Scroll down to check for any errors or missing information."
@@ -198,6 +204,48 @@ module Events
       @event.registration_form
     end
 
+    def assign_nested_form_fields
+      @scholarship_fields = @scholarship_form ? nested_visible_fields(@scholarship_form) : []
+      @continuing_education_fields = @continuing_education_form ? nested_visible_fields(@continuing_education_form) : []
+    end
+
+    # A form nested inside this event's registration form (scholarship, CE) should
+    # never re-ask a question the registration form already asks — the registrant
+    # would answer it twice, and the person/org data is captured from the
+    # registration form regardless. Drop any nested field whose identifier matches
+    # one on the registration form (legacy aliases included), plus any section
+    # header left with no surviving field. Standalone forms don't pass through here,
+    # so they still show every field.
+    def nested_visible_fields(form)
+      taken = registration_field_identifiers
+      visible = []
+      pending_header = nil
+
+      form.form_fields.reorder(position: :asc).each do |field|
+        if field.group_header?
+          pending_header = field
+          next
+        end
+        next if field.field_identifier.present? && taken.include?(field.field_identifier)
+
+        if pending_header
+          visible << pending_header
+          pending_header = nil
+        end
+        visible << field
+      end
+
+      visible
+    end
+
+    def registration_field_identifiers
+      @registration_field_identifiers ||= @registration_form.form_fields
+                                              .where.not(field_identifier: [ nil, "" ])
+                                              .pluck(:field_identifier)
+                                              .flat_map { |identifier| FormField.aliased_identifiers(identifier) }
+                                              .to_set
+    end
+
     # Surface the dedicated scholarship form's application in its own card on the
     # view-submission page when the registrant filled it out. Answers are gathered
     # by field identifier (they may live on the scholarship submission or on the
@@ -214,7 +262,7 @@ module Events
 
       @scholarship_submission = application.submission
       @scholarship_form = scholarship_form
-      @scholarship_fields = scholarship_form.form_fields.reorder(position: :asc)
+      @scholarship_fields = nested_visible_fields(scholarship_form)
       @scholarship_responses = application.answers_by_field_id
     end
 
@@ -227,7 +275,7 @@ module Events
 
       @continuing_education_submission = submission
       @continuing_education_form = ce_form
-      @continuing_education_fields = ce_form.form_fields.reorder(position: :asc)
+      @continuing_education_fields = nested_visible_fields(ce_form)
       @continuing_education_responses = submission.form_answers.index_by(&:form_field_id)
     end
 

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -474,7 +474,15 @@ module EventRegistrationServices
       ce_field_value(CE_LICENSE_EXPIRES_ON_IDENTIFIER).presence
     end
 
+    # A CE question can be asked on the nested CE form, on the registration form's
+    # built-in continuing_education section, or both — and the nested copy is
+    # suppressed as a duplicate when both carry it — so read whichever copy the
+    # registrant was actually shown.
     def ce_field_value(key)
+      nested_ce_value(key).presence || field_value(key)
+    end
+
+    def nested_ce_value(key)
       field = @continuing_education_form.form_fields.find_by(field_identifier: key)
       return nil unless field
 

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -141,20 +141,6 @@ class FormBuilderService
     bulk_payment: %w[bulk_payment]
   }.freeze
 
-  # Built-in section keys that apply to a form with the given role. Scholarship
-  # and bulk-payment forms show only their own section; every other role shows
-  # all sections except those two.
-  def self.applicable_section_keys(role)
-    SECTIONS.keys.select do |key|
-      case role
-      when "scholarship" then key == :scholarship
-      when "bulk_payment" then key == :bulk_payment
-      when "continuing_education" then key == :continuing_education
-      else key != :scholarship && key != :bulk_payment && key != :continuing_education
-      end
-    end
-  end
-
   # Built-in section keys that currently have fields on the form. This — not the
   # stored `sections` column — is the source of truth for which sections are
   # present, so add/remove stays consistent with the edit-sections checkboxes
@@ -205,7 +191,10 @@ class FormBuilderService
 
     entries = []
     last_position = 0
-    applicable_section_keys(form.role).each_with_index do |key, rank|
+    # Every built-in section is offered here regardless of the form's role, so a
+    # form (e.g. a copy of a single-section scholarship form) can be built out
+    # with any section rather than being locked to the one its role implies.
+    SECTIONS.keys.each_with_index do |key, rank|
       position = positions[key]
       last_position = position if position
       default_header = SECTION_HEADERS.fetch(key).first

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -133,14 +133,14 @@
           <% end %>
         </div>
 
-        <% if @scholarship_form && @scholarship_form.form_fields.any? %>
+        <% if @scholarship_form && @scholarship_fields.any? %>
           <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">
             <h3 class="flex items-center gap-2.5 text-lg font-bold text-purple-900 mb-5">
               <i class="fa-solid fa-hand-holding-heart text-accent"></i><%= @scholarship_form.display_name %>
             </h3>
             <%= render "forms/header", form: @scholarship_form, event: @event %>
             <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
-              <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
+              <% @scholarship_fields.each do |field| %>
                 <% if field.group_header? %>
                   <%# Skip a section header that just repeats the form name shown as the title above %>
                   <% next if field.name.to_s.strip.casecmp?(@scholarship_form.display_name.to_s.strip) %>
@@ -156,7 +156,7 @@
           </div>
         <% end %>
 
-        <% if @continuing_education_form && @continuing_education_form.form_fields.any? %>
+        <% if @continuing_education_form && @continuing_education_fields.any? %>
           <div class="mt-8 rounded-xl border border-teal-100 bg-teal-50/50 px-5 py-6">
             <h3 class="flex items-center gap-2.5 text-lg font-bold text-teal-900 mb-5">
               <i class="fa-solid fa-certificate text-teal-600"></i><%= @continuing_education_form.display_name %>
@@ -179,7 +179,7 @@
               </dl>
             <% end %>
             <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
-              <% @continuing_education_form.form_fields.reorder(position: :asc).each do |field| %>
+              <% @continuing_education_fields.each do |field| %>
                 <% if field.group_header? %>
                   <% next if field.name.to_s.strip.casecmp?(@continuing_education_form.display_name.to_s.strip) %>
                   <%= render "events/public_registrations/group_header", field: field %>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -84,8 +84,9 @@
   </div>
 
   <%# ---- SCHOLARSHIP APPLICATION CARD — only when the registrant filled out the
-      separate scholarship form (its own role: "scholarship" submission). ---- %>
-  <% if @scholarship_submission %>
+      separate scholarship form (its own role: "scholarship" submission) and it
+      still has questions of its own once the registration form's are dropped. ---- %>
+  <% if @scholarship_submission && @scholarship_fields.any? %>
     <div id="scholarship-application" class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8 scroll-mt-24">
 
       <%# Card Header %>
@@ -135,8 +136,8 @@
 
   <%# ---- CONTINUING EDUCATION CARD — only when the registrant filled out the
       separate continuing_education form (its own role: "continuing_education"
-      submission). ---- %>
-  <% if @continuing_education_submission %>
+      submission) and it still has questions of its own. ---- %>
+  <% if @continuing_education_submission && @continuing_education_fields.any? %>
     <div id="continuing-education" class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8 scroll-mt-24">
 
       <%# Card Header %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -42,6 +42,7 @@
   area: registration
   display_status: user_facing
   released_on: 2026-08-22
+  pr_number: 2364
   summary: >-
     A scholarship or continuing-education form attached to an event now hides any question it
     shares with the event's registration form (name, email, address, organization), so
@@ -51,6 +52,7 @@
   area: content
   display_status: admin_facing
   released_on: 2026-08-22
+  pr_number: 2364
   summary: >-
     The form "Edit sections" page now offers every built-in section regardless of the form's
     role, so a copied single-section form (e.g. a scholarship form) can be built out with any

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,24 @@
   pro_tips:
     - "Filter the people list first — the email list always matches whatever the list is showing."
 
+- name: "Nested forms skip questions the registration form already asks"
+  area: registration
+  display_status: user_facing
+  released_on: 2026-08-22
+  summary: >-
+    A scholarship or continuing-education form attached to an event now hides any question it
+    shares with the event's registration form (name, email, address, organization), so
+    registrants aren't asked twice. The same form still shows every question when used standalone.
+
+- name: "Edit sections: every section available on any form"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-22
+  summary: >-
+    The form "Edit sections" page now offers every built-in section regardless of the form's
+    role, so a copied single-section form (e.g. a scholarship form) can be built out with any
+    section. Currently-used sections stay checked.
+
 - name: "Affiliation editor: FileMaker code"
   area: people
   display_status: admin_facing

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -284,6 +284,43 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
              } } }
       }.to change(EventRegistration, :count).by(1)
     end
+
+    # Both forms come from the same builder, so every CE question on the nested
+    # form is a duplicate and gets suppressed — the opt-in and license details
+    # have to be read from the copy the registrant was actually shown.
+    context "when the registration form carries the built-in CE section" do
+      let(:ce_section_event) { create(:event, cost_cents: 0, ce_hours_offered: 3) }
+      let(:builder_registration_form) do
+        FormBuilderService.new(name: "Reg", sections: %i[person_identifier continuing_education],
+                               role: "registration").call
+      end
+      let(:builder_ce_form) do
+        FormBuilderService.new(name: "CE", sections: %i[continuing_education],
+                               role: "continuing_education").call
+      end
+
+      before do
+        EventForm.create!(event: ce_section_event, form: builder_registration_form, role: "registration")
+        EventForm.create!(event: ce_section_event, form: builder_ce_form, role: "continuing_education")
+      end
+
+      def registration_answers
+        %w[first_name last_name primary_email confirm_email ce_credit_interest ce_license_number]
+          .zip([ "Pat", "Lee", "pat@example.com", "pat@example.com", "Yes", "12345" ])
+          .to_h { |identifier, answer|
+            [ builder_registration_form.form_fields.find_by(field_identifier: identifier).id.to_s, answer ]
+          }
+      end
+
+      it "creates the CE registration from the registration form's answer" do
+        expect {
+          post event_public_registration_path(ce_section_event),
+               params: { public_registration: { form_fields: registration_answers } }
+        }.to change(ContinuingEducationRegistration, :count).by(1)
+
+        expect(ContinuingEducationRegistration.last.professional_license.number).to eq("12345")
+      end
+    end
   end
 
   describe "GET new" do
@@ -839,6 +876,32 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Why do you need a scholarship?")
         expect(response.body).to include("Our agency training budget was cut.")
+      end
+    end
+
+    context "when the scholarship form only repeats registration questions" do
+      let(:scholarship_form) { create(:form, role: "scholarship") }
+      let!(:registration_twin) do
+        create(:form_field, form: form, field_identifier: "impact_description",
+               name: "How will this help?", required: false)
+      end
+      let!(:scholarship_duplicate) do
+        create(:form_field, form: scholarship_form, field_identifier: "impact_description",
+               answer_type: :free_form_input_paragraph, name: "How will this help?", required: false)
+      end
+
+      before do
+        EventForm.create!(event: event, form: scholarship_form, role: "scholarship")
+        submission = FormSubmission.create!(person: person, form: scholarship_form, event: event, role: "scholarship")
+        submission.form_answers.create!(form_field: scholarship_duplicate,
+                                        submitted_answer: "Our agency training budget was cut.")
+      end
+
+      it "omits the scholarship card instead of rendering it with no questions" do
+        get event_public_registration_path(event, person_id: person.id)
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include("Scholarship application")
       end
     end
 

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -243,6 +243,49 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     end
   end
 
+  describe "nested-form question de-duplication" do
+    let!(:reg_first_name) do
+      create(:form_field, form: form, field_identifier: "first_name", name: "Reg first name", required: false)
+    end
+    let!(:reg_last_name) do
+      create(:form_field, form: form, field_identifier: "last_name", name: "Reg last name", required: false)
+    end
+    let!(:reg_email) do
+      create(:form_field, form: form, field_identifier: "primary_email", name: "Reg email", required: false)
+    end
+    let(:ce_form) { create(:form, role: "continuing_education") }
+    let!(:ce_duplicate) do
+      create(:form_field, form: ce_form, field_identifier: "first_name", name: "Nested first name", required: false)
+    end
+    let!(:ce_unique) do
+      create(:form_field, form: ce_form, field_identifier: "ce_license_number", name: "License number", required: false)
+    end
+
+    before { event.event_forms.create!(form: ce_form, role: "continuing_education") }
+
+    it "hides a nested-form question the registration form already asks, but keeps its own" do
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include("Reg first name")
+      expect(response.body).to include("License number")
+      expect(response.body).not_to include("Nested first name")
+    end
+
+    it "does not require a suppressed nested duplicate to complete registration" do
+      ce_duplicate.update!(required: true)
+
+      expect {
+        post event_public_registration_path(event),
+             params: { public_registration: { form_fields: {
+               essay_field.id.to_s => "this answer has plenty of words",
+               reg_first_name.id.to_s => "Pat",
+               reg_last_name.id.to_s => "Lee",
+               reg_email.id.to_s => "pat@example.com"
+             } } }
+      }.to change(EventRegistration, :count).by(1)
+    end
+  end
+
   describe "GET new" do
     it "shows the minimum word hint below the field" do
       get new_event_public_registration_path(event)

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -430,6 +430,18 @@ RSpec.describe FormBuilderService do
       expect(excluded).to include(:marketing, :payment)
     end
 
+    it "offers every built-in section even for a role-restricted form" do
+      scholarship_form = described_class.new(name: "Aid", sections: %i[scholarship], role: "scholarship").call
+
+      keys = described_class.editable_sections(scholarship_form)
+        .select { |e| e[:kind] == :builtin }.map { |e| e[:key] }
+
+      expect(keys).to match_array(FormBuilderService::SECTIONS.keys)
+      included = described_class.editable_sections(scholarship_form)
+        .select { |e| e[:included] }.map { |e| e[:key] }
+      expect(included).to eq([ :scholarship ])
+    end
+
     it "includes a custom section with the questions that follow it" do
       add_field("My Custom Section", :group_header, 100)
       first = add_field("Favorite color", :free_form_input_one_line, 101)


### PR DESCRIPTION
> **NOTE — parking the follow-ups.** Review surfaced two known limitations (see the [review comment](https://github.com/rubyforgood/awbw/pull/2364#issuecomment-5389291161)): the submission page hides answers captured on a nested form for a de-duplicated question, and the CE fallback can't fire when only the registration form asks. We're waiting until users actually hit these before reworking — merging as-is.

🤖 suggested review level: 5 Inspect 🔬 substantive logic in public-registration rendering/validation and the form section builder

### What is the goal of this PR and why is this important?
Two form improvements: a copied single-section form (e.g. scholarship) can now be built out with any section, and a scholarship/CE form nested in an event's registration form no longer re-asks questions the registration form already covers — so registrants aren't asked their name/email/org twice.

### How did you approach the change?
- **Edit sections:** `FormBuilderService.editable_sections` now offers every built-in section regardless of the form's `role` (present sections stay checked); removed the now-unused role gate.
- **Nested de-dup:** `PublicRegistrations` renders a nested form through `nested_visible_fields`, dropping any field whose identifier (aliases included) already appears on the registration form, plus emptied section headers. Validation matches, so a suppressed-but-required duplicate can't block submission. Standalone `/f/:slug` forms are untouched and still show everything.

### Where the de-dup needed a second read
Both fixed here, each with a failing-first spec.

- **CE opt-in.** A registration form carrying the built-in CE section shares every identifier with a nested CE form, so the nested copy collapses to nothing. `PublicRegistration` read the opt-in and license details only from the CE form's params, so answering "Yes" created no `ContinuingEducationRegistration`. `ce_field_value` now falls back to the registration form's answer — nested copy wins when it's the one shown.
- **Empty cards.** Same collapse left the submission page's scholarship/CE cards with a heading and "Submitted on …" and no questions. Both are now gated on having fields, matching the public form.

### UI Testing Checklist
- [ ] Copy a scholarship form → Edit sections offers all sections.
- [ ] Attach a scholarship/CE form (with person/org fields) to an event → those questions don't duplicate on the public registration page.
- [ ] Registration form with the CE section + a nested CE form → answering "Yes" still issues CE credit.
- [ ] Open the same form standalone → all fields show.

### Anything else to add?
Person/org data is always captured from the registration form, so suppressing the nested copies changes no persisted data. Added `config/features.yml` entries for both.

