### PR TITLE
Multiselect form filter + filters card + empty date-hint styling

### DIFF
--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -5,7 +5,10 @@ class FormSubmissionsController < ApplicationController
     authorize! FormSubmission
 
     @person = Person.find_by(id: params[:person_id]) if params[:person_id].present?
-    @form = Form.find_by(id: params[:form_id]) if params[:form_id].present?
+    # The eyebrow/heading only names a single form; when several are selected the
+    # results say "across N forms" instead, so @form stays nil.
+    @form_ids = Array(params[:form_id]).reject(&:blank?)
+    @form = Form.find_by(id: @form_ids.first) if @form_ids.one?
 
     if turbo_frame_request?
       @form_submissions = FormSubmission.search_by_params(params)

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -147,6 +147,7 @@
    real date still renders in the normal text color. */
 input.date-filter-empty::-webkit-datetime-edit {
   color: var(--color-gray-400);
+  font-size: 0.875rem;   /* text-sm, to match the neighboring placeholders */
 }
 
 /* Tom Select "flat" variant: the wrapper inherits the field's bordered box,
@@ -162,7 +163,9 @@ input.date-filter-empty::-webkit-datetime-edit {
   background: transparent;
   border: 0;
   box-shadow: none;
-  padding: 0;
+  /* !important beats the searchable-checkbox controller's `!py-2` on the control,
+     so a flat multiselect stays height-matched to the sibling fields. */
+  padding: 0 !important;
   min-height: 1.5rem;
 }
 

--- a/app/helpers/search_form_helper.rb
+++ b/app/helpers/search_form_helper.rb
@@ -19,4 +19,12 @@ module SearchFormHelper
   def search_label_class(extra: nil)
     [ SEARCH_LABEL_CLASSES, extra ].compact.join(" ")
   end
+
+  # Tag a date FILTER input `date-filter-empty` while its param is blank, so the
+  # stylesheet greys and shrinks its mm/dd/yyyy hint to match the neighboring
+  # placeholders; a real value keeps the normal dark, full-size rendering. See
+  # application.tailwind.css (input.date-filter-empty::-webkit-datetime-edit).
+  def date_filter_class(base_class, value)
+    value.present? ? base_class : "#{base_class} date-filter-empty"
+  end
 end

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -159,7 +159,8 @@ class FormSubmission < ApplicationRecord
   def self.search_by_params(params)
     results = all
     results = results.where(person_id: params[:person_id]) if params[:person_id].present?
-    results = results.where(form_id: params[:form_id]) if params[:form_id].present?
+    form_ids = Array(params[:form_id]).reject(&:blank?)
+    results = results.where(form_id: form_ids) if form_ids.any?
     results = results.where(event_id: params[:event_id]) if params[:event_id].present?
     results = results.where(role: params[:role]) if params[:role].present?
     results = results.for_organization(params[:organization_id]) if params[:organization_id].present?

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -91,7 +91,7 @@
               </label>
               <%= date_field_tag :from,
                                  params[:from],
-                                 class: search_field_class %>
+                                 class: date_filter_class(search_field_class, params[:from]) %>
             </div>
 
             <div class="flex-1 min-w-0">
@@ -100,7 +100,7 @@
               </label>
               <%= date_field_tag :to,
                                  params[:to],
-                                 class: search_field_class %>
+                                 class: date_filter_class(search_field_class, params[:to]) %>
             </div>
 
             <div class="flex-none w-24">

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -63,7 +63,7 @@
                 From
               </label>
               <%= date_field_tag :from, params[:from],
-                                 class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm" %>
+                                 class: date_filter_class("w-full px-3 py-2 border-gray-300 rounded-md shadow-sm", params[:from]) %>
             </div>
 
             <!-- Date To -->
@@ -72,7 +72,7 @@
                 To
               </label>
               <%= date_field_tag :to, params[:to],
-                                 class: "w-full px-3 py-2 border-gray-300 rounded-md shadow-sm" %>
+                                 class: date_filter_class("w-full px-3 py-2 border-gray-300 rounded-md shadow-sm", params[:to]) %>
             </div>
 
           </div>

