### PR TITLE
Add cross-event bulk payments admin index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,12 @@ This codebase (Rails 8.1)
 
 | Directory | Purpose | Count |
 |---|---|---|
-| `app/controllers/` | Rails controllers (admin/, events/, home/) | ~91 files |
+| `app/controllers/` | Rails controllers (admin/, events/, home/) | ~92 files |
 | `app/views/` | ERB templates | ~824 files |
 | `app/decorators/` | Draper decorators for view logic | ~50 files |
 | `app/policies/` | ActionPolicy authorization rules | ~63 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~36 files |
+| `app/helpers/` | View helpers | ~37 files |
 | `app/mailers/` | ActionMailer classes | 5 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 

--- a/app/controllers/bulk_payments_controller.rb
+++ b/app/controllers/bulk_payments_controller.rb
@@ -1,0 +1,16 @@
+class BulkPaymentsController < ApplicationController
+  def index
+    authorize! FormSubmission, to: :index?
+
+    if turbo_frame_request?
+      @submissions = FormSubmission.bulk_payment
+        .search_by_params(params)
+        .includes(:person, :event, :payment, { form: :events })
+        .order(created_at: :desc)
+        .paginate(page: params[:page], per_page: 50)
+      render :bulk_payments_results
+    else
+      render :index
+    end
+  end
+end

--- a/app/controllers/bulk_payments_controller.rb
+++ b/app/controllers/bulk_payments_controller.rb
@@ -1,15 +1,19 @@
 class BulkPaymentsController < ApplicationController
+  include AhoyTracking
+
   def index
     authorize! FormSubmission, to: :index?
 
     if turbo_frame_request?
       @submissions = FormSubmission.bulk_payment
         .search_by_params(params)
+        .payment_status(params[:payment_status])
         .includes(:person, :event, :payment, { form: :events })
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 50)
       render :bulk_payments_results
     else
+      track_view("bulk_payments")
       render :index
     end
   end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -77,7 +77,7 @@ module AdminCardsHelper
     [
       custom_card("Allocations", allocations_path, icon: "📤", color: :sky, intensity: 100),
       custom_card("Author credit divergences", author_credit_divergences_path, icon: "✍️", color: :sky, intensity: 100),
-      disabled_card("Bulk payments", icon: "💳"),
+      custom_card("Bulk payments", bulk_payments_path, icon: "💳", color: :sky, intensity: 100),
       custom_card("Event registrations", event_registrations_path, icon: "🎟️", color: :sky, intensity: 100),
       custom_card("Features & tips", features_path, icon: "⭐", color: :sky, intensity: 100),
       custom_card("Forms", forms_path, icon: "📋", color: :sky, intensity: 100),

--- a/app/helpers/bulk_payments_helper.rb
+++ b/app/helpers/bulk_payments_helper.rb
@@ -1,0 +1,20 @@
+module BulkPaymentsHelper
+  # Link from the global bulk payments index to a submission's row on its event's
+  # bulk payments page: scrolls to the card (`#payment-card-<id>`), expands it, and
+  # paints the yellow highlight ring — the same anchor+highlight round trip the
+  # registrants roster uses. `return_to` lets that page's eyebrow come back here.
+  def event_bulk_payment_row_path(event, submission)
+    bulk_payments_event_path(
+      event,
+      expand: submission.id,
+      highlight: submission.id,
+      anchor: "payment-card-#{submission.id}",
+      return_to: "bulk_payments_index"
+    )
+  end
+
+  # True when any index filter is active — drives whether "Clear filters" shows.
+  def bulk_payment_filters_active?(params)
+    params.values_at(:search, :event_id, :start_date, :end_date).any?(&:present?)
+  end
+end

--- a/app/helpers/bulk_payments_helper.rb
+++ b/app/helpers/bulk_payments_helper.rb
@@ -12,9 +12,4 @@ module BulkPaymentsHelper
       return_to: "bulk_payments_index"
     )
   end
-
-  # True when any index filter is active — drives whether "Clear filters" shows.
-  def bulk_payment_filters_active?(params)
-    params.values_at(:search, :event_id, :start_date, :end_date).any?(&:present?)
-  end
 end

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -34,6 +34,26 @@ class FormSubmission < ApplicationRecord
 
   scope :bulk_payment, -> { where(role: "bulk_payment") }
 
