### PR TITLE
Preserve transfer-in attendance days, flag day-count mismatch

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -251,12 +251,14 @@ class EventRegistrationsController < ApplicationController
       # Copy the registrant's progress/profile state forward so the new reg reflects
       # where they left off (money & CE resolve separately). Days attended, expected
       # payment method, buddy-pay, and the recipients-page feature/shout-out flag. (#1944)
+      # Days attended carry per-day, compressing when the source had more days than
+      # the destination so no completion is lost off the end.
       copied = {
         expected_payment_method: @event_registration.expected_payment_method,
         someone_else_will_pay: @event_registration.someone_else_will_pay,
         shoutout: @event_registration.shoutout
       }
-      EventRegistration::DAY_FIELDS.each { |field| copied[field] = @event_registration[field] }
+      copied.merge!(@event_registration.day_completion_carried_to(destination_event.day_count))
       destination.assign_attributes(copied)
     end
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1010,6 +1010,22 @@ class EventRegistration < ApplicationRecord
     DAY_FIELDS.first(event.day_count).count { |field| public_send(field) }
   end
 
+  # The completed_day_* flags to set on a destination registration when this
+  # registration transfers into an event with `dest_day_count` days. Normally a
+  # straight per-day carry (day N here → day N there). When this event had more
+  # days than the destination, its later completed days have no matching day
+  # there, so they compress to the front: the destination is marked from day 1 up
+  # to however many were complete here, capped at its own day count — no
+  # completion falls off the end. (#2384)
+  def day_completion_carried_to(dest_day_count)
+    overflow = event.day_count > dest_day_count
+    filled = [ completed_day_count, dest_day_count ].min
+    DAY_FIELDS.each_with_index.to_h do |field, index|
+      completed = index < dest_day_count && (overflow ? index < filled : self[field])
+      [ field, completed ]
+    end
+  end
+
   # The attendance status implied purely by how many days are marked complete:
   # none → registered, all → attended, some-but-not-all → incomplete_attendance.
   # (A one-day event has no partial state: 0 → registered, 1 → attended.)

--- a/app/views/event_registrations/_form.html.erb
+++ b/app/views/event_registrations/_form.html.erb
@@ -24,7 +24,7 @@
         <div class="flex items-start gap-3 rounded-xl border border-teal-200 bg-teal-50 p-4 text-sm text-teal-900">
           <i class="fa-solid fa-right-to-bracket mt-0.5 shrink-0 text-teal-600"></i>
           <div>
-            <p class="font-semibold">This registration was transferred in from <%= transfer_source.event.title %>.</p>
+            <p class="font-semibold">This registration was transferred in from <%= transfer_source.event.decorate.title_with_month_year %>.</p>
             <p class="mt-0.5 text-teal-800">
               Their payment, scholarship, and continuing-education records live on the
               <%= link_to "original registration", edit_event_registration_path(transfer_source, return_to: params[:return_to].presence), class: "font-medium underline", data: { turbo_frame: "_top" } %>;
@@ -156,7 +156,7 @@
               <p class="mt-1.5 text-xs text-teal-700">
                 <i class="fa-solid fa-right-to-bracket"></i>
                 Transferred in from
-                <%= link_to f.object.transferred_from_registration.event.title, edit_event_registration_path(f.object.transferred_from_registration, return_to: params[:return_to].presence), class: "font-medium underline", data: { turbo_frame: "_top" } %>
+                <%= link_to f.object.transferred_from_registration.event.decorate.title_with_month_year, edit_event_registration_path(f.object.transferred_from_registration, return_to: params[:return_to].presence), class: "font-medium underline", data: { turbo_frame: "_top" } %>
                 ·
                 <%= link_to "Manage transfer", transfer_event_registration_path(f.object.transferred_from_registration, return_to: params[:return_to].presence), class: "font-medium underline", data: { turbo_frame: "_top" } %>
               </p>
@@ -220,6 +220,12 @@
                 <p class="text-2xs mt-1 text-teal-700">
                   <i class="fa-solid fa-right-to-bracket"></i>
                   <%= "Day".pluralize(prior_days.size) %> <%= prior_days.to_sentence %> completed in prior training.
