### PR TITLE
Link org to all of a registrant's matching submissions

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -703,6 +703,24 @@ class EventRegistrationsController < ApplicationController
     @submission_entries_by_org[organization.id] = find_submission_entry(registration, organization, linked_count)
   end
 
+  # Every submission entry whose answers describe `organization` (not just the
+  # first): the pinned one, plus every one whose typed org name matches. Falls
+  # back to the sole entry only when the pairing is unambiguous (one submission,
+  # one linked org) — the same rule as find_submission_entry. Used to back-apply
+  # the metadata link to all of a registrant's submissions that named this org.
+  def submission_entries_for(registration, organization)
+    entries = registration_submission_entries(registration)
+    pinned = pinned_submission_ids(registration)[organization.id]
+    matches = entries.select do |entry|
+      entry[:submission].id == pinned ||
+        (entry[:org_name].present? && entry[:org_name].strip.casecmp?(organization.name.to_s.strip))
+    end
+    return matches if matches.any?
+    return [] unless entries.one?
+
+    registration.organizations.count == 1 ? entries : []
+  end
+
   def find_submission_entry(registration, organization, linked_count)
     entries = registration_submission_entries(registration)
     # The pinned submission wins: the name and sole-org rules below are re-derived
@@ -762,9 +780,14 @@ class EventRegistrationsController < ApplicationController
     # Pin the pairing even when nothing was filled — an org whose every answer
     # conflicts fills nothing, and that's exactly the one whose note has to survive.
     link.record_form_submission(entry[:submission]) if entry
-    # Back-apply the resolution onto the submission itself, so the form
-    # submissions side reads it as linked too (even under a name mismatch).
-    entry[:submission].link_organization!(organization.id) if entry
+    # Back-apply the resolution onto every submission this org describes, so each
+    # reads as linked in its own editor too (even under a name mismatch). A
+    # registrant can have several submissions naming the same org; the pin and
+    # profile note above stay on the single primary entry, but the metadata link
+    # fans out to all of them.
+    submission_entries_for(@event_registration, organization).each do |describing|
+      describing[:submission].link_organization!(organization.id)
+    end
     link.record_autofill(result.saved) if record_fills
 
     warning = result.warning(organization: organization)

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -1704,6 +1704,42 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(submission.reload.linked_organization_ids).to eq([ organization.id ])
         end
 
+        it "back-applies the link to every submission that names the org, pinning one" do
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          sub1 = create(:form_submission, person: regular_user.person, form: reg_form)
+          sub2 = create(:form_submission, person: regular_user.person, form: reg_form)
+          [ sub1, sub2 ].each do |submission|
+            create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Helping Hands")
+          end
+
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(sub1.reload.linked_organization_ids).to include(organization.id)
+          expect(sub2.reload.linked_organization_ids).to include(organization.id)
+          # The link row still pins a single submission — only the metadata link fans out.
+          link = existing_registration.event_registration_organizations.find_by(organization: organization)
+          expect([ sub1.id, sub2.id ]).to include(link.form_submission_id)
+        end
+
+        it "leaves a submission that named a different org unlinked" do
+          reg_form = create(:form, name: "Reg form")
+          field = create(:form_field, form: reg_form, field_identifier: "agency_name")
+          create(:event_form, :registration, event: event, form: reg_form)
+          matching = create(:form_submission, person: regular_user.person, form: reg_form)
+          other = create(:form_submission, person: regular_user.person, form: reg_form)
+          create(:form_answer, form_submission: matching, form_field: field, submitted_answer: "Helping Hands")
+          create(:form_answer, form_submission: other, form_field: field, submitted_answer: "Beta Agency")
+
+          post select_organization_event_registration_path(existing_registration),
+            params: { organization_id: organization.id }
+
+          expect(matching.reload.linked_organization_ids).to include(organization.id)
+          expect(other.reload.linked_organization_ids).to be_empty
+        end
+
         it "records the linking registration on the created affiliations" do
           post select_organization_event_registration_path(existing_registration),
             params: { organization_id: organization.id }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic change in one controller method + request specs

### What is the goal of this PR and why is this important?
A registrant can have more than one registration-form submission for the same event (legacy or duplicate data). Linking an org back-applied the `linked_organization_ids` flag to only the first matching submission, so the others wrongly read as unlinked in their own org-linking editor.

### How did you approach the change?
Added `submission_entries_for`, which returns every submission that describes the org (pinned or name-matched, same rules as `find_submission_entry`), and fans the metadata link out to all of them in `link_and_report`. A submission that named a *different* org is left untouched. The single-record pin and profile-diff card note are unchanged — only the metadata link fans out.

### Anything else to add?
Request specs cover the multi-match case and the "different org left alone" case; the existing sole-entry fallback test still guards that path.