+  # The bulk payments index "Payment status" filter vocabulary, keyed on the
+  # submission's payment (see the payment badge):
+  #   unpaid               — no payment recorded yet ("No payment yet").
+  #   partially_allocated  — a payment exists with some amount unallocated.
+  #   fully_allocated      — a payment exists with everything allocated.
+  PAYMENT_STATUS_FILTER_OPTIONS = [
+    [ "No payment yet", "unpaid" ],
+    [ "Not fully allocated", "partially_allocated" ],
+    [ "Fully allocated", "fully_allocated" ]
+  ].freeze
+
+  scope :payment_status, ->(value) {
+    case value
+    when "unpaid" then where.missing(:payment)
+    when "partially_allocated" then joins(:payment).where("payments.amount_cents_remaining > 0")
+    when "fully_allocated" then joins(:payment).where(payments: { amount_cents_remaining: 0 })
+    else all
+    end
+  }
+
   # Submitted on `created_at` — there is no separate submitted_at column.
   scope :submitted_between, ->(start_date, end_date) {
     scope = all

--- a/app/views/bulk_payments/bulk_payments_results.html.erb
+++ b/app/views/bulk_payments/bulk_payments_results.html.erb
@@ -1,0 +1,69 @@
+<%= turbo_frame_tag :bulk_payments_results do %>
+  <div class="mb-3 text-sm text-gray-600">
+    <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:events) %> <%= DomainTheme.text_class_for(:events, intensity: 700) %> border <%= DomainTheme.border_class_for(:events, intensity: 200) %> px-2.5 py-0.5 font-semibold">
+      <%= pluralize(@submissions.total_entries, "submission") %>
+    </span>
+  </div>
+
+  <% if @submissions.any? %>
+    <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">
+            <th class="px-4 py-3">Payer</th>
+            <th class="px-4 py-3">Event</th>
+            <th class="px-4 py-3">Amount</th>
+            <th class="px-4 py-3">Status</th>
+            <th class="px-4 py-3">Submitted</th>
+            <th class="px-4 py-3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @submissions.each do |submission| %>
+            <% event = submission.resolved_event %>
+            <% highlighted = params[:highlight].to_s == submission.id.to_s %>
+            <tr id="<%= form_submission_row_id(submission) %>" class="scroll-mt-24 border-b border-gray-100 text-sm text-gray-800 transition-colors duration-150 last:border-0 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "" %>">
+              <td class="px-4 py-3">
+                <div class="font-medium text-gray-900"><%= submission.person&.name %></div>
+                <div class="text-gray-500 break-all"><%= submission.person&.email %></div>
+              </td>
+              <td class="px-4 py-3">
+                <% if event %>
+                  <span class="font-medium text-gray-900"><%= event.name %></span>
+                  <% if event.decorate.month_year %>
+                    <span class="text-gray-400">·</span>
+                    <span class="whitespace-nowrap text-gray-500"><%= event.decorate.month_year %></span>
+                  <% end %>
+                <% else %>
+                  <span class="text-gray-300">—</span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap tabular-nums">
+                <% amount_cents = submission.payment&.amount_cents || (event && submission.bulk_payment_amount_cents(event)) %>
+                <%= amount_cents ? dollars_from_cents(amount_cents) : content_tag(:span, "—", class: "text-gray-300") %>
+              </td>
+              <td class="px-4 py-3"><%= render "events/payment_badge", payment: submission.payment %></td>
+              <td class="px-4 py-3 whitespace-nowrap"><%= submission.created_at.to_fs(:long) %></td>
+              <td class="px-4 py-3 text-right">
+                <% if event %>
+                  <%= link_to event_bulk_payment_row_path(event, submission), data: { turbo_frame: "_top" }, class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors whitespace-nowrap" do %>
+                    <i class="fa-solid fa-credit-card text-xs"></i> Bulk payments
+                  <% end %>
+                <% else %>
+                  <span class="text-gray-300">—</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagination mt-6 flex w-full justify-center"><%= tailwind_paginate @submissions %></div>
+  <% else %>
+    <div class="rounded-xl border border-dashed border-gray-300 bg-white py-12 text-center">
+      <i class="fa-regular fa-receipt text-3xl text-gray-300" aria-hidden="true"></i>
+      <p class="mt-3 text-gray-500">No bulk payment submissions found.</p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/bulk_payments/bulk_payments_results.html.erb
+++ b/app/views/bulk_payments/bulk_payments_results.html.erb
@@ -25,7 +25,7 @@
             <tr id="<%= form_submission_row_id(submission) %>" class="scroll-mt-24 border-b border-gray-100 text-sm text-gray-800 transition-colors duration-150 last:border-0 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "" %>">
               <td class="px-4 py-3">
                 <div class="font-medium text-gray-900"><%= submission.person&.name %></div>