--- a/app/views/comments/_search_boxes.html.erb
+++ b/app/views/comments/_search_boxes.html.erb
@@ -43,14 +43,14 @@
     <div class="w-36">
       <label for="from" class="<%= search_label_class %>">From</label>
       <%= f.date_field :from, value: params[:from],
-                       class: search_field_class(extra: "bg-white"),
+                       class: date_filter_class(search_field_class(extra: "bg-white"), params[:from]),
                        onchange: "this.form.requestSubmit()" %>
     </div>
 
     <div class="w-36">
       <label for="to" class="<%= search_label_class %>">To</label>
       <%= f.date_field :to, value: params[:to],
-                       class: search_field_class(extra: "bg-white"),
+                       class: date_filter_class(search_field_class(extra: "bg-white"), params[:to]),
                        onchange: "this.form.requestSubmit()" %>
     </div>
 

--- a/app/views/continuing_education_registrations/_search_boxes.html.erb
+++ b/app/views/continuing_education_registrations/_search_boxes.html.erb
@@ -48,12 +48,12 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div>
         <label for="issued_from" class="<%= label_class %>">Issued from</label>
-        <%= date_field_tag "issued_from", params[:issued_from], class: field_class %>
+        <%= date_field_tag "issued_from", params[:issued_from], class: date_filter_class(field_class, params[:issued_from]) %>
       </div>
 
       <div>
         <label for="issued_to" class="<%= label_class %>">Issued to</label>
-        <%= date_field_tag "issued_to", params[:issued_to], class: field_class %>
+        <%= date_field_tag "issued_to", params[:issued_to], class: date_filter_class(field_class, params[:issued_to]) %>
       </div>
     </div>
 

--- a/app/views/events/_filter_date.html.erb
+++ b/app/views/events/_filter_date.html.erb
@@ -10,8 +10,7 @@
     the stylesheet can grey that hint to match the text/select placeholders next
     to it; the class drops once a date is set (server-rendered), so a real value
     stays dark. %>
-<% input_class = params[param].present? ? field_class : "#{field_class} date-filter-empty" %>
 <div class="<%= local_assigns.fetch(:wrapper_class, "w-full md:w-48") %>">
   <%= label_tag param, label, class: search_label_class %>
-  <%= date_field_tag param, params[param], class: input_class %>
+  <%= date_field_tag param, params[param], class: date_filter_class(field_class, params[param]) %>
 </div>

--- a/app/views/features/_search_boxes.html.erb
+++ b/app/views/features/_search_boxes.html.erb
@@ -35,14 +35,14 @@
       <label for="released_from" class="<%= search_label_class %>">Released from</label>
       <%= f.date_field :released_from, value: params[:released_from],
             onchange: "this.form.requestSubmit()",
-            class: search_field_class %>
+            class: date_filter_class(search_field_class, params[:released_from]) %>
     </div>
 
     <div>
       <label for="released_to" class="<%= search_label_class %>">Released to</label>
       <%= f.date_field :released_to, value: params[:released_to],
             onchange: "this.form.requestSubmit()",
-            class: search_field_class %>
+            class: date_filter_class(search_field_class, params[:released_to]) %>
     </div>
 
     <div>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -37,7 +37,14 @@
           <% @form_submissions.each do |submission| %>
             <% highlighted = params[:highlight].to_s == submission.id.to_s %>
             <tr id="<%= form_submission_row_id(submission) %>" class="scroll-mt-24 border-b border-gray-100 text-sm text-gray-800 transition-colors duration-150 last:border-0 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "" %>">
-              <td class="px-4 py-3 font-medium"><%= submission.form&.display_name %></td>
+              <td class="px-4 py-3 font-medium">
+                <% if submission.bulk_payment? && submission.resolved_event %>
+                  <%# Deep-link to this submission's card on its event's bulk payments page (scrolls + highlights). %>
+                  <%= link_to submission.form&.display_name, event_bulk_payment_row_path(submission.resolved_event, submission), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
+                <% else %>
+                  <%= submission.form&.display_name %>
+                <% end %>
+              </td>
               <td class="px-4 py-3" data-column-toggle-col="role"><%= submission.role&.humanize %></td>
               <td class="px-4 py-3" data-column-toggle-col="event">
                 <% if submission.resolved_event %>
