### PR TITLE
Comments & communications on every record that had comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ This codebase (Rails 8.1)
 | `app/models/` | ActiveRecord models | ~90 files |
 | `app/services/` | Service objects and POROs (e.g. `MoneyFormatter` for currency display, `StoryImporter` for WordPress CSV import) | ~70 files |
 | `app/jobs/` | SolidQueue background jobs | 6 files |
-| `app/models/concerns/` | Shared model modules | 18 concerns |
+| `app/models/concerns/` | Shared model modules | 19 concerns |
 
 ### Presentation
 
@@ -139,6 +139,7 @@ This codebase (Rails 8.1)
 |---|---|
 | `AgeGroupTaggable` | Splits AgeRange category taggings into primary/additional via `categorizable_items.is_primary` (Person, Organization) |
 | `AhoyTrackable` | Event tracking integration |
+| `Communicable` | Gives a record the `notifications` association, nested attributes, a default `communications_scope`, and a `before_validation` addressing a hand-logged communication to the record's `communications_email`. Included by every model whose form renders `shared/_comments_and_communications` |
 | `AuthorCreditable` | Author attribution. Credits are formatted by the credited **person's profile** (`Person#display_name_preference`), not by the record. The record's `author_credit_preference` is the consent snapshot taken at create time and is human-editable only on the author credit divergences page. Anonymity is a one-way latch: the profile or the record can set it, neither can strip it from the other. `credits_to_org` flips the unattributed label to "AWBW Staff"; `credits_creator` (idea models, workshop logs) credits the submitting account's person when no author is named |
 | `Featureable` | `featured`, `publicly_featured` scopes |
 | `Mentioner` | ActionText @mention extraction and grouping |

--- a/app/controllers/affiliations_controller.rb
+++ b/app/controllers/affiliations_controller.rb
@@ -102,7 +102,8 @@ class AffiliationsController < ApplicationController
     params.require(:affiliation).permit(
       :person_id, :organization_id, :title, :start_date, :end_date, :primary_contact,
       :organization_address_id, :filemaker_code, :event_registration_id,
-      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 

--- a/app/controllers/continuing_education_registrations_controller.rb
+++ b/app/controllers/continuing_education_registrations_controller.rb
@@ -115,9 +115,11 @@ class ContinuingEducationRegistrationsController < ApplicationController
       ce_registration.cost_cents = (cost.to_d * 100).round if cost.present?
     end
 
-    comments = params.fetch(:continuing_education_registration, {})
-      .permit(comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ])[:comments_attributes]
-    ce_registration.comments_attributes = comments if comments.present?
+    nested = params.fetch(:continuing_education_registration, {})
+      .permit(comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+              notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ])
+    ce_registration.comments_attributes = nested[:comments_attributes] if nested[:comments_attributes].present?
+    ce_registration.notifications_attributes = nested[:notifications_attributes] if nested[:notifications_attributes].present?
   end
 
   # Staff corrections to the registrant's attendance times, submitted alongside the

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -94,10 +94,6 @@ class EventRegistrationsController < ApplicationController
     @event_registration.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
     @event_registration.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
-    # Inline-logged notifications are addressed to the registrant.
-    recipient_email = @event_registration.registrant&.preferred_email.presence || "n/a"
-    @event_registration.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
-
     if @event_registration.save
       # Marking transferred out — from the edit-form save OR the inline roster/
       # onboarding status chip (Turbo) — with no destination yet sends the admin

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -260,6 +260,7 @@ class OrganizationsController < ApplicationController
         :_destroy
       ],
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ],
       addresses_attributes: [
         :id,
         :address_type,

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -301,10 +301,6 @@ class PeopleController < ApplicationController
     @person.comments.select(&:new_record?).each { |c| c.created_by = current_user; c.updated_by = current_user }
     @person.comments.select { |c| c.persisted? && c.body_changed? }.each { |c| c.updated_by = current_user }
 
-    # Inline-logged notifications are addressed to the person.
-    recipient_email = @person.preferred_email.presence || "n/a"
-    @person.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
-
     if @person.save
       assign_associations(@person) if params.dig(:person, :category_ids)
       redirect_to person_update_return_path, notice: "Person was successfully updated."

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -76,10 +76,6 @@ class ScholarshipsController < ApplicationController
     @scholarship.assign_attributes(scholarship_params)
     attribute_comment_authorship
 
-    # Inline-logged notifications are addressed to the scholarship recipient.
-    recipient_email = @scholarship.recipient&.preferred_email.presence || "n/a"
-    @scholarship.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
-
     if @scholarship.save
       redirect_to scholarship_save_path, notice: "Scholarship updated."
     else

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -100,7 +100,6 @@ class StoriesController < ApplicationController
     Story.transaction do
       @story.assign_attributes(story_params.except(:images, :category_ids, :sector_ids))
       attribute_comment_authorship
-      stamp_new_notification_recipients
       if @story.save
         assign_associations(@story)
         if params[:promote_idea_assets] == "true"
@@ -190,11 +189,6 @@ class StoriesController < ApplicationController
       notification_type: 0)
   end
 
-  # Inline-logged communications are addressed to the story's credited author.
-  def stamp_new_notification_recipients
-    recipient_email = @story.communications_email.presence || "n/a"
-    @story.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
-  end
 
   def set_story
     # Accepts both the bare id ("23") and the slugged param ("23-my-great-story");

--- a/app/controllers/story_ideas_controller.rb
+++ b/app/controllers/story_ideas_controller.rb
@@ -93,7 +93,6 @@ class StoryIdeasController < ApplicationController
     StoryIdea.transaction do
       @story_idea.assign_attributes(story_idea_params.except(:images, :category_ids, :sector_ids))
       attribute_comment_authorship
-      stamp_new_notification_recipients
       if @story_idea.save
         assign_associations(@story_idea)
         success = true
@@ -137,11 +136,6 @@ class StoryIdeasController < ApplicationController
     end
   end
 
-  # Inline-logged communications are addressed to the idea's submitter.
-  def stamp_new_notification_recipients
-    recipient_email = @story_idea.communications_email.presence || "n/a"
-    @story_idea.notifications.select(&:new_record?).each { |n| n.recipient_email = recipient_email }
-  end
 
   def set_story_idea
     @story_idea = StoryIdea.find(params[:id])

--- a/app/controllers/topic_subscriptions_controller.rb
+++ b/app/controllers/topic_subscriptions_controller.rb
@@ -125,6 +125,7 @@ class TopicSubscriptionsController < ApplicationController
   def topic_subscription_params
     permitted = params.require(:topic_subscription).permit(:person_id, :topic_subscription_type_id, :interested_event_id, :organization_id, :source,
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ],
       person_attributes: [ :first_name, :last_name, :email ])
 
     # The new-person toggle is CSS-only, so both the person select and the new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -442,6 +442,7 @@ class UsersController < ApplicationController
       #####
 
       comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ],
       affiliations_attributes: [ :id, :organization_id, :title, :inactive, :primary_contact, :start_date, :end_date, :_destroy ],
     )
   end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -293,7 +293,8 @@ class WorkshopsController < ApplicationController
       workshop_series_children_attributes: [ :id, :workshop_child_id, :workshop_parent_id, :theme_name,
                                             :series_description, :series_description_spanish,
                                             :position, :_destroy ],
-      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ]
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
     )
   end
 end

--- a/app/helpers/chip_helper.rb
+++ b/app/helpers/chip_helper.rb
@@ -18,11 +18,10 @@ module ChipHelper
     CHIP_COLORS[(id || 0) % CHIP_COLORS.length]
   end
 
-  # Border + background for a comment card. `admin_only` wins on a page
-  # non-admins can view (comments are always staff-only there); `warning` is the
-  # amber tint for an imported [AGE_RANGE_DATA] note.
-  def comment_card_class(admin_only: false, warning: false)
-    return "admin-only border-blue-200 bg-blue-100" if admin_only
+  # Border + background for a comment card. `warning` is the amber tint for an
+  # imported [AGE_RANGE_DATA] note. Staff-only-ness is signalled by the add
+  # button alone — tinting every card blue read as a wall of blue.
+  def comment_card_class(warning: false)
     return "border-amber-200 bg-amber-50" if warning
 
     "#{DomainTheme.border_class_for(:comments, intensity: 200)} #{DomainTheme.bg_class_for(:comments, intensity: 50)}"

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,4 +1,5 @@
 class Affiliation < ApplicationRecord