-                <div class="text-gray-500 break-all"><%= submission.person&.email %></div>
+                <div class="break-all text-gray-500"><%= submission.person&.email %></div>
               </td>
               <td class="px-4 py-3">
                 <% if event %>

--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -1,0 +1,69 @@
+<% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-6 shadow">
+  <div class="w-full">
+    <div class="mb-4">
+      <%= link_to admin_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
+      <% end %>
+    </div>
+
+    <div class="mb-6 flex items-start gap-4">
+      <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:events) %> <%= DomainTheme.text_class_for(:events, intensity: 700) %> border <%= DomainTheme.border_class_for(:events, intensity: 200) %> shadow-sm">
+        <i class="fa-solid fa-credit-card text-xl" aria-hidden="true"></i>
+      </span>
+      <div>
+        <h2 class="text-2xl font-semibold text-gray-900">Bulk payments</h2>
+        <p class="mt-1 text-gray-600">
+          Every "Pay for Other(s)" submission across events. Open one to allocate it on its event's bulk payments page.
+        </p>
+      </div>
+    </div>
+
+    <%# Filters. Auto-submit into the results frame on change. %>
+    <%= form_with url: bulk_payments_path, method: :get, autocomplete: "off",
+          data: { controller: "collection", turbo_frame: "bulk_payments_results" } do %>
+      <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+        <div>
+          <%= label_tag :search, "Search", class: search_label_class %>
+          <%= text_field_tag :search, params[:search], placeholder: "Name or email", class: search_field_class %>
+        </div>
+
+        <div>
+          <%= label_tag :event_id, "Event", class: search_label_class %>
+          <%= select_tag :event_id,
+                options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.name, event.id ] }, params[:event_id]),
+                include_blank: true,
+                prompt: "Search for an event",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "event" } %>
+        </div>
+
+        <div>
+          <%= label_tag :start_date, "Submitted from", class: search_label_class %>
+          <%= date_field_tag :start_date, params[:start_date], class: search_field_class %>
+        </div>
+
+        <div>
+          <%= label_tag :end_date, "Submitted to", class: search_label_class %>
+          <%= date_field_tag :end_date, params[:end_date], class: search_field_class %>
+        </div>
+
+        <% if bulk_payment_filters_active?(params) %>
+          <div class="flex flex-col items-start">
+            <span class="<%= search_label_class %>" aria-hidden="true">&nbsp;</span>
+            <%= link_to "Clear filters", bulk_payments_path, class: "btn btn-utility whitespace-nowrap" %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% result_src = bulk_payments_path(request.query_parameters) %>
+    <%= turbo_frame_tag :bulk_payments_results, src: result_src, data: { turbo: "temporary" } do %>
+      <div class="rounded-xl border border-gray-200 bg-white py-16 text-center text-gray-400 shadow-sm">
+        <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
+        <p class="mt-2 text-sm">Loading submissions…</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -52,15 +52,9 @@
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
 
-        <div class="w-40">
-          <%= label_tag :start_date, "Submitted from", class: search_label_class %>
-          <%= date_field_tag :start_date, params[:start_date], class: search_field_class %>
-        </div>
+        <%= render "events/filter_date", param: :start_date, label: "Submitted from", field_class: search_field_class, wrapper_class: "w-40" %>
 
