### PR TITLE
Credit and search the submitter when content names no author

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ This codebase (Rails 8.1)
 |---|---|
 | `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
-| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page. Anonymity is a one-way latch: the profile or the record can set it, neither can strip it from the other |
+| `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page. Anonymity is a one-way latch: the profile or the record can set it, neither can strip it from the other. `credits_to_org` flips the unattributed label to "AWBW Staff"; `credits_creator` (idea models, workshop logs) credits the submitting account's person when no author is named |
 | `Featureable` | `featured`, `publicly_featured` scopes |
 | `Mentioner` | ActionText @mention extraction and grouping |
 | `NameFilterable` | Name-based filtering |

--- a/app/controllers/monthly_reports_controller.rb
+++ b/app/controllers/monthly_reports_controller.rb
@@ -7,7 +7,7 @@ class MonthlyReportsController < ApplicationController
 
     if turbo_frame_request?
       per_page = params[:number_of_items_per_page].presence || 25
-      base_scope = authorized_scope(MonthlyReport.includes(:created_by, :windows_type, :organization))
+      base_scope = authorized_scope(MonthlyReport.includes(:author, :windows_type, :organization, created_by: :person))
       filtered = base_scope.search(params)
       @monthly_reports_unpaginated = filtered
       @monthly_reports = filtered.paginate(page: params[:page], per_page: per_page)
@@ -26,7 +26,7 @@ class MonthlyReportsController < ApplicationController
 
   def show
     @monthly_report = MonthlyReport.includes(
-      :organization, :windows_type, { created_by: :person },
+      :organization, :windows_type, :author, { created_by: :person },
       { quotes: :workshop },
       { gallery_assets: { file_attachment: :blob } }
     ).find(params[:id]).decorate

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -5,7 +5,8 @@ class StoryIdeasController < ApplicationController
   def index
     authorize!
     per_page = params[:number_of_items_per_page].presence || 25
-    base_scope = authorized_scope(StoryIdea.includes(:windows_type, :organization, :workshop, :created_by, :updated_by))
+    base_scope = authorized_scope(StoryIdea.includes(:windows_type, :organization, :workshop, :author, :updated_by,
+                                                     created_by: :person))
     filtered = base_scope.search_by_params(params)
     @story_ideas = filtered.order(created_at: :desc)
                            .paginate(page: params[:page], per_page: per_page)

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -72,7 +72,7 @@ class WorkshopLogsController < ApplicationController
 
   def show
     @workshop_log = WorkshopLog.includes(
-      :organization, :windows_type, { created_by: :person },
+      :organization, :windows_type, :author, { created_by: :person },
       { quotes: :workshop },
       { gallery_assets: { file_attachment: :blob } }
     ).find(params[:id]).decorate

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -5,7 +5,8 @@ class WorkshopLogsController < ApplicationController
     authorize!
     @per_page = params[:number_of_items_per_page].presence || 10
     params[:workshop_id] ||= @workshop&.id
-    base_scope = authorized_scope(WorkshopLog.includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets, created_by: :person))
+    base_scope = authorized_scope(WorkshopLog.includes(:workshop, :windows_type, :quotable_item_quotes, :gallery_assets,
+                                                       :author, created_by: :person))
     filtered = base_scope.search(params)
     @workshop_logs_unpaginated = filtered
     @workshop_logs = filtered.paginate(page: params[:page], per_page: @per_page)

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -194,8 +194,7 @@ module AuthorCreditable
 
     private
 
-    # Only an explicit author is ever credited, so search and sort reach that person
-    # alone — and nobody at all on the idea models, which have no author_id.
+    # Only an explicit author is ever credited, so search and sort reach that person alone.
     def credited_person_aliases
       explicit_author? ? [ "credited_author" ] : []
     end

--- a/app/models/concerns/author_creditable.rb
+++ b/app/models/concerns/author_creditable.rb
@@ -9,6 +9,10 @@ module AuthorCreditable
 
   ANONYMOUS = "anonymous"
 
+  # Join aliases for the people a record credits, in display precedence order.
+  CREDITED_AUTHOR_ALIAS = "credited_author".freeze
+  CREATOR_PERSON_ALIAS = "creator_person".freeze
+
   # The generic credit AWBW puts on content with no named credit. Content AWBW produces
   # itself — news, workshops, resources — reads as "AWBW Staff"; everything else,
   # including facilitator submissions and the idea forms, reads as "AWBW Facilitator".
@@ -41,6 +45,11 @@ module AuthorCreditable
     # content follows the facilitator label; org-produced models flip it to the org
     # label with `credits_to_org`.
     class_attribute :unattributed_author_label, instance_writer: false, default: FACILITATOR_AUTHOR_LABEL
+
+    # Whether the submitting account's person is credited when no explicit author is
+    # on file. Off by default — on most models the creator entered the content rather
+    # than writing it. Turn it on with `credits_creator`.
+    class_attribute :creator_credited, instance_writer: false, default: false
 
     before_create :snapshot_author_credit_preference
     # Blank means "follow the profile"; nil keeps it off the divergence worklist.
@@ -89,6 +98,13 @@ module AuthorCreditable
     author if respond_to?(:author)
   end
 
+  # The creator's person, on models where the submitter is the author
+  # (`credits_creator`). Rows that predate the author column carry no author_id, so
+  # the account that entered them is their only authorship signal.
+  def creator_credit_person
+    created_by&.person if creator_credited
+  end
+
   # Free-text author name with no linkable person. Overridden by Workshop, Resource.
   def legacy_author_name_text
     nil
@@ -100,13 +116,17 @@ module AuthorCreditable
     return credit_for(person) if person
     # Anonymous suppresses a legacy name too; with no person behind it, nothing is left.
     return legacy_author_name_text if legacy_author_name_text.present? && author_credit_preference != ANONYMOUS
+    # Nobody named the author, so the submitter is it (see `credits_creator`).
+    creator = creator_credit_person
+    return credit_for(creator) if creator
     # No author at all, so it reads as the org's own content.
     missing_author_label
   end
 
-  # Only an explicit author links — a creator fallback never declared authorship.
+  # Only a credited person links, and only where they aren't hidden — the explicit
+  # author, or the submitter on a model that credits them.
   def author_credit_person
-    person = primary_author_person
+    person = primary_author_person || creator_credit_person
     person && !credit_anonymous?(person) ? person : nil
   end
 
@@ -116,7 +136,8 @@ module AuthorCreditable
   end
 
   # Only an explicit author has a governing profile. A legacy name follows nobody's,
-  # and an unattributed record credits nobody, so neither has a governing person.
+  # and a creator credit reads the live profile with no snapshot taken against it,
+  # so neither has a governing person.
   def credit_governing_person
     primary_author_person
   end
@@ -162,6 +183,14 @@ module AuthorCreditable
       self.unattributed_author_label = ORG_AUTHOR_LABEL
     end
 
+    # Content whose submitter is its author — the idea forms and workshop logs. An
+    # author-less row (anything predating the author column) then credits, links,
+    # searches and sorts under the creating account's person, through that person's
+    # own credit preference.
+    def credits_creator
+      self.creator_credited = true
+    end
+
     # Fully-qualified legacy name columns, e.g. "resources.legacy_author_name".
     def legacy_author_name_columns
       []
