### PR TITLE
Link the W-9 to every payment callout, gate its display on cost

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -405,24 +405,24 @@ module Events
     # The payment page's Documents section as grey callout cards, rendered through
     # the shared card partial like every other callout surface: the dynamic
     # invoice/receipt first, then the payment callout's linked resources (the W-9
-    # by default on paid events), each reading its admin-editable subtitle from the
-    # materialized join row.
+    # by default), each reading its admin-editable subtitle from the materialized
+    # join row. All are payment-event documents, so nothing renders on a free event
+    # — the W-9 is always linked but stays dormant until the event has a cost.
     def payment_document_cards
+      return [] unless @event_registration.invoice_available?
+
       slug = @event_registration.slug
-      cards = []
-      if @event_registration.invoice_available?
-        cards << document_card(title: "Invoice", subtitle: "Itemized invoice for this registration",
-          icon: "fa-solid fa-file-invoice-dollar", href: registration_invoice_path(slug, return_to: "payment"))
-        # The receipt is proof money changed hands, so it links once an actual
-        # payment settles the balance in full; until then (balance owing, or a
-        # balance cleared only by scholarship/discount) it's a locked card.
-        if @event_registration.receipt_available?
-          cards << document_card(title: "Receipt", subtitle: "Paid-in-full receipt for this registration",
-            icon: "fa-solid fa-receipt", href: registration_receipt_path(slug, return_to: "payment"))
-        else
-          cards << locked_document_card(title: "Receipt", icon: "fa-solid fa-receipt",
-            subtitle: "Available once your payment is received in full")
-        end
+      cards = [ document_card(title: "Invoice", subtitle: "Itemized invoice for this registration",
+        icon: "fa-solid fa-file-invoice-dollar", href: registration_invoice_path(slug, return_to: "payment")) ]
+      # The receipt is proof money changed hands, so it links once an actual
+      # payment settles the balance in full; until then (balance owing, or a
+      # balance cleared only by scholarship/discount) it's a locked card.
+      if @event_registration.receipt_available?
+        cards << document_card(title: "Receipt", subtitle: "Paid-in-full receipt for this registration",
+          icon: "fa-solid fa-receipt", href: registration_receipt_path(slug, return_to: "payment"))
+      else
+        cards << locked_document_card(title: "Receipt", icon: "fa-solid fa-receipt",
+          subtitle: "Available once your payment is received in full")
       end
       cards + payment_document_resources.map { |link| payment_resource_card(link, slug) }
     end
@@ -439,9 +439,10 @@ module Events
                             icon: "fa-solid fa-file-pdf", color: "gray")
     end
 
-    # The payment callout's linked resource join rows (the W-9 by default on paid
-    # events). Uses the materialized Payment row's links when present (so admins
-    # can add/remove them), else transient links for the W-9 on paid events not
+    # The payment callout's linked resource join rows (the W-9 by default). Only
+    # reached for a paid registration (the caller gates on invoice_available?).
+    # Uses the materialized Payment row's links when present (so admins can
+    # add/remove them), else transient links for the W-9 on a payment callout not
     # yet materialized.
     def payment_document_resources
       payment_callout = @event.registration_ticket_callouts.find_by(builtin_key: "payment")

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -201,10 +201,11 @@ class BuiltinCallouts
         icon_class: "fa-solid fa-credit-card",
         color_class: "orange",
         hidden: ->(_event) { true },
-        # The W-9 is a removable linked resource, included by default only on paid
-        # events (where a tax form applies); the invoice/receipt stay dynamic on
-        # the payment page. Admins add/remove it per event.
-        resources: -> { @event.cost_cents.to_i.positive? ? [ Resource.find_by(title: "W-9") ].compact : [] },
+        # The W-9 is a removable linked resource, always linked so free→paid needs
+        # no backfill. It stays dormant on a free event — the payment surface (and
+        # its documents) only renders once the event has a cost. Admins add/remove
+        # it per event; the invoice/receipt stay dynamic on the payment page.
+        resources: -> { [ Resource.find_by(title: "W-9") ].compact },
         # Its card subtitle is materialized here (admin-editable), not hard-coded in the view.
         resource_content: {
           "W-9" => { subtitle: "AWBW's W-9 tax form for your records" }

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "W-9 linked to every event by default"
+  area: payments
+  display_status: admin_facing
+  released_on: 2026-08-27
+  action_path: "/registration/sample"
+  pr_number: 2388
+  summary: >-
+    The W-9 is now linked to every event's payment callout by default, so it shows
+    on the ticket automatically once the event has a cost — even for events created
+    free and priced later. Remove it per event when it doesn't apply.
+
 - name: "Bulk payments index across all events"
   area: payments
   display_status: admin_facing

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).not_to include("AWBW's W-9 tax form for your records")
     end
 
