### PR TITLE
Staff tagging edit page with comments & communications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ This codebase (Rails 8.1)
 | `Resource` | Handouts, toolkits, templates with downloadable assets |
 | `Person` | Organization affiliates with contacts, addresses, sectors |
 | `StaffTag` | Internal, admin-only label for people (talent pipeline / roster / outreach — "Potential future trainer", "DV Leadership Cohort"). Admin-CRUD'd; `Publishable` (`published` flag) retires a tag from the pickers without deleting; never shown publicly (`StaffTagPolicy` gates every action + relation scope). Applied via the polymorphic `StaffTagging` join (`StaffTaggable` concern, Person today). Starter set seeded in db/seeds.rb |
-| `StaffTagging` | Polymorphic join linking a `StaffTag` to the record it tags (`staff_taggable`); `created_by`/`updated_by` (stamped from `Current.user`) record which admin applied and last touched it |
+| `StaffTagging` | Polymorphic join linking a `StaffTag` to the record it tags (`staff_taggable`); `created_by`/`updated_by` (stamped from `Current.user`) record which admin applied and last touched it. Has its own admin edit page (`StaffTaggingsController`, `/staff_taggings/:id/edit`) rendering the shared comments & communications section (`Communicable` + `commentable`), with communications keyed on the taggable person's email |
 | `OtherResponse` | A free-text "Other" typed on a form question, captured at submission time (registration, scholarship, bulk payment). Polymorphic `owner`: a **sector** "Other" is owned by the `Person` (promotable into a `Sector`, shown on their profile/edit chip); an **organization_type** "Other" is owned by the `Organization` (stored now, not promotable until `OrganizationType` is a model). `generic` questions aren't captured — that stays searchable in the form answers. `field_identifier` records the question; `kind` is derived. Curated at `/other_responses` (grouped by kind/question): `promote` (sectors only), `keep`, `dismiss`. `dismissed` hides the chip from the profile but stays in the review queue (still promotable later); only `promoted` leaves the queue. Admins deep-link there from a person's chip. |
 | `Organization` | Groups with affiliations, addresses, logos via ActiveStorage |
 | `Grant` | Funds (polymorphic `funder`: Organization or Person) with eligibility criteria, tasks, deadlines; parent of `Scholarship`. Scholarship totals cannot exceed the grant amount |
@@ -159,7 +159,7 @@ This codebase (Rails 8.1)
 
 ### Namespaces
 
-- **Root level** (~69 controllers): Workshops, stories, resources, events, people, organizations, registration ticket callouts, etc.
+- **Root level** (~70 controllers): Workshops, stories, resources, events, people, organizations, registration ticket callouts, etc.
 - **`admin/`**: HomeController, AnalyticsController, AhoyActivitiesController
 - **`events/`**: Registrations sub-resource (create/destroy + slug-based show at `/registration/:slug`)
 - **Devise overrides**: Registrations, Confirmations, Passwords

--- a/app/controllers/staff_taggings_controller.rb
+++ b/app/controllers/staff_taggings_controller.rb
@@ -1,0 +1,56 @@
+class StaffTaggingsController < ApplicationController
+  before_action :set_staff_tagging
+
+  def edit
+    authorize! @staff_tagging
+  end
+
+  def update
+    authorize! @staff_tagging
+    @staff_tagging.assign_attributes(staff_tagging_params)
+    @staff_tagging.comments.select(&:new_record?).each do |comment|
+      comment.created_by = current_user
+      comment.updated_by = current_user
+    end
+    @staff_tagging.comments.select { |comment| comment.persisted? && comment.body_changed? }.each do |comment|
+      comment.updated_by = current_user
+    end
+
+    if @staff_tagging.save
+      redirect_to staff_tagging_return_path, notice: "Staff tag updated.", status: :see_other
+    else
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def set_staff_tagging
+    @staff_tagging = StaffTagging.find(params[:id])
+  end
+
+  def staff_tagging_params
+    params.require(:staff_tagging).permit(
+      comments_attributes: [ :id, :topic, :body, :flagged, :_destroy ],
+      notifications_attributes: [ :id, :channel, :sender_id, :email_subject, :email_body_text, :direction, :responded, :noticeable_type, :noticeable_id, :_destroy ]
+    )
+  end
+
+  def staff_tagging_return_path
+    case params[:return_to]
+    when "staff_tag"
+      staff_tag_path(@staff_tagging.staff_tag)
+    when "person"
+      edit_person_path(params[:origin_id], anchor: helpers.dom_id(@staff_tagging), admin: params[:admin].presence)
+    else
+      person_return_path
+    end
+  end
+
+  def person_return_path
+    taggable = @staff_tagging.staff_taggable
+    return staff_tag_path(@staff_tagging.staff_tag) unless taggable.is_a?(Person)
+
+    edit_person_path(taggable, anchor: helpers.dom_id(@staff_tagging))
+  end
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -15,6 +15,7 @@ module CommentsHelper
     when Story then "Story · #{record.title}"
     when StoryIdea then "Story idea · #{record.title.presence || "##{record.id}"}"
     when Affiliation then "Affiliation · #{record.person&.full_name} @ #{record.organization&.name}"
