### PR TITLE
Link the org profile features entry to the PR that shipped it

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -2531,6 +2531,7 @@
   area: people
   display_status: user_facing
   released_on: 2026-08-28
+  pr_number: 2402
   summary: >-
     The organization profile has been restyled to match awbw.org: a navy hero
     carrying the logo, name, location and contact details, with the rest of the


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 one line in the features seed

The **Organization profile in the AWBW brand** entry on the Features & tips page has no `pr_number`, so unlike every other brand entry it doesn't link back to the PR that shipped it.

```yaml
+  pr_number: 2402
```

It lost the field when the branch was rebuilt as #2402. Every sibling has one — 2386, 2391, 2393, 2394, 2398, 2399.

**This PR previously held the organization profile redesign.** That work merged as #2402, so this branch was reset to `main` and now carries only the one-line fix.