### PR TITLE
Redesign the organization profile in the new AWBW marketing brand

### DIFF
--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,46 +1,47 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="overflow-hidden rounded-xl border border-gray-200 shadow">
-    <!-- Organization header banner -->
-    <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:organizations, intensity: 300) %> px-8 py-3">
-      <div class="flex items-center gap-2">
-        <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
-        </svg>
-        <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:organizations, intensity: 900) %> tracking-wide uppercase">Organization Profile</span>
+<div class="bg-brand-cream border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
+  <!-- Rainbow accent strip (AWBW brand) -->
+  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <!-- Organization hero -->
+  <div class="bg-primary px-4 pt-5 pb-8 text-white sm:px-8">
+    <!-- Eyebrow + header actions -->
+    <div class="mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+      <span class="text-2xs inline-flex items-center gap-2 font-semibold tracking-widest text-white/70 uppercase">
+        <i class="fa-solid fa-building"></i> Organization profile
+      </span>
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        <%= link_to "Home", root_path, class: "text-sm text-white/80 hover:text-white px-2 py-1" %>
+        <%= link_to "Organizations", organizations_path, class: "text-sm text-white/80 hover:text-white px-2 py-1" %>
+        <% if allowed_to?(:edit?, @organization) %>
+          <%= link_to edit_organization_path(@organization),
+                        class: "admin-only inline-flex items-center gap-1.5 text-sm font-semibold rounded-full bg-brand-gold hover:bg-brand-gold-dark text-primary px-4 py-1.5 shadow-sm transition" do %>
+            <i class="fa-solid fa-pen text-xs"></i> Edit
+          <% end %>
+        <% end %>
+        <span class="inline-flex rounded-lg bg-white text-sm shadow-sm">
+          <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
+        </span>
       </div>
     </div>
-    <div class="p-8">
-    <!-- Header actions -->
-    <div class="mb-4 flex flex-wrap justify-end gap-2">
-      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <% if allowed_to?(:edit?, @organization) %>
-        <%= link_to "Edit", edit_organization_path(@organization),
-                    class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <% end %>
-      <span class="inline-block text-sm">
-        <%= render "bookmarks/editable_bookmark_button", resource: @organization %>
-      </span>
-    </div>
-    <!-- Header: logo + name + badges -->
-    <div class="mb-8 flex flex-col gap-6 md:flex-row md:items-center">
+    <!-- Identity: logo + name + contact + badges -->
+    <div class="flex flex-col gap-6 md:flex-row md:items-center">
       <div class="flex flex-shrink-0 justify-center md:justify-start">
         <% if @organization.logo&.attached? %>
           <%= image_tag @organization.logo,
-                        class: "w-28 h-28 rounded-full object-cover border-2 border-gray-200 shadow" %>
+                        class: "w-28 h-28 rounded-full object-cover ring-4 ring-white/25 shadow-lg" %>
         <% else %>
           <%= image_tag "missing.png",
-                        class: "w-28 h-28 rounded-full object-cover border-2 border-dashed border-gray-300" %>
+                        class: "w-28 h-28 rounded-full object-cover ring-4 ring-white/20 opacity-90" %>
         <% end %>
       </div>
       <div class="flex-1 text-center md:text-left">
         <% org_decorated = @organization.decorate %>
         <div class="flex flex-wrap items-center justify-center gap-3 md:justify-start">
-          <h1 class="text-3xl font-bold text-gray-900">
+          <h1 class="font-display text-4xl font-semibold tracking-tight text-white">
             <%= @organization.name %>
           </h1>
           <% if allowed_to?(:manage?, @organization) %>
-            <span id="program-status" class="admin-only scroll-mt-20 rounded-lg bg-blue-100 px-2 py-1">
+            <span id="program-status" class="admin-only scroll-mt-20 rounded-full bg-white/10 px-2 py-1">
               <%= org_decorated.organization_status_chip %>
             </span>
           <% end %>
@@ -51,29 +52,29 @@
                        @organization.addresses.active.first
                      end %>
         <% if address %>
