### PR TITLE
Add CE-payment gate option to ticket callouts

### DIFF
--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -922,15 +922,14 @@ class EventRegistration < ApplicationRecord
     end
   end
 
-  # True when a CE registration exists and every one is fully paid. A transferred-in
-  # reg whose CE didn't split down to a record here (its CE credit and payment stayed
-  # on the origin) follows the source, mirroring #payment_access_granted?. When the CE
-  # did split, its own live record carries any remaining balance, so we read that.
+  # True when the full CE amount due is paid across the whole transfer chain — every
+  # CE registration on this reg and on the reg(s) it transferred in from. After a
+  # transfer the money splits (the origin keeps a paid stub, this reg's live record
+  # carries the remaining balance), so a partly-paid balance riding forward still
+  # reads as unpaid. A chain with no CE anywhere isn't CE-registered, so it's not paid.
   def ce_paid_in_full?
-    return transferred_from_registration.ce_paid_in_full? if !ce_registered? && transferred_in?
-    return false unless ce_registered?
-
-    continuing_education_registrations.all?(&:paid_in_full?)
+    chain = continuing_education_registrations_across_transfers
+    chain.any? && chain.all?(&:paid_in_full?)
   end
 
   # Whether the attendance sign-in sheet is open to this registrant. Deliberately
@@ -945,6 +944,16 @@ class EventRegistration < ApplicationRecord
   # License numbers on file across this registration's CE registrations.
   def ce_license_numbers
     continuing_education_registrations.filter_map { |c| c.professional_license&.number }
+  end
+
+  # This reg's CE registrations plus those of every reg it transferred in from, so
+  # CE money can be read across the whole transfer chain — the origin's paid stub
+  # and this reg's live record together (see TransferContinuingEducation, #1944).
+  def continuing_education_registrations_across_transfers
+    own = continuing_education_registrations.to_a
+    return own unless transferred_in?
+
+    own + transferred_from_registration.continuing_education_registrations_across_transfers
   end
 
   # Read CE registrations from the in-memory collection rather than the DB when

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -922,8 +922,12 @@ class EventRegistration < ApplicationRecord
     end
   end
 
-  # True when a CE registration exists and every one is fully paid.
+  # True when a CE registration exists and every one is fully paid. A transferred-in
+  # reg whose CE didn't split down to a record here (its CE credit and payment stayed
+  # on the origin) follows the source, mirroring #payment_access_granted?. When the CE
+  # did split, its own live record carries any remaining balance, so we read that.
   def ce_paid_in_full?
+    return transferred_from_registration.ce_paid_in_full? if !ce_registered? && transferred_in?
     return false unless ce_registered?
 
     continuing_education_registrations.all?(&:paid_in_full?)

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -202,7 +202,7 @@ class EventPolicy < ApplicationPolicy
                   sector_ids: [],
                   primary_asset_attributes: [ :id, :file, :_destroy ],
                   gallery_assets_attributes: [ :id, :file, :_destroy ],
-                  registration_ticket_callouts_attributes: [ :id, :builtin_key, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :display_from, :payment_access_gated, :published, :reset_to_default, :_destroy,
+                  registration_ticket_callouts_attributes: [ :id, :builtin_key, :title, :subtitle, :description, :callout_type, :icon_class, :color_class, :display_from, :payment_access_gated, :ce_payment_access_gated, :published, :reset_to_default, :_destroy,
                     { registration_ticket_callout_resources_attributes: [ :id, :resource_id, :subtitle, :page_content, :_destroy ] } ],
                   event_staffs_attributes: [ :id, :person_id, :title, :expected_to_attend, :bio, :_destroy ]
         ]

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -1,24 +1,24 @@
 <% preview = local_assigns.fetch(:preview, false) %>
 <% show_all = local_assigns.fetch(:show_all, false) %>
-<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
+<div class="mx-auto max-w-3xl px-4 pt-6 pb-12">
   <%= render "event_registrations/transfer_notice", event_registration: event_registration %>
   <!-- Ticket Container -->
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
     <!-- Ticket Header -->
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0"><%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %></div>
 
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Registration ticket</h1>
+          <h1 class="text-xl leading-tight font-semibold tracking-wide">Registration ticket</h1>
         </div>
       </div>
 
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
+      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
 
     <!-- Ticket Body -->
