### PR TITLE
Email addresses page for the people index

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -29,6 +29,12 @@ class PeopleController < ApplicationController
     end
   end
 
+  def email_addresses
+    authorize! Person, to: :index?
+    people = authorized_scope(Person.includes(:user)).search_by_params(params.to_unsafe_h)
+    @email_addresses = people.filter_map { |person| person.preferred_email.presence }.uniq.sort
+  end
+
   def show
     authorize! @person
     @person = Person.includes(:avatar_attachment, :contact_methods, :user,

--- a/app/policies/topic_subscription_policy.rb
+++ b/app/policies/topic_subscription_policy.rb
@@ -1,2 +1,5 @@
 class TopicSubscriptionPolicy < ApplicationPolicy
+  def index?
+    admin?
+  end
 end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,30 +1,30 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="overflow-hidden rounded-xl border border-gray-200 shadow">
     <!-- Organization header banner -->
     <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:organizations, intensity: 300) %> px-8 py-3">
       <div class="flex items-center gap-2">
-        <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
         </svg>
-        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> uppercase tracking-wide">Organization Profile</span>
+        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> tracking-wide uppercase">Organization Profile</span>
       </div>
     </div>
     <div class="p-8">
     <!-- Header actions -->
-    <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <div class="mb-4 flex flex-wrap justify-end gap-2">
       <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% if allowed_to?(:edit?, @organization) %>
         <%= link_to "Edit", edit_organization_path(@organization),
-                    class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+                    class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       <% end %>
       <span class="inline-block text-sm">
         <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
       </span>
     </div>
     <!-- Header: logo + name + badges -->
-    <div class="flex flex-col md:flex-row md:items-center gap-6 mb-8">
-      <div class="flex-shrink-0 flex justify-center md:justify-start">
+    <div class="mb-8 flex flex-col gap-6 md:flex-row md:items-center">
+      <div class="flex flex-shrink-0 justify-center md:justify-start">
         <% if @organization.logo&.attached? %>
           <%= image_tag @organization.logo,
                         class: "w-28 h-28 rounded-full object-cover border-2 border-gray-200 shadow" %>
@@ -35,12 +35,12 @@
       </div>
       <div class="flex-1 text-center md:text-left">
         <% org_decorated = @organization.decorate %>
-        <div class="flex flex-wrap items-center justify-center md:justify-start gap-3">
+        <div class="flex flex-wrap items-center justify-center gap-3 md:justify-start">
           <h1 class="text-3xl font-bold text-gray-900">
             <%= @organization.name %>
           </h1>
           <% if allowed_to?(:manage?, @organization) %>
-            <span id="program-status" class="admin-only bg-blue-100 rounded-lg px-2 py-1 scroll-mt-20">
+            <span id="program-status" class="admin-only scroll-mt-20 rounded-lg bg-blue-100 px-2 py-1">
               <%= org_decorated.organization_status_chip %>
             </span>
           <% end %>
@@ -51,26 +51,26 @@
                        @organization.addresses.active.first
                      end %>
         <% if address %>
-          <p class="mt-1 text-gray-500 text-sm">
+          <p class="mt-1 text-sm text-gray-500">
             <%= [address.locality, [address.city, address.state].compact_blank.join(", "), address.district].compact_blank.join(" · ") %>
           </p>
         <% end %>
         <% affiliated_since = org_decorated.affiliated_since_display %>
         <% if affiliated_since.present? %>
-          <p class="text-gray-500 text-sm mt-1">
+          <p class="mt-1 text-sm text-gray-500">
             Affiliated since
             <span class="font-medium"><%= affiliated_since %></span>
           </p>
         <% end %>
         <% program_since = org_decorated.program_since_display %>
         <% if program_since.present? %>
-          <p class="text-gray-500 text-sm mt-1">
+          <p class="mt-1 text-sm text-gray-500">
             Facilitators since
             <span class="font-medium"><%= program_since %></span>
           </p>
         <% end %>
         <!-- Contact info -->
-        <div class="mt-3 flex flex-wrap justify-center md:justify-start items-center gap-x-4 gap-y-2 text-sm">
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm md:justify-start">
           <% if @organization.profile_show_email? && @organization.email.present? %>
             <span class="text-gray-600">
               📧 <%= mail_to @organization.email, @organization.email, class: "text-blue-600 hover:underline" %>
@@ -98,7 +98,7 @@
               </span>
             <% elsif allowed_to?(:edit?, @organization) %>
               <span class="admin-only bg-blue-100 p-3">
-                <span class="bg-red-100 text-red-700 text-xs px-2 py-1 rounded">
+                <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700">
                   Bad URL: "<%= link_to @organization.website_url, edit_organization_path(@organization, anchor: "website-url-field") %>"
                 </span>
               </span>