@@ -104,15 +111,9 @@
                 <% end %>
               </td>
               <td class="px-4 py-3 whitespace-nowrap" data-column-toggle-col="submitted"><%= submission.created_at.to_fs(:long) %></td>
-              <td class="px-4 py-3 text-right">
-                <div class="flex items-center justify-end gap-3 whitespace-nowrap">
-                  <% if submission.bulk_payment? && submission.resolved_event %>
-                    <%# Same deep-link as the bulk payments index: scroll to and highlight this submission's card on its event's bulk payments page. %>
-                    <%= link_to "Bulk payments", event_bulk_payment_row_path(submission.resolved_event, submission), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
-                  <% end %>
-                  <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. person_id/form_id are carried only when they were active filters — the back-link anchors to this row via highlight, so it need not re-scope to this submission's person. %>
-                  <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: params[:person_id].presence, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
-                </div>
+              <td class="px-4 py-3 text-right whitespace-nowrap">
+                <%# origin: where this index itself was reached from, so the detail page can hand it back and the eyebrow survives the round trip. person_id/form_id are carried only when they were active filters — the back-link anchors to this row via highlight, so it need not re-scope to this submission's person. %>
+                <%= link_to "View", form_submission_path(submission, return_to: "form_submissions", origin: params[:return_to].presence, person_id: params[:person_id].presence, form_id: @form&.id, **form_submission_carryover_params(params)), data: { turbo_frame: "_top" }, class: "text-blue-600 hover:underline" %>
               </td>
             </tr>
           <% end %>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -5,6 +5,8 @@
     </span>
     <% if @form %>
       for <span class="font-medium text-gray-900"><%= @form.display_name %></span>
+    <% elsif @form_ids.many? %>
+      across <span class="font-medium text-gray-900"><%= @form_ids.size %> forms</span>
     <% end %>
   </div>
 

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -40,21 +40,33 @@
 
     <%# Filters. Auto-submit into the results frame on change. %>
     <%= form_with url: form_submissions_path, method: :get, autocomplete: "off",
-          data: { controller: "collection", turbo_frame: "form_submissions_results" } do |f| %>
+          data: { controller: "collection searchable-checkbox", turbo_frame: "form_submissions_results" },
+          class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do |f| %>
       <%# Carried so a filter change keeps the eyebrow, and the View links keep their origin. %>
       <% if params[:return_to].present? %><%= hidden_field_tag :return_to, params[:return_to] %><% end %>
-      <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      <div class="mb-3 flex items-center gap-2 text-gray-600">
+        <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
+        <span class="text-xs font-semibold uppercase tracking-wide">Filters</span>
+      </div>
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
         <div>
           <%= label_tag :search, "Search", class: search_label_class %>
           <%= text_field_tag :search, params[:search], placeholder: "Name or email", class: search_field_class %>
         </div>
 
         <div>
-          <%= f.label :form_id, "Form", class: search_label_class %>
-          <%= f.select :form_id,
-                options_from_collection_for_select(@forms, :id, :display_name, params[:form_id].to_i),
-                { include_blank: "All forms" },
-                class: search_field_class(extra: "search-select-placeholder") %>
+          <%= label_tag :form_id, "Form", class: search_label_class %>
+          <%# Multiselect so submissions from several forms (e.g. an agreement and
+              its new-job / reinstatement copies) can be viewed together. ts-flat keeps
+              the inner control transparent and height-matched to the sibling fields. %>
+          <%= select_tag "form_id",
+                options_from_collection_for_select(@forms, :id, :display_name, Array(params[:form_id]).map(&:to_i)),
+                multiple: true,
+                include_blank: false,
+                placeholder: "All forms",
+                class: search_field_class(extra: "ts-flat"),
+                data: { searchable_checkbox_target: "select" } %>
+          <p class="mt-1 text-xs text-gray-500">Matches <span class="font-semibold">any</span> selected form.</p>
         </div>
 
         <div>