+  include Communicable
   # Standing title given to the "facilitator affiliation" we create on registration
   # and org linking. Matches the `facilitators` scope / `facilitator?` predicate
   # (both treat exactly "Facilitator" as canonical).
@@ -22,6 +23,11 @@ class Affiliation < ApplicationRecord
   belongs_to :event_registration, optional: true, inverse_of: :affiliations
 
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  # A communication logged on an affiliation is addressed to the affiliated person.
+  def communications_email
+    person&.preferred_email
+  end
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
 
   # Validations

--- a/app/models/concerns/communicable.rb
+++ b/app/models/concerns/communicable.rb
@@ -1,0 +1,37 @@
+# A record that carries hand-logged communications alongside its comments, so it
+# can render the shared comments-and-communications section.
+#
+# Including models must define `communications_email` — the address a
+# communication logged here is addressed to (usually the record's person). Most
+# also want the default `communications_scope`: only what was filed against this
+# record. Person overrides it to show a whole history matched by email.
+module Communicable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :notifications, as: :noticeable, dependent: :nullify
+    # A blank subject means the row was added and left untouched, so drop it.
+    accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
+    before_validation :stamp_new_notification_recipients
+  end
+
+  # Communications this record's section shows, newest-first ordering applied by
+  # the caller.
+  def communications_scope
+    notifications
+  end
+
+  private
+
+  # A hand-logged communication is addressed to whoever this record is about, so
+  # the inline form never asks for a recipient — we stamp it on the way in.
+  # Reads the association's in-memory target rather than the association itself,
+  # so an unrelated save doesn't load every notification just to find none new.
+  def stamp_new_notification_recipients
+    pending = association(:notifications).target.select(&:new_record?)
+    return if pending.empty?
+
+    email = communications_email.presence || "n/a"
+    pending.each { |notification| notification.recipient_email = email }
+  end
+end

--- a/app/models/continuing_education_registration.rb
+++ b/app/models/continuing_education_registration.rb
@@ -1,6 +1,7 @@
 class ContinuingEducationRegistration < ApplicationRecord
   include Registerable
   include Certifiable
+  include Communicable
 
   # AWBW's continuing-education accreditation, referenced by the CE callout copy
   # and the completion certificate's CE clause. Kept here as the single source of
@@ -21,6 +22,10 @@ class ContinuingEducationRegistration < ApplicationRecord
   has_many :allocations, as: :allocatable, dependent: :destroy
   has_many :payments, through: :allocations, source: :source, source_type: "Payment"
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  def communications_email
+    registrant&.preferred_email
+  end
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -2,6 +2,7 @@ class EventRegistration < ApplicationRecord
   include RemoteSearchable
   include Registerable
   include Certifiable
+  include Communicable
 
   # Sentinel for the roster's Payment method filter that matches buddy-system
   # registrations (someone_else_will_pay), which isn't an expected_payment_method
@@ -12,7 +13,6 @@ class EventRegistration < ApplicationRecord
   belongs_to :event
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :event_registration_organizations, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :organizations, through: :event_registration_organizations
   has_many :allocations, as: :allocatable
   has_many :continuing_education_registrations, dependent: :destroy
@@ -33,7 +33,6 @@ class EventRegistration < ApplicationRecord
   has_one :transferred_to_registration, class_name: "EventRegistration",
     foreign_key: :transferred_from_registration_id, inverse_of: :transferred_from_registration, dependent: :nullify
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
-  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
   # Staff correct/add attendance times on the CE edit form; a row with no sign-in
   # time is an untouched blank and dropped.
   accepts_nested_attributes_for :event_attendance_time_entries, allow_destroy: true,
@@ -585,9 +584,8 @@ class EventRegistration < ApplicationRecord
     "(#{ registrant&.full_name }) #{ event.start_date.strftime("%Y-%m-%d @ %I:%M %p") }: #{ event.title }"
   end
 
-  # Only comms filed against this registration, not the registrant's whole history.
-  def communications_scope
-    notifications
+  def communications_email
+    registrant&.preferred_email
   end
 
   def active?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,6 @@
 class Organization < ApplicationRecord
   include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, SectorsTaggable, AgeGroupTaggable # Publishable
+  include Communicable
   belongs_to :organization_status
   belongs_to :organization_obligation, optional: true
   belongs_to :location, optional: true # TODO - remove Location if unused
@@ -13,6 +14,11 @@ class Organization < ApplicationRecord
   has_many :people, through: :affiliations
   has_many :users, through: :people
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  # An organization is its own correspondent — there is no person behind it.
+  def communications_email
+    email
+  end
   has_many :reports
   has_many :workshop_logs
   has_many :grants, as: :funder, dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person < ApplicationRecord
   include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, SectorsTaggable, AgeGroupTaggable, StaffTaggable
+  include Communicable
 
   pay_customer default_payment_processor: :stripe
 
@@ -20,7 +21,6 @@ class Person < ApplicationRecord
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :contact_methods, as: :contactable, dependent: :destroy
   has_many :categorizable_items, inverse_of: :categorizable, as: :categorizable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :sectorable_items, as: :sectorable, dependent: :destroy
   has_many :other_responses, as: :owner, dependent: :destroy
   has_many :stories_as_spotlighted_facilitator, inverse_of: :spotlighted_facilitator, class_name: "Story",
@@ -136,7 +136,6 @@ class Person < ApplicationRecord
   accepts_nested_attributes_for :affiliations, allow_destroy: true,
     reject_if: proc { |attrs| attrs["organization_id"].blank? }
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
-  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
   # A blank row (number + kind + state + expiry all empty) is ignored rather than
   # creating an empty license.
   accepts_nested_attributes_for :professional_licenses, allow_destroy: true,

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -1,15 +1,14 @@
 class Scholarship < ApplicationRecord
+  include Communicable
   belongs_to :recipient, class_name: "Person"
   belongs_to :grant, optional: true
   has_one :allocation, as: :source, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :agreement_responses, -> { chronological }, class_name: "ScholarshipAgreementResponse", dependent: :destroy
 
   AGREEMENT_RESPONSE_STATUSES = %w[pending accepted declined].freeze
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
-  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :agreement_response_status, inclusion: { in: AGREEMENT_RESPONSE_STATUSES }
@@ -127,9 +126,8 @@ class Scholarship < ApplicationRecord
     self.amount_cents = (value.to_d * 100).to_i if value.present?
   end
 
-  # Only comms filed against this scholarship, not the recipient's whole history.
-  def communications_scope
-    notifications
+  def communications_email
+    recipient&.preferred_email
   end
 
   private

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,6 +1,7 @@
 class Story < ApplicationRecord
   include AuthorCreditable
   include Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
+  include Communicable
 
   has_rich_text :rhino_body
 
@@ -20,7 +21,6 @@ class Story < ApplicationRecord
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
-  has_many :notifications, as: :noticeable, dependent: :nullify
 
   # Asset associations
   has_one :primary_asset, -> { where(type: "PrimaryAsset") },
@@ -49,7 +49,6 @@ class Story < ApplicationRecord
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
-  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   # SearchCop
   include SearchCop
@@ -133,11 +132,6 @@ class Story < ApplicationRecord
 
   def communications_email
     author_person&.preferred_email
-  end
-
-  # Only comms filed against this story, not the author's whole history.
-  def communications_scope
-    notifications
   end
 
   def organization_name

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -1,5 +1,6 @@
 class StoryIdea < ApplicationRecord
   include AuthorCreditable
+  include Communicable
   # The submitter is the author when none is named.
   credits_creator
 
@@ -28,7 +29,6 @@ class StoryIdea < ApplicationRecord
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable
-  has_many :notifications, as: :noticeable, dependent: :nullify
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :stories
 
@@ -56,7 +56,6 @@ class StoryIdea < ApplicationRecord
   accepts_nested_attributes_for :primary_asset, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :gallery_assets, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
-  accepts_nested_attributes_for :notifications, allow_destroy: true, reject_if: proc { |attrs| attrs["email_subject"].blank? }
 
   def name
     "StoryIdea ##{id}"
@@ -64,11 +63,6 @@ class StoryIdea < ApplicationRecord
 
   def communications_email
     created_by&.email