+                </p>
+              <% end %>
+              <% if prior.event.day_count != f.object.event.day_count %>
+                <p class="text-2xs mt-0.5 text-amber-600">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  The prior training had <%= prior.event.day_count > f.object.event.day_count ? "more" : "fewer" %> days than this event.
                 </p>
               <% end %>
             <% end %>

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -292,6 +292,33 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#day_completion_carried_to" do
+    let(:three_day) { create(:event, start_date: 12.days.from_now, end_date: 14.days.from_now) }  # day_count == 3
+    let(:two_day)   { create(:event, start_date: 12.days.from_now, end_date: 13.days.from_now) }   # day_count == 2
+
+    it "carries each day forward per-index when the destination has at least as many days" do
+      reg = create(:event_registration, event: two_day, completed_day_1: true, completed_day_2: false)
+      carried = reg.day_completion_carried_to(three_day.day_count)
+      expect(carried).to include("completed_day_1" => true, "completed_day_2" => false, "completed_day_3" => false)
+    end
+
+    it "compresses to the front so no completion is lost when the source had more days than the destination" do
+      reg = create(:event_registration, event: three_day,
+        completed_day_1: true, completed_day_2: true, completed_day_3: true)
+      carried = reg.day_completion_carried_to(two_day.day_count)
+      # Three complete days, only two slots → both destination days marked.
+      expect(carried).to include("completed_day_1" => true, "completed_day_2" => true, "completed_day_3" => false)
+    end
+
+    it "compresses the completed count even when the source's completed days had gaps" do
+      reg = create(:event_registration, event: three_day,
+        completed_day_1: false, completed_day_2: true, completed_day_3: true)
+      carried = reg.day_completion_carried_to(two_day.day_count)
+      # Two complete days out of three → the destination's two days both fill.
+      expect(carried).to include("completed_day_1" => true, "completed_day_2" => true, "completed_day_3" => false)
+    end
+  end
+
   describe "#deletable?" do
     it "returns true for a plain registration with no allocations or attendance" do
       reg = create(:event_registration, status: "registered")

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -967,6 +967,23 @@ RSpec.describe "EventRegistrations", type: :request do
           )
         end
 
+        it "compresses carried days and flags the mismatch when the source had more days than the destination" do
+          three_day = create(:event, published: true, start_date: 12.days.from_now, end_date: 14.days.from_now)
+          one_day = create(:event, published: true, start_date: 12.days.from_now, end_date: 12.days.from_now)
+          big_source = create(:event_registration, event: three_day, status: "transferred_out",
+            completed_day_1: true, completed_day_2: true, completed_day_3: true)
+
+          post process_transfer_event_registration_path(big_source),
+               params: { destination_event_id: one_day.id }
+
+          incoming = EventRegistration.find_by(registrant: big_source.registrant, event: one_day)
+          expect(incoming.completed_day_1).to be(true)
+
+          get edit_event_registration_path(incoming)
+          expect(response.body).to include("had more days than this event")
+          expect(response.body).to include(three_day.decorate.month_year)
+        end
+
         it "collapses a double transfer, pointing the new reg at the original and dropping the middle" do
           original = create(:event_registration, status: "transferred_out")
           middle = create(:event_registration, registrant: original.registrant,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained transfer-attendance logic + view notes

Fixes lost attendance when a registrant transfers in from a training with more days than the destination event — their completed days no longer fall off the end, and staff can see how the two events line up.

### What is the goal of this PR and why is this important?
When a multi-day training was transferred into an event with fewer days, the extra completed days were copied into hidden `completed_day_*` slots and silently dropped from the attendance/completion count. Facilitators had no signal that the source and destination day counts differed.

### How did you approach the change?
- On transfer, day completions carry per-day; when the source had more days than the destination, they compress to the front so the completion count is preserved (`EventRegistration#day_completion_carried_to`).
- The registration form flags when the prior training had more/fewer days than this event, under the "completed in prior training" note.
- The "transferred in from …" notes now show the source event's month + year (via `title_with_month_year`) so same-titled trainings are distinguishable.

### Anything else to add?
Applies to new transfers going forward; existing transferred-in records are unchanged. Covered by model and request specs.


<img width="326" height="213" alt="Screenshot 2026-08-26 at 7 01 36 PM" src="https://github.com/user-attachments/assets/33db8738-f9a3-469c-8fdf-6c53d6412127" />
