### PR TITLE
Catalog 3 uncataloged shipped features in the Features & tips seed

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,48 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Person profile in the new AWBW brand"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-28
+  action_path: "/people/1"
+  pr_number: 2386
+  summary: >-
+    A person's profile is restyled to match the new awbw.org brand — a navy hero with the
+    rainbow accent strip, serif display headings, and a warm cream body of colored-border
+    cards for published content, participation history, and submitted content — so the
+    portal looks like part of the same organization.
+  pro_tips:
+    - "Presentation only — every section, badge, and permission on the profile works exactly as before."
+
+- name: "Transferred-in attendance days are preserved"
+  area: registration
+  display_status: admin_facing
+  released_on: 2026-08-26
+  action_path: "/transfer_guide"
+  pr_number: 2383
+  summary: >-
+    When a registrant transfers in from a longer multi-day training, their completed
+    attendance days are kept instead of dropping off the end, and the registration form
+    flags when the source and destination events have different day counts.
+  pro_tips:
+    - "Applies to new transfers going forward; already-transferred records are unchanged."
+    - "The \"transferred in from …\" notes now show the source event's month and year, so same-titled trainings are easy to tell apart."
+
+- name: "A person's history reaches more records that hang off them"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-26
+  action_path: "/people/1"
+  pr_number: 2354
+  summary: >-
+    The History on a person now surfaces activity that only connects to them through a
+    related record — payments and allocations, onboarding checklist steps, attendance
+    times, form answers and their uploads, event staffing, refunds, membership invoices,
+    and scholarship agreement responses — so the timeline is complete.
+  pro_tips:
+    - "It's read at request time, so it already covers everything on record — nothing needed backfilling."
+
 - name: "W-9 linked to every event by default"
   area: payments
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -35,9 +35,9 @@
   pr_number: 2386
   summary: >-
     A person's profile is restyled to match the new awbw.org brand — a navy hero with the
-    rainbow accent strip, serif display headings, and a warm cream body of colored-border
-    cards for published content, participation history, and submitted content — so the
-    portal looks like part of the same organization.
+    rainbow accent, serif headings, and a warm cream body of colored-border cards for
+    published content, participation history, and submitted content — so the portal matches
+    the wider organization.
   pro_tips:
     - "Presentation only — every section, badge, and permission on the profile works exactly as before."
 
@@ -62,10 +62,10 @@
   action_path: "/people/1"
   pr_number: 2354
   summary: >-
-    The History on a person now surfaces activity that only connects to them through a
-    related record — payments and allocations, onboarding checklist steps, attendance
-    times, form answers and their uploads, event staffing, refunds, membership invoices,
-    and scholarship agreement responses — so the timeline is complete.
+    A person's History now surfaces activity that only reaches them through a related
+    record — payments and allocations, onboarding steps, attendance times, form answers
+    and uploads, staffing, refunds, membership invoices, and scholarship agreements — so
+    the timeline is complete.
   pro_tips:
     - "It's read at request time, so it already covers everything on record — nothing needed backfilling."
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 seed-data only — three new entries in config/features.yml, no code

Audited every recent merged PR (all contributors) against the Features & tips seed and found three user-facing changes that shipped without a catalog entry, so admins can surface them on `/features`.

### What is the goal of this PR and why is this important?
The Features & tips page only shows what's in the seed. Three shipped changes were missing, so facilitators/admins couldn't see them. This adds them.

### How did you approach the change?
Cross-checked merged PR numbers against the `pr_number`s already in `config/features.yml`, then added the genuine gaps (skipping bugfixes, staged/dark work, and pure refactors):
- **Person profile in the new AWBW brand** (#2386) — the profile restyled to the new awbw.org brand.
- **Transferred-in attendance days are preserved** (#2383) — completed days are kept on transfer, with a day-count mismatch flag.
- **A person's history reaches records that hang off them** (#2354) — payments, checklist steps, form answers, and more now appear in the History.

### Anything else to add?
Seed only — an admin still clicks **Sync latest updates** on `/features` to pull these into the live database-backed page. Deliberately excluded: #2382 (a bugfix), #2325 (owner view is staged/not live), and #2269 (already folded into the transfer entry).