@@ -108,7 +108,7 @@
         <!-- Badges -->
         <% badges = @organization.decorate.badges %>
         <% if badges.any? %>
-          <div class="mt-3 flex flex-wrap justify-center md:justify-start gap-1.5">
+          <div class="mt-3 flex flex-wrap justify-center gap-1.5 md:justify-start">
             <% badges.each do |badge| %>
               <%= render "shared/badge", label: badge[:label], classes: "#{badge[:bg]} #{badge[:text]} #{badge[:border]}" %>
             <% end %>
@@ -118,10 +118,10 @@
     </div>
     <hr class="my-8 border-gray-200">
     <!-- Info grid -->
-    <div class="grid grid-cols-1 md:grid-cols-5 gap-8">
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-5">
         <!-- Organization affiliations -->
-        <div id="affiliations" class="md:col-span-3 scroll-mt-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
-          <h2 class="text-lg font-semibold text-gray-800 mb-2">
+        <div id="affiliations" class="scroll-mt-4 md:col-span-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
+          <h2 class="mb-2 text-lg font-semibold text-gray-800">
             Affiliations
           </h2>
           <% active_affiliations = @organization.affiliations
@@ -129,7 +129,7 @@
                .sort_by { |a| [a.person.first_name.to_s.downcase, a.person.last_name.to_s.downcase] } %>
           <% grouped = active_affiliations.group_by(&:person) %>
           <% if grouped.any? %>
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
               <% grouped.each do |person, person_affiliations| %>
                 <div data-paginated-fields-target="item">
                   <% titles = person_affiliations.filter_map { |a| a.title.presence }.uniq %>
@@ -150,11 +150,11 @@
         <% additional_age_groups = @organization.profile_show_age_ranges? ? @organization.all_additional_age_groups : [] %>
         <% show_age = primary_age_groups.any? || additional_age_groups.any? %>
         <% if show_sectors || show_age %>
-          <div class="md:col-span-2 p-3">
-            <div class="flex flex-col sm:flex-row gap-4 items-start">
+          <div class="p-3 md:col-span-2">
+            <div class="flex flex-col items-start gap-4 sm:flex-row">
               <% if show_sectors %>
-                <div class="flex-1 min-w-0">
-                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Sectors</h2>
+                <div class="min-w-0 flex-1">
+                  <h2 class="mb-3 text-lg font-semibold text-gray-800">Sectors</h2>
                   <% if sectors.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% sectors.first(3).each do |sector| %>
@@ -163,7 +163,7 @@
                                    display_leader: true %>
                       <% end %>
                       <% if sectors.length > 3 %>
-                        <span class="text-gray-500 px-2">...</span>
+                        <span class="px-2 text-gray-500">...</span>
                       <% end %>
                     </div>
                   <% else %>
@@ -177,8 +177,8 @@
                 </div>
               <% end %>
               <% if show_age %>
-                <div class="flex-1 min-w-0">
-                  <h2 class="text-lg font-semibold text-gray-800 mb-3">Age groups served</h2>
+                <div class="min-w-0 flex-1">
+                  <h2 class="mb-3 text-lg font-semibold text-gray-800">Age groups served</h2>
                   <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
                 </div>
               <% end %>