@@ -122,12 +134,14 @@
 
         <div>
           <%= label_tag :start_date, "Submitted from", class: search_label_class %>
-          <%= date_field_tag :start_date, params[:start_date], class: search_field_class %>
+          <%= date_field_tag :start_date, params[:start_date],
+                class: date_filter_class(search_field_class, params[:start_date]) %>
         </div>
 
         <div>
           <%= label_tag :end_date, "Submitted to", class: search_label_class %>
-          <%= date_field_tag :end_date, params[:end_date], class: search_field_class %>
+          <%= date_field_tag :end_date, params[:end_date],
+                class: date_filter_class(search_field_class, params[:end_date]) %>
         </div>
 
         <% if form_submission_filters_active?(params) %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -43,7 +43,12 @@
       <%= render "form_submissions/submission", submission: @form_submission %>
 
       <% if event && @form_submission.role == "bulk_payment" %>
-        <div class="mt-6 flex justify-center">
+        <div class="mt-6 flex flex-wrap justify-center gap-3">
+          <%# Deep-link to this submission's card on its event's bulk payments page (scrolls + highlights). %>
+          <%= link_to event_bulk_payment_row_path(event, @form_submission),
+                      class: "inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
+            <i class="fa-solid fa-money-check-dollar"></i> Bulk payments
+          <% end %>
           <%= link_to event_invoice_path(event, submission_id: @form_submission.id, return_to: "form_submission"),
                       class: "inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
             <i class="fa-solid fa-file-invoice-dollar"></i> View invoice

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -1,6 +1,7 @@
 <% event = @form_submission.resolved_event %>
 <div class="mx-auto max-w-2xl px-4 pt-4">
-  <div class="flex flex-wrap items-center gap-2">
+  <div class="flex flex-wrap items-center justify-between gap-2">
+    <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>
       <%= link_to form_submissions_path(person_id: params[:person_id].presence, form_id: params[:form_id].presence, **form_submission_carryover_params(params), return_to: params[:origin].presence, anchor: form_submission_row_id(@form_submission), highlight: @form_submission.id), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
@@ -20,6 +21,13 @@
     <% elsif event %>
       <%= link_to event_path(event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
+      <% end %>
+    <% end %>
+    </div>
+    <% if event && @form_submission.role == "bulk_payment" %>
+      <%# Deep-link to this submission's card on its event's bulk payments page (scrolls + highlights). %>
+      <%= link_to event_bulk_payment_row_path(event, @form_submission), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        Bulk payments <i class="fa-solid fa-arrow-right text-xs"></i>
       <% end %>
     <% end %>
   </div>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -26,9 +26,7 @@
     </div>
     <% if event && @form_submission.role == "bulk_payment" %>
       <%# Deep-link to this submission's card on its event's bulk payments page (scrolls + highlights). %>
-      <%= link_to event_bulk_payment_row_path(event, @form_submission), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-        Bulk payments <i class="fa-solid fa-arrow-right text-xs"></i>
-      <% end %>
+      <%= link_to "Bulk payments", event_bulk_payment_row_path(event, @form_submission), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
 </div>

--- a/app/views/payments/_search_boxes.html.erb
+++ b/app/views/payments/_search_boxes.html.erb
@@ -75,14 +75,14 @@
         <label for="start_date" class="<%= label_class %>">Created from</label>
 
         <%= date_field_tag "start_date", params[:start_date],
-          class: field_class %>
+          class: date_filter_class(field_class, params[:start_date]) %>
       </div>
 
       <div class="md:col-span-2">
         <label for="end_date" class="<%= label_class %>">Created to</label>
 
         <%= date_field_tag "end_date", params[:end_date],
-          class: field_class %>
+          class: date_filter_class(field_class, params[:end_date]) %>
       </div>
 
       <div class="md:col-span-2">

--- a/app/views/people/_comments_and_communications_filters.html.erb
+++ b/app/views/people/_comments_and_communications_filters.html.erb
@@ -71,14 +71,14 @@
     <div class="w-36">
       <label for="from" class="<%= search_label_class %>">From date</label>
       <%= f.date_field :from, value: params[:from],
-                       class: search_field_class(extra: "bg-white"),
+                       class: date_filter_class(search_field_class(extra: "bg-white"), params[:from]),
                        onchange: "this.form.requestSubmit()" %>
     </div>
 
     <div class="w-36">
       <label for="to" class="<%= search_label_class %>">To date</label>
       <%= f.date_field :to, value: params[:to],
-                       class: search_field_class(extra: "bg-white"),
+                       class: date_filter_class(search_field_class(extra: "bg-white"), params[:to]),
                        onchange: "this.form.requestSubmit()" %>
     </div>
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -37,6 +37,16 @@
     submission across events. Search by payer or event, then jump straight to that submission's row
     on its event's bulk payments page — it scrolls to and highlights the card, ready to allocate.
 
+- name: "Filter form submissions by several forms at once"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-25
+  action_path: /form_submissions
+  summary: >-
+    The Form filter on the form submissions list is now multi-select, so you can view submissions
+    across several forms together — e.g. a collaboration agreement alongside its new-job and
+    reinstatement copies.
+
 - name: "Comments & communications on a staff tag"
   area: people
   display_status: admin_facing

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe FormSubmission do
                                              event_id: event.id, person_id: person.id)).to contain_exactly(wanted)
     end
 