-  end
-
-  # Only comms filed against this story idea, not the submitter's whole history.
-  def communications_scope
-    notifications
   end
 
   def full_name

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -1,4 +1,5 @@
 class TopicSubscription < ApplicationRecord
+  include Communicable
   belongs_to :person
   belongs_to :topic_subscription_type
   # Optional narrowing to a specific event (e.g. one training). Null = the topic
@@ -10,6 +11,10 @@ class TopicSubscription < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  def communications_email
+    person&.preferred_email
+  end
 
   accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
   # Lets the new-subscription form create a brand-new person inline instead of

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Communicable
   # Include default devise modules. Others available are:
   # :confirmable, :timeoutable and :omniauthable
   devise :database_authenticatable, :recoverable, :confirmable,
@@ -34,8 +35,12 @@ class User < ApplicationRecord
   belongs_to :favorite_event, class_name: "Event", optional: true
   has_many :bookmarks, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  # A user account's communications are addressed to its login email.
+  def communications_email
+    email
+  end
   has_many :event_registrations, through: :person
-  has_many :notifications, as: :noticeable, dependent: :nullify
 
   has_many :reports, foreign_key: :created_by_id, inverse_of: :created_by
   has_many :resources, foreign_key: :created_by_id, inverse_of: :created_by

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -2,6 +2,7 @@ class Workshop < ApplicationRecord
   include AuthorCreditable
   credits_to_org
   include Featureable, Publishable, RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
+  include Communicable
   include PunctuationStrippable
   include Rails.application.routes.url_helpers
   include ActionText::Attachable
@@ -31,6 +32,11 @@ class Workshop < ApplicationRecord
 
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+
+  # A communication logged on a workshop is addressed to its credited author.
+  def communications_email
+    author&.preferred_email
+  end
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :quotable_item_quotes, as: :quotable, dependent: :destroy
   has_many :associated_resources, class_name: "Resource", foreign_key: "workshop_id", dependent: :restrict_with_error

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -182,43 +182,7 @@
       </div>
     </div>
 
-    <%# ---- Comments (saved with the affiliation, like the other forms) ---- %>
-    <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
-      <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-        <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:comments, intensity: 100) %> <%= DomainTheme.text_class_for(:comments, intensity: 600) %>">
-          <i class="fa-solid fa-comments"></i>
-        </span>
-        <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
-      </div>
-
-      <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
-        <div id="comment-list" class="space-y-4">
-          <%= f.simple_fields_for :comments do |cf| %>
-            <%= render "comments/comment_fields", f: cf %>
-          <% end %>
-        </div>
-
-        <div data-paginated-fields-target="nav"></div>
-
-        <div class="flex items-center justify-between gap-2">
-          <%= link_to_add_association f, :comments,
-                partial: "comments/comment_fields",
-                data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
-                class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
-            <i class="fa-solid fa-plus text-2xs"></i>
-            Add comment
-          <% end %>
-
-          <button type="button"
-                  class="inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
-                  data-action="edit-toggle#toggle">
-            <i class="fa-solid fa-pen text-2xs"></i>
-            <span data-edit-toggle-target="editLabel">Edit comments</span>
-            <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
-          </button>
-        </div>
-      </div>
-    </section>
+    <%= render "shared/comments_and_communications", f: f, view_all_person: f.object.person %>
 
   <% end %>
 

--- a/app/views/comments/_comment_fields.html.erb
+++ b/app/views/comments/_comment_fields.html.erb
@@ -1,6 +1,3 @@
-<%# On a page non-admins can view, callers pass mark_admin_only: true — a comment
-    is always staff-only, so the whole card takes the app's admin-only blue wash. %>
-<% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
 <% created_user = f.object.created_by %>
 <% updated_user = f.object.updated_by %>
 <% created_name = created_user&.person&.name || created_user&.name %>
@@ -12,7 +9,7 @@
 <% is_age_range_data = f.object.persisted? && f.object.body&.include?("[AGE_RANGE_DATA]") %>
 <div class="nested-fields" data-paginated-fields-target="item">
   <%= f.hidden_field :id if f.object.persisted? %>
-  <div class="flex items-start gap-x-1 rounded-md border <%= comment_card_class(admin_only: mark_admin_only, warning: is_age_range_data) %> px-3 py-2">
+  <div class="flex items-start gap-x-1 rounded-md border <%= comment_card_class(warning: is_age_range_data) %> px-3 py-2">
     <label class="mt-1 inline-flex w-4 shrink-0 cursor-pointer justify-center leading-none" title="Flag for follow-up">
       <%= f.check_box :flagged, class: "peer sr-only" %>
       <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]! hover:text-orange-400"></i>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -57,51 +57,7 @@
       </div>
 
       <%# ---- Comments (saved with the CE registration, like the other forms) ---- %>
-      <section class="mt-6 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
-        <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
-            <i class="fa-solid fa-comments"></i>
-          </span>
-          <h2 class="text-sm font-semibold text-gray-700">CE comments</h2>
-          <% if registration.registrant %>
-            <%# Carry the origin so the feed can show a back eyebrow to this record. %>
-            <%= link_to comments_and_communications_person_path(registration.registrant, return_to_type: "ContinuingEducationRegistration", return_to_id: registration.id),
-                        class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
-                        target: "_blank", rel: "noopener" do %>
-              <%= t("communications.view_all") %>
-              <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
-            <% end %>
-          <% end %>
-        </div>
-
-        <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
-          <div id="comment-list" class="space-y-4">
-            <%= f.simple_fields_for :comments do |cf| %>
-              <%= render "comments/comment_fields", f: cf %>
-            <% end %>
-          </div>
-
-          <div data-paginated-fields-target="nav"></div>
-
-          <div class="flex items-center justify-between gap-2">
-            <%= link_to_add_association f, :comments,
-                  partial: "comments/comment_fields",
-                  data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
-                  class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
-              <i class="fa-solid fa-plus text-2xs"></i>
-              Add comment
-            <% end %>
-
-            <button type="button"
-                    class="inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
-                    data-action="edit-toggle#toggle">
-              <i class="fa-solid fa-pen text-2xs"></i>
-              <span data-edit-toggle-target="editLabel">Edit comments</span>
-              <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
-            </button>
-          </div>
-        </div>
-      </section>
+      <%= render "shared/comments_and_communications", f: f, view_all_person: f.object.registrant %>
     <% end %>
 
     <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -8,7 +8,7 @@
   <% has_affiliations = f.object.persisted? && f.object.affiliations.any? %>
   <% automanaged_notice = "<span class='text-xs text-amber-700 mt-1'>Auto-managed by affiliations</span>" %>
 
-  <div class="grid grid-cols-1 md:grid-cols-[3fr_1fr] gap-6 mb-8 items-start">
+  <div class="mb-8 grid grid-cols-1 items-start gap-6 md:grid-cols-[3fr_1fr]">
     <!-- LEFT SIDE (3/4) -->
     <div>
       <!-- Organization Name + Hidden -->
@@ -28,13 +28,13 @@
       </div>
 
       <!-- Sectors & Windows audience -->
-      <div class="grid grid-cols-1 md:grid-cols-[3fr_1fr] gap-4 items-start">
+      <div class="grid grid-cols-1 items-start gap-4 md:grid-cols-[3fr_1fr]">
         <div class="form-group space-y-4">
-          <div class="font-semibold text-gray-700 mb-2">
+          <div class="mb-2 font-semibold text-gray-700">
             Sectors
           </div>
 
-          <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> p-4 mb-4 shadow-sm">
+          <div class="rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:sectors) %> mb-4 p-4 shadow-sm">
             <%= f.simple_fields_for :sectorable_items do |sfi| %>
               <%= render "shared/sectorable_item_fields", f: sfi %>
             <% end %>
@@ -75,16 +75,16 @@
   <!-- Profile-specific Categories (e.g. Workshop Settings) -->
   <% if @org_categories_grouped.present? %>
     <% primary_age_ids = @organization.primary_age_category_ids %>
-    <div class="form-group space-y-4 mb-8">
+    <div class="form-group mb-8 space-y-4">
       <%# Ensures the primary-age param is always submitted so unchecking every
           toggle clears the primary flags. %>
       <%= hidden_field_tag "organization[primary_age_category_ids][]", "" %>
       <% @org_categories_grouped.each do |type, cats| %>
         <% is_age = type.name == "AgeRange" %>
