### PR TITLE
Give the People and Organizations lists the AWBW brand surface

### DIFF
--- a/app/views/organizations/_organizations_count.html.erb
+++ b/app/views/organizations/_organizations_count.html.erb
@@ -1,5 +1,5 @@
 <div id="organizations_count">
-  <h1 class="text-2xl font-semibold text-gray-900">
+  <h1 class="text-primary font-display text-3xl">
     Organizations (<%= number_with_delimiter(@organizations_count) %>)
   </h1>
 </div>

--- a/app/views/organizations/_results_skeleton.html.erb
+++ b/app/views/organizations/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
-<div class="rounded bg-white p-6">
+<div class="border-primary/10 rounded-2xl border bg-white p-6">
   <div class="overflow-x-auto">
-    <table class="min-w-full border border-gray-200 rounded divide-y divide-gray-200 animate-pulse">
+    <table class="min-w-full animate-pulse divide-y divide-gray-200 rounded border border-gray-200">
       <thead class="bg-gray-100">
         <tr>
           <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Organization</th>
@@ -17,13 +17,13 @@
       <tbody class="divide-y divide-gray-100">
         <% 8.times do %>
           <tr>
-            <td class="px-4 py-3"><div class="h-4 w-40 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-24 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-24 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-12 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3 text-center"><div class="h-4 w-8 bg-gray-200 rounded mx-auto"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-40 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-24 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-24 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-12 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-8 rounded bg-gray-200"></div></td>
             <% if allowed_to?(:manage?, Organization) %>
-              <td class="px-4 py-3 text-center"><div class="h-4 w-12 bg-gray-200 rounded mx-auto"></div></td>
+              <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-12 rounded bg-gray-200"></div></td>
             <% end %>
           </tr>
         <% end %>
@@ -33,8 +33,8 @@
 </div>
 
 <!-- Pagination skeleton -->
-<div class="mt-6 flex justify-center space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,29 +1,36 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:organizations) %> rounded-xl border border-gray-200 p-6 shadow">
-      <!-- Header -->
-      <div class="mb-6 flex flex-col items-center justify-between gap-3 sm:flex-row">
+<div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+  <!-- Rainbow accent strip (AWBW brand) -->
+  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <div class="p-6">
+    <!-- Header -->
+    <div class="mb-6 flex flex-col items-center justify-between gap-3 sm:flex-row sm:items-start">
+      <div class="pr-6">
+        <span class="text-2xs font-semibold tracking-widest uppercase <%= DomainTheme.text_class_for(:organizations, intensity: 700) %>">Directory</span>
         <div id="organizations_count">
-          <h1 class="text-2xl font-semibold text-gray-900">Organizations</h1>
-        </div>
-        <div class="flex items-center gap-3">
-          <% if allowed_to?(:manage?, Organization) %>
-            <%= link_to "Dedupe", dedupe_index_organizations_path,
-                        class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
-          <% end %>
-          <% if allowed_to?(:new?, Organization) %>
-            <%= link_to "New Organization",
-                        new_organization_path,
-                        class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-          <% end %>
+          <h1 class="text-primary font-display text-3xl">Organizations</h1>
         </div>
       </div>
+      <div class="flex items-center gap-3">
+        <% if allowed_to?(:manage?, Organization) %>
+          <%= link_to "Dedupe", dedupe_index_organizations_path,
+                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:new?, Organization) %>
+          <%= link_to "New Organization",
+                      new_organization_path,
+                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+        <% end %>
+      </div>
+    </div>
 
-      <!-- Optional filters -->
-      <%= render "search_boxes" %>
+    <!-- Optional filters -->
+    <%= render "search_boxes" %>
 
-      <% result_src = organizations_path + "?" + request.query_string %>
+    <% result_src = organizations_path + "?" + request.query_string %>
 
-      <%= turbo_frame_tag :organizations_results, src: result_src, data: {turbo: "temporary"} do %>
-        <%= render "results_skeleton" %>
-      <% end %>
+    <%= turbo_frame_tag :organizations_results, src: result_src, data: {turbo: "temporary"} do %>
+      <%= render "results_skeleton" %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/organizations/organizations_results.html.erb
+++ b/app/views/organizations/organizations_results.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag :organizations_results do %>
   <%= turbo_stream.replace("organizations_count", partial: "organizations_count") %>
 