+    when StaffTagging then "Staff tag · #{record.staff_tag&.name}"
     else record.class.name.underscore.humanize
     end
   end
@@ -33,6 +34,7 @@ module CommentsHelper
     when Story then edit_story_path(record)
     when StoryIdea then edit_story_idea_path(record)
     when Affiliation then edit_affiliation_path(record)
+    when StaffTagging then edit_staff_tagging_path(record)
     end
   end
 
@@ -49,6 +51,7 @@ module CommentsHelper
     when Story then :stories
     when StoryIdea then :story_ideas
     when Affiliation then :organizations
+    when StaffTagging then :people
     else :comments
     end
   end

--- a/app/models/staff_tagging.rb
+++ b/app/models/staff_tagging.rb
@@ -1,11 +1,22 @@
 class StaffTagging < ApplicationRecord
+  include Communicable
+
   belongs_to :staff_tag
   belongs_to :staff_taggable, polymorphic: true, touch: true
   belongs_to :created_by, class_name: "User", optional: true
   belongs_to :updated_by, class_name: "User", optional: true
 
+  has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
+  accepts_nested_attributes_for :comments, allow_destroy: true, reject_if: proc { |attrs| attrs["body"].blank? }
+
   validates :staff_tag_id,
             uniqueness: { scope: [ :staff_taggable_type, :staff_taggable_id ], message: "has already been added" }
+
+  # The taggable is always a Person today; guard the polymorphism so a comm logged
+  # here is addressed to them.
+  def communications_email
+    staff_taggable.try(:preferred_email)
+  end
 
   before_create :stamp_created_by
   before_save :stamp_updated_by

--- a/app/policies/staff_tagging_policy.rb
+++ b/app/policies/staff_tagging_policy.rb
@@ -1,0 +1,9 @@
+class StaffTaggingPolicy < ApplicationPolicy
+  def edit?
+    record.persisted? && admin?
+  end
+
+  def update?
+    edit?
+  end
+end

--- a/app/views/people/_staff_tag_item_fields.html.erb
+++ b/app/views/people/_staff_tag_item_fields.html.erb
@@ -1,5 +1,6 @@
 <% collection ||= @staff_tags_collection || StaffTag.published.ordered.pluck(:name, :id) %>
-<div class="nested-fields inline-flex items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 transition">
+<div class="nested-fields inline-flex scroll-mt-24 items-center gap-2 rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 transition"
+     <%= tag.attributes(id: dom_id(f.object)) if f.object&.persisted? %>>
   <% if f.object&.staff_tag_id.present? %>
     <%= f.hidden_field :staff_tag_id %>
     <span>
@@ -16,6 +17,14 @@
                 input_html: {
                   class: "bg-transparent border-none focus:ring-0 text-sm text-gray-500 cursor-pointer py-0"
                 } %>
+  <% end %>
+  <% if f.object&.persisted? %>
+    <%= link_to edit_staff_tagging_path(f.object, return_to: "person", origin_id: f.object.staff_taggable_id, admin: params[:admin].presence),
+                target: "_blank", rel: "noopener",
+                class: "text-gray-300 transition hover:text-gray-500",
+                title: "Edit tag, add comments or communications (opens in a new tab)" do %>
+      <i class="fa-solid fa-gear text-xs"></i>
+    <% end %>
   <% end %>
   <%= link_to_remove_association "✖",
                                  f,