-        <div class="font-semibold text-gray-700 mb-2"><%= type.display_label %></div>
+        <div class="mb-2 font-semibold text-gray-700"><%= type.display_label %></div>
         <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
           <% if is_age %>
-            <p class="text-sm text-gray-500 mb-3">Check every age group served, then mark the primary ones.</p>
+            <p class="mb-3 text-sm text-gray-500">Check every age group served, then mark the primary ones.</p>
           <% end %>
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
@@ -100,14 +100,14 @@
   <% end %>
 
   <!-- Background info -->
-  <div class="form-group space-y-4 mb-8">
-    <div class="font-semibold text-gray-700 mb-2">
+  <div class="form-group mb-8 space-y-4">
+    <div class="mb-2 font-semibold text-gray-700">
       Background Info
     </div>
 
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 mb-4 shadow-sm">
+    <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
 
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <div class="flex flex-col">
       <% agency_type_option = f.object.decorate.agency_type_option %>
       <%= f.input :agency_type,
@@ -173,9 +173,9 @@
     <% end %>
   </div>
   <% if params[:admin] && allowed_to?(:manage?, Organization) %>
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+    <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
       <div class="admin-only bg-blue-100 p-3">
-        <label class="block text-md font-medium text-gray-700 mb-1">Affiliation start date</label>
+        <label class="mb-1 block text-md font-medium text-gray-700">Affiliation start date</label>
         <%= f.input :start_date,
                     label: false,
                     as: :string,
@@ -186,7 +186,7 @@
                     } %>
       </div>
       <div class="admin-only bg-blue-100 p-3">
-        <label class="block text-md font-medium text-gray-700 mb-1">Affiliation end date</label>
+        <label class="mb-1 block text-md font-medium text-gray-700">Affiliation end date</label>
         <%= f.input :end_date,
                     label: false,
                     as: :string,
@@ -200,7 +200,7 @@
   <% end %>
 
   <!-- Mission/Vision/Values -->
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+  <div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
     <%= f.input :description,
                 as: :text,
                 label: "Description",
@@ -221,12 +221,12 @@
     </div>
   </div>
 
-  <div id="addresses" class="form-group space-y-4 mb-8 scroll-mt-20">
-    <div class="font-semibold text-gray-700 mb-2">
+  <div id="addresses" class="form-group mb-8 scroll-mt-20 space-y-4">
+    <div class="mb-2 font-semibold text-gray-700">
       Addresses
     </div>
 
-    <div class="rounded-lg border border-gray-200 bg-yellow-50 p-4 mb-4 shadow-sm">
+    <div class="mb-4 rounded-lg border border-gray-200 bg-yellow-50 p-4 shadow-sm">
       <div class="flex flex-wrap items-center gap-4 p-3">
         <%= f.simple_fields_for :addresses do |sfi| %>
           <%= render "organizations/address_fields", f: sfi %>
@@ -245,12 +245,12 @@
     </div>
   </div>
 
-  <div id="affiliations" class="form-group space-y-4 mb-8 scroll-mt-20">
-    <div class="font-semibold text-gray-700 mb-2">
+  <div id="affiliations" class="form-group mb-8 scroll-mt-20 space-y-4">
+    <div class="mb-2 font-semibold text-gray-700">
       Affiliations
     </div>
 
-    <div class="relative rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:people) %> p-4 mb-4 shadow-sm">
+    <div class="relative rounded-lg border border-gray-200 <%= DomainTheme.bg_class_for(:people) %> mb-4 p-4 shadow-sm">
       <% if show_status_select %>
         <div class="absolute top-4 right-4 z-10 w-56">
           <%= f.input :organization_status_id,
@@ -268,18 +268,18 @@
           <% end %>
         </div>
       <% elsif allowed_to?(:manage?, Organization) && !status_matches_affiliations %>
-        <div class="absolute top-4 right-4 z-10 group cursor-help">
-          <i class="fa-solid fa-triangle-exclamation text-amber-500 text-lg"></i>
-          <div class="hidden group-hover:block absolute z-50 right-0 top-full mt-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+        <div class="group absolute top-4 right-4 z-10 cursor-help">
+          <i class="fa-solid fa-triangle-exclamation text-lg text-amber-500"></i>
+          <div class="absolute top-full right-0 z-50 mt-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
             Legacy organization status does not match affiliation status
           </div>
         </div>
       <% end %>
       <% org_decorated = f.object.decorate %>
-      <div class="flex flex-col md:flex-row gap-6 mb-4">
+      <div class="mb-4 flex flex-col gap-6 md:flex-row">
         <% unless has_affiliations %>
           <div class="shrink-0">
-            <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">Affiliated since</label>
+            <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">Affiliated since</label>
             <%= f.input :start_date,
                         label: false,
                         as: :string,
@@ -290,22 +290,22 @@
                         } %>
           </div>
         <% end %>
-        <div class="shrink-0 relative">
+        <div class="relative shrink-0">
           <div class="group/fac relative inline-block cursor-help">
-            <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
-              Facilitators since <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+            <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
+              Facilitators since <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
             </label>
-            <div class="hidden group-hover/fac:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+            <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/fac:block">
               <p>When this organization started having AWBW facilitators, from its 'Facilitator' affiliations — one period per stretch of facilitating, so a lapse and a return read as separate periods (e.g. "Aug 2015 – Jun 2018, Feb 2024"). Updates live as you edit the affiliation rows below.</p>
             </div>
           </div>
           <div class="pt-1">
-            <span class="text-gray-900 font-medium" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>
+            <span class="font-medium text-gray-900" data-affiliation-dates-target="facilitatorSince"><%= org_decorated.program_since_display.presence || "—" %></span>
             <div class="mt-1 <%= "hidden" unless org_decorated.affiliated_since_note %>" data-affiliation-dates-target="affiliatedNote">
-              <span class="group/aff relative inline-flex items-center gap-1 cursor-help">
+              <span class="group/aff relative inline-flex cursor-help items-center gap-1">
                 <span class="text-xs text-gray-500" data-affiliation-dates-target="affiliatedNoteText"><%= org_decorated.affiliated_since_note %></span>
-                <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
-                <div class="hidden group-hover/aff:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+                <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
+                <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover/aff:block">
                   <p>The earliest date this organization was affiliated with anyone, in any role. Shown only when it's earlier than the facilitator start — otherwise the two dates are the same.</p>
                 </div>
               </span>
@@ -314,17 +314,17 @@
         </div>
         <% if allowed_to?(:manage?, Organization) %>
           <% org_events = @organization_events || [] %>
-          <div id="program-status" class="flex-1 min-w-0 relative group cursor-help scroll-mt-20">
-            <label class="inline-flex items-center gap-1 text-md font-medium text-gray-700 mb-1">
-              Program status <i class="fa-solid fa-circle-info text-gray-400 text-xs"></i>
+          <div id="program-status" class="group relative min-w-0 flex-1 cursor-help scroll-mt-20">
+            <label class="mb-1 inline-flex items-center gap-1 text-md font-medium text-gray-700">
+              Program status <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
             </label>
-            <div class="hidden group-hover:block absolute z-50 left-0 bottom-full mb-1 bg-blue-100 text-gray-700 text-xs rounded-lg shadow-lg ring-1 ring-blue-200 p-3 w-64 whitespace-normal">
+            <div class="absolute bottom-full left-0 z-50 mb-1 hidden w-64 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
               <p>Overall status first (Active / Formerly active / Never active), then the facilitator-program status as of each event's date:<br>
                 • <span class="font-medium">New</span> — no facilitator affiliations yet<br>
                 • <span class="font-medium">Ongoing</span> — has an active facilitator<br>
                 • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).</p>
             </div>
-            <div class="pt-1 flex flex-wrap items-center gap-2">
+            <div class="flex flex-wrap items-center gap-2 pt-1">
               <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }) %>
               <%= render "organizations/program_status_event_chips",
                          organization: f.object, events: org_events, return_to: "organization_edit" %>
@@ -355,31 +355,31 @@
   </div>
 
   <% if f.object.persisted? %>
-    <div class="form-group space-y-4 mb-8">
-      <div class="font-semibold text-gray-700 mb-2">
+    <div class="form-group mb-8 space-y-4">
+      <div class="mb-2 font-semibold text-gray-700">
         Associated records
       </div>