-  <div class="rounded bg-white p-6 animate-fade blur-on-submit">
+  <div class="border-primary/10 animate-fade blur-on-submit rounded-2xl border bg-white p-6">
     <% if @organizations.any? %>
       <div class="overflow-x-auto">
         <table class="min-w-full border border-gray-200 rounded divide-y divide-gray-200">

--- a/app/views/people/_people_count.html.erb
+++ b/app/views/people/_people_count.html.erb
@@ -1,3 +1,3 @@
 <div id="people_count">
-  <h2 class="mb-2 text-2xl font-semibold">People (<%= @count_display %>)</h2>
+  <h1 class="text-primary font-display text-3xl">People (<%= @count_display %>)</h1>
 </div>

--- a/app/views/people/_results_skeleton.html.erb
+++ b/app/views/people/_results_skeleton.html.erb
@@ -1,30 +1,30 @@
-<div class="rounded-xl bg-white p-6">
+<div class="border-primary/10 rounded-2xl border bg-white p-6">
   <div class="overflow-x-auto">
-    <table class="w-full border-collapse border border-gray-200 animate-pulse">
+    <table class="w-full border-collapse animate-pulse border border-gray-200">
       <thead class="bg-gray-100">
         <tr>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Name</th>
-          <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">Affiliated since</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/5">Primary sector</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Primary age range</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">Affiliation(s)</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Socials</th>
+          <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
+          <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Affiliated since</th>
+          <th class="w-1/5 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary sector</th>
+          <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary age range</th>
+          <th class="w-1/4 px-4 py-2 text-left text-sm font-semibold text-gray-700">Affiliation(s)</th>
+          <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Socials</th>
           <% if allowed_to?(:manage?, Person) %>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+            <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
           <% end %>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">
         <% 8.times do %>
           <tr>
-            <td class="px-4 py-3"><div class="h-4 w-32 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3 text-center"><div class="h-4 w-12 bg-gray-200 rounded mx-auto"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-20 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-16 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-36 bg-gray-200 rounded"></div></td>
-            <td class="px-4 py-3"><div class="h-4 w-16 bg-gray-200 rounded"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-32 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-12 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-20 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-16 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-36 rounded bg-gray-200"></div></td>
+            <td class="px-4 py-3"><div class="h-4 w-16 rounded bg-gray-200"></div></td>
             <% if allowed_to?(:manage?, Person) %>
-              <td class="px-4 py-3 text-center"><div class="h-4 w-12 bg-gray-200 rounded mx-auto"></div></td>
+              <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-12 rounded bg-gray-200"></div></td>
             <% end %>
           </tr>
         <% end %>
@@ -34,8 +34,8 @@
 </div>
 
 <!-- Pagination skeleton -->
-<div class="mt-6 flex justify-center space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="community-news-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> rounded-xl border border-gray-200 p-6 shadow">
-  <div class="w-full">
+<div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+  <!-- Rainbow accent strip (AWBW brand) -->
+  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <div class="w-full p-6">
     <% back_label, back_path =
          case params[:return_to]
          when "staff_tags"
@@ -19,8 +21,11 @@
       </div>
     <% end %>
     <div class="mb-6 flex items-start justify-between">
-      <div id="people_count" class="pr-6">
-        <h2 class="mb-2 text-2xl font-semibold">People</h2>
+      <div class="pr-6">
+        <span class="text-2xs font-semibold tracking-widest uppercase <%= DomainTheme.text_class_for(:people, intensity: 700) %>">Directory</span>
+        <div id="people_count">
+          <h1 class="text-primary font-display text-3xl">People</h1>
+        </div>
       </div>
       <div class="flex flex-wrap items-center justify-end gap-2 text-right">
         <% if allowed_to?(:index?, TopicSubscription) %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -1,27 +1,27 @@
 <%= turbo_frame_tag :people_results do %>
   <%= turbo_stream.replace("people_count", partial: "people_count") %>
 