@@ -189,7 +189,7 @@
     <hr class="my-8 border-gray-200">
     <!-- Workshops authored -->
     <% if @organization.profile_show_description? && @organization.description.present? %>
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">
           Description
         </h2>
         <%= sanitize(@organization.description, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
@@ -198,7 +198,7 @@
     <!-- Workshops authored -->
     <% if @organization.profile_show_workshops? %>
         <div>
-          <h2 class="text-lg font-semibold text-gray-800 mb-2">
+          <h2 class="mb-2 text-lg font-semibold text-gray-800">
             Workshops authored
           </h2>
           <% if @organization.workshops.any? %>
@@ -213,7 +213,7 @@
     <!-- Stories authored -->
     <% if @organization.profile_show_stories? %>
       <div class="mt-10">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">
           Stories
         </h2>
         <%# stories = @organization.stories_as_creator + @organization.stories_as_spotlighted_organization %>
@@ -229,7 +229,7 @@
       <!-- Events attended -->
     <% if @organization.profile_show_events_registered? %>
       <div class="mt-10">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">
           Events attended
         </h2>
         <%= turbo_frame_tag "organization_events_section", src: organization_path(@organization, section: "events"), loading: :lazy do %>
@@ -242,15 +242,14 @@
         <div class="organization-only <%= DomainTheme.bg_class_for(:user_only) %>
           border <%= DomainTheme.border_class_for(:user_only) %> rounded-lg shadow-sm">
           <!-- Header -->
-          <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3
-            border-b <%= DomainTheme.border_class_for(:user_only) %>">
+          <div class="section-header flex flex-col justify-between gap-2 border-b px-6 py-3 sm:flex-row sm:items-center sm:px-7 <%= DomainTheme.border_class_for(:user_only) %>">
             <h2 class="text-xl font-semibold text-gray-800">
               Associated records
             </h2>
             <span class="text-sm text-amber-700 italic">Only visible to you</span>
           </div>
           <!-- Content -->
-          <div class="section-content px-6 sm:px-7 py-4 sm:py-6">
+          <div class="section-content px-6 py-4 sm:px-7 sm:py-6">
             <%= render "associated_records", organization: @organization %>
           </div>
         </div>

--- a/app/views/people/_people_count.html.erb
+++ b/app/views/people/_people_count.html.erb
@@ -1,12 +1,3 @@
 <div id="people_count">
-  <div class="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-    <h2 class="text-2xl font-semibold">People (<%= @count_display %>)</h2>
-    <% if @count_display.to_i.positive? %>
-      <%= link_to email_addresses_people_path(request.query_parameters),
-            class: "text-sm #{eyebrow_link_class} inline-flex items-center gap-1" do %>
-        <i class="fa-solid fa-envelope text-xs" aria-hidden="true"></i>
-        Email addresses
-      <% end %>
-    <% end %>
-  </div>
+  <h2 class="mb-2 text-2xl font-semibold">People (<%= @count_display %>)</h2>
 </div>

--- a/app/views/people/_people_count.html.erb
+++ b/app/views/people/_people_count.html.erb
@@ -1,3 +1,12 @@
 <div id="people_count">
-  <h2 class="text-2xl font-semibold mb-2">People (<%= @count_display %>)</h2>
+  <div class="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+    <h2 class="text-2xl font-semibold">People (<%= @count_display %>)</h2>
+    <% if @count_display.to_i.positive? %>
+      <%= link_to email_addresses_people_path(request.query_parameters),
+            class: "text-sm #{eyebrow_link_class} inline-flex items-center gap-1" do %>
+        <i class="fa-solid fa-envelope text-xs" aria-hidden="true"></i>
+        Email addresses
+      <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/people/email_addresses.html.erb
+++ b/app/views/people/email_addresses.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> rounded-xl border border-gray-200 p-6 shadow">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← People", people_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
@@ -10,7 +10,7 @@
       <i class="fa-solid fa-envelope <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
       Email addresses
     </h1>
-    <p class="text-gray-600 mt-1">
+    <p class="mt-1 text-gray-600">
       <%= pluralize(@email_addresses.size, "unique email address") %> from the current people filter.
     </p>
   </div>

--- a/app/views/people/email_addresses.html.erb
+++ b/app/views/people/email_addresses.html.erb
@@ -1,0 +1,19 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+    <%= link_to "← People", people_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  </div>
+
+  <div class="mb-6">
+    <h1 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
+      <i class="fa-solid fa-envelope <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
+      Email addresses
+    </h1>
+    <p class="text-gray-600 mt-1">
+      <%= pluralize(@email_addresses.size, "unique email address") %> from the current people filter.
+    </p>
+  </div>
+
+  <%= render "shared/email_address_list", emails: @email_addresses %>
+</div>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -22,11 +22,14 @@
       <div id="people_count" class="pr-6">
         <h2 class="mb-2 text-2xl font-semibold">People</h2>
       </div>
-      <div class="flex items-center gap-2 text-right">
+      <div class="flex flex-wrap items-center justify-end gap-2 text-right">
         <% if allowed_to?(:index?, TopicSubscription) %>
-          <%= link_to "Subscriptions",
-                      topic_subscriptions_path,
-                      class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+          <%= link_to "Subscriptions", topic_subscriptions_path,
+                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:index?, Person) %>
+          <%= link_to "Email addresses", email_addresses_people_path(request.query_parameters),
+                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:new?, Person) %>
           <%= link_to "New Person",

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -25,11 +25,11 @@
       <div class="flex flex-wrap items-center justify-end gap-2 text-right">
         <% if allowed_to?(:index?, TopicSubscription) %>
           <%= link_to "Subscriptions", topic_subscriptions_path,
-                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:index?, Person) %>
           <%= link_to "Email addresses", email_addresses_people_path(request.query_parameters),
-                      class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
         <% if allowed_to?(:new?, Person) %>
           <%= link_to "New Person",