@@ -194,15 +223,26 @@ module AuthorCreditable
 
     private
 
-    # Only an explicit author is ever credited, so search and sort reach that person alone.
+    # The people a credit can reach, in display precedence order: the explicit
+    # author, then the submitter where the model credits them.
     def credited_person_aliases
-      explicit_author? ? [ "credited_author" ] : []
+      aliases = []
+      aliases << CREDITED_AUTHOR_ALIAS if explicit_author?
+      aliases << CREATOR_PERSON_ALIAS if creator_credited
+      aliases
     end
 
     def credited_person_join_sql
-      return [] if credited_person_aliases.empty?
-
-      [ "LEFT OUTER JOIN people credited_author ON credited_author.id = #{table_name}.author_id" ]
+      joins = []
+      if explicit_author?
+        joins << "LEFT OUTER JOIN people #{CREDITED_AUTHOR_ALIAS} " \
+                 "ON #{CREDITED_AUTHOR_ALIAS}.id = #{table_name}.author_id"
+      end
+      if creator_credited
+        joins << "LEFT OUTER JOIN users creator_account ON creator_account.id = #{table_name}.created_by_id"
+        joins << "LEFT OUTER JOIN people #{CREATOR_PERSON_ALIAS} ON #{CREATOR_PERSON_ALIAS}.id = creator_account.person_id"
+      end
+      joins
     end
 
     def explicit_author?
@@ -237,7 +277,11 @@ module AuthorCreditable
         "(#{preference} = '#{value}' AND (#{expressions.map { |e| name_like(e) }.join(' OR ')}))"
       end
 
-      "(#{sql_alias}.anonymous_contributions = FALSE AND #{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
+      # The creator only stands in for an author nobody named, matching what displays.
+      outranked = sql_alias == CREATOR_PERSON_ALIAS ? "#{no_person_author_sql} AND " : ""
+
+      "(#{outranked}#{sql_alias}.anonymous_contributions = FALSE AND " \
+        "#{not_anonymous_sql} AND (#{by_preference.join(' OR ')}))"
     end
 
     # A legacy name only displays when no person author outranks it, so it's only

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -2,6 +2,7 @@ class MonthlyReport < Report
   include AuthorCreditable
   # No explicit author → credit the creator's person by name, else "Anonymous".
   self.unattributed_author_label = "Anonymous"
+  credits_creator
 
   PARTICIPANT_ONGOING_QUESTION = "Total # On-going Participants"
   PARTICIPANT_FIRST_TIME_QUESTION = "Total # First-Time Participants"
@@ -106,14 +107,6 @@ class MonthlyReport < Report
 
   def name
     "Monthly Report ##{id}"
-  end
-
-  # The legacy (pre-Person-author) credit for a report: the creator's person by
-  # name, honoring their credit preference — suppressed when the person opted
-  # out. Nil (no creator/person, or opted out) reads "Anonymous".
-  def legacy_author_name_text
-    person = created_by&.person
-    person.name unless person.nil? || person.anonymous_contributions?
   end
 
   def display_date

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -79,6 +79,7 @@ class MonthlyReport < Report
   def self.search(params)
     logs = is_a?(ActiveRecord::Relation) ? self : all
     logs = logs.created_by_id(params[:created_by_id]) if params[:created_by_id].present?
+    logs = logs.where(id: by_credited_person_name(params[:author_name]).select("reports.id")) if params[:author_name].present?
     logs = logs.month_and_year(params[:month_and_year]) if params[:month_and_year].present?
     logs = logs.year(params[:year]) if params[:year].present?
     logs = logs.organization_id(params[:organization_id]) if params[:organization_id].present?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -200,7 +200,12 @@ class Person < ApplicationRecord
   scope :blog_contributors, -> { where(blog_contributor: true) }
   scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
   scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
-  scope :workshop_log_authors, -> { joins(:workshop_logs_as_author).distinct }
+  # Mirrors what a log credits (WorkshopLog `credits_creator`): the named author,
+  # or — on logs that predate the author column — the person whose account logged it.
+  scope :workshop_log_authors, -> {
+    where(id: WorkshopLog.where.not(author_id: nil).select(:author_id))
+      .or(where(id: User.where(id: WorkshopLog.where(author_id: nil).select(:created_by_id))
+                        .where.not(person_id: nil).select(:person_id))) }
   # People with at least one currently-active facilitator affiliation.
   scope :facilitators_active, -> {
     where(id: Affiliation.facilitators.active.select(:person_id)) }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -198,14 +198,17 @@ class Person < ApplicationRecord
     joins(:staff_taggings).where(staff_taggings: { staff_tag_id: tag_ids }).distinct }
   scope :story_authors, -> { joins(:stories_as_author).distinct }
   scope :blog_contributors, -> { where(blog_contributor: true) }
-  scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
-  scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
-  # Mirrors what a log credits (WorkshopLog `credits_creator`): the named author,
-  # or — on logs that predate the author column — the person whose account logged it.
-  scope :workshop_log_authors, -> {
-    where(id: WorkshopLog.where.not(author_id: nil).select(:author_id))
-      .or(where(id: User.where(id: WorkshopLog.where(author_id: nil).select(:created_by_id))
-                        .where.not(person_id: nil).select(:person_id))) }
+  scope :workshop_authors, -> { credited_on(Workshop) }
+  scope :workshop_variation_authors, -> { credited_on(WorkshopVariation) }
+  scope :workshop_log_authors, -> { credited_on(WorkshopLog) }
+  # Everyone a model credits, mirroring what the record itself displays: its named
+  # authors, plus — where the model credits its submitter (`credits_creator`) — the
+  # person behind the account that entered a row naming no author.
+  scope :credited_on, ->(model) {
+    named = where(id: model.where.not(author_id: nil).select(:author_id))
+    next named unless model.creator_credited
+    named.or(where(id: User.where(id: model.where(author_id: nil).select(:created_by_id))
+                           .where.not(person_id: nil).select(:person_id))) }
   # People with at least one currently-active facilitator affiliation.
   scope :facilitators_active, -> {
     where(id: Affiliation.facilitators.active.select(:person_id)) }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -200,13 +200,7 @@ class Person < ApplicationRecord
   scope :blog_contributors, -> { where(blog_contributor: true) }
   scope :workshop_authors, -> { joins(:workshops_as_author).distinct }
   scope :workshop_variation_authors, -> { joins(:workshop_variations_as_author).distinct }