-          <p class="mt-1 text-sm text-gray-500">
+          <p class="mt-1 text-sm text-white/70">
             <%= [address.locality, [address.city, address.state].compact_blank.join(", "), address.district].compact_blank.join(" · ") %>
           </p>
         <% end %>
         <% affiliated_since = org_decorated.affiliated_since_display %>
         <% if affiliated_since.present? %>
-          <p class="mt-1 text-sm text-gray-500">
+          <p class="mt-1 text-sm text-white/70">
             Affiliated since
-            <span class="font-medium"><%= affiliated_since %></span>
+            <span class="text-brand-gold font-semibold"><%= affiliated_since %></span>
           </p>
         <% end %>
         <% program_since = org_decorated.program_since_display %>
         <% if program_since.present? %>
-          <p class="mt-1 text-sm text-gray-500">
+          <p class="mt-1 text-sm text-white/70">
             Facilitators since
-            <span class="font-medium"><%= program_since %></span>
+            <span class="text-brand-gold font-semibold"><%= program_since %></span>
           </p>
         <% end %>
         <!-- Contact info -->
-        <div class="mt-3 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm md:justify-start">
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm md:justify-start">
           <% if @organization.profile_show_email? && @organization.email.present? %>
-            <span class="text-gray-600">
-              📧 <%= mail_to @organization.email, @organization.email, class: "text-blue-600 hover:underline" %>
+            <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
+              <i class="fa-solid fa-envelope text-xs text-white/70"></i> <%= mail_to @organization.email, @organization.email, class: "hover:text-brand-gold" %>
             </span>
           <% end %>
           <% if @organization.profile_show_phone? %>
@@ -83,32 +84,31 @@
                          @organization.addresses.active.filter_map(&:phone).first
                        end %>
             <% if phone.present? %>
-              <span class="text-gray-600">
-                📞 <%= link_to phone, "tel:#{phone}", class: "text-blue-600 hover:underline" %>
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
+                <i class="fa-solid fa-phone text-xs text-white/70"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-brand-gold" %>
               </span>
             <% end %>
           <% end %>
           <% if @organization.profile_show_website? && @organization.website_url.present? %>
             <% safe_url = @organization.website_link_url %>
             <% if safe_url.present? %>
-              <span class="text-gray-600">
-                🌎 <%= link_to @organization.website_url, safe_url,
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
+                <i class="fa-solid fa-globe text-xs text-white/70"></i> <%= link_to @organization.website_url, safe_url,
                               target: "_blank", rel: "noopener noreferrer",
-                              class: "text-blue-600 hover:underline" %>
+                              class: "hover:text-brand-gold" %>
               </span>
             <% elsif allowed_to?(:edit?, @organization) %>
-              <span class="admin-only bg-blue-100 p-3">
-                <span class="rounded bg-red-100 px-2 py-1 text-xs text-red-700">
-                  Bad URL: "<%= link_to @organization.website_url, edit_organization_path(@organization, anchor: "website-url-field") %>"
-                </span>
+              <span class="admin-only inline-flex items-center gap-1.5 rounded-full bg-red-100 px-3 py-1 text-xs text-red-700">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                Bad URL: "<%= link_to @organization.website_url, edit_organization_path(@organization, anchor: "website-url-field"), class: "underline" %>"
               </span>
             <% end %>
           <% end %>
         </div>
         <!-- Badges -->
-        <% badges = @organization.decorate.badges %>
+        <% badges = org_decorated.badges %>
         <% if badges.any? %>
-          <div class="mt-3 flex flex-wrap justify-center gap-1.5 md:justify-start">
+          <div class="mt-4 flex flex-wrap justify-center gap-1.5 md:justify-start">
             <% badges.each do |badge| %>
               <%= render "shared/badge", label: badge[:label], classes: "#{badge[:bg]} #{badge[:text]} #{badge[:border]}" %>
             <% end %>
@@ -116,143 +116,165 @@
         <% end %>
       </div>
     </div>
-    <hr class="my-8 border-gray-200">
-    <!-- Info grid -->
+  </div>
+  <!-- Profile body -->
+  <div class="space-y-8 p-4 sm:p-8">
+    <!-- Affiliations + sectors/age groups -->
     <div class="grid grid-cols-1 gap-8 md:grid-cols-5">