-    <div class="bg-gray-50 px-6 py-6 space-y-5">
+    <div class="space-y-5 bg-gray-50 px-6 py-6">
       <!-- Event thumbnail + title -->
       <div class="flex items-center justify-center gap-4">
         <%= render "assets/display_image",
@@ -30,12 +30,12 @@
 
         <div class="min-w-0 text-left">
           <% if event_registration.event.respond_to?(:pre_title) && event_registration.event.pre_title.present? %>
-            <p class="text-sm font-semibold text-gray-700 mb-0.5" style="font-family: 'Telefon Bold', sans-serif"><%= event_registration.event.pre_title %></p>
+            <p class="mb-0.5 text-sm font-semibold text-gray-700" style="font-family: 'Telefon Bold', sans-serif"><%= event_registration.event.pre_title %></p>
           <% end %>
 
-          <h2 class="text-2xl font-bold text-green-800 leading-tight" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
+          <h2 class="text-2xl leading-tight font-bold text-green-800" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
 
-          <p class="text-sm font-semibold text-blue-900 mt-0.5" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
+          <p class="mt-0.5 text-sm font-semibold text-blue-900" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
 
           <%
             venue = if event_registration.event.autoshow_videoconference_label && event_registration.event.videoconference_label.present?
@@ -46,7 +46,7 @@
             summary = [ event_registration.event.decorate.labelled_cost.presence, ("Location: #{venue}" if venue.present?) ].compact
           %>
           <% if summary.any? %>
-            <p class="text-sm text-gray-600 mt-0.5"><%= summary.join(" · ") %></p>
+            <p class="mt-0.5 text-sm text-gray-600"><%= summary.join(" · ") %></p>
           <% end %>
         </div>
       </div>
@@ -54,15 +54,15 @@
       <!-- Divider (perforation style) -->
       <div class="relative my-6">
         <div class="border-t border-dashed border-gray-300"></div>
-        <div class="absolute -left-3 top-1/2 -translate-y-1/2 w-6 h-6 bg-gray-100 rounded-full"></div>
-        <div class="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 bg-gray-100 rounded-full"></div>
+        <div class="absolute top-1/2 -left-3 h-6 w-6 -translate-y-1/2 rounded-full bg-gray-100"></div>
+        <div class="absolute top-1/2 -right-3 h-6 w-6 -translate-y-1/2 rounded-full bg-gray-100"></div>
       </div>
 
       <!-- Registrant -->
       <div class="text-center">
-        <p class="text-gray-500 uppercase tracking-wide text-xs">Registrant</p>
+        <p class="text-xs tracking-wide text-gray-500 uppercase">Registrant</p>
 
-        <p class="font-medium text-gray-900 text-lg">
+        <p class="text-lg font-medium text-gray-900">
           <% if user_signed_in? && !preview %>
             <%= link_to event_registration.registrant.full_name, person_path(event_registration.registrant), class: "text-blue-700 hover:text-blue-900 underline" %>
           <% else %>
@@ -79,10 +79,10 @@
       <% end %>
 
       <% if event_registration.event.cost_cents.to_i > 0 && event_registration.status != "cancelled" && event_registration.remaining_cost > 0 && @checkout_payment_status != "paid" && !event_registration.transferred_out? %>
-        <div class="text-center mt-2 space-y-3">
+        <div class="mt-2 space-y-3 text-center">
           <% if event_registration.intends_to_pay? %>
             <div>
-              <span class="inline-flex items-center gap-1.5 rounded-full text-sm font-medium border px-3 py-1 bg-blue-50 text-blue-700 border-blue-200">
+              <span class="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700">
                 <i class="fa-solid fa-circle-check"></i> Access granted · payment to follow
               </span>
             </div>
@@ -91,7 +91,7 @@
           <div>
             <% if preview %>
               <button type="button" disabled
-                      class="btn btn-accent px-6 py-2 text-sm uppercase font-telefon opacity-60 cursor-not-allowed">Pay with Credit Card</button>
+                      class="btn btn-accent cursor-not-allowed px-6 py-2 font-telefon text-sm uppercase opacity-60">Pay with Credit Card</button>
             <% else %>
               <%= button_to "Pay with Credit Card",
                             registration_pay_path(event_registration.slug),