-  # WorkshopLog has no author column — it is created_by a User, so "author" here
-  # means the person whose linked user account created the log. Confirmed intended
-  # (rubyforgood/awbw#2326): the logger is the author; we deliberately don't add an
-  # author_id column, since created_by.person already carries that meaning.
-  scope :workshop_log_authors, -> {
-    creator_user_ids = WorkshopLog.where.not(created_by_id: nil).select(:created_by_id)
-    where(id: User.where(id: creator_user_ids).where.not(person_id: nil).select(:person_id)) }
+  scope :workshop_log_authors, -> { joins(:workshop_logs_as_author).distinct }
   # People with at least one currently-active facilitator affiliation.
   scope :facilitators_active, -> {
     where(id: Affiliation.facilitators.active.select(:person_id)) }

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -8,6 +8,7 @@ class StoryIdea < ApplicationRecord
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.search(params[:query]) if params[:query].present?
+    results = results.where(id: by_credited_person_name(params[:author_name]).select("story_ideas.id")) if params[:author_name].present?
     results = results.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     results = results.created_by_person(params[:created_by_person_id]) if params[:created_by_person_id].present?
     results

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -1,5 +1,8 @@
 class StoryIdea < ApplicationRecord
   include AuthorCreditable
+  # The submitter is the author when none is named.
+  credits_creator
+
   include SearchCop
   search_scope :search do
     attributes :title, :body

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -1,5 +1,7 @@
 class WorkshopIdea < ApplicationRecord
   include AuthorCreditable
+  # The submitter is the author when none is named.
+  credits_creator
 
   belongs_to :author, class_name: "Person", inverse_of: :workshop_ideas_as_author, optional: true
   belongs_to :created_by, class_name: "User"

--- a/app/models/workshop_idea.rb
+++ b/app/models/workshop_idea.rb
@@ -74,16 +74,8 @@ class WorkshopIdea < ApplicationRecord
 
   # Scopes
   scope :title, ->(title) { where("workshop_ideas.title like ?", "%#{ title }%") }
-  # An idea credits nobody — `author_credit` is always the generic label — so there is
-  # no credit for this filter to leak. It matches the submitter the pages actually show
-  # (`created_by.name`, i.e. the person), falling back to the account email.
   scope :author_name, ->(author_name) {
-    needle = "%#{author_name.to_s.strip.downcase}%"
-    joins("INNER JOIN users ON users.id = workshop_ideas.created_by_id")
-      .joins("LEFT OUTER JOIN people ON people.id = users.person_id")
-      .where("LOWER(CONCAT(people.first_name, ' ', people.last_name)) LIKE :needle " \
-             "OR LOWER(people.first_name) LIKE :needle OR LOWER(people.last_name) LIKE :needle " \
-             "OR LOWER(users.email) LIKE :needle", needle: needle)
+    where(id: by_credited_person_name(author_name).select("workshop_ideas.id"))
   }
 
   def self.search(params)

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -1,5 +1,7 @@
 class WorkshopLog < ApplicationRecord
   include AuthorCreditable
+  # The facilitator who logged the workshop is its author when none is named.
+  credits_creator
 
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :author, class_name: "Person", optional: true

--- a/app/models/workshop_log.rb
+++ b/app/models/workshop_log.rb
@@ -68,6 +68,7 @@ class WorkshopLog < ApplicationRecord
   def self.search(params)
     logs = is_a?(ActiveRecord::Relation) ? self : all
     logs = logs.created_by_id(params[:created_by_id]) if params[:created_by_id].present?
+    logs = logs.where(id: by_credited_person_name(params[:author_name]).select("workshop_logs.id")) if params[:author_name].present?
     logs = logs.month_and_year(params[:month_and_year]) if params[:month_and_year].present?
     logs = logs.year(params[:year]) if params[:year].present?
     logs = logs.workshop_id(params[:workshop_id]) if params[:workshop_id].present?

--- a/app/models/workshop_variation.rb
+++ b/app/models/workshop_variation.rb
@@ -2,6 +2,7 @@ class WorkshopVariation < ApplicationRecord
   include AuthorCreditable
   # No explicit author → credit the creator's person by name, else "Anonymous".
   self.unattributed_author_label = "Anonymous"
+  credits_creator
 
   include Publishable, Trendable, RichTextSearchable
   include SearchCop
@@ -66,14 +67,6 @@ class WorkshopVariation < ApplicationRecord
 
   def title
     name
-  end
-
-  # The legacy (pre-Person-author) credit for a variation: the creator's person
-  # by name, honoring their credit preference — suppressed when the person opted
-  # out. Nil (no creator/person, or opted out) reads "Anonymous".
-  def legacy_author_name_text
-    person = created_by&.person
-    person.name unless person.nil? || person.anonymous_contributions?
   end
 
   def attach_assets_from_idea!

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -8,6 +8,7 @@ class WorkshopVariationIdea < ApplicationRecord
   def self.search_by_params(params)
     results = is_a?(ActiveRecord::Relation) ? self : all
     results = results.search(params[:query]) if params[:query].present?
+    results = results.where(id: by_credited_person_name(params[:author_name]).select("workshop_variation_ideas.id")) if params[:author_name].present?
     results = results.created_by_person(params[:created_by_person_id]) if params[:created_by_person_id].present?
     results
   end

--- a/app/models/workshop_variation_idea.rb
+++ b/app/models/workshop_variation_idea.rb
@@ -1,5 +1,8 @@
 class WorkshopVariationIdea < ApplicationRecord
   include AuthorCreditable
+  # The submitter is the author when none is named.
+  credits_creator
+
   include SearchCop
   search_scope :search do
     attributes :name, :body

--- a/app/views/monthly_reports/_monthly_reports_results.html.erb
+++ b/app/views/monthly_reports/_monthly_reports_results.html.erb
@@ -5,7 +5,7 @@
     <thead class="bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">Date</th>
-        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">Submitter</th>
+        <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">Author</th>
         <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">Organization</th>
         <th class="px-6 py-3 text-left text-sm font-semibold text-gray-700">Windows type</th>
         <th class="px-4 py-3 text-center text-sm font-semibold text-white bg-blue-500"># On-going</th>
@@ -29,7 +29,7 @@
                           class: "font-bold text-gray-800 hover:text-indigo-800 hover:underline" %>
             </td>
 
-            <td class="px-6 py-4 text-sm text-gray-800"><%= report.created_by&.name || "—" %></td>
+            <td class="px-6 py-4 text-sm text-gray-800"><%= credited_author_link(report, class: eyebrow_link_class) %></td>
 
             <td class="px-6 py-4 text-sm text-gray-600"><%= report.organization&.name || "—" %></td>
 

--- a/app/views/monthly_reports/_search_boxes.html.erb
+++ b/app/views/monthly_reports/_search_boxes.html.erb
@@ -34,14 +34,26 @@
                      onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <!-- Person -->
+    <!-- Submitted by -->
     <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
-      <%= label_tag :created_by_id, "Person", class: search_label_class %>
+      <%= label_tag :created_by_id, "Submitted by", class: search_label_class %>
       <%= select_tag :created_by_id,
                      options_from_collection_for_select(@users, :id, :full_name_with_email, params[:created_by_id]),
-                     include_blank: "All people",
+                     include_blank: "Anyone",
                      class: search_field_class,
                      data: { searchable_select_target: "select", action: "change->searchable-select#submit" } %>
+    </div>
+
+    <!-- Author name -->
+    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
     </div>
 
     <!-- Organization -->

--- a/app/views/monthly_reports/show.html.erb
+++ b/app/views/monthly_reports/show.html.erb
@@ -32,6 +32,10 @@
           <% end %>
         </div>
         <div>