-        <div class="w-40">
-          <%= label_tag :end_date, "Submitted to", class: search_label_class %>
-          <%= date_field_tag :end_date, params[:end_date], class: search_field_class %>
-        </div>
+        <%= render "events/filter_date", param: :end_date, label: "Submitted to", field_class: search_field_class, wrapper_class: "w-40" %>
 
         <div class="flex items-end">
           <%= render "shared/search_clear", url: bulk_payments_path %>

--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -13,7 +13,7 @@
         <i class="fa-solid fa-credit-card text-xl" aria-hidden="true"></i>
       </span>
       <div>
-        <h2 class="text-2xl font-semibold text-gray-900">Bulk payments</h2>
+        <h2 class="text-2xl font-semibold text-gray-900">Bulk payment form submissions</h2>
         <p class="mt-1 text-gray-600">
           Every "Pay for Other(s)" submission across events. Open one to allocate it on its event's bulk payments page.
         </p>

--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -22,14 +22,19 @@
 
     <%# Filters. Auto-submit into the results frame on change. %>
     <%= form_with url: bulk_payments_path, method: :get, autocomplete: "off",
-          data: { controller: "collection", turbo_frame: "bulk_payments_results" } do %>
-      <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
-        <div>
+          data: { controller: "collection", turbo_frame: "bulk_payments_results" },
+          class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
+      <div class="mb-3 flex items-center gap-2 text-gray-600">
+        <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
+        <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>
+      </div>
+      <div class="flex flex-wrap items-end gap-3">
+        <div class="min-w-48 flex-1">
           <%= label_tag :search, "Search", class: search_label_class %>
           <%= text_field_tag :search, params[:search], placeholder: "Name or email", class: search_field_class %>
         </div>
 
-        <div>
+        <div class="w-56">
           <%= label_tag :event_id, "Event", class: search_label_class %>
           <%= select_tag :event_id,
                 options_for_select(Event.where(id: params[:event_id]).map { |event| [ event.name, event.id ] }, params[:event_id]),
@@ -39,22 +44,27 @@
                 data: { controller: "remote-select", remote_select_model_value: "event" } %>
         </div>
 
-        <div>
+        <div class="w-44">
+          <%= label_tag :payment_status, "Payment status", class: search_label_class %>
+          <%= select_tag :payment_status,
+                options_for_select(FormSubmission::PAYMENT_STATUS_FILTER_OPTIONS, params[:payment_status]),
+                include_blank: "Any status",
+                class: search_field_class(extra: "search-select-placeholder") %>
+        </div>
+
+        <div class="w-40">
           <%= label_tag :start_date, "Submitted from", class: search_label_class %>
           <%= date_field_tag :start_date, params[:start_date], class: search_field_class %>
         </div>
 
-        <div>
+        <div class="w-40">
           <%= label_tag :end_date, "Submitted to", class: search_label_class %>
           <%= date_field_tag :end_date, params[:end_date], class: search_field_class %>
         </div>
 
-        <% if bulk_payment_filters_active?(params) %>
-          <div class="flex flex-col items-start">
-            <span class="<%= search_label_class %>" aria-hidden="true">&nbsp;</span>
-            <%= link_to "Clear filters", bulk_payments_path, class: "btn btn-utility whitespace-nowrap" %>
-          </div>
-        <% end %>
+        <div class="flex items-end">
+          <%= render "shared/search_clear", url: bulk_payments_path %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -9,6 +9,11 @@
   # allocate/create turbo stream also forces it open via `expanded: true`.
   expanded = local_assigns.fetch(:expanded) { params[:expand].to_i == submission.id }
 
+  # Yellow ring when arrived here via a link that names this submission in
+  # `highlight` (e.g. the global bulk payments index) — same cue as the
+  # registrants roster's highlighted row.
+  highlighted = params[:highlight].to_i == submission.id
+
   # Shared across every card so attendee matching and allocated totals don't
   # re-query per registration per card (preloaded by the controller).
   event_registrations ||= @event_registrations || @event.event_registrations.active.includes(:registrant)
@@ -18,7 +23,7 @@
   linked_regs = event_registrations.select { |r| linked_ids.include?(r.id) }
   attendee_matches = submission.matched_attendees(event_registrations) %>
 