-      <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 mb-4 shadow-sm">
+      <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
         <%= render "associated_records", organization: f.object %>
       </div>
     </div>
   <% end %>
 
   <div class="profile-preferences-section mb-8">
-    <div class="font-medium text-gray-700 mb-2 block">
+    <div class="mb-2 block font-medium text-gray-700">
       Profile display preferences:
     </div>
 
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 mb-4 shadow-sm">
-      <div class="pl-3 pr-3 pb-3">
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-3">
+    <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+      <div class="pr-3 pb-3 pl-3">
+        <div class="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           <%= f.input :profile_show_email, label: "Show email" %>
           <%= f.input :profile_show_phone, label: "Show phone" %>
           <%= f.input :profile_show_website, label: "Show website" %>
           <%= f.input :profile_show_description, label: "Show description" %>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-3">
+        <div class="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           <%= f.input :profile_show_sectors, label: "Show sectors" %>
           <%= f.input :profile_show_age_ranges, label: "Show age ranges" %>
           <%= f.input :profile_show_workshops, label: "Show workshops" %>
@@ -387,7 +387,7 @@
           <%= f.input :profile_show_events_registered, label: "Show events hosted" %>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-3">
+        <div class="mt-3 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
           <%= f.input :profile_show_workshop_logs, label: "Show workshop logs" %>
         </div>
       </div>
@@ -395,36 +395,7 @@
   </div>
 
   <% if f.object.persisted? %>
-    <!-- Comments -->
-    <% if allowed_to?(:manage?, Comment) %>
-      <div class="form-group space-y-4 mb-8" id="comments-section">
-        <div class="font-semibold text-gray-700 mb-2">Comments</div>
-
-        <div class="admin-only bg-blue-50 rounded-lg border border-gray-200 p-4 mb-4 shadow-sm" data-controller="paginated-fields edit-toggle" data-paginated-fields-per-page-value="5">
-          <%= f.simple_fields_for :comments do |cf| %>
-            <%= render "comments/comment_fields", f: cf %>
-          <% end %>
-
-          <div data-paginated-fields-target="nav"></div>
-
-          <button
-            type="button"
-            class="text-sm text-gray-400 hover:text-blue-600 underline cursor-pointer whitespace-nowrap"
-            style="float:right"
-            data-action="edit-toggle#toggle"
-          >
-            <span data-edit-toggle-target="editLabel">Edit Comments</span>
-            <span data-edit-toggle-target="viewLabel" class="hidden">Done Editing</span>
-          </button>
-
-          <%= link_to_add_association "➕ Add Comment",
-                                    f,
-                                    :comments,
-                                    partial: "comments/comment_fields",
-                                    class: "btn btn-secondary-outline" %>
-        </div>
-      </div>
-    <% end %>
+    <%= render "shared/comments_and_communications", f: f %>
 
   <% end %>
 

--- a/app/views/shared/_comments_and_communications.html.erb
+++ b/app/views/shared/_comments_and_communications.html.erb
@@ -10,9 +10,6 @@
 <%# `record` may be a Draper decorator — read the type via model_name, not class.name. %>
 <% record_type = record.model_name.name %>
 <% list_id = "#{record.model_name.param_key}-activity-list" %>
-<%# On a page non-admins can view, everything in this section is staff-only — flag
-    it with the app's admin-only blue wash. %>
-<% admin_marker = mark_admin_only ? "admin-only bg-blue-100 rounded px-1.5 py-0.5" : "" %>
 
 <% notifications = record.communications_scope.order(created_at: :desc).to_a %>
 <% new_notifications = admin ? record.notifications.select(&:new_record?) : [] %>
@@ -36,9 +33,11 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= can_manage_comments ? t("communications.section_title") : t("communications.title") %></h2>
     <div class="ml-auto flex items-center gap-3">
       <%# Carry the origin so the feed can show a back eyebrow to this record. %>
-      <% if view_all_person && can_manage_comments && admin %>
+      <%# Both must be saved: a form can build an unsaved person inline (the new
+          subscription form), and the eyebrow needs a real record to return to. %>
+      <% if view_all_person&.persisted? && record.persisted? && can_manage_comments && admin %>
         <%= link_to comments_and_communications_person_path(view_all_person, return_to_type: record_type, return_to_id: record.id),
-                    class: "inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline #{admin_marker}",
+                    class: "inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
                     target: "_blank", rel: "noopener" do %>
           <%= t("communications.view_all") %>
           <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
@@ -52,7 +51,7 @@
       <% entries.each do |entry| %>
         <% if entry.is_a?(Comment) %>
           <%= f.simple_fields_for :comments, entry do |cf| %>
-            <%= render "comments/comment_fields", f: cf, mark_admin_only: mark_admin_only %>
+            <%= render "comments/comment_fields", f: cf %>
           <% end %>
         <% elsif editable_notifications.include?(entry) %>
           <%= f.simple_fields_for :notifications, own_notifications_by_id.fetch(entry.id, entry) do |nf| %>
@@ -67,7 +66,7 @@
 
       <% if can_manage_comments %>
         <%= f.simple_fields_for :comments, new_comments do |cf| %>
-          <%= render "comments/comment_fields", f: cf, mark_admin_only: mark_admin_only %>
+          <%= render "comments/comment_fields", f: cf %>
         <% end %>
       <% end %>
       <% if admin %>
@@ -91,7 +90,6 @@
           <% if can_manage_comments %>
             <%= link_to_add_association f, :comments,
                   partial: "comments/comment_fields",
-                  render_options: { locals: { mark_admin_only: mark_admin_only } },
                   data: { association_insertion_node: "##{list_id}", association_insertion_method: "append" },
                   class: admin_marked_button do %>
               <i class="fa-solid fa-plus text-2xs"></i>
@@ -112,7 +110,7 @@
 
         <% if (can_manage_comments && comments.any?) || editable_notifications.any? %>
           <button type="button"
-                  class="cursor-pointer text-sm whitespace-nowrap text-gray-400 underline hover:text-gray-600 <%= admin_marker %>"
+                  class="cursor-pointer text-sm whitespace-nowrap text-gray-400 underline hover:text-gray-600"
                   data-action="edit-toggle#toggle">
             <span data-edit-toggle-target="editLabel"><%= t("communications.section_edit") %></span>
             <span data-edit-toggle-target="viewLabel" class="hidden"><%= t("communications.done_editing") %></span>

--- a/app/views/topic_subscriptions/_form.html.erb
+++ b/app/views/topic_subscriptions/_form.html.erb
@@ -24,7 +24,7 @@
 
   <% if @topic_subscription.errors.any? %>
     <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-      <ul class="list-disc list-inside space-y-1">
+      <ul class="list-inside list-disc space-y-1">
         <% @topic_subscription.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -55,9 +55,9 @@
 
       <div class="mb-2 flex w-fit text-sm">
         <label for="person-source-existing"
-               class="cursor-pointer rounded-l-lg border border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/existing:border-primary peer-checked/existing:bg-primary peer-checked/existing:text-white">Existing person</label>
+               class="peer-checked/existing:border-primary peer-checked/existing:bg-primary cursor-pointer rounded-l-lg border border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/existing:text-white">Existing person</label>
         <label for="person-source-new"
-               class="cursor-pointer rounded-r-lg border border-l-0 border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/new:border-primary peer-checked/new:bg-primary peer-checked/new:text-white">New person</label>
+               class="peer-checked/new:border-primary peer-checked/new:bg-primary cursor-pointer rounded-r-lg border border-l-0 border-gray-300 px-3 py-1.5 font-medium text-gray-600 peer-checked/new:text-white">New person</label>
       </div>
 
       <div class="hidden peer-checked/existing:block"><%= person_select %></div>
@@ -147,55 +147,9 @@
     <%= f.text_field :source, class: field_class, placeholder: "e.g. Facilitator Training registration, admin" %>
   </div>
 