+          <span class="font-semibold text-gray-700">Author credit:</span>
+          <%= credited_author_link(@monthly_report) %>
+        </div>
+        <div>
           <span class="font-semibold text-gray-700">Organization:</span>
           <% if @monthly_report.organization && allowed_to?(:show?, @monthly_report.organization) %>
             <%= link_to @monthly_report.organization.name,

--- a/app/views/shared/_author_credit_note.html.erb
+++ b/app/views/shared/_author_credit_note.html.erb
@@ -22,4 +22,13 @@
       profile. Pick a person to replace it.
     </span>
   </p>
+<% elsif record.author.blank? && record.creator_credit_person %>
+  <p class="mt-1 flex items-start gap-2 text-sm text-gray-600">
+    <i class="fa-solid fa-circle-info mt-1"></i>
+    <span>
+      No author is set, so this is credited to
+      <%= record.creator_credit_person.name %>, who submitted it, and follows their profile.
+      Pick a person to credit someone else.
+    </span>
+  </p>
 <% end %>

--- a/app/views/story_ideas/_search_boxes.html.erb
+++ b/app/views/story_ideas/_search_boxes.html.erb
@@ -1,10 +1,22 @@
 <%= form_tag(story_ideas_path, method: :get, class: "space-y-4", data: { controller: "collection" }) do %>
-  <div class="flex flex-col md:flex-row md:items-end md:gap-4 mb-6">
+  <div class="mb-6 flex flex-col md:flex-row md:items-end md:gap-4">
     <!-- Search -->
-    <div class="w-full md:flex-1 mb-3 md:mb-0">
+    <div class="mb-3 w-full md:mb-0 md:flex-1">
       <%= label_tag :query, "Search", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :query, params[:query],
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
+    <!-- Author name -->
+    <div class="mb-3 w-full md:mb-0 md:w-64">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
                            class: search_field_class(extra: "pr-10") %>
 
         <%= render "shared/search_submit" %>

--- a/app/views/story_ideas/index.html.erb
+++ b/app/views/story_ideas/index.html.erb
@@ -43,7 +43,7 @@
                                file: story_idea.display_image %>
                   </div>
                 </td>
-                <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.created_by.name %></td>
+                <td class="px-4 py-2 text-sm text-gray-800"><%= credited_author_link(story_idea, class: eyebrow_link_class) %></td>
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <%= link_to story_idea.name, story_idea_path(story_idea),
                               class: "font-bold hover:text-indigo-800 hover:underline" %>

--- a/app/views/workshop_logs/_index.html.erb
+++ b/app/views/workshop_logs/_index.html.erb
@@ -50,7 +50,7 @@
             <tr class="bg-gray-100">
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Date</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Workshop</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Person</th>
+              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Author</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 bg-purple-200">Participants</th>
 
               <!-- Ongoing -->
@@ -100,7 +100,7 @@
                     <% end %>
                   </td>
                   <td class="px-2 text-left text-xs">
-                    <%= log.created_by ? link_to(log.created_by.name, log.created_by.person ? person_path(log.created_by.person) : user_path(log.created_by)) : "—" %>
+                    <%= credited_author_link(log) %>
                   </td>
 
                   <td class="text-center font-bold text-lg bg-purple-100"><%= display_count(log.total_attendance) %></td>

--- a/app/views/workshop_logs/_search_boxes.html.erb
+++ b/app/views/workshop_logs/_search_boxes.html.erb
@@ -30,12 +30,12 @@
                      onchange: "this.form.requestSubmit()" %>
     </div>
 
-    <!-- Person -->
+    <!-- Submitted by -->
     <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
-      <%= label_tag :created_by_id, "Person", class: search_label_class %>
+      <%= label_tag :created_by_id, "Submitted by", class: search_label_class %>
       <%= select_tag :created_by_id,
                      options_from_collection_for_select(@users, :id, :full_name_with_email, params[:created_by_id]),
-                     include_blank: "All people",
+                     include_blank: "Anyone",
                      class: search_field_class,
                      data: { searchable_select_target: "select", action: "change->searchable-select#submit" } %>
     </div>

--- a/app/views/workshop_logs/_search_boxes.html.erb
+++ b/app/views/workshop_logs/_search_boxes.html.erb
@@ -40,6 +40,18 @@
                      data: { searchable_select_target: "select", action: "change->searchable-select#submit" } %>
     </div>
 
+    <!-- Author name -->
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
     <!-- Organization -->
     <div class="flex w-full flex-col sm:w-2/3 md:w-1/3 lg:flex-1">
       <%= label_tag :organization_id, "Organization", class: search_label_class %>

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -33,6 +33,10 @@
           <% end %>
         </div>
         <div>
+          <span class="font-semibold text-gray-700">Author credit:</span>
+          <%= credited_author_link(@workshop_log) %>
+        </div>
+        <div>
           <span class="font-semibold text-gray-700">Organization:</span>
           <% if @workshop_log.organization && allowed_to?(:show?, @workshop_log.organization) %>
             <%= link_to @workshop_log.organization.name,

--- a/app/views/workshop_variation_ideas/_search_boxes.html.erb
+++ b/app/views/workshop_variation_ideas/_search_boxes.html.erb
@@ -1,10 +1,22 @@
 <%= form_tag(workshop_variation_ideas_path, method: :get, class: "space-y-4", data: { controller: "collection" }) do %>
-  <div class="flex flex-col md:flex-row md:items-end md:gap-4 mb-6">
+  <div class="mb-6 flex flex-col md:flex-row md:items-end md:gap-4">
     <!-- Search -->
-    <div class="w-full md:flex-1 mb-3 md:mb-0">
+    <div class="mb-3 w-full md:mb-0 md:flex-1">
       <%= label_tag :query, "Search", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :query, params[:query],
+                           class: search_field_class(extra: "pr-10") %>
+
+        <%= render "shared/search_submit" %>
+      </div>
+    </div>
+
+    <!-- Author name -->
+    <div class="mb-3 w-full md:mb-0 md:w-64">
+      <%= label_tag :author_name, "Author name", class: search_label_class %>
+      <div class="relative">
+        <%= text_field_tag :author_name, params[:author_name],
+                           placeholder: "e.g. Jane Doe",
                            class: search_field_class(extra: "pr-10") %>
 
         <%= render "shared/search_submit" %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -46,14 +46,18 @@
     Workshop ideas, story ideas, workshop variation ideas, and workshop logs now have an
     "Author name" search box that finds records by their credited author.
   description: >-
-    These index pages already showed each record's credited author; now you can search by
-    that author too. The "Author name" box matches the credited author on file, following
-    the same credit and anonymity rules as the rest of the site — so a name someone's
-    profile hides from their credit won't surface their content, and anonymous work isn't
-    findable by name. Workshop logs keep their separate "Person" filter for who logged the
-    workshop; the new box searches the credited author instead.
+    The "Author name" box matches the credited author on file, and falls back to whoever
+    submitted the record when no author is named — so older entries, from before content
+    carried an author, are still findable under the submitter's name. It follows the same
+    credit and anonymity rules as the rest of the site: a name someone's profile hides
+    from their credit won't surface their content, and anonymous work isn't findable by
+    name. Workshop logs keep their separate "Person" filter for who logged the workshop.
+    Two pages now show the credit they match: the story ideas list credits the author
+    rather than the account that entered the idea, and a workshop log's page shows its
+    author credit alongside who submitted it.
   pro_tips:
     - "The Author name box searches the credited author — on a workshop log that can differ from whoever logged it."