-    it "keeps the W-9 dormant on a free event — linked, but no document renders" do
+    it "keeps the W-9 dormant on a free event (linked, but no document renders)" do
       free_event = create(:event, cost_cents: 0)
       callout = create(:registration_ticket_callout, event: free_event, builtin_key: "payment")
       w9 = create(:resource, title: "W-9")

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -253,6 +253,23 @@ RSpec.describe "Events::Callouts", type: :request do
       expect(response.body).not_to include("AWBW's W-9 tax form for your records")
     end
 
+    it "keeps the W-9 dormant on a free event — linked, but no document renders" do
+      free_event = create(:event, cost_cents: 0)
+      callout = create(:registration_ticket_callout, event: free_event, builtin_key: "payment")
+      w9 = create(:resource, title: "W-9")
+      create(:registration_ticket_callout_resource, registration_ticket_callout: callout,
+             resource: w9, subtitle: "AWBW's W-9 tax form for your records")
+      free_registration = create(:event_registration, event: free_event)
+
+      get registration_payment_path(free_registration.slug)
+
+      expect(response).to have_http_status(:success)
+      # The link exists, but the payment surface only shows documents once the
+      # event has a cost, so neither the W-9 nor the invoice renders.
+      expect(response.body).not_to include("AWBW's W-9 tax form for your records")
+      expect(response.body).not_to include("Itemized invoice for this registration")
+    end
+
     it "shows the ticket payment deadline while a balance is due" do
       event.update!(payment_due_deadline: Time.zone.local(2026, 4, 9, 17, 0))
 

--- a/spec/services/builtin_callouts_spec.rb
+++ b/spec/services/builtin_callouts_spec.rb
@@ -99,15 +99,17 @@ RSpec.describe BuiltinCallouts do
       expect(payment.resources).to eq([ w9 ])
     end
 
-    it "omits the W-9 from the Payment card on a free (training) event" do
-      create(:resource, title: "W-9")
+    it "links the W-9 to the Payment card on a free event too (dormant until it's priced)" do
+      w9 = create(:resource, title: "W-9")
       event = create(:event, facilitator_training: true, cost_cents: 0)
 
       described_class.seed(event)
 
       payment = event.registration_ticket_callouts.find_by(builtin_key: "payment")
       expect(payment).to be_present
-      expect(payment.resources).to be_empty # no W-9 on a free event
+      # The link is always present; the payment surface (and this document) only
+      # renders once the event has a cost, so free→paid needs no backfill.
+      expect(payment.resources).to eq([ w9 ])
     end
 
     it "seeds CE hours with its default title and no content" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained logic change to when the W-9 attaches and shows

Events are often created free and priced later, but the W-9 tax form only auto-attached to events that were *already* priced — so those events never showed the W-9 once a cost was added. This makes the W-9 attach reliably regardless of when the price is set.

- **Link the W-9 to every payment callout at creation** (not just paid events). It sits dormant on a free event.
- **Gate the payment documents on cost at render time** (`invoice_available?`) so a free event shows nothing, and the W-9 surfaces automatically the moment the event has a cost.
- **No transition callback, no backfill** — the link is always-present data; cost is the single live gate (same pattern the payment card already uses).
- Admins can still remove the W-9 per event; the link is real, deletable data.

### Not covered
- Existing events that are **free right now** and get priced later won't have the link (they materialized before this change). They can be fixed per-event via "Restore to default", or a one-off backfill if needed. (Existing *paid* events were already backfilled.)