-<div id="payment-card-<%= submission.id %>" data-controller="dropdown" class="bg-white border border-gray-200 rounded-xl shadow-sm px-4 py-3 hover:shadow-md transition-shadow scroll-mt-4">
+<div id="payment-card-<%= submission.id %>" data-controller="dropdown" class="bg-white border rounded-xl shadow-sm px-4 py-3 hover:shadow-md transition-shadow transition-colors duration-150 scroll-mt-4 <%= highlighted ? "border-yellow-500 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200" %>">
   <%#
     Fixed column template (shared by every card so columns align row-to-row):
     name | email | method | amount | badge | date | submission | chevron.

--- a/app/views/events/_payment_badge.html.erb
+++ b/app/views/events/_payment_badge.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 <% else %>
   <%= render "shared/badge",
-        label: "Pending",
+        label: "No payment yet",
         classes: "bg-amber-100 text-amber-800 border-amber-200",
         icon: "fa-solid fa-clock text-amber-500",
         extra: "shrink-0" %>

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -1,13 +1,17 @@
 <% content_for(:page_title, "Bulk payments — #{@event.title}") %>
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
+    <% if params[:return_to] == "bulk_payments_index" %>
+      <%= link_to "← Bulk payments", bulk_payments_path(anchor: form_submission_row_id(params[:highlight]), highlight: params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <% else %>
+      <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <% end %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 
-  <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
     <h1 class="text-2xl font-semibold text-gray-900">Bulk payments</h1>
     <div class="flex items-center gap-3">
       <%= link_to event_invoice_path(@event),
@@ -27,8 +31,8 @@
       <% end %>
     </div>
   <% else %>
-    <div class="text-center py-16 bg-white border border-gray-200 rounded-lg">
-      <i class="fa-regular fa-receipt text-4xl text-gray-300 mb-3"></i>
+    <div class="rounded-lg border border-gray-200 bg-white py-16 text-center">
+      <i class="fa-regular fa-receipt mb-3 text-4xl text-gray-300"></i>
       <p class="text-gray-500">No bulk payment submissions yet.</p>
     </div>
   <% end %>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -11,7 +11,7 @@
   <% if @form_submissions.any? %>
     <div data-column-toggle-root data-column-toggle-scope="form-submissions">
     <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
-      <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Columns</span>
+      <span class="text-xs font-semibold tracking-wide text-gray-400 uppercase">Columns</span>
       <%= render "shared/column_toggle_switch", group: "role", label: "Role", on: true %>
       <%= render "shared/column_toggle_switch", group: "event", label: "Event", on: true %>
       <%= render "shared/column_toggle_switch", group: "submitted", label: "Submitted date", on: true %>
@@ -26,7 +26,7 @@
             <th class="px-4 py-3" data-column-toggle-col="event">Event</th>
             <% unless @person %><th class="px-4 py-3">Person</th><% end %>
             <th class="px-4 py-3">Organization</th>
-            <th class="px-4 py-3 hidden" data-column-toggle-col="user_account">User account</th>
+            <th class="hidden px-4 py-3" data-column-toggle-col="user_account">User account</th>
             <th class="px-4 py-3" data-column-toggle-col="submitted">Submitted</th>
             <th class="px-4 py-3"></th>
           </tr>
@@ -103,8 +103,14 @@
               </td>
               <td class="px-4 py-3 whitespace-nowrap" data-column-toggle-col="submitted"><%= submission.created_at.to_fs(:long) %></td>
               <td class="px-4 py-3 text-right">
-                <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. person_id/form_id are carried only when they were active filters — the back-link anchors to this row via highlight, so it need not re-scope to this submission's person. %>
-                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: params[:person_id].presence, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                <div class="flex items-center justify-end gap-3 whitespace-nowrap">
+                  <% if submission.bulk_payment? && submission.resolved_event %>
+                    <%# Same deep-link as the bulk payments index: scroll to and highlight this submission's card on its event's bulk payments page. %>
+                    <%= link_to "Bulk payments", event_bulk_payment_row_path(submission.resolved_event, submission), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                  <% end %>
+                  <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. person_id/form_id are carried only when they were active filters — the back-link anchors to this row via highlight, so it need not re-scope to this submission's person. %>
+                  <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: params[:person_id].presence, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,16 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Bulk payments index across all events"
+  area: payments
+  display_status: admin_facing
+  released_on: 2026-08-25
+  action_path: /bulk_payments
+  summary: >-
+    The "Bulk payments" card on Admin home now opens a filterable list of every "Pay for Other(s)"
+    submission across events. Search by payer or event, then jump straight to that submission's row
+    on its event's bulk payments page — it scrolls to and highlights the card, ready to allocate.
+
 - name: "Comments & communications on a staff tag"
   area: people
   display_status: admin_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
       post :create_organization
     end
   end
+  resources :bulk_payments, only: [ :index ]
   resources :form_answers, only: [ :index ]
   resources :grants
   resources :scholarships, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do

--- a/spec/requests/bulk_payments_spec.rb
+++ b/spec/requests/bulk_payments_spec.rb
@@ -52,10 +52,42 @@ RSpec.describe "BulkPayments", type: :request do
         expect(response.body).not_to include("form-submission-row-#{theirs.id}")
       end
 
-      it "offers a Clear filters link when a filter is active" do
-        get bulk_payments_path(search: "Priya")
+      it "filters by payment status" do
+        event = create(:event)
+        unpaid = create(:form_submission, role: "bulk_payment", event: event)
+        allocated = create(:form_submission, role: "bulk_payment", event: event)
+        create(:payment, form_submission: allocated, amount_cents: 1000, amount_cents_remaining: 0)
+        unallocated = create(:form_submission, role: "bulk_payment", event: event)
+        create(:payment, form_submission: unallocated, amount_cents: 1000, amount_cents_remaining: 500)
+
+        get bulk_payments_path(payment_status: "unpaid"), headers: frame_headers
+        expect(response.body).to include("form-submission-row-#{unpaid.id}")
+        expect(response.body).not_to include("form-submission-row-#{allocated.id}")
+        expect(response.body).not_to include("form-submission-row-#{unallocated.id}")
+
+        get bulk_payments_path(payment_status: "fully_allocated"), headers: frame_headers
+        expect(response.body).to include("form-submission-row-#{allocated.id}")
+        expect(response.body).not_to include("form-submission-row-#{unpaid.id}")
+
+        get bulk_payments_path(payment_status: "partially_allocated"), headers: frame_headers
+        expect(response.body).to include("form-submission-row-#{unallocated.id}")
+        expect(response.body).not_to include("form-submission-row-#{allocated.id}")
+      end
+
+      it "offers a Clear filters link" do
+        get bulk_payments_path
 
         expect(response.body).to include("Clear filters")
+      end
+
+      it "tracks a view event on the full page" do
+        expect(Analytics::AhoyTracker).to receive(:track_event).with(anything, "view.bulk_payments", {})
+        get bulk_payments_path
+      end
+
+      it "does not track on the results frame request" do
+        expect(Analytics::AhoyTracker).not_to receive(:track_event)
+        get bulk_payments_path, headers: frame_headers
       end
     end
 

--- a/spec/requests/bulk_payments_spec.rb
+++ b/spec/requests/bulk_payments_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "BulkPayments", type: :request do
         get bulk_payments_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Bulk payments")
+        expect(response.body).to include("Bulk payment form submissions")
       end
 
       it "lists only bulk payment submissions" do

--- a/spec/requests/bulk_payments_spec.rb
+++ b/spec/requests/bulk_payments_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "BulkPayments", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:frame_headers) { { "Turbo-Frame" => "bulk_payments_results" } }
+
+  describe "GET /bulk_payments" do
+    context "as an admin" do
+      before { sign_in admin }
+
+      it "renders the filterable index shell" do
+        get bulk_payments_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Bulk payments")
+      end
+
+      it "lists only bulk payment submissions" do
+        event = create(:event)
+        bulk = create(:form_submission, role: "bulk_payment", event: event)
+        other = create(:form_submission, role: "registration", event: event)
+
+        get bulk_payments_path, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("form-submission-row-#{bulk.id}")
+        expect(response.body).not_to include("form-submission-row-#{other.id}")
+      end
+
+      it "links each row to its event's bulk payments page with anchor and highlight" do
+        event = create(:event)
+        submission = create(:form_submission, role: "bulk_payment", event: event)
+
+        get bulk_payments_path, headers: frame_headers
+
+        expect(response.body).to include(bulk_payments_event_path(event))
+        expect(response.body).to include("highlight=#{submission.id}")
+        expect(response.body).to include("return_to=bulk_payments_index")
+        expect(response.body).to include("#payment-card-#{submission.id}")
+      end
+
+      it "filters by search on the payer name" do
+        event = create(:event)
+        priya = create(:person, first_name: "Priya", last_name: "Patel")
+        other = create(:person, first_name: "Sam", last_name: "Jones")
+        mine = create(:form_submission, role: "bulk_payment", event: event, person: priya)
+        theirs = create(:form_submission, role: "bulk_payment", event: event, person: other)
+
+        get bulk_payments_path(search: "Priya"), headers: frame_headers
+
+        expect(response.body).to include("form-submission-row-#{mine.id}")
+        expect(response.body).not_to include("form-submission-row-#{theirs.id}")
+      end
+
+      it "offers a Clear filters link when a filter is active" do
+        get bulk_payments_path(search: "Priya")
+
+        expect(response.body).to include("Clear filters")
+      end
+    end
+
+    context "as a non-admin" do
+      it "is forbidden" do
+        sign_in create(:user)
+
+        get bulk_payments_path
+
+        expect(response).not_to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -78,6 +78,19 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).not_to include(form_submission_path(elsewhere))
       end
 