@@ -132,6 +132,7 @@
             material (videoconference, staff, handouts, FAQ, custom callouts). (#1944) %>
         <% next if event_registration.transferred_out? && !callout.financial_record? %>
         <% next if callout.payment_access_gated && !payment_access && !(preview && show_all) %>
+        <% next if callout.ce_payment_access_gated && !event_registration.ce_paid_in_full? && !(preview && show_all) %>
         <% if callout.behavioral_builtin? %>
           <% card = builtin_cards.card_for(callout) %>
           <% if card %>
@@ -164,9 +165,9 @@
       <div class="border-t border-gray-200"></div>
 
       <!-- Status -->
-      <div class="text-center space-y-2">
+      <div class="space-y-2 text-center">
         <% if event_registration.status == "cancelled" %>
-          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800"> Registration cancelled </span>
+          <span class="inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-sm font-medium text-red-800"> Registration cancelled </span>
           <% if event_registration.event.registerable? %>
             <div><%= button_to "Register again", registration_reactivate_path(event_registration.slug),
                               class: "text-sm text-gray-500 hover:text-blue-600 underline bg-transparent border-0 cursor-pointer p-0" %></div>
@@ -188,8 +189,8 @@
           <% end %>
 
           <% if preview %>
-            <button type="button" disabled class="text-sm text-gray-400 underline bg-transparent border-0 cursor-not-allowed p-0">Resend confirmation email</button>
-            <button type="button" disabled class="text-sm text-gray-400 underline bg-transparent border-0 cursor-not-allowed p-0">Cancel registration</button>
+            <button type="button" disabled class="cursor-not-allowed border-0 bg-transparent p-0 text-sm text-gray-400 underline">Resend confirmation email</button>
+            <button type="button" disabled class="cursor-not-allowed border-0 bg-transparent p-0 text-sm text-gray-400 underline">Cancel registration</button>
           <% else %>
             <%= button_to "Resend confirmation email",
                             registration_resend_confirmation_path(event_registration.slug),
@@ -203,15 +204,15 @@
         </div>
 
         <!-- Add to calendar (secondary utility, kept at the bottom) -->
-        <div class="flex flex-col items-center pt-5 border-t border-gray-100">
-          <div class="flex items-center gap-1 mb-2">
-            <p class="text-xs font-bold text-gray-400 uppercase tracking-wide">
+        <div class="flex flex-col items-center border-t border-gray-100 pt-5">
+          <div class="mb-2 flex items-center gap-1">
+            <p class="text-xs font-bold tracking-wide text-gray-400 uppercase">
               Add to your calendar
             </p>
             <%= render "events/videoconference_calendar_notice", event: event_registration.event, registration: event_registration %>
           </div>
 
-          <div class="flex flex-wrap gap-1 items-center justify-center w-full text-sm text-blue-600 font-medium"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?, re_add_url: registration_videoconference_url(event_registration.slug), payment_pending: !event_registration.payment_access_granted?) %></div>
+          <div class="flex w-full flex-wrap items-center justify-center gap-1 text-sm font-medium text-blue-600"><%= event_registration.event.decorate.calendar_links(show_videoconference_details: event_registration.videoconference_details_visible?, re_add_url: registration_videoconference_url(event_registration.slug), payment_pending: !event_registration.payment_access_granted?) %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/events/_registration_ticket_callout_fields.html.erb
+++ b/app/views/events/_registration_ticket_callout_fields.html.erb
@@ -200,7 +200,7 @@
             built-in, which the app shows/hides from live balance status.
           %>
           <% unless f.object.payment? %>
-            <details class="group" <%= "open" if f.object.display_from.present? || f.object.payment_access_gated? %>>
+            <details class="group" <%= "open" if f.object.display_from.present? || f.object.payment_access_gated? || f.object.ce_payment_access_gated? %>>
               <summary class="flex items-center gap-1.5 cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden text-xs font-medium text-gray-600">
                 <i class="fa-solid fa-chevron-right text-2xs text-gray-400 transition-transform group-open:rotate-90"></i>
                 Visibility