-  <%# ---- Comments (saved with the subscription; shown on the person's aggregated
-      comments page). Replaces the old free-text note field. ---- %>
-  <section class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm" id="comments-section" data-controller="edit-toggle">
-    <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
-      <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:topic_subscriptions, intensity: 100) %> <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>">
-        <i class="fa-solid fa-comments"></i>
-      </span>
-      <h2 class="text-sm font-semibold text-gray-700">Comments</h2>
-      <% if @topic_subscription.person&.persisted? %>
-        <%# Carry the origin so the feed can show a back eyebrow to this record. %>
-        <%= link_to comments_and_communications_person_path(@topic_subscription.person, return_to_type: "TopicSubscription", return_to_id: @topic_subscription.id),
-                    class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
-                    target: "_blank", rel: "noopener" do %>
-          <%= t("communications.view_all") %>
-          <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
-        <% end %>
-      <% end %>
-    </div>
+  <%= render "shared/comments_and_communications", f: f, view_all_person: f.object.person %>
 
-    <div class="space-y-4 p-4" data-controller="paginated-fields" data-paginated-fields-per-page-value="5">
-      <div id="comment-list" class="space-y-4">
-        <%= f.simple_fields_for :comments do |cf| %>
-          <%= render "comments/comment_fields", f: cf %>
-        <% end %>
-      </div>
-
-      <div data-paginated-fields-target="nav"></div>
-
-      <div class="flex items-center justify-between gap-2">
-        <%= link_to_add_association f, :comments,
-              partial: "comments/comment_fields",
-              data: { association_insertion_node: "#comment-list", association_insertion_method: "append" },
-              class: "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer" do %>
-          <i class="fa-solid fa-plus text-2xs"></i>
-          Add comment
-        <% end %>
-
-        <button type="button"
-                class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 cursor-pointer"
-                data-action="edit-toggle#toggle">
-          <i class="fa-solid fa-pen text-2xs"></i>
-          <span data-edit-toggle-target="editLabel">Edit comments</span>
-          <span data-edit-toggle-target="viewLabel" class="hidden">Done editing</span>
-        </button>
-      </div>
-    </div>
-  </section>
-
-  <div class="flex gap-2 justify-end">
+  <div class="flex justify-end gap-2">
     <%= link_to "Cancel", cancel_path, class: "btn btn-utility-outline", data: { action: "dirty-form#confirmCancel" } %>
     <%= f.submit submit_label, class: "btn btn-primary" %>
   </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -130,45 +130,7 @@
   </div>
 
   <% if f.object.persisted? %>
-    <!-- Comments -->
-    <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm" id="comments-section">
-      <div class="mb-4 flex items-center">
-        <h4 class="text-sm font-semibold text-gray-700 uppercase">Comments</h4>
-        <% if f.object.person %>
-          <%# Carry the origin so the feed can show a back eyebrow to this record. %>
-          <%= link_to comments_and_communications_person_path(f.object.person, return_to_type: "User", return_to_id: f.object.id),
-                      class: "ml-auto inline-flex items-center gap-1.5 text-xs font-medium #{eyebrow_link_class} hover:underline",
-                      target: "_blank", rel: "noopener" do %>
-            <%= t("communications.view_all") %>
-            <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
-          <% end %>
-        <% end %>
-      </div>
-
-      <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm"
-           data-controller="paginated-fields edit-toggle"
-           data-paginated-fields-per-page-value="5">
-        <%= f.simple_fields_for :comments do |cf| %>
-          <%= render "comments/comment_fields", f: cf %>
-        <% end %>
-
-        <div data-paginated-fields-target="nav"></div>
-
-        <div class="mt-3 flex items-center justify-between">
-          <%= link_to_add_association "➕ Add Comment",
-                                      f,
-                                      :comments,
-                                      partial: "comments/comment_fields",
-                                      class: "btn btn-secondary-outline" %>
-          <button type="button"
-                  class="cursor-pointer text-sm whitespace-nowrap text-gray-400 underline hover:text-blue-600"
-                  data-action="edit-toggle#toggle">
-            <span data-edit-toggle-target="editLabel">Edit Comments</span>
-            <span data-edit-toggle-target="viewLabel" class="hidden">Done Editing</span>
-          </button>
-        </div>
-      </div>
-    </div>
+    <%= render "shared/comments_and_communications", f: f, view_all_person: f.object.person %>
   <% end %>
 
   <div class="flex justify-center gap-3 pt-2">

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full mx-auto" data-controller="timeframe">
+<div class="mx-auto w-full" data-controller="timeframe">
   <%= simple_form_for @workshop, data: { turbo: false } do |f| %>
     <!-- Errors -->
     <% if @workshop.errors.any? %>
@@ -6,7 +6,7 @@
     <% end %>
 
     <!-- Row 1 -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+    <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-3">
       <div>
         <%= f.input :title,
                     as: :text,
@@ -30,21 +30,21 @@
       </div>
 
       <div>
-        <label class="block text-md font-medium text-gray-700 mb-1">Timeframe / Duration</label>
+        <label class="mb-1 block text-md font-medium text-gray-700">Timeframe / Duration</label>
 
-        <div class="flex gap-x-2 font-bold text-xl items-center">
-          <span data-timeframe-target="output" class="text-gray-900 font-medium"><%= f.object.time_frame_total %></span>
+        <div class="flex items-center gap-x-2 text-xl font-bold">
+          <span data-timeframe-target="output" class="font-medium text-gray-900"><%= f.object.time_frame_total %></span>
         </div>
 
-        <p class="text-sm text-gray-500 mt-1">
+        <p class="mt-1 text-sm text-gray-500">
           Automatic total time, in 15min increments
         </p>
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+    <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-3">
       <% if allowed_to?(:manage?, Workshop) %>
-        <div class="admin-only bg-blue-100 p-3 space-y-4">
+        <div class="admin-only space-y-4 bg-blue-100 p-3">
           <% if f.object.full_name.present? && params[:admin] == "true" %>
             <%= f.input :full_name, as: :text,
                         label: "Author's name",
@@ -75,7 +75,7 @@
           <%= render "shared/author_credit_field", f: f %>
           <%= render "shared/author_credit_warning", record: f.object %>
         </div>
-        <div class="admin-only bg-blue-100 p-3 space-y-4">
+        <div class="admin-only space-y-4 bg-blue-100 p-3">
           <%= f.input :workshop_idea_id,
                       as: :select,
                       label: "Workshop Idea parent",