+    - "The people list's \"Workshop log authors\" role covers anyone credited on a log, including logs that only record who submitted them."
 
 - name: "Hide the View ticket button in a bulk email"
   area: communications

--- a/config/features.yml
+++ b/config/features.yml
@@ -43,21 +43,21 @@
   display_status: admin_facing
   released_on: 2026-08-23
   summary: >-
-    Workshop ideas, story ideas, workshop variation ideas, and workshop logs now have an
-    "Author name" search box that finds records by their credited author.
+    Workshop ideas, story ideas, workshop variation ideas, workshop logs, and monthly
+    reports now have an "Author name" search box that finds records by their credited author.
   description: >-
     The "Author name" box matches the credited author on file, and falls back to whoever
     submitted the record when no author is named — so older entries, from before content
     carried an author, are still findable under the submitter's name. It follows the same
     credit and anonymity rules as the rest of the site: a name someone's profile hides
     from their credit won't surface their content, and anonymous work isn't findable by
-    name. Workshop variations search the same way now. Lists show the credit they match:
-    the story ideas list credits the author rather than the account that entered the idea,
-    the workshop logs list swaps its "Person" column for "Author", and a workshop log's
-    page shows its author credit. The workshop log filter for who turned the log in is
-    still there, now labeled "Submitted by".
+    name. Workshop variations and monthly reports search the same way now. Lists show the
+    credit they match: the story ideas list credits the author rather than the account
+    that entered the idea, and the workshop logs and monthly reports lists swap their
+    submitter column for "Author". Each page shows its author credit too. The filters for
+    who turned a log or report in are still there, now labeled "Submitted by".
   pro_tips:
-    - "The Author name box searches the credited author — on a workshop log that can differ from whoever submitted it."
+    - "The Author name box searches the credited author — on a workshop log or monthly report that can differ from whoever submitted it."
     - "The people list's \"Workshop log authors\" and \"Workshop variation authors\" roles cover anyone credited, including records that only name who submitted them."
 
 - name: "Hide the View ticket button in a bulk email"

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,23 @@
   pro_tips:
     - "Filter the people list first — the email list always matches whatever the list is showing."
 
+- name: "Search workshop ideas, story ideas, and workshop logs by author"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-23
+  summary: >-
+    Workshop ideas, story ideas, workshop variation ideas, and workshop logs now have an
+    "Author name" search box that finds records by their credited author.
+  description: >-
+    These index pages already showed each record's credited author; now you can search by
+    that author too. The "Author name" box matches the credited author on file, following
+    the same credit and anonymity rules as the rest of the site — so a name someone's
+    profile hides from their credit won't surface their content, and anonymous work isn't
+    findable by name. Workshop logs keep their separate "Person" filter for who logged the
+    workshop; the new box searches the credited author instead.
+  pro_tips:
+    - "The Author name box searches the credited author — on a workshop log that can differ from whoever logged it."
+
 - name: "Hide the View ticket button in a bulk email"
   area: communications
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -51,13 +51,14 @@
     carried an author, are still findable under the submitter's name. It follows the same
     credit and anonymity rules as the rest of the site: a name someone's profile hides
     from their credit won't surface their content, and anonymous work isn't findable by
-    name. Workshop logs keep their separate "Person" filter for who logged the workshop.
-    Two pages now show the credit they match: the story ideas list credits the author
-    rather than the account that entered the idea, and a workshop log's page shows its
-    author credit alongside who submitted it.
+    name. Workshop variations search the same way now. Lists show the credit they match:
+    the story ideas list credits the author rather than the account that entered the idea,
+    the workshop logs list swaps its "Person" column for "Author", and a workshop log's
+    page shows its author credit. The workshop log filter for who turned the log in is
+    still there, now labeled "Submitted by".
   pro_tips:
-    - "The Author name box searches the credited author — on a workshop log that can differ from whoever logged it."
-    - "The people list's \"Workshop log authors\" role covers anyone credited on a log, including logs that only record who submitted them."
+    - "The Author name box searches the credited author — on a workshop log that can differ from whoever submitted it."
+    - "The people list's \"Workshop log authors\" and \"Workshop variation authors\" roles cover anyone credited, including records that only name who submitted them."
 
 - name: "Hide the View ticket button in a bulk email"
   area: communications

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe MonthlyReport do
     end
   end
 
+  describe ".search" do
+    it "filters by author_name matching the credited author" do
+      author = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      report = create(:monthly_report, author: author)
+      other = create(:monthly_report)
+
+      results = MonthlyReport.search(author_name: "Bartholomew")
+
+      expect(results).to include(report)
+      expect(results).not_to include(other)
+    end
+
+    it "filters by author_name matching the submitter when no author is named" do
+      submitter = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      report = create(:monthly_report, author: nil, created_by: create(:user, person: submitter))
+      other = create(:monthly_report)
+
+      results = MonthlyReport.search(author_name: "Bartholomew")
+
+      expect(results).to include(report)
+      expect(results).not_to include(other)
+    end
+  end
+
   it "uses the reports table" do
     expect(MonthlyReport.table_name).to eq("reports")
   end

--- a/spec/models/monthly_report_spec.rb
+++ b/spec/models/monthly_report_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe MonthlyReport do
-  it_behaves_like "author_creditable", factory: :monthly_report, org_credited: false, credits_creator_legacy: true
+  it_behaves_like "author_creditable", factory: :monthly_report, org_credited: false, credits_creator: true,
+                                      anonymous_when_unattributed: true
 
   describe "#author_credit" do
     it "credits an unauthored report to the creator's person by name" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -564,6 +564,15 @@ RSpec.describe Person, type: :model do
         expect(results).to include(person_bob)
         expect(results).not_to include(person_alice)
       end
+
+      it "credits the submitter on a variation that names no author" do
+        create(:workshop_variation, author: nil, created_by: create(:user, person: person_bob))
+
+        results = Person.search_by_params(role: "workshop_variation_author")
+
+        expect(results).to include(person_bob)
+        expect(results).not_to include(person_alice)
+      end
     end
 
     context "role: workshop_log_author" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -584,8 +584,17 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_bob)
       end
 
-      it "ignores logs with no credited author" do
-        create(:workshop_log, author: nil)
+      it "credits the logger on a log that names no author (predates author_id)" do
+        create(:workshop_log, created_by: create(:user, person: person_bob), author: nil)
+
+        results = Person.search_by_params(role: "workshop_log_author")
+
+        expect(results).to include(person_bob)
+        expect(results).not_to include(person_alice)
+      end
+
+      it "ignores logs with neither an author nor a person behind the account" do
+        create(:workshop_log, author: nil, created_by: create(:user, person: nil))
         results = Person.search_by_params(role: "workshop_log_author")
         expect(results).not_to include(person_alice, person_bob)
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -567,18 +567,16 @@ RSpec.describe Person, type: :model do
     end
 
     context "role: workshop_log_author" do