+    it "filters by several forms at once when form_id is an array" do
+      agreement = create(:form)
+      new_job = create(:form)
+      on_agreement = create(:form_submission, form: agreement)
+      on_new_job = create(:form_submission, form: new_job)
+      create(:form_submission)
+
+      expect(FormSubmission.search_by_params(form_id: [ agreement.id, new_job.id ]))
+        .to contain_exactly(on_agreement, on_new_job)
+    end
+
+    it "ignores blank entries in a multi-form filter" do
+      form = create(:form)
+      wanted = create(:form_submission, form: form)
+      create(:form_submission)
+
+      expect(FormSubmission.search_by_params(form_id: [ "", form.id.to_s ])).to contain_exactly(wanted)
+    end
+
     it "filters by submission date range on created_at, ignoring unparseable dates" do
       old = create(:form_submission, created_at: 2.years.ago)
       recent = create(:form_submission, created_at: Date.current)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small filter-param logic change plus contained view edits across ~10 filter pages

### What is the goal of this PR and why is this important?
Viewing form submissions across related forms (e.g. a collaboration agreement and its new-job / reinstatement copies) previously took one query per form. The Form filter on the submissions index is now multiselect, so those show together.

### How did you approach the change?
Switched the Form select to a `searchable-checkbox` multiselect and made `FormSubmission.search_by_params` filter on an array of form ids; the heading says "across N forms" when several are picked. Wrapped the filters in a titled "Filters" card matching sibling indexes, and added a `date_filter_class` helper that greys + shrinks each filter date box's empty `mm/dd/yyyy` hint (applied to every filter date input site-wide). For bulk-payment rows, the Form cell now links to the submission's card on its event's bulk payments page (replacing the separate actions-cell link), and the submission page carries the same link by the invoice button. Added a `config/features.yml` entry and model specs.

### UI Testing Checklist
- [ ] Form filter: select several forms → results include submissions from all; heading shows "across N forms"
- [ ] Single form still shows its name; "All forms" placeholder shows when empty
- [ ] Multiselect box empty height matches sibling inputs; grows once forms are selected
- [ ] Filter date boxes: empty shows small grey `mm/dd/yyyy`; a chosen date renders normal (dark, full-size)
- [ ] Bulk-payment row: the Form name links to the event's bulk payments card; the submission page shows a "Bulk payments" link by the invoice button

### Anything else to add?
Filter field backgrounds were left white (a transparent-site-wide treatment was discussed but deferred).