@@ -86,7 +86,7 @@
                       input_html: { value: f.object.workshop_idea_id,
                                     class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm" } %>
           <div class="mt-4">
-            <label class="block font-medium text-gray-700 mb-1">Workshop created</label>
+            <label class="mb-1 block font-medium text-gray-700">Workshop created</label>
             <div class="flex gap-x-2">
               <%= f.input :month, as: :select,
                           collection: Date::MONTHNAMES.compact.each_with_index.map { |m, i| [m, i + 1] },
@@ -249,15 +249,13 @@
         <button
           type="button"
           id="tags_button"
-          class="
-            flex items-center justify-between cursor-pointer w-full
-            bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md"
+          class="flex w-full cursor-pointer items-center justify-between rounded-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"tags":"hidden"}, {"tags_arrow":"rotate-180"}, {"tags_button":"rounded-md rounded-t-md"}]'>
           Tags
           <svg
             id="tags_arrow"
-            class="w-6 h-6 shrink-0"
+            class="h-6 w-6 shrink-0"
             fill="currentColor"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg">
@@ -269,10 +267,10 @@
           </svg>
         </button>
 
-        <div id="tags" class="hidden border border-gray-300 p-4 rounded-b-md">
-          <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm mb-6">
+        <div id="tags" class="hidden rounded-b-md border border-gray-300 p-4">
+          <div class="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
             <!-- Header -->
-            <h3 class="text-base font-semibold text-gray-800 mb-3">
+            <h3 class="mb-3 text-base font-semibold text-gray-800">
               Sectors
             </h3>
 
@@ -283,9 +281,7 @@
 
                 <label
                   for="<%= id %>"
-                  class="
-                    flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border border-gray-200
-                    rounded-lg shadow-sm hover:bg-gray-100 transition">
+                  class="flex w-auto min-w-[180px] cursor-pointer items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
                   <%= hidden_field_tag "workshop[sector_ids][]", "" %>
                   <!-- # To ensure unchecked boxes are submitted -->
                   <%= check_box_tag "workshop[sector_ids][]",
@@ -294,7 +290,7 @@
                                     id: id,
                                     class: "h-4 w-4 text-blue-600 rounded" %>
 
-                  <span class="text-sm text-gray-700 whitespace-nowrap"><%= sector.name %></span>
+                  <span class="text-sm whitespace-nowrap text-gray-700"><%= sector.name %></span>
                 </label>
               <% end %>
             </div>
@@ -304,19 +300,19 @@
             <% @categories_grouped.each do |type, cats| %>
               <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
                 <!-- Header -->
-                <h3 class="text-base font-semibold text-gray-800 mb-3"><%= type.name.underscore.humanize %></h3>
+                <h3 class="mb-3 text-base font-semibold text-gray-800"><%= type.name.underscore.humanize %></h3>
 
                 <% if type.name == "AgeRange" && @age_range_comments.present? %>
-                  <div class="flex flex-wrap gap-2 mb-2">
+                  <div class="mb-2 flex flex-wrap gap-2">
                     <% @age_range_comments.each do |comment| %>
                       <a href="#comments-section"
-                         class="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1 hover:bg-amber-100 transition">
+                         class="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-700 transition hover:bg-amber-100">
                         <%= comment.body %>
                       </a>
                     <% end %>
                   </div>
                   <a href="#comments-section"
-                     class="block text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1 mb-3 hover:bg-amber-100 transition">
+                     class="mb-3 block rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-xs text-amber-700 transition hover:bg-amber-100">
                     <i class="fa-solid fa-triangle-exclamation"></i>
                     Apply the correct tags to satisfy the comments, then delete the comments below once resolved.
                   </a>
@@ -329,9 +325,7 @@
 
                     <label
                       for="<%= id %>"
-                      class="
-                        flex items-center gap-2 p-3 cursor-pointer w-auto min-w-[180px] bg-white border
-                        border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
+                      class="flex w-auto min-w-[180px] cursor-pointer items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
                       <%= hidden_field_tag "workshop[category_ids][]", "" %>
                       <!-- # To ensure unchecked boxes are submitted -->
                       <%= check_box_tag "workshop[category_ids][]",
@@ -340,7 +334,7 @@
                                         id: id,
                                         class: "h-4 w-4 text-blue-600 rounded" %>
 
-                      <span class="text-sm text-gray-700 whitespace-nowrap"><%= category.name %></span>
+                      <span class="text-sm whitespace-nowrap text-gray-700"><%= category.name %></span>
                     </label>
                   <% end %>
                 </div>
@@ -354,17 +348,14 @@
         <button
           type="button"
           id="translations_button"
-          class="
-            flex items-center justify-between cursor-pointer w-full
-            bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md
-          "
+          class="flex w-full cursor-pointer items-center justify-between rounded-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"translations":"hidden"}, {"translations_arrow":"rotate-180"}, {"translations_button":"rounded-md rounded-t-md"}]'
         >
           Spanish Translations
           <svg
             id="translations_arrow"
-            class="w-6 h-6 shrink-0"
+            class="h-6 w-6 shrink-0"
             fill="currentColor"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
@@ -377,8 +368,8 @@
           </svg>
         </button>
 
-        <div id="translations" class="hidden border border-gray-300 p-4 rounded-b-md">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div id="translations" class="hidden rounded-b-md border border-gray-300 p-4">
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
             <% @workshop.decorate.display_spanish_fields.each do |field| %>
               <%= rhino_editor(f, field, label: field.to_s.humanize) %>
             <% end %>
@@ -391,17 +382,14 @@
           <button
             type="button"
             id="series_button"
-            class="
-              flex items-center justify-between cursor-pointer w-full
-              bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md
-            "
+            class="flex w-full cursor-pointer items-center justify-between rounded-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"series":"hidden"}, {"series_arrow":"rotate-180"}, {"series_button":"rounded-md rounded-t-md"}]'
           >
             Series workshops
             <svg
               id="series_arrow"
-              class="w-6 h-6 shrink-0"
+              class="h-6 w-6 shrink-0"
               fill="currentColor"
               viewBox="0 0 20 20"
               xmlns="http://www.w3.org/2000/svg"
@@ -416,7 +404,7 @@
 
           <div
             id="series"
-            class="<%= "hidden" unless f.object.workshop_series_children.any? %> border border-gray-300 p-4 rounded-b-md"
+            class="<%= "hidden" unless f.object.workshop_series_children.any? %> rounded-b-md border border-gray-300 p-4"
           >
             <p class="mb-2 text-sm text-gray-600">
               If this Workshop is a series, add the other "series workshops" below. You can also add a series-specific
@@ -439,17 +427,14 @@
         <button
           type="button"
           id="images_button"
-          class="
-            flex items-center justify-between cursor-pointer w-full
-            bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-t-md
-          "
+          class="flex w-full cursor-pointer items-center justify-between rounded-t-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
           data-action="dropdown#toggle"
           data-dropdown-payload-param='[{"images":"hidden"}, {"images_arrow":"rotate-180"}, {"images_button":"rounded-md rounded-t-md"}]'
         >
           Images/attachments
           <svg
             id="images_arrow"
-            class="w-6 h-6 shrink-0 rotate-180"
+            class="h-6 w-6 shrink-0 rotate-180"
             fill="currentColor"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
@@ -462,41 +447,14 @@
           </svg>
         </button>
 
-        <div id="images" class="border border-gray-300 p-4 rounded-b-md">
+        <div id="images" class="rounded-b-md border border-gray-300 p-4">
           <%= render "shared/form_image_fields", f: f, include_primary_asset: true %>
         </div>
       </div>
     </div>
 
     <% if f.object.persisted? %>
-      <% if allowed_to?(:manage?, Comment) %>
-        <div class="admin-only bg-blue-100 form-group p-3 space-y-4 mt-6 rounded-md" id="comments-section">
-          <div class="font-semibold text-gray-700 mb-2">Comments</div>
-
-          <div class="admin-only bg-blue-100 rounded-lg border border-gray-200 p-4 mb-4 shadow-sm"
-              data-controller="paginated-fields edit-toggle"
-              data-paginated-fields-per-page-value="5">
-            <%= f.simple_fields_for :comments do |cf| %>
-              <%= render "comments/comment_fields", f: cf %>
-            <% end %>
-
-            <div data-paginated-fields-target="nav"></div>
-
-            <button type="button"
-                    class="text-sm text-gray-400 hover:text-blue-600 underline cursor-pointer whitespace-nowrap"
-                    style="float:right"
-                    data-action="edit-toggle#toggle">
-              <span data-edit-toggle-target="editLabel">Edit Comments</span>
-              <span data-edit-toggle-target="viewLabel" class="hidden">Done Editing</span>
-            </button>
-            <%= link_to_add_association "➕ Add Comment",
-                                        f,
-                                        :comments,
-                                        partial: "comments/comment_fields",
-                                        class: "btn btn-secondary-outline" %>
-          </div>
-        </div>
-      <% end %>
+      <%= render "shared/comments_and_communications", f: f, view_all_person: f.object.author %>
     <% end %>
 
     <div class="action-buttons mt-8 flex justify-center gap-3">
@@ -516,11 +474,11 @@
           <%= check_box_tag :promote_idea_assets, true, false, class: "mt-1 h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500" %>
 
           <div class="ml-2 flex flex-col">
-            <span class="text-gray-900 font-medium">
+            <span class="font-medium text-gray-900">
               If the workshop idea was submitted with attachments, check this box to transfer them to this new workshop.
             </span>
 
-            <p class="text-gray-500 text-sm mt-1">
+            <p class="mt-1 text-sm text-gray-500">
               (This will override any attachments uploaded in the form below once you click submit.)
             </p>
           </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,18 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Comments & communications on every record that had comments"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-08-24
+  summary: >-
+    Affiliations, CE registrations, organizations, subscriptions, user accounts, and workshops
+    now show the same combined "Comments & communications" section as people, registrations,
+    scholarships, and stories — so a call or email can be logged wherever the record lives.
+  pro_tips:
+    - "Logging a communication addresses it to whoever the record is about, so you never type the email."
+    - "An organization has no person behind it, so its communications go to the organization's own email."
+
 - name: "Comments and communications in one section"
   area: communications
   display_status: admin_facing

--- a/spec/models/concerns/communicable_spec.rb
+++ b/spec/models/concerns/communicable_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Communicable do
+  # Every record that renders the combined comments-and-communications section
+  # includes this, so the section can rely on the same three things everywhere.
+  INCLUDING_MODELS = [
+    Affiliation, ContinuingEducationRegistration, EventRegistration, Organization,
+    Person, Scholarship, Story, StoryIdea, TopicSubscription, User, Workshop
+  ].freeze
+
+  it "is included by every record whose form renders the combined section" do
+    expect(INCLUDING_MODELS).to all(include(described_class))
+  end
+
+  it "gives each of them a notifications association and a communications email" do
+    INCLUDING_MODELS.each do |model|
+      expect(model.reflect_on_association(:notifications).options[:as]).to eq(:noticeable), model.name
+      expect(model.new).to respond_to(:communications_email), model.name
+      expect(model.new).to respond_to(:communications_scope), model.name
+    end
+  end
+
+  describe "stamping a nested communication's recipient" do
+    it "addresses a hand-logged communication to the record's person" do
+      registration = create(:event_registration)
+
+      registration.update!(notifications_attributes: { "0" => { channel: "phone", email_subject: "Left a voicemail" } })
+
+      expect(registration.notifications.last.recipient_email).to eq(registration.registrant.preferred_email)
+    end
+
+    it "falls back to n/a when the record has nobody to address" do
+      workshop = create(:workshop, author: nil)
+
+      workshop.update!(notifications_attributes: { "0" => { channel: "phone", email_subject: "Called the author" } })
+
+      expect(workshop.notifications.last.recipient_email).to eq("n/a")
+    end
+
+    it "leaves an already-saved communication's recipient alone" do
+      person = create(:person)
+      logged = create(:notification, noticeable: person, recipient_email: "old@example.com",
+                                     kind: "manual_log", channel: "phone", recipient_role: "person",
+                                     notification_type: 0, email_subject: "Called")
+
+      person.update!(first_name: "Renamed")
+
+      expect(logged.reload.recipient_email).to eq("old@example.com")
+    end
+
+    it "does not load the association on a save that touches no communications" do
+      person = create(:person)
+      create(:notification, noticeable: person, recipient_email: person.preferred_email,
+                            kind: "manual_log", channel: "phone", recipient_role: "person",
+                            notification_type: 0, email_subject: "Called")
+      person.reload
+
+      person.update!(first_name: "Renamed")
+
+      expect(person.notifications).not_to be_loaded
+    end
+  end
+end

--- a/spec/requests/continuing_education_registrations_spec.rb
+++ b/spec/requests/continuing_education_registrations_spec.rb
@@ -137,10 +137,11 @@ RSpec.describe "ContinuingEducationRegistrations", type: :request do
         issuing_state: "CA", expires_on: Date.new(2027, 1, 31))
     end
 