--- a/app/views/staff_taggings/edit.html.erb
+++ b/app/views/staff_taggings/edit.html.erb
@@ -1,0 +1,40 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% taggable = @staff_tagging.staff_taggable %>
+<% if params[:return_to] == "staff_tag" %>
+  <% back_path = staff_tag_path(@staff_tagging.staff_tag) %>
+  <% back_label = "← Staff tag: #{@staff_tagging.staff_tag.name}" %>
+<% elsif taggable.is_a?(Person) %>
+  <% back_path = edit_person_path(params[:origin_id].presence || taggable, anchor: dom_id(@staff_tagging), admin: params[:admin].presence) %>
+  <% back_label = "← #{taggable.name}" %>
+<% else %>
+  <% back_path = staff_tags_path %>
+  <% back_label = "← Staff tags" %>
+<% end %>
+<div class="min-h-screen py-8">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <div class="mb-4">
+      <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    </div>
+
+    <h1 class="mb-1 text-2xl font-semibold text-gray-900">Staff tag: <%= @staff_tagging.staff_tag.name %></h1>
+    <% if taggable %>
+      <p class="mb-6 text-gray-600">
+        on <%= link_to taggable.name, polymorphic_path(taggable), class: "#{DomainTheme.text_class_for(:people)} hover:underline" %>
+      </p>
+    <% end %>
+
+    <%= simple_form_for @staff_tagging,
+          url: staff_tagging_path(@staff_tagging, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
+          method: :patch,
+          html: { data: { turbo: false } } do |f| %>
+      <%= render "shared/comments_and_communications", f: f, view_all_person: (taggable.is_a?(Person) ? taggable : nil) %>
+
+      <div class="mt-8 flex justify-center gap-3">
+        <%= link_to "Cancel", back_path, class: "btn btn-secondary-outline" %>
+        <%= f.button :submit, "Save changes", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+
+    <%= render "shared/audit_info", resource: @staff_tagging %>
+  </div>
+</div>

--- a/app/views/staff_tags/show.html.erb
+++ b/app/views/staff_tags/show.html.erb
@@ -38,9 +38,13 @@
               <li class="flex flex-wrap items-baseline justify-between gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2">
                 <%= link_to taggable.name, polymorphic_path(taggable),
                             class: "font-medium #{DomainTheme.text_class_for(:people)} hover:underline" %>
-                <span class="text-xs text-gray-500">
-                  Tagged<% if tagging.created_by&.person %> by <%= tagging.created_by.full_name %><% end %>
-                  on <%= tagging.created_at.strftime("%b %-d, %Y") %>
+                <span class="flex items-baseline gap-3 text-xs text-gray-500">
+                  <span>
+                    Tagged<% if tagging.created_by&.person %> by <%= tagging.created_by.full_name %><% end %>
+                    on <%= tagging.created_at.strftime("%b %-d, %Y") %>
+                  </span>
+                  <%= link_to "Comments", edit_staff_tagging_path(tagging, return_to: "staff_tag"),
+                              class: "#{eyebrow_link_class} hover:underline" %>
                 </span>
               </li>
             <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,15 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Comments & communications on a staff tag"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-24
+  summary: >-
+    Each staff tag on a person now opens its own page (the gear on the tag chip, or "Comments"
+    from the staff tag's people list) with the combined "Comments & communications" section, so
+    you can record why someone carries a tag and log calls or emails about it.
+
 - name: "Comments & communications on every record that had comments"
   area: communications
   display_status: admin_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
   end
   resources :category_types
   resources :staff_tags
+  resources :staff_taggings, only: [ :edit, :update ]
   resources :categories do
     collection do
       get :dedupe_index

--- a/spec/requests/staff_taggings_spec.rb
+++ b/spec/requests/staff_taggings_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "StaffTaggings", type: :request do
+  let(:admin)         { create(:user, :with_person, super_user: true) }
+  let(:staff_tag)     { create(:staff_tag, name: "VIP") }
+  let(:staff_tagging) { create(:staff_tagging, staff_tag: staff_tag) }
+  let(:person)        { staff_tagging.staff_taggable }
+
+  describe "GET /staff_taggings/:id/edit" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the combined comments and communications section for the tagging" do
+        get edit_staff_tagging_path(staff_tagging)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Staff tag: VIP")
+        expect(response.body).to include("Comments &amp; communications")
+        expect(response.body).to include("Add comment")
+        expect(response.body).to include("Add communication")
+      end
+    end
+
+    context "as a non-admin" do
+      it "redirects to root" do
+        sign_in create(:user)
+
+        get edit_staff_tagging_path(staff_tagging)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "PATCH /staff_taggings/:id" do
+    before { sign_in admin }
+
+    it "saves a new comment authored by the current user" do
+      expect {
+        patch staff_tagging_path(staff_tagging), params: {
+          staff_tagging: { comments_attributes: { "0" => { topic: "Why", body: "Flagged VIP after a call" } } }
+        }
+      }.to change { staff_tagging.comments.count }.by(1)
+
+      comment = staff_tagging.comments.order(:created_at).last
+      expect(comment.body).to eq("Flagged VIP after a call")
+      expect(comment.created_by).to eq(admin)
+    end
+
+    it "logs a communication filed against the tagging, addressed to the person" do
+      expect {
+        patch staff_tagging_path(staff_tagging), params: {
+          staff_tagging: { notifications_attributes: { "0" => { email_subject: "Called about VIP status" } } }
+        }
+      }.to change { staff_tagging.notifications.count }.by(1)
+
+      note = staff_tagging.notifications.last
+      expect(note.noticeable).to eq(staff_tagging)
+      expect(note.email_subject).to eq("Called about VIP status")
+      expect(note.recipient_email).to eq(person.preferred_email.presence || "n/a")
+    end
+  end
+end

--- a/spec/routing/staff_taggings_routing_spec.rb
+++ b/spec/routing/staff_taggings_routing_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe StaffTaggingsController, type: :routing do
+  describe "routing" do
+    it "routes to #edit" do
+      expect(get: "/staff_taggings/1/edit").to route_to("staff_taggings#edit", id: "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/staff_taggings/1").to route_to("staff_taggings#update", id: "1")
+    end
+
+    it "does not route to #index" do
+      expect(get: "/staff_taggings").not_to be_routable
+    end
+  end
+end

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/staff_tags/show.html.erb"               => "admin-only bg-blue-100",
     "app/views/staff_tags/new.html.erb"                => "admin-only bg-blue-100",
     "app/views/staff_tags/edit.html.erb"               => "admin-only bg-blue-100",
+    "app/views/staff_taggings/edit.html.erb"           => "admin-only bg-blue-100",
     "app/views/events/dashboard.html.erb"              => "admin-or-owner bg-blue-100",
     "app/views/events/attendance.html.erb"             => "admin-or-owner bg-blue-100",
     "app/views/events/signins.html.erb"                => "admin-or-owner bg-blue-100",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new admin page (controller/policy/view/route) built on the existing Affiliation pattern; contained logic

Gives a **staff tag on a person** its own admin edit page with the shared **Comments & communications** section — so staff can record *why* a person carries a tag and log calls/emails about it.

## What's new
- **`StaffTaggingsController` + `/staff_taggings/:id/edit`** (edit/update only), modeled on `AffiliationsController`.
- **`StaffTagging`** now `include Communicable` + `has_many :comments, as: :commentable`; `communications_email` keys on the taggable person's email (`staff_taggable.try(:preferred_email)`).
- **`StaffTaggingPolicy`** — admin-only.
- **Entry points:** a gear icon on each tag chip on the person form (opens in a new tab, carries `return_to`), and a "Comments" link per tagging on the staff tag's people list.
- **Aggregated feed:** `CommentsHelper` learns `StaffTagging` (label/edit-path/theme) so tag comments show correctly in a person's combined feed.

## Notes
- Communications filed here are `noticeable: <tagging>` and addressed to the person, so they also appear (email-matched) on the person's own page.
- No migration.

## Tests
Request spec (edit renders, comment + communication save, non-admin redirect), routing spec, page_bg_class mapping, features seed. Targeted suites green; full suite not yet run.