-      it "returns people whose linked user created a workshop log" do
-        user = create(:user, person: person_alice)
-        create(:workshop_log, created_by: user)
+      it "returns only people credited as a workshop log author" do
+        create(:workshop_log, author: person_alice)
         results = Person.search_by_params(role: "workshop_log_author")
         expect(results).to include(person_alice)
         expect(results).not_to include(person_bob)
       end
 
-      it "credits the log's creator, not other people (confirmed meaning, awbw#2326)" do
-        alice_user = create(:user, person: person_alice)
-        create(:workshop_log, created_by: alice_user)
-        create(:user, person: person_bob)
+      it "matches the credited author, not whoever logged it" do
+        logger = create(:user, person: person_bob)
+        create(:workshop_log, created_by: logger, author: person_alice)
 
         results = Person.search_by_params(role: "workshop_log_author")
 
@@ -586,8 +584,8 @@ RSpec.describe Person, type: :model do
         expect(results).not_to include(person_bob)
       end
 
-      it "ignores logs whose creating user has no linked person" do
-        create(:workshop_log, created_by: create(:user, person: nil))
+      it "ignores logs with no credited author" do
+        create(:workshop_log, author: nil)
         results = Person.search_by_params(role: "workshop_log_author")
         expect(results).not_to include(person_alice, person_bob)
       end

--- a/spec/models/story_idea_spec.rb
+++ b/spec/models/story_idea_spec.rb
@@ -71,5 +71,15 @@ RSpec.describe StoryIdea, type: :model do
       expect(results).to include(idea_alpha)
       expect(results).not_to include(idea_beta)
     end
+
+    it "filters by author_name matching the credited author" do
+      author = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      authored = create(:story_idea, title: "Authored", author: author)
+
+      results = StoryIdea.search_by_params(author_name: "Bartholomew")
+
+      expect(results).to include(authored)
+      expect(results).not_to include(idea_alpha, idea_beta)
+    end
   end
 end

--- a/spec/models/story_idea_spec.rb
+++ b/spec/models/story_idea_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe StoryIdea, type: :model do
-  it_behaves_like "author_creditable", factory: :story_idea, org_credited: false
+  it_behaves_like "author_creditable", factory: :story_idea, org_credited: false, credits_creator: true
 
   describe "#workshop_title" do
     it "returns workshop title when only workshop is present" do
@@ -79,6 +79,17 @@ RSpec.describe StoryIdea, type: :model do
       results = StoryIdea.search_by_params(author_name: "Bartholomew")
 
       expect(results).to include(authored)
+      expect(results).not_to include(idea_alpha, idea_beta)
+    end
+
+    it "filters by author_name matching the submitter when no author is named" do
+      submitter = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      submitted = create(:story_idea, title: "Submitted", author: nil,
+                                      created_by: create(:user, person: submitter))
+
+      results = StoryIdea.search_by_params(author_name: "Bartholomew")
+
+      expect(results).to include(submitted)
       expect(results).not_to include(idea_alpha, idea_beta)
     end
   end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -15,37 +15,27 @@ RSpec.describe WorkshopIdea, type: :model do
     end
   end
 
-  # An idea usually names no author, so `by_credited_person_name` can't reach the
-  # submitter — the admin filter matches the submitting account directly instead.
   describe ".author_name" do
-    let(:creator) { create(:user, :with_person) }
-
-    before { creator.person.update!(first_name: "Marguerite", last_name: "Enterer") }
-
-    it "finds an idea by its submitter's first name" do
-      idea = create(:workshop_idea, created_by: creator)
+    it "finds an idea by its credited author's first name" do
+      idea = create(:workshop_idea, author: create(:person, first_name: "Marguerite", last_name: "Enterer"))
 
       expect(WorkshopIdea.author_name("Marguerite")).to include(idea)
     end
 
-    it "finds an idea by its submitter's full name" do
-      idea = create(:workshop_idea, created_by: creator)
+    it "finds an idea by its credited author's full name" do
+      idea = create(:workshop_idea, author: create(:person, first_name: "Marguerite", last_name: "Enterer"))
 
       expect(WorkshopIdea.author_name("Marguerite Enterer")).to include(idea)
     end
 
-    it "finds an idea by the submitter's account email" do
-      idea = create(:workshop_idea, created_by: creator)
+    it "excludes ideas credited to someone else" do
+      idea = create(:workshop_idea, title: "Marguerite's idea", author: create(:person, first_name: "Marguerite", last_name: "Enterer"))
+      other = create(:workshop_idea, title: "Bartholomew's idea", author: create(:person, first_name: "Bartholomew", last_name: "Elsewhere"))
 
-      expect(WorkshopIdea.author_name(creator.email)).to include(idea)
-    end
+      results = WorkshopIdea.author_name("Marguerite")
 
-    it "excludes ideas submitted by someone else" do
-      other = create(:user, :with_person)
-      other.person.update!(first_name: "Bartholomew", last_name: "Elsewhere")
-      create(:workshop_idea, created_by: other)
-
-      expect(WorkshopIdea.author_name("Marguerite")).to be_empty
+      expect(results).to include(idea)
+      expect(results).not_to include(other)
     end
   end
 end

--- a/spec/models/workshop_idea_spec.rb
+++ b/spec/models/workshop_idea_spec.rb
@@ -1,17 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe WorkshopIdea, type: :model do
-  it_behaves_like "author_creditable", factory: :workshop_idea, org_credited: false
+  it_behaves_like "author_creditable", factory: :workshop_idea, org_credited: false, credits_creator: true
 
-  # With no author set the creator never claims authorship, so the idea falls to the
-  # generic label rather than crediting whoever entered it.
+  # An idea nobody named an author on still credits its submitter, who filled the form in.
   describe "#author_credit" do
-    it "credits the generic label, not the creating user's person" do
+    it "credits the creating user's person, not the generic label" do
       creator = create(:user, :with_person)
       idea = create(:workshop_idea, created_by: creator)
 
+      expect(idea.author_credit).to eq(creator.person.name)
+      expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to include(idea)
+    end
+
+    it "falls back to the generic label when the creator has no person" do
+      idea = create(:workshop_idea, created_by: create(:user, person: nil))
+
       expect(idea.author_credit).to eq("AWBW Facilitator")
-      expect(WorkshopIdea.by_credited_person_name(creator.person.first_name)).to be_empty
     end
   end
 
@@ -26,6 +31,13 @@ RSpec.describe WorkshopIdea, type: :model do
       idea = create(:workshop_idea, author: create(:person, first_name: "Marguerite", last_name: "Enterer"))
 
       expect(WorkshopIdea.author_name("Marguerite Enterer")).to include(idea)
+    end
+
+    it "finds an idea by its submitter's name when no author is named" do
+      idea = create(:workshop_idea, title: "Unnamed author", author: nil,
+                                    created_by: create(:user, person: create(:person, first_name: "Marguerite", last_name: "Enterer")))
+
+      expect(WorkshopIdea.author_name("Marguerite")).to include(idea)
     end
 
     it "excludes ideas credited to someone else" do