-    it "renders a comments box on the edit page" do
+    it "renders the combined comments and communications section on the edit page" do
       get edit_continuing_education_registration_path(ce_registration)
-      expect(response.body).to include("CE comments")
-      expect(response.body).to include("comment-list")
+      expect(response.body).to include("Comments &amp; communications")
+      expect(response.body).to include("continuing_education_registration-activity-list")
+      expect(response.body).to include("Add communication")
     end
 
     it "saves a comment added on the CE form (with the record)" do

--- a/spec/requests/people_notifications_spec.rb
+++ b/spec/requests/people_notifications_spec.rb
@@ -133,13 +133,19 @@ RSpec.describe "Person notifications", type: :request do
       expect(id_fields).not_to include(autoemail.id.to_s)
     end
 
-    it "flags the comment cards admin-only, since the person can view this page" do
+    it "flags the add buttons admin-only but leaves the comment cards untinted" do
       create(:comment, commentable: person, body: "Internal staff note", created_by: admin)
 
       get edit_person_path(person)
 
-      card = Nokogiri::HTML(response.body).at_css("#comments-section .nested-fields > div")
-      expect(card["class"]).to include("admin-only")
+      doc = Nokogiri::HTML(response.body)
+      # The buttons carry the staff-only signal...
+      buttons = doc.css("#comments-section a").select { |a| a["class"].to_s.include?("admin-only") }
+      expect(buttons.map(&:text).map(&:strip)).to include(a_string_matching(/Add comment/))
+      # ...while the cards stay on the comments theme, so the page isn't a wall of blue.
+      card = doc.at_css("#comments-section .nested-fields > div")
+      expect(card["class"]).not_to include("admin-only")
+      expect(card["class"]).not_to include("bg-blue-100")
       expect(response.body).to include("Internal staff note")
     end
   end

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -460,7 +460,24 @@ RSpec.describe "TopicSubscriptions", type: :request do
 
     it "renders a comments box on the edit page" do
       get edit_topic_subscription_path(subscription)
-      expect(response.body).to include("comment-list")
+      expect(response.body).to include("topic_subscription-activity-list")
+      expect(response.body).to include("Add communication")
+    end
+
+    it "logs a communication inline, addressed to the subscriber" do
+      subscription = create(:topic_subscription)
+
+      expect {
+        patch topic_subscription_path(subscription), params: {
+          topic_subscription: {
+            notifications_attributes: { "0" => { channel: "phone", email_subject: "Called about the topic" } }
+          }
+        }
+      }.to change { subscription.notifications.count }.by(1)
+
+      logged = subscription.notifications.last
+      expect(logged.email_subject).to eq("Called about the topic")
+      expect(logged.recipient_email).to eq(subscription.person.preferred_email)
     end
 
     it "saves a comment added on the subscription form" do

--- a/spec/views/users/edit.html.erb_spec.rb
+++ b/spec/views/users/edit.html.erb_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe "users/edit", type: :view do
     end
   end
 
-  it "renders the comments section" do
+  it "renders the combined comments and communications section" do
     render
 
     assert_select "#comments-section" do
-      assert_select ".font-semibold", text: "Comments"
+      assert_select ".font-semibold", text: "Comments & communications"
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 a new model concern included by 11 models, replacing duplicated wiring in 5 controllers, plus 6 forms swapped to the shared section

## Why

Six records still had a comments-only box — affiliations, CE registrations, organizations, subscriptions, user accounts, workshops. A call or email about any of them had nowhere to live.

The wiring needed to add the section was already copy-pasted across 5 models and 5 controllers, so adding 6 more copies wasn't the move.

## `Communicable`

New model concern (`app/models/concerns/communicable.rb`) supplying:

- `has_many :notifications, as: :noticeable` + nested attributes
- a default `communications_scope` (only what's filed against this record; `Person` overrides it)
- a `before_validation` addressing a hand-logged communication to the record's `communications_email`

Included by all 11: Affiliation, ContinuingEducationRegistration, EventRegistration, Organization, Person, Scholarship, Story, StoryIdea, TopicSubscription, User, Workshop. Each supplies `communications_email` and nothing else.

### What it replaces

Five controllers stamped `recipient_email` by hand right before `save`; all five copies are deleted (`people`, `scholarships`, `event_registrations`, and `stamp_new_notification_recipients` in `stories` / `story_ideas`).

The callback reads `association(:notifications).target` rather than the association, so an unrelated save doesn't load every notification to find none new — covered by a spec.

## Admin-only styling

Only the **add buttons** carry `admin-only bg-blue-100` now. Comment cards, the view-all link, and the Edit toggle are back on the comments theme. The workshop form was washing its entire comments block in `bg-blue-100`; that's gone.

A hand-noted communication's **body** still gets the wash on a page non-admins can view — that's the genuinely privileged content.

## Notes for review

- **`view_all_person` must be persisted.** The new-subscription form builds a Person inline via `person_attributes`; on a validation re-render that person has no id and the route helper raised a 500. Guarded on both the person and the record.
- **Organizations get no view-all link** — there's no person behind an org, so its `communications_email` is the org's own `email`.
- **Workshops** address communications to `author&.preferred_email`, falling back to `"n/a"`.

## Testing

Full suite green: 8083 examples, 0 failures. New `spec/models/concerns/communicable_spec.rb` (6 examples) pins the include list, the association shape, stamping, and the no-extra-load behavior; an end-to-end "log a communication inline" spec added for subscriptions. Four existing specs updated for the new section heading and list id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="659" height="617" alt="Screenshot 2026-08-23 at 9 55 33 PM" src="https://github.com/user-attachments/assets/ef9322f6-a3bb-4374-b0c1-3e8660828dbc" />
<img width="1220" height="543" alt="Screenshot 2026-08-24 at 8 38 54 AM" src="https://github.com/user-attachments/assets/e87bcb9c-4b57-4798-960d-2794b9b3ac3f" />