+      it "links a bulk payment submission to its event's bulk payments row" do
+        event = create(:event)
+        bulk = create(:form_submission, role: "bulk_payment", event: event)
+        registration = create(:form_submission, role: "registration", event: event)
+
+        get form_submissions_path(event_id: event.id), headers: frame_headers
+
+        expect(response.body).to include(bulk_payments_event_path(event))
+        expect(response.body).to include("highlight=#{bulk.id}")
+        expect(response.body).to include("return_to=bulk_payments_index")
+        expect(response.body).not_to include("highlight=#{registration.id}")
+      end
+
       it "filters by submission date range" do
         old = create(:form_submission, created_at: 1.year.ago)
         recent = create(:form_submission, created_at: Date.current)

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/topic_subscription_types/new.html.erb"  => "admin-only bg-blue-100",
     "app/views/topic_subscription_types/edit.html.erb" => "admin-only bg-blue-100",
     "app/views/form_submissions/index.html.erb"        => "admin-only bg-blue-100",
+    "app/views/bulk_payments/index.html.erb"           => "admin-only bg-blue-100",
     "app/views/form_answers/index.html.erb"            => "admin-only bg-blue-100",
     "app/views/form_submissions/link_organization.html.erb" => "admin-only bg-blue-100",
     # show


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 new admin index + small shared-partial and event-card tweaks

## What
- New `/bulk_payments` admin index: every bulk-payment ("Pay for Other(s)") submission across events, in a "Filters" card (search / event / payment status / date range) with a shared Clear filters button, lazy-loaded via the `bulk_payments_results` Turbo frame.
- Admin home "Bulk payments" card is now live (was a disabled placeholder) and points here.
- Each row (here **and** on the general form submissions index) deep-links to the submission's card on its event's bulk payments page, scrolling to + highlighting it — same anchored-row cue as the registrants roster.
- **Payment status filter**: No payment yet / Not fully allocated / Fully allocated (`FormSubmission.payment_status` scope).
- Ahoy view tracking (`view.bulk_payments`) on the full page load to see if staff use it.

## Why
- Allocation started per-event; this gives one filterable place to find any bulk payment and jump straight to it.

## Notes
- Renamed the shared payment badge's amber state from "Pending" → "No payment yet" (also shows on the event card and payer ticket).
- Event bulk-payments card gains a yellow highlight ring via `highlight=<id>`; its eyebrow returns to this index when `return_to=bulk_payments_index`.
- Admin-only via `FormSubmissionPolicy#index?`; reuses `FormSubmission.bulk_payment` + `search_by_params`.