--- a/spec/models/workshop_log_spec.rb
+++ b/spec/models/workshop_log_spec.rb
@@ -139,6 +139,16 @@ RSpec.describe WorkshopLog do
         expect(results).not_to include(other_log)
       end
 
+      it "filters by author_name matching the credited author" do
+        author = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+        log = create(:workshop_log, author: author)
+        other_log = create(:workshop_log)
+
+        results = WorkshopLog.search(author_name: "Bartholomew")
+        expect(results).to include(log)
+        expect(results).not_to include(other_log)
+      end
+
       it "returns all when no filters" do
         log1 = create(:workshop_log)
         log2 = create(:workshop_log)

--- a/spec/models/workshop_log_spec.rb
+++ b/spec/models/workshop_log_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe WorkshopLog do
-  it_behaves_like "author_creditable", factory: :workshop_log, org_credited: false
+  it_behaves_like "author_creditable", factory: :workshop_log, org_credited: false, credits_creator: true
 
   describe "associations" do
     it { should belong_to(:created_by).optional }
@@ -142,6 +142,16 @@ RSpec.describe WorkshopLog do
       it "filters by author_name matching the credited author" do
         author = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
         log = create(:workshop_log, author: author)
+        other_log = create(:workshop_log)
+
+        results = WorkshopLog.search(author_name: "Bartholomew")
+        expect(results).to include(log)
+        expect(results).not_to include(other_log)
+      end
+
+      it "filters by author_name matching the logger when no author is named" do
+        logger = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+        log = create(:workshop_log, author: nil, created_by: create(:user, person: logger))
         other_log = create(:workshop_log)
 
         results = WorkshopLog.search(author_name: "Bartholomew")

--- a/spec/models/workshop_variation_idea_spec.rb
+++ b/spec/models/workshop_variation_idea_spec.rb
@@ -2,4 +2,17 @@ require "rails_helper"
 
 RSpec.describe WorkshopVariationIdea, type: :model do
   it_behaves_like "author_creditable", factory: :workshop_variation_idea, org_credited: false
+
+  describe ".search_by_params" do
+    it "filters by author_name matching the credited author" do
+      author = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      authored = create(:workshop_variation_idea, author: author)
+      other = create(:workshop_variation_idea)
+
+      results = WorkshopVariationIdea.search_by_params(author_name: "Bartholomew")
+
+      expect(results).to include(authored)
+      expect(results).not_to include(other)
+    end
+  end
 end

--- a/spec/models/workshop_variation_idea_spec.rb
+++ b/spec/models/workshop_variation_idea_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe WorkshopVariationIdea, type: :model do
-  it_behaves_like "author_creditable", factory: :workshop_variation_idea, org_credited: false
+  it_behaves_like "author_creditable", factory: :workshop_variation_idea, org_credited: false, credits_creator: true
 
   describe ".search_by_params" do
     it "filters by author_name matching the credited author" do
@@ -12,6 +12,18 @@ RSpec.describe WorkshopVariationIdea, type: :model do
       results = WorkshopVariationIdea.search_by_params(author_name: "Bartholomew")
 
       expect(results).to include(authored)
+      expect(results).not_to include(other)
+    end
+
+    it "filters by author_name matching the submitter when no author is named" do
+      submitter = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      submitted = create(:workshop_variation_idea, author: nil,
+                                                   created_by: create(:user, person: submitter))
+      other = create(:workshop_variation_idea)
+
+      results = WorkshopVariationIdea.search_by_params(author_name: "Bartholomew")
+
+      expect(results).to include(submitted)
       expect(results).not_to include(other)
     end
   end

--- a/spec/models/workshop_variation_spec.rb
+++ b/spec/models/workshop_variation_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe WorkshopVariation do
-  it_behaves_like "author_creditable", factory: :workshop_variation, org_credited: false, credits_creator_legacy: true
+  it_behaves_like "author_creditable", factory: :workshop_variation, org_credited: false, credits_creator: true,
+                                      anonymous_when_unattributed: true
 
   describe "associations" do
     it { should belong_to(:workshop).optional }
@@ -178,6 +179,16 @@ RSpec.describe WorkshopVariation do
 
       results = WorkshopVariation.search_by_params(author_name: "Bartholomew")
       expect(results).to include(authored)
+      expect(results).not_to include(variation_a, variation_b)
+    end
+
+    it "filters by author_name matching the submitter when no author is named" do
+      facilitator = create(:person, first_name: "Bartholomew", last_name: "Snazzlepants")
+      submitted = create(:workshop_variation, name: "Submitted", author: nil,
+                                              created_by: create(:user, person: facilitator))
+
+      results = WorkshopVariation.search_by_params(author_name: "Bartholomew")
+      expect(results).to include(submitted)
       expect(results).not_to include(variation_a, variation_b)
     end
   end

--- a/spec/services/author_credit_divergence_query_spec.rb
+++ b/spec/services/author_credit_divergence_query_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe AuthorCreditDivergenceQuery do
       expect(described_class.new.call.creator.flat_map(&:records)).to include(idea)
     end
 
+    it "includes a variation with a creator but no author, whose credit now names them" do
+      variation = create(:workshop_variation, created_by: author_user, author: nil)
+      expect(described_class.new.call.creator.flat_map(&:records)).to include(variation)
+    end
+
     it "excludes records covered by the legacy section instead" do
       workshop = create(:workshop, created_by: author_user, author: nil, full_name: "Legacy Name")
       expect(described_class.new.call.creator.flat_map(&:records)).not_to include(workshop)

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,13 +1,11 @@
-RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_creator_legacy: false, credits_creator: false|
+RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_creator: false, anonymous_when_unattributed: false|
   model = factory.to_s.camelize.constantize
   names_author = model.column_names.include?("author_id")
-  # What an unattributed record credits to. Most models fall to a generic label
-  # ("AWBW Staff" for org-produced content, otherwise the facilitator label).
-  # A creator-legacy model (workshop variation, monthly report) instead credits
-  # the creator's person by name, and reads "Anonymous" only when there is none.
-  # `credits_creator` is the declared form of the same fallback — the creator is
-  # credited by name, and the generic label only shows once nobody is left.
-  unattributed_label = if credits_creator_legacy
+  # What a record with nobody left to credit falls to: a generic label ("AWBW Staff"
+  # for org-produced content, otherwise the facilitator label), or "Anonymous" on the
+  # models that say so. A `credits_creator` model only gets here once the creator is
+  # gone or hidden too — otherwise it credits them by name.
+  unattributed_label = if anonymous_when_unattributed
     "Anonymous"
   else
     org_credited ? "AWBW Staff" : "AWBW Facilitator"
@@ -110,7 +108,7 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_c
           expect(record.missing_author_label).to eq(unattributed_label)
         end
 
-        if credits_creator_legacy || credits_creator
+        if credits_creator
           it "credits the creator's person by name instead of the generic label" do
             expect(record.author_credit).to eq(person.name)
           end

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -11,8 +11,8 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_c
     org_credited ? "AWBW Staff" : "AWBW Facilitator"
   end
 
