### PR TITLE
Reject events whose end date is before their start date

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -70,6 +70,7 @@ class Event < ApplicationRecord
   validates :hint_dates, length: { maximum: 255 }
   validates :hint_times, length: { maximum: 255 }
   validates :hint_registration_cost, length: { maximum: 255 }
+  validate :end_date_not_before_start_date
   validate :registration_form_required_when_publicly_registerable, on: :update
   validate :staff_members_are_unique, on: :update
 
@@ -458,6 +459,15 @@ class Event < ApplicationRecord
     return Time.zone.parse(date_str) if date_str.present? && time_str.blank?
     return Time.zone.parse("2000-01-01 #{time_str}") if date_str.blank? && time_str.present?
     Time.zone.parse("#{date_str} #{time_str}")
+  end
+
+  # Compared by calendar day so an event that starts and ends the same day passes
+  # even when no end time was entered (end_date lands at midnight, before the start).
+  def end_date_not_before_start_date
+    return if start_date.blank? || end_date.blank?
+    return if end_date.to_date >= start_date.to_date
+
+    errors.add(:end_date, "can't be before the start date")
   end
 
   def registration_form_required_when_publicly_registerable

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:start_date) }
     it { should validate_presence_of(:end_date) }
     it { should validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0).allow_nil }
+
+    describe "end date not before start date" do
+      it "is invalid when the end date is before the start date" do
+        event = build(:event, start_date: Time.zone.parse("2026-09-14 09:00"), end_date: Time.zone.parse("2026-09-13 17:00"))
+        expect(event).not_to be_valid
+        expect(event.errors[:end_date]).to include("can't be before the start date")
+      end
+
+      it "is valid when the end date is on the same day as the start date" do
+        event = build(:event, start_date: Time.zone.parse("2026-09-14 09:00"), end_date: Time.zone.parse("2026-09-14 00:00"))
+        expect(event).to be_valid
+      end
+
+      it "is valid when the end date is after the start date" do
+        event = build(:event, start_date: Time.zone.parse("2026-09-14 09:00"), end_date: Time.zone.parse("2026-09-15 17:00"))
+        expect(event).to be_valid
+      end
+    end
   end
 
   describe "destroying with form submissions" do

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -743,7 +743,7 @@ RSpec.describe "Events::Callouts", type: :request do
   end
 
   describe "GET /registration/:slug/certificate" do
-    let(:event) { create(:event, end_date: 2.days.ago) }
+    let(:event) { create(:event, :ended) }
     let(:registration) { create(:event_registration, event: event, status: "attended") }
 
     it "renders the certificate once it is unlocked" do

--- a/spec/requests/people_send_form_link_spec.rb
+++ b/spec/requests/people_send_form_link_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe "People send_form_link", type: :request do
 
       it "sends an upcoming facilitator training's public registration form link" do
         training = create(:event, :published, facilitator_training: true, on_demand: false,
-                          title: "Facilitator Training", start_date: 2.months.from_now)
+                          title: "Facilitator Training", start_date: 2.months.from_now,
+                          end_date: 2.months.from_now + 2.hours)
 
         expect {
           post send_form_link_person_path(person, event_id: training.id)
@@ -116,9 +117,11 @@ RSpec.describe "People send_form_link", type: :request do
       on_demand_event = create(:event, :published, facilitator_training: true, on_demand: true,
                                title: "On-Demand Training", start_date: 2.months.ago)
       soon = create(:event, :published, facilitator_training: true, on_demand: false,
-                    title: "Spring Training", start_date: 3.months.from_now)
+                    title: "Spring Training", start_date: 3.months.from_now,
+                    end_date: 3.months.from_now + 2.hours)
       create(:event, :published, facilitator_training: true, on_demand: false,
-             title: "Distant Training", start_date: 14.months.from_now)
+             title: "Distant Training", start_date: 14.months.from_now,
+             end_date: 14.months.from_now + 2.hours)
       # On-demand events list by "hasn't ended", regardless of start date.
       far_on_demand = create(:event, :published, facilitator_training: true, on_demand: true,
                              title: "Far On-Demand Training", start_date: 14.months.from_now, end_date: 26.months.from_now)

--- a/spec/services/builtin_callouts_spec.rb
+++ b/spec/services/builtin_callouts_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe BuiltinCallouts do
     end
 
     it "seeds the Videoconference card with a drip date a week before start" do
-      event = create(:event, start_date: Date.new(2026, 9, 10))
+      event = create(:event, start_date: Date.new(2026, 9, 10), end_date: Date.new(2026, 9, 12))
       described_class.seed(event)
 
       vc = event.registration_ticket_callouts.find_by(builtin_key: "videoconference")

--- a/spec/system/events_show_spec.rb
+++ b/spec/system/events_show_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "Event show page", type: :system do
 
     context "event ended" do
       before do
-        event.update!(end_date: 1.day.ago)
+        event.update!(start_date: 3.days.ago, end_date: 1.day.ago)
         create(:event_registration, event: event, registrant: user.person, status: "registered")
       end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one contained model validation plus specs

### What is the goal of this PR and why is this important?
Prevent saving an `Event` whose end date falls before its start date — an inverted range produced negative spans and broke downstream date math (day counts, attendance windows).

### How did you approach the change?
Added an `end_date_not_before_start_date` validation that compares at the calendar-day level, so an event that starts and ends the same day still passes even when no end time was entered (`end_date` lands at midnight, before the start time). Skips when either date is blank, since presence validations already cover that.

### UI Testing Checklist
- [ ] Editing an event with an end date before the start date shows a validation error and doesn't save
- [ ] An event that starts and ends on the same day (no end time entered) saves successfully

### Anything else to add?
Covered by three model specs (end before start → invalid; same day → valid; end after start → valid).