-  <div class="rounded-xl bg-white overflow-hidden animate-fade blur-on-submit">
+  <div class="border-primary/10 animate-fade overflow-hidden rounded-2xl border bg-white blur-on-submit">
     <% if @people.any? %>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse border border-gray-200">
           <thead class="bg-gray-100">
             <tr>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Name</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">Affiliated since</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/5">Primary sector</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Primary age range</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">Affiliation(s)</th>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Socials</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
+              <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Affiliated since</th>
+              <th class="w-1/5 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary sector</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Primary age range</th>
+              <th class="w-1/4 px-4 py-2 text-left text-sm font-semibold text-gray-700">Affiliation(s)</th>
+              <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Socials</th>
               <% if allowed_to?(:manage?, Person) %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+                <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
               <% end %>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200">
             <% @people.each do |person| %>
               <% cache [ person, current_user.super_user?, current_user.person_id == person.id ] do %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150 <%= "admin-only bg-blue-100" unless person.published? %>">
+              <tr class="transition-colors duration-150 hover:bg-gray-50 <%= "admin-only bg-blue-100" unless person.published? %>">
                 <td class="px-4 py-2">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
                   <% if allowed_to?(:show?, person) %>
@@ -107,12 +107,12 @@
                   <% end %>
                 </td>
                 <!-- Socials -->
-                <td class="px-4 py-2 text-sm text-gray-800 whitespace-nowrap">
+                <td class="px-4 py-2 text-sm whitespace-nowrap text-gray-800">
                   <%= render "social_media_buttons", person: person %>
                 </td>
                 <!-- Actions -->
                 <% if allowed_to?(:manage?, Person) %>
-                  <td class="px-4 py-2 justify-center gap-2">
+                  <td class="justify-center gap-2 px-4 py-2">
                     <%= link_to "User", user_path(person.user),
                             data: { turbo_frame: "_top" },
                             class: "admin-only bg-blue-100 btn btn-secondary-outline px-2.5 py-1 text-xs" if person.user %>
@@ -128,7 +128,7 @@
         </table>
       </div>
     <% else %>
-      <p class="text-gray-500 text-center px-6 py-6">
+      <p class="px-6 py-6 text-center text-gray-500">
         No <%= Person.model_name.human.pluralize.downcase %> found.
       </p>
     <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2344,3 +2344,14 @@
     - "Edit the kept organization's fields right in the preview before you merge."
     - "Use Swap if you picked the wrong record to keep."
     - "Both records' FileMaker codes are kept on the merged organization — a field flagged 'Kept on merge' is combined, not dropped."
+
+- name: "People and Organizations lists in the AWBW brand"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-27
+  action_path: "/people"
+  summary: >-
+    The People and Organizations directories now carry the awbw.org look — a cream
+    page card topped by the rainbow accent strip, a serif page title, and the
+    results table in its own bordered card. Filters, columns, and counts are
+    unchanged.

--- a/config/features.yml
+++ b/config/features.yml
@@ -2349,6 +2349,7 @@
   area: people
   display_status: user_facing
   released_on: 2026-08-27
+  pr_number: 2391
   action_path: "/people"
   summary: >-
     The People and Organizations directories now carry the awbw.org look — a cream


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only restyle of two index shells plus a features.yml seed entry; no logic, query, or column changes

The People and Organizations directories now read as the same brand as awbw.org — cream page card, rainbow accent strip, serif title — without the navy hero the profile pages use.

- Deliberately light: the results tables, filters, columns, counts and pagination are untouched. Only the page shell and the panel the results sit in changed.
- Page title moved to `font-display` navy, with a small domain-colored "Directory" eyebrow above it. Restyled in the `_*_count` partials too, since Turbo swaps those in once the count loads.
- People's page title was an `h2` with no `h1` on the page; it's now an `h1`, matching Organizations.
- Results panel and its loading skeleton both became `rounded-2xl border-primary/10` so the swap isn't a visual jump.
- Dropped the stray `community-news-index` class copy-pasted onto the People index — nothing styles it.

**Stacked on `maebeale/redesign-person-profile`**, which owns the `brand-cream` / `font-display` tokens. Retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)