-  # Only a model with an author_id credits a person; the idea models (no author_id)
-  # never credit whoever entered them, so they always fall to the generic label.
+  # Only a model with an author_id credits a person; without one, a record always
+  # falls to the generic label no matter who entered it.
   def credited_record(factory, user, person, names_author, **attrs)
     attrs[:author] = person if names_author
     create(factory, created_by: user, **attrs)

--- a/spec/support/shared_examples/author_creditable.rb
+++ b/spec/support/shared_examples/author_creditable.rb
@@ -1,10 +1,12 @@
-RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_creator_legacy: false|
+RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_creator_legacy: false, credits_creator: false|
   model = factory.to_s.camelize.constantize
   names_author = model.column_names.include?("author_id")
   # What an unattributed record credits to. Most models fall to a generic label
   # ("AWBW Staff" for org-produced content, otherwise the facilitator label).
   # A creator-legacy model (workshop variation, monthly report) instead credits
   # the creator's person by name, and reads "Anonymous" only when there is none.
+  # `credits_creator` is the declared form of the same fallback — the creator is
+  # credited by name, and the generic label only shows once nobody is left.
   unattributed_label = if credits_creator_legacy
     "Anonymous"
   else
@@ -108,13 +110,30 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_c
           expect(record.missing_author_label).to eq(unattributed_label)
         end
 
-        if credits_creator_legacy
+        if credits_creator_legacy || credits_creator
           it "credits the creator's person by name instead of the generic label" do
             expect(record.author_credit).to eq(person.name)
           end
         else
           it "falls back to the generic label rather than crediting the creator" do
             expect(record.author_credit).to eq(unattributed_label)
+          end
+        end
+
+        if credits_creator
+          it "formats the creator credit by their own profile preference" do
+            person.update!(display_name_preference: "first_name_only")
+            expect(record.author_credit).to eq(person.first_name)
+          end
+
+          it "links the credit to the creator's profile" do
+            expect(record.author_credit_person).to eq(person)
+          end
+
+          it "suppresses the credit when the creator opted out of being named" do
+            person.update!(anonymous_contributions: true)
+            expect(record.author_credit).to eq(unattributed_label)
+            expect(record.author_credit_person).to be_nil
           end
         end
       end
@@ -260,6 +279,34 @@ RSpec.shared_examples "author_creditable" do |factory:, org_credited:, credits_c
       it "still matches the full name when the record asked for first_name_only" do
         record.update!(author_credit_preference: "first_name_only")
         expect(model.by_credited_person_name("Quixotel")).to include(record)
+      end
+
+      if credits_creator
+        context "when no author is named, so the creator is credited" do
+          before { record.update!(author: nil) }
+
+          it "matches the creator's person by name" do
+            expect(model.by_credited_person_name("Zephyrine")).to include(record)
+            expect(model.by_credited_person_name("Quixotel")).to include(record)
+          end
+
+          it "honors the creator's own display preference" do
+            person.update!(display_name_preference: "first_name_only")
+            expect(model.by_credited_person_name("Quixotel")).not_to include(record)
+          end
+
+          it "matches nothing when the creator opted out of being named" do
+            person.update!(anonymous_contributions: true)
+            expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
+          end
+        end
+
+        it "does not reach the creator once someone else is the named author" do
+          record.update!(author: create(:person, first_name: "Corvid", last_name: "Talbotson"))
+
+          expect(model.by_credited_person_name("Zephyrine")).not_to include(record)
+          expect(model.by_credited_person_name("Corvid")).to include(record)
+        end
       end
     else
       it "matches nobody, since an idea names no author" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 changes what `AuthorCreditable` credits (display + search + sort + role filters) across 6 models

Follows up #2312 / #2335. Routes author search through the credited author — and makes an author-less record credit its submitter, since `author_id` shipped nullable with no backfill on most of these models.

## Why
- Pointing author search and the **Workshop log authors** role filter at `author_id` alone matched nothing for every log on file.
- `credited_to_person` (what the profile lists) already falls back to `created_by`, so the two disagreed — a profile showed logs the person wasn't findable by.
- Workshop variations and monthly reports had the fallback for *display* only, via a `legacy_author_name_text` override that SQL can't reach — so their author search and role filter missed author-less rows.
- Some lists displayed something other than the credit they filter on.

## Changes

### `credits_creator` (AuthorCreditable)
- Opt-in per model: an author-less record credits the submitting account's person, through **that person's** `display_name_preference`, suppressed by their anonymity latch.
- On for `WorkshopLog`, `WorkshopIdea`, `StoryIdea`, `WorkshopVariationIdea`, `WorkshopVariation`, `MonthlyReport`. Off elsewhere — on `Story`/`Workshop`/`Resource` the creator is an entry clerk, not the author.
- One seam drives display (`author_credit`, `author_credit_person`), search (a `creator_person` join alias), and sort (`order_by_author` coalesce).
- The creator clause is gated on `author_id IS NULL`, so a named author always outranks the submitter.
- `WorkshopVariation` / `MonthlyReport` drop their duplicate `legacy_author_name_text` overrides.

### Search by credited author
- **Workshop log** / **Monthly report** — `search` gains `author_name`.
- **Workshop idea** — `.author_name` searches the credited author instead of joining `created_by`'s user/person + email.
- **Story idea** / **Workshop variation idea** — `search_by_params` gains `author_name`.
- **Workshop variation** — its existing `author_name` box now reaches author-less rows.

### Person role filters
- New `Person.credited_on(model)` derives a role filter from what the model credits: named authors, plus the submitter where `credits_creator` is on.
- `workshop_authors`, `workshop_variation_authors`, `workshop_log_authors` all go through it.

### UI
- "Author name" box on the story-idea, workshop-variation-idea, workshop-log and monthly-report index search forms (workshop idea and workshop variation already had one).
- Story ideas index "Author" column used `created_by.name` raw, bypassing credit/anonymity rules → now `credited_author_link`.
- Workshop logs index "Person" column and monthly reports index "Submitter" column → **Author** (credited author, falling back to the submitter); both `created_by_id` filters are relabeled **Submitted by** so the two read distinctly.
- Workshop log and monthly report show pages gain "Author credit:", matching the idea show pages.
- The author-picker note explains a creator-based credit instead of going silent on it.
- `:author` added to the story-idea, workshop-log and monthly-report `includes` to keep those columns off an N+1.

### Docs
- `/features` entry; `AuthorCreditable` row in AGENTS.md.

## Tests
- `author_creditable` shared example gains a `credits_creator:` mode: creator credit, their profile preference, anonymity suppression, and "a named author outranks the creator" in search. `credits_creator_legacy:` is replaced by `anonymous_when_unattributed:`, which is what it actually controlled.
- Model specs for each `author_name` path incl. the creator fallback; `person_spec` covers the log and variation role filters' fallback and their no-person case; `monthly_report_spec` covers its new `.search` filter.
- Divergence query: an author-less variation now surfaces in the creator section, where an admin can assign the author.