-        <!-- Organization affiliations -->
-        <div id="affiliations" class="scroll-mt-4 md:col-span-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
-          <h2 class="mb-2 text-lg font-semibold text-gray-800">
-            Affiliations
-          </h2>
-          <% active_affiliations = @organization.affiliations
-               .select { |a| !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) && a.person.present? }
-               .sort_by { |a| [a.person.first_name.to_s.downcase, a.person.last_name.to_s.downcase] } %>
-          <% grouped = active_affiliations.group_by(&:person) %>
-          <% if grouped.any? %>
-            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              <% grouped.each do |person, person_affiliations| %>
-                <div data-paginated-fields-target="item">
-                  <% titles = person_affiliations.filter_map { |a| a.title.presence }.uniq %>
-                  <% titles = titles.sort_by { |t| [t.downcase.include?("facilitator") ? 0 : 1, t.downcase] } %>
-                  <%= person_profile_button(person, subtitle: titles.any? ? titles.join(", ") : nil) %>
-                </div>
-              <% end %>
-            </div>
-            <div data-paginated-fields-target="nav" class="mt-3"></div>
-          <% else %>
-            <p class="text-gray-500 italic">No active affiliations.</p>
-          <% end %>
-        </div>
-        <!-- Sectors + Age groups served (two columns on desktop; stack on narrow viewports) -->
-        <% show_sectors = @organization.profile_show_sectors? %>
-        <% sectors = show_sectors ? @organization.all_sectors.sort_by { |s| s&.name.to_s } : [] %>
-        <% primary_age_groups = @organization.profile_show_age_ranges? ? @organization.all_primary_age_groups : [] %>
-        <% additional_age_groups = @organization.profile_show_age_ranges? ? @organization.all_additional_age_groups : [] %>
-        <% show_age = primary_age_groups.any? || additional_age_groups.any? %>
-        <% if show_sectors || show_age %>
-          <div class="p-3 md:col-span-2">
-            <div class="flex flex-col items-start gap-4 sm:flex-row">
-              <% if show_sectors %>
-                <div class="min-w-0 flex-1">
-                  <h2 class="mb-3 text-lg font-semibold text-gray-800">Sectors</h2>
-                  <% if sectors.any? %>
-                    <div class="flex flex-wrap gap-2">
-                      <% sectors.first(3).each do |sector| %>
-                        <%= render "sectors/tagging_label",
-                                   sector: sector,
-                                   display_leader: true %>
-                      <% end %>
-                      <% if sectors.length > 3 %>
-                        <span class="px-2 text-gray-500">...</span>
-                      <% end %>
-                    </div>
-                  <% else %>
-                    <p class="text-gray-500 italic">None selected.</p>
-                  <% end %>
-                  <div class="mt-4">
-                    <%= link_to "Explore sector data",
-                                populations_served_organization_path(@organization),
-                                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-                  </div>
-                </div>
-              <% end %>
-              <% if show_age %>
-                <div class="min-w-0 flex-1">
-                  <h2 class="mb-3 text-lg font-semibold text-gray-800">Age groups served</h2>
-                  <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <hr class="my-8 border-gray-200">
-    <!-- Workshops authored -->
-    <% if @organization.profile_show_description? && @organization.description.present? %>
-        <h2 class="mb-2 text-lg font-semibold text-gray-800">
-          Description
-        </h2>
-        <%= sanitize(@organization.description, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
-        <hr class="my-8 border-gray-200">
-      <% end %>
-    <!-- Workshops authored -->
-    <% if @organization.profile_show_workshops? %>
-        <div>
-          <h2 class="mb-2 text-lg font-semibold text-gray-800">
-            Workshops authored
-          </h2>
-          <% if @organization.workshops.any? %>
-            <% @organization.workshops.each do |workshop| %>
-              <%= link_to workshop.name, workshop_path(workshop), class: "btn btn-secondary-outline" %>
+      <!-- Organization affiliations -->
+      <div id="affiliations" class="scroll-mt-4 md:col-span-3" data-controller="paginated-fields" data-paginated-fields-per-page-value="9">
+        <h2 class="mb-3 font-display text-2xl text-gray-900">Affiliations</h2>
+        <% active_affiliations = @organization.affiliations
+             .select { |a| !a.inactive? && (a.end_date.nil? || a.end_date >= Date.current) && a.person.present? }
+             .sort_by { |a| [a.person.first_name.to_s.downcase, a.person.last_name.to_s.downcase] } %>
+        <% grouped = active_affiliations.group_by(&:person) %>
+        <% if grouped.any? %>
+          <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <% grouped.each do |person, person_affiliations| %>
+              <div data-paginated-fields-target="item">
+                <% titles = person_affiliations.filter_map { |a| a.title.presence }.uniq %>
+                <% titles = titles.sort_by { |t| [t.downcase.include?("facilitator") ? 0 : 1, t.downcase] } %>
+                <%= person_profile_button(person, subtitle: titles.any? ? titles.join(", ") : nil) %>
+              </div>
             <% end %>
-          <% else %>
-            <p class="text-gray-500 italic">No workshops authored yet.</p>
-          <% end %>
-        </div>
-      <% end %>
-    <!-- Stories authored -->
-    <% if @organization.profile_show_stories? %>
-      <div class="mt-10">
-        <h2 class="mb-2 text-lg font-semibold text-gray-800">
-          Stories
-        </h2>
-        <%# stories = @organization.stories_as_creator + @organization.stories_as_spotlighted_organization %>
-        <%# if stories.any? %>
-        <%# stories.each do |story| %>
-          <%#= link_to story.title, story_path(story), class: "btn btn-secondary-outline" %>
-          <%# end %>
-          <%# else %>
-          <p class="text-gray-500 italic">No stories yet.</p>
-          <%# end %>
-        </div>
-      <% end %>
-      <!-- Events attended -->
-    <% if @organization.profile_show_events_registered? %>
-      <div class="mt-10">
-        <h2 class="mb-2 text-lg font-semibold text-gray-800">
-          Events attended
-        </h2>
-        <%= turbo_frame_tag "organization_events_section", src: organization_path(@organization, section: "events"), loading: :lazy do %>
-          <p class="text-gray-500 italic">Loading events...</p>
+          </div>
+          <div data-paginated-fields-target="nav" class="mt-3"></div>
+        <% else %>
+          <p class="text-gray-500 italic">No active affiliations.</p>
         <% end %>
       </div>
-    <% end %>
-    <hr class="my-8 border-gray-200">
-    <% if allowed_to?(:show_workshop_logs?, @organization) %>
-        <div class="organization-only <%= DomainTheme.bg_class_for(:user_only) %>
-          border <%= DomainTheme.border_class_for(:user_only) %> rounded-lg shadow-sm">
-          <!-- Header -->
-          <div class="section-header flex flex-col justify-between gap-2 border-b px-6 py-3 sm:flex-row sm:items-center sm:px-7 <%= DomainTheme.border_class_for(:user_only) %>">
-            <h2 class="text-xl font-semibold text-gray-800">
-              Associated records
-            </h2>
-            <span class="text-sm text-amber-700 italic">Only visible to you</span>
-          </div>
-          <!-- Content -->
-          <div class="section-content px-6 py-4 sm:px-7 sm:py-6">
-            <%= render "associated_records", organization: @organization %>
+      <!-- Sectors + Age groups served (two columns on desktop; stack on narrow viewports) -->
+      <% show_sectors = @organization.profile_show_sectors? %>
+      <% sectors = show_sectors ? @organization.all_sectors.sort_by { |s| s&.name.to_s } : [] %>
+      <% primary_age_groups = @organization.profile_show_age_ranges? ? @organization.all_primary_age_groups : [] %>
+      <% additional_age_groups = @organization.profile_show_age_ranges? ? @organization.all_additional_age_groups : [] %>
+      <% show_age = primary_age_groups.any? || additional_age_groups.any? %>
+      <% if show_sectors || show_age %>
+        <div class="md:col-span-2">
+          <div class="flex flex-col items-start gap-4 sm:flex-row">
+            <% if show_sectors %>
+              <div class="min-w-0 flex-1">
+                <h2 class="mb-3 font-display text-2xl text-gray-900">Sectors</h2>
+                <% if sectors.any? %>
+                  <div class="flex flex-wrap gap-2">
+                    <% sectors.first(3).each do |sector| %>
+                      <%= render "sectors/tagging_label",
+                                 sector: sector,
+                                 display_leader: true %>
+                    <% end %>
+                    <% if sectors.length > 3 %>
+                      <span class="px-2 text-gray-500">...</span>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <p class="text-gray-500 italic">None selected.</p>
+                <% end %>
+                <div class="mt-4">
+                  <%= link_to "Explore sector data",
+                              populations_served_organization_path(@organization),
+                              class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+                </div>
+              </div>
+            <% end %>
+            <% if show_age %>
+              <div class="min-w-0 flex-1">
+                <h2 class="mb-3 font-display text-2xl text-gray-900">Age groups served</h2>
+                <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups %>
+              </div>
+            <% end %>
           </div>
         </div>
       <% end %>
     </div>
+    <!-- Description -->
+    <% if @organization.profile_show_description? && @organization.description.present? %>
+      <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 50) %>
+          border-2 <%= DomainTheme.border_class_for(:organizations) %> rounded-2xl p-5 sm:p-6">
+        <h2 class="mb-3 font-display text-2xl text-gray-900">Description</h2>
+        <div class="leading-relaxed text-gray-700">
+          <%= sanitize(@organization.description, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
+        </div>
+      </div>
+    <% end %>
+    <!-- AUTHORED SECTION -->
+    <% if @organization.profile_show_workshops? || @organization.profile_show_stories? %>
+      <div class="organization-only border-2 bg-white <%= DomainTheme.border_class_for(:workshops) %> overflow-hidden rounded-2xl shadow-sm">
+        <!-- Header -->
+        <div class="section-header flex items-center gap-3 border-b px-5 py-4 sm:px-6 <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>">
+          <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full <%= DomainTheme.bg_class_for(:workshops, intensity: 100) %> <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>">
+            <i class="fa-solid fa-pen-nib"></i>
+          </span>
+          <h2 class="font-display text-2xl text-gray-900">Published content</h2>
+        </div>
+        <!-- Contributed content -->
+        <div class="section-content space-y-8 px-4 py-5 sm:space-y-10 sm:px-6 sm:py-6">
+          <!-- Workshops authored -->
+          <% if @organization.profile_show_workshops? %>
+            <div>
+              <h3 class="mb-3 font-display text-xl text-gray-900">Workshops authored</h3>
+              <% if @organization.workshops.any? %>
+                <% @organization.workshops.each do |workshop| %>
+                  <%= link_to workshop.name, workshop_path(workshop), class: "btn btn-secondary-outline" %>
+                <% end %>
+              <% else %>
+                <p class="text-gray-500 italic">No workshops authored yet.</p>
+              <% end %>
+            </div>
+          <% end %>
+          <!-- Stories authored -->
+          <% if @organization.profile_show_stories? %>
+            <div>
+              <h3 class="mb-3 font-display text-xl text-gray-900">Stories</h3>
+              <%# stories = @organization.stories_as_creator + @organization.stories_as_spotlighted_organization %>
+              <%# if stories.any? %>
+              <%# stories.each do |story| %>
+                <%#= link_to story.title, story_path(story), class: "btn btn-secondary-outline" %>
+                <%# end %>
+                <%# else %>
+                <p class="text-gray-500 italic">No stories yet.</p>
+                <%# end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <!-- PARTICIPATION SECTION -->
+    <% if @organization.profile_show_events_registered? %>
+      <div class="organization-only border-2 bg-white <%= DomainTheme.border_class_for(:events) %> overflow-hidden rounded-2xl shadow-sm">
+        <!-- Header -->
+        <div class="section-header flex items-center gap-3 border-b px-5 py-4 sm:px-6 <%= DomainTheme.border_class_for(:events, intensity: 200) %>">
+          <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full <%= DomainTheme.bg_class_for(:events, intensity: 100) %> <%= DomainTheme.text_class_for(:events, intensity: 700) %>">
+            <i class="fa-solid fa-calendar-check"></i>
+          </span>
+          <h2 class="font-display text-2xl text-gray-900">Participation history</h2>
+        </div>
+        <!-- Events attended -->
+        <div class="section-content space-y-8 px-4 py-5 sm:space-y-10 sm:px-6 sm:py-6">
+          <div>
+            <h3 class="mb-3 font-display text-xl text-gray-900">Events attended</h3>
+            <%= turbo_frame_tag "organization_events_section", src: organization_path(@organization, section: "events"), loading: :lazy do %>
+              <p class="text-gray-500 italic">Loading events...</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <!-- ASSOCIATED RECORDS SECTION -->
+    <% if allowed_to?(:show_workshop_logs?, @organization) %>
+      <div class="organization-only border-2 bg-white <%= DomainTheme.border_class_for(:user_only) %> overflow-hidden rounded-2xl shadow-sm">
+        <!-- Header -->
+        <div class="section-header flex items-center gap-3 border-b px-5 py-4 sm:px-6 <%= DomainTheme.border_class_for(:user_only, intensity: 200) %>">
+          <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full <%= DomainTheme.bg_class_for(:user_only, intensity: 100) %> <%= DomainTheme.text_class_for(:user_only, intensity: 700) %>">
+            <i class="fa-solid fa-lock"></i>
+          </span>
+          <h2 class="font-display text-2xl text-gray-900">Associated records</h2>
+          <span class="ml-auto text-sm text-amber-700 italic">Only visible to you</span>
+        </div>
+        <!-- Content -->
+        <div class="section-content px-4 py-5 sm:px-6 sm:py-6">
+          <%= render "associated_records", organization: @organization %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2306,6 +2306,7 @@
   area: people
   display_status: user_facing
   released_on: 2026-08-27
+  pr_number: 2387
   summary: >-
     The organization profile has been restyled to match awbw.org: a navy hero
     carrying the logo, name, location, and contact details, and the rest of the

--- a/config/features.yml
+++ b/config/features.yml
@@ -2301,3 +2301,15 @@
     - "\"New tagging\" tags a person in one step; each staff tag on the staff tags page also has a \"View taggings\" link, pre-filtered to that tag."
     - "Editing a tagging lets you switch its tag and record comments or communications about it, all on one page."
     - "Reach it from the admin home page under \"Staff taggings\"."
+
+- name: "Organization profile in the AWBW brand"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-27
+  summary: >-
+    The organization profile has been restyled to match awbw.org: a navy hero
+    carrying the logo, name, location, and contact details, and the rest of the
+    page grouped into labelled cards on a warm cream background.
+  pro_tips:
+    - "Everything that was on the page is still there — description, affiliations, sectors, age groups, workshops, and events attended — just grouped into cards."
+    - "The organization's status chip still sits beside the name for admins."


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only restyle of one page plus a features.yml seed entry; no logic or data changes

The organization profile now looks like awbw.org — a navy hero for the logo, name and contact details, with the rest of the page grouped into cards on cream — so the portal reads as the same brand as the public site.

- Mirrors the person profile exactly: same hero, same rainbow strip, same `font-display` headings, same card treatment per section.
- Nothing was added or removed from the page. Description, affiliations, sectors, age groups, workshops, stories, events attended and associated records all render under the same `profile_show_*` conditions as before.
- Workshops and Stories moved into one "Published content" card, events into "Participation history" — matching the person profile's grouping rather than the old run of `<hr>`s.
- Admin markers on the navy hero (`admin-only` Edit link, the program-status chip, the bad-URL warning) keep their `admin-only` class but drop the `bg-blue-100` tint, which is unreadable on navy.
- `#program-status` and `#affiliations` anchors and their `scroll-mt-*` are preserved — both are linked from elsewhere.

**Stacked on `maebeale/redesign-person-profile`**, which owns the brand tokens (`brand-cream`, `brand-gold`, `font-display`) and the Fraunces font link. Retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)