@@ -220,6 +220,8 @@
                   <%= f.label :payment_access_gated, "Payment-gated", class: "block text-xs font-medium text-gray-600 mb-0.5" %>
 
                   <label class="flex items-center gap-2 text-sm text-gray-600"><%= f.check_box :payment_access_gated, class: "rounded border-gray-300 text-purple-600" %> Only show if paid or intends to pay</label>
+
+                  <label class="flex items-center gap-2 text-sm text-gray-600 mt-1"><%= f.check_box :ce_payment_access_gated, class: "rounded border-gray-300 text-purple-600" %> Only show if CE hours are paid</label>
                 </div>
               </div>
             </details>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2367,3 +2367,17 @@
     page card topped by the rainbow accent strip, a serif page title, and the
     results table in its own bordered card. Filters, columns, and counts are
     unchanged.
+
+- name: "Gate a callout on CE-hour payment"
+  area: registration
+  display_status: user_facing
+  released_on: 2026-08-26
+  action_path: "/registration/sample"
+  summary: >-
+    A ticket callout can now be set to show only after a registrant has paid for
+    their CE hours — a CE-payment gate alongside the existing registration-payment
+    gate and display date.
+  pro_tips:
+    - "Find it under a callout's Visibility section: tick \"Only show if CE hours are paid\"."
+    - "Combine it with a display date to reveal CE-only material on a set day for paid CE registrants."
+    - "The registration-payment and CE-payment gates are independent — set either or both."

--- a/db/migrate/20260827000453_add_ce_payment_access_gated_to_registration_ticket_callouts.rb
+++ b/db/migrate/20260827000453_add_ce_payment_access_gated_to_registration_ticket_callouts.rb
@@ -1,0 +1,11 @@
+class AddCePaymentAccessGatedToRegistrationTicketCallouts < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:registration_ticket_callouts, :ce_payment_access_gated)
+
+    add_column :registration_ticket_callouts, :ce_payment_access_gated, :boolean, null: false, default: false
+  end
+
+  def down
+    remove_column :registration_ticket_callouts, :ce_payment_access_gated, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_000453) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -116,12 +116,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
     t.boolean "primary_contact", default: false, null: false
     t.date "start_date"
     t.string "title"
+    t.string "type"
     t.datetime "updated_at", precision: nil, null: false
     t.index ["event_registration_id"], name: "index_affiliations_on_event_registration_id"
     t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
     t.index ["person_id"], name: "index_affiliations_on_person_id"
     t.index ["title"], name: "index_affiliations_on_title"
+    t.index ["type"], name: "index_affiliations_on_type"
   end
 
   create_table "age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -543,6 +545,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "abbreviation"
+    t.datetime "affiliations_reconciled_at"
     t.boolean "autoshow_cost", default: true, null: false
     t.boolean "autoshow_date", default: true, null: false
     t.boolean "autoshow_location", default: true, null: false
@@ -1196,6 +1199,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_184624) do
   create_table "registration_ticket_callouts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "builtin_key"
     t.string "callout_type", default: "reference", null: false
+    t.boolean "ce_payment_access_gated", default: false, null: false
     t.string "color_class"
     t.datetime "created_at", null: false
     t.text "description"

--- a/spec/factories/registration_ticket_callouts.rb
+++ b/spec/factories/registration_ticket_callouts.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     description { "<p>Details for this callout.</p>" }
     callout_type { "reference" }
     payment_access_gated { false }
+    ce_payment_access_gated { false }
     hidden { false }
     # position is assigned by the positioning gem on save (appended within the event)
 
@@ -27,6 +28,10 @@ FactoryBot.define do
 
     trait :payment_access_gated do
       payment_access_gated { true }
+    end
+
+    trait :ce_payment_access_gated do
+      ce_payment_access_gated { true }
     end
 
     trait :hidden do

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -247,6 +247,85 @@ RSpec.describe EventRegistration, type: :model do
     end
   end
 