--- a/app/views/shared/_email_address_list.html.erb
+++ b/app/views/shared/_email_address_list.html.erb
@@ -1,0 +1,7 @@
+<% if emails.any? %>
+  <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-800 break-words select-all">
+    <%= emails.join(", ") %>
+  </div>
+<% else %>
+  <p class="text-gray-500">No email addresses found.</p>
+<% end %>

--- a/app/views/shared/_email_address_list.html.erb
+++ b/app/views/shared/_email_address_list.html.erb
@@ -1,5 +1,5 @@
 <% if emails.any? %>
-  <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-800 break-words select-all">
+  <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm break-words text-gray-800 select-all">
     <%= emails.join(", ") %>
   </div>
 <% else %>

--- a/app/views/topic_subscriptions/email_addresses.html.erb
+++ b/app/views/topic_subscriptions/email_addresses.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:topic_subscriptions) %> rounded-xl border border-gray-200 p-6 shadow">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
@@ -10,7 +10,7 @@
       <i class="fa-solid fa-envelope <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
       Email addresses
     </h1>
-    <p class="text-gray-600 mt-1">
+    <p class="mt-1 text-gray-600">
       <%= pluralize(@email_addresses.size, "unique email address") %> from the current subscriptions filter.
     </p>
 
@@ -55,11 +55,5 @@
     <% end %>
   <% end %>
 
-  <% if @email_addresses.any? %>
-    <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-800 break-words select-all">
-      <%= @email_addresses.join(", ") %>
-    </div>
-  <% else %>
-    <p class="text-gray-500">No email addresses found.</p>
-  <% end %>
+  <%= render "shared/email_address_list", emails: @email_addresses %>
 </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Copy email addresses from the people list"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-23
+  action_path: "/people"
+  summary: >-
+    The people index has an "Email addresses" link that opens a copy-paste list of every unique
+    email address for the people your current filters narrow to.
+  pro_tips:
+    - "Filter the people list first — the email list always matches whatever the list is showing."
+
 - name: "Affiliation editor: FileMaker code"
   area: people
   display_status: admin_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,6 +239,7 @@ Rails.application.routes.draw do
   resources :people do
     collection do
       get :check_duplicates
+      get :email_addresses
     end
     member do
       get :workshop_logs

--- a/spec/requests/people_email_addresses_spec.rb
+++ b/spec/requests/people_email_addresses_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "People email addresses", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "GET /people/email_addresses" do
+    it "lists the filtered people's unique emails comma-separated" do
+      create(:person, first_name: "Alice", last_name: "Wonderland",
+                      email: "alice@example.com", user: nil)
+      create(:person, first_name: "Bob", last_name: "Builder",
+                      email: "bob@example.com", user: nil)
+
+      get email_addresses_people_path(contact_info: "Alice")
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("alice@example.com")
+      expect(response.body).not_to include("bob@example.com")
+    end
+
+    it "falls back to the person's preferred email when the email column is blank" do
+      create(:person, email: nil, user: create(:user, email: "dana@example.com"))
+      create(:person, email: nil, email_2: "rio@example.com", user: nil)
+
+      get email_addresses_people_path
+
+      expect(response.body).to include("dana@example.com")
+      expect(response.body).to include("rio@example.com")
+    end
+
+    it "shows the empty state when no people match" do
+      get email_addresses_people_path(contact_info: "nobody-matches-this")
+
+      expect(response.body).to include("No email addresses found.")
+    end
+
+    it "is admin-only" do
+      sign_out admin
+      sign_in create(:user)
+
+      get email_addresses_people_path
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/other_responses/index.html.erb"         => "admin-only bg-blue-100",
     "app/views/banners/index.html.erb"                 => "admin-only bg-blue-100",
     "app/views/people/all_comments.html.erb"           => "admin-only bg-blue-100",
+    "app/views/people/email_addresses.html.erb"        => "admin-only bg-blue-100",
     "app/views/comments/index.html.erb"                => "admin-only bg-blue-100",
     "app/views/bookmarks/index.html.erb"               => "admin-only bg-blue-100",
     "app/views/categories/index.html.erb"              => "admin-only bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new admin action + view, plus small nav-styling/policy tweaks

## What
- New **Email addresses** link on the people index → a copy-paste list of unique emails for the currently filtered people (`PeopleController#email_addresses`).
- Mirrors the topic-subscriptions email list; shares the copy box via a new `shared/_email_address_list` partial.

## Admin nav styling
- People-index **Subscriptions** and **Email addresses**, and organization-show **Edit**, now use the `admin-only bg-blue-100` marker to match the person-show Edit/People links.
- Both people-index links are gated on their admin index policies; `TopicSubscriptionPolicy#index?` made explicitly `admin?`.

## Why
- Admins want to email the exact set of people a filter narrows to, without hand-collecting addresses.
- Admin-restricted nav actions should visually read as admin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)