+  describe "#ce_paid_in_full? across a transfer (#1944 split model)" do
+    let(:person) { create(:person) }
+    let(:license) { create(:professional_license, person: person) }
+    let(:origin_event) { create(:event, ce_hours_offered: 6, ce_hours_cost_cents: 15_000) }
+    let(:dest_event) { create(:event, ce_hours_offered: 6, ce_hours_cost_cents: 15_000) }
+    let!(:source) { create(:event_registration, event: origin_event, registrant: person, status: "transferred_out") }
+    let!(:ce) do
+      create(:continuing_education_registration, event_registration: source,
+        professional_license: license, hours: 6, cost_cents: 15_000)
+    end
+    let!(:destination) do
+      create(:event_registration, event: dest_event, registrant: person,
+        status: "registered", transferred_from_registration: source)
+    end
+
+    def pay_ce(cents)
+      create(:allocation, allocatable: ce, amount: cents,
+        source: create(:payment, person: person, amount_cents: cents, amount_cents_remaining: nil))
+    end
+
+    def transfer!
+      EventRegistrationServices::TransferContinuingEducation.new(
+        transferred_out: source, destination: destination
+      ).call
+    end
+
+    context "when CE was paid in full at the origin before transferring" do
+      before do
+        pay_ce(15_000)
+        transfer!
+      end
+
+      it "reads the destination reg as CE-paid (its live record carries no balance)" do
+        expect(destination.reload.ce_paid_in_full?).to be(true)
+      end
+
+      it "offers attendance sign-in on the destination reg" do
+        expect(destination.reload.ce_attendance_offered?).to be(true)
+      end
+
+      it "keeps the paid stub on the source reg CE-paid too" do
+        expect(source.reload.ce_paid_in_full?).to be(true)
+      end
+    end
+
+    context "when only part of the CE cost was paid at the origin" do
+      before do
+        pay_ce(5_000)
+        transfer!
+      end
+
+      it "reads the destination reg as not CE-paid (the balance rides forward to the new event)" do
+        expect(destination.reload.ce_paid_in_full?).to be(false)
+      end
+    end
+
+    context "when no CE was paid at the origin" do
+      before { transfer! }
+
+      it "reads the destination reg as not CE-paid" do
+        expect(destination.reload.ce_paid_in_full?).to be(false)
+      end
+    end
+
+    context "when the transferred-in reg holds no CE record of its own but the source paid CE" do
+      before { pay_ce(15_000) }
+
+      it "counts the destination as CE-paid via the source (its CE credit lives on the origin)" do
+        expect(destination.reload.ce_registered?).to be(false)
+        expect(destination.ce_paid_in_full?).to be(true)
+      end
+
+      it "does not count it paid when the source's CE is unpaid" do
+        ce.allocations.destroy_all
+        expect(destination.reload.ce_paid_in_full?).to be(false)
+      end
+    end
+  end
+
   describe "#sync_attendance_status_to_days!" do
     # A two-day event: start and end one day apart → day_count == 2.
     let(:event) { create(:event, start_date: 12.days.from_now, end_date: 13.days.from_now) }

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe EventRegistration, type: :model do
         transfer!
       end
 
-      it "reads the destination reg as CE-paid (its live record carries no balance)" do
+      it "reads the destination reg as CE-paid (the amount due is settled across the chain)" do
         expect(destination.reload.ce_paid_in_full?).to be(true)
       end
 
@@ -298,7 +298,7 @@ RSpec.describe EventRegistration, type: :model do
         transfer!
       end
 
-      it "reads the destination reg as not CE-paid (the balance rides forward to the new event)" do
+      it "reads the destination reg as not CE-paid — the origin's partial payment does not settle the remaining balance that rode forward" do
         expect(destination.reload.ce_paid_in_full?).to be(false)
       end
     end
@@ -314,7 +314,7 @@ RSpec.describe EventRegistration, type: :model do
     context "when the transferred-in reg holds no CE record of its own but the source paid CE" do
       before { pay_ce(15_000) }
 
-      it "counts the destination as CE-paid via the source (its CE credit lives on the origin)" do
+      it "counts the destination as CE-paid — the chain's only CE record (on the origin) is settled" do
         expect(destination.reload.ce_registered?).to be(false)
         expect(destination.ce_paid_in_full?).to be(true)
       end

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe "Event registration show page", type: :system do
       expect(page).to have_link("Your workbook",
         href: event_registration_ticket_callout_path(event, gated_callout, reg: registration.slug))
     end
+
+    it "hides a CE-payment-gated callout until CE hours are paid in full" do
+      gated_callout = create(:registration_ticket_callout, :ce_payment_access_gated, event: event, title: "CE evaluation")
+      ce_registration = create(:continuing_education_registration, event_registration: registration, cost_cents: 15_000)
+
+      sign_in(user)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_no_link("CE evaluation")
+
+      create(:allocation, source: create(:payment), allocatable: ce_registration, amount: ce_registration.cost_cents)
+      visit registration_ticket_path(registration.slug)
+
+      expect(page).to have_link("CE evaluation",
+        href: event_registration_ticket_callout_path(event, gated_callout, reg: registration.slug))
+    end
   end
 
   describe "view registration form link" do

--- a/spec/system/event_registration_show_spec.rb
+++ b/spec/system/event_registration_show_spec.rb
@@ -125,6 +125,28 @@ RSpec.describe "Event registration show page", type: :system do
       expect(page).to have_link("CE evaluation",
         href: event_registration_ticket_callout_path(event, gated_callout, reg: registration.slug))
     end
+
+    it "shows both payment- and CE-payment-gated callouts on a transferred-in ticket when the source paid" do
+      origin_event = create(:event, :published, cost_cents: 10_000, ce_hours_offered: 6, ce_hours_cost_cents: 15_000)
+      source = create(:event_registration, event: origin_event, registrant: user.person, status: "transferred_out")
+      create(:allocation, source: create(:payment), allocatable: source, amount: origin_event.cost_cents)
+      source_ce = create(:continuing_education_registration, event_registration: source, cost_cents: 15_000)
+      create(:allocation, source: create(:payment), allocatable: source_ce, amount: source_ce.cost_cents)
+
+      dest_event = create(:event, :published, cost_cents: 10_000, ce_hours_offered: 6, ce_hours_cost_cents: 15_000)
+      destination = create(:event_registration, event: dest_event, registrant: user.person,
+        status: "registered", transferred_from_registration: source)
+      pay_gated = create(:registration_ticket_callout, :payment_access_gated, event: dest_event, title: "Your workbook")
+      ce_gated = create(:registration_ticket_callout, :ce_payment_access_gated, event: dest_event, title: "CE evaluation")
+
+      sign_in(user)
+      visit registration_ticket_path(destination.slug)
+
+      expect(page).to have_link("Your workbook",
+        href: event_registration_ticket_callout_path(dest_event, pay_gated, reg: destination.slug))
+      expect(page).to have_link("CE evaluation",
+        href: event_registration_ticket_callout_path(dest_event, ce_gated, reg: destination.slug))
+    end
   end
 
   describe "view registration form link" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained gate + transfer-chain payment logic with model/system tests

### Goal
- Facilitators want to withhold CE-only material (e.g. a CE evaluation) until a trainee has **paid for their CE hours**.
- Callouts already gate on registration payment + a display date; this adds an **independent CE-payment gate**.

### Approach
- New boolean `ce_payment_access_gated` on `registration_ticket_callouts` (parallel to `payment_access_gated`, no backfill).
- Ticket enforcement mirrors the registration gate, using `EventRegistration#ce_paid_in_full?`.
- Editor: second checkbox in the callout Visibility section — "Only show if CE hours are paid".
- The two gates are independent (set either or both).

### Transfers
- A transfer splits CE money: the origin keeps a paid stub, this reg's live record carries the remaining balance.
- `ce_paid_in_full?` now asks a single question — **is the full CE amount due paid across the whole transfer chain?** (this reg's CE records plus the reg it transferred in from).
- So someone who paid CE at the origin isn't wrongly denied after transferring, and a partial payment at the origin does **not** unlock material while a balance still rides forward to the new event.
- The regular payment gate already follows the transfer chain (`payment_access_granted?` delegates to the source).

### Tests
- Model: `ce_paid_in_full?` across a transfer — fully paid → paid; partial/none → not paid; origin-only record → settled across the chain.
- System: CE gate hidden until CE paid; both gates show on a transferred-in ticket when the source paid.
- `config/features.yml` entry.

### Notes
- First slice of a larger effort; a follow-up will let a callout attach and inline-render an arbitrary Form (the CE-eval survey) behind this gate.