### PR TITLE
Bring the registration ticket and callout pages into the AWBW brand

### DIFF
--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -32,7 +32,7 @@
             <p class="mb-0.5 font-telefon text-sm font-semibold text-gray-700"><%= event_registration.event.pre_title %></p>
           <% end %>
 
-          <h2 class="text-primary font-display text-2xl leading-tight"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
+          <h2 class="text-primary text-2xl leading-tight font-bold"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
 
           <p class="text-primary mt-0.5 text-sm font-semibold"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
 

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -4,21 +4,20 @@
   <%= render "event_registrations/transfer_notice", event_registration: event_registration %>
   <!-- Ticket Container -->
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
+    <%= render "shared/brand_accent_strip" %>
     <!-- Ticket Header -->
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0"><%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %></div>
 
         <div class="flex-1">
-          <h1 class="text-xl leading-tight font-semibold tracking-wide">Registration ticket</h1>
+          <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight">Registration ticket</h1>
         </div>
       </div>
-
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
 
     <!-- Ticket Body -->
-    <div class="space-y-5 bg-gray-50 px-6 py-6">
+    <div class="bg-brand-cream space-y-5 px-6 py-6">
       <!-- Event thumbnail + title -->
       <div class="flex items-center justify-center gap-4">
         <%= render "assets/display_image",
@@ -30,12 +29,12 @@
 
         <div class="min-w-0 text-left">
           <% if event_registration.event.respond_to?(:pre_title) && event_registration.event.pre_title.present? %>
-            <p class="mb-0.5 text-sm font-semibold text-gray-700" style="font-family: 'Telefon Bold', sans-serif"><%= event_registration.event.pre_title %></p>
+            <p class="mb-0.5 font-telefon text-sm font-semibold text-gray-700"><%= event_registration.event.pre_title %></p>
           <% end %>
 
-          <h2 class="text-2xl leading-tight font-bold text-green-800" style="font-family: Lato, sans-serif"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
+          <h2 class="text-primary font-display text-2xl leading-tight"><%= link_to event_registration.event.title, event_path(event_registration.event, reg: event_registration.slug), class: "hover:underline" %></h2>
 
-          <p class="mt-0.5 text-sm font-semibold text-blue-900" style="font-family: Lato, sans-serif"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
+          <p class="text-primary mt-0.5 text-sm font-semibold"><%= event_registration.event.decorate.times(display_day: true, display_date: true) %></p>
 
           <%
             venue = if event_registration.event.autoshow_videoconference_label && event_registration.event.videoconference_label.present?
@@ -54,8 +53,8 @@
       <!-- Divider (perforation style) -->
       <div class="relative my-6">
         <div class="border-t border-dashed border-gray-300"></div>
-        <div class="absolute top-1/2 -left-3 h-6 w-6 -translate-y-1/2 rounded-full bg-gray-100"></div>
-        <div class="absolute top-1/2 -right-3 h-6 w-6 -translate-y-1/2 rounded-full bg-gray-100"></div>
+        <div class="absolute top-1/2 -left-3 h-6 w-6 -translate-y-1/2 rounded-full bg-white"></div>
+        <div class="absolute top-1/2 -right-3 h-6 w-6 -translate-y-1/2 rounded-full bg-white"></div>
       </div>
 
       <!-- Registrant -->
@@ -162,7 +161,7 @@
       <% end %>
 
       <!-- Divider -->
-      <div class="border-t border-gray-200"></div>
+      <div class="border-primary/10 border-t"></div>
 
       <!-- Status -->
       <div class="space-y-2 text-center">
@@ -204,7 +203,7 @@
         </div>
 
         <!-- Add to calendar (secondary utility, kept at the bottom) -->
-        <div class="flex flex-col items-center border-t border-gray-100 pt-5">
+        <div class="border-primary/10 flex flex-col items-center border-t pt-5">
           <div class="mb-2 flex items-center gap-1">
             <p class="text-xs font-bold tracking-wide text-gray-400 uppercase">
               Add to your calendar

--- a/app/views/events/callouts/_callout_page.html.erb
+++ b/app/views/events/callouts/_callout_page.html.erb
@@ -19,25 +19,25 @@
   </div>
 <% end %>
 
-<div class="<%= container_width %> mx-auto pb-12 pt-6 px-4">
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+<div class="<%= container_width %> mx-auto px-4 pt-6 pb-12">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight"><%= title %></h1>
+          <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= title %></h1>
           <%# @event is decorated in some callout actions and raw in others; the date
               range lives on the decorator, so decorate only when it isn't already. %>
           <% event = @event.respond_to?(:short_date_range) ? @event : @event.decorate %>
-          <p class="text-sm text-blue-200"><%= event.title %></p>
+          <p class="text-sm text-white/70"><%= event.title %></p>
           <% if event.start_date.present? %>
-            <p class="text-sm text-blue-200"><%= event.short_date_range %> · <%= event.times %></p>
+            <p class="text-sm text-white/70"><%= event.short_date_range %> · <%= event.times %></p>
           <% end %>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <div class="px-6 sm:px-8 py-7">

--- a/app/views/events/callouts/_resource_body.html.erb
+++ b/app/views/events/callouts/_resource_body.html.erb
@@ -20,7 +20,7 @@
 <% end %>
 
 <% if inline_title.present? %>
-  <h2 class="text-2xl font-semibold text-gray-900 break-words"><%= inline_title %></h2>
+  <h2 class="font-display text-2xl text-gray-900 break-words"><%= inline_title %></h2>
 <% end %>
 
 <% if page_content.present? %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <!-- Rainbow accent strip (AWBW brand) -->
-  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <%= render "shared/brand_accent_strip" %>
   <div class="p-6">
     <!-- Header -->
     <div class="mb-6 flex flex-col items-center justify-between gap-3 sm:flex-row sm:items-start">

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <!-- Rainbow accent strip (AWBW brand) -->
-  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <%= render "shared/brand_accent_strip" %>
   <div class="w-full p-6">
     <% back_label, back_path =
          case params[:return_to]

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -10,8 +10,7 @@
   </div>
 <% end %>
 <div class="admin-or-owner bg-brand-cream border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
-  <!-- Rainbow accent strip (AWBW brand) -->
-  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <%= render "shared/brand_accent_strip" %>
   <!-- Person hero -->
   <div class="bg-primary px-4 pt-5 pb-8 text-white sm:px-8">
     <!-- Eyebrow + header actions -->

--- a/app/views/shared/_brand_accent_strip.html.erb
+++ b/app/views/shared/_brand_accent_strip.html.erb
@@ -1,0 +1,2 @@
+<%# The AWBW rainbow rule that tops a branded page card (matches awbw.org). %>
+<div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2428,6 +2428,7 @@
   area: registration
   display_status: public_facing
   released_on: 2026-08-28
+  pr_number: 2393
   summary: >-
     The registration ticket and every callout page it links to (payment, CE,
     certificate, scholarship, handouts, FAQ, and the rest) now carry the awbw.org

--- a/config/features.yml
+++ b/config/features.yml
@@ -2423,3 +2423,15 @@
     - "Find it under a callout's Visibility section: tick \"Only show if CE hours are paid\"."
     - "Combine it with a display date to reveal CE-only material on a set day for paid CE registrants."
     - "The registration-payment and CE-payment gates are independent — set either or both."
+
+- name: "Registration ticket and callout pages in the AWBW brand"
+  area: registration
+  display_status: public_facing
+  released_on: 2026-08-28
+  summary: >-
+    The registration ticket and every callout page it links to (payment, CE,
+    certificate, scholarship, handouts, FAQ, and the rest) now carry the awbw.org
+    look — navy header topped by the rainbow rule, serif headings, and a warm
+    cream ticket body. Nothing moved; only the styling changed.
+  pro_tips:
+    - "Registrants see this, so it's the most public-facing page in the portal — preview it from an event's dashboard with \"Sample ticket\"."


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only restyle of shared ticket/callout chrome plus a features.yml seed entry; no logic, route, or data changes

The registration ticket and every callout page it links to now look like awbw.org instead of the old purple-gradient header — this is the page registrants actually see, so it was the most off-brand surface left.

- Two shared partials carry the whole change: the ticket header/body and `callouts/_callout_page`, which is the chrome for all 11 callout pages (payment, CE, certificate, scholarship, videoconference, staff, handouts, FAQ, resource, custom).
- Navy `bg-primary` header topped by the rainbow rule, `font-display` titles, cream ticket body. Nothing moved or was removed.
- Dropped two inline `style="font-family: …"` attributes on the event title in favor of `font-telefon` / `font-display`.
- Perforation dots are now white so they read as punched through to the page, not as grey blobs on grey.
- Callout **cards** are untouched — their per-type colors are doing real work.

### Shared partial
The rainbow rule literal had reached three copies on `main` and this adds two more, so it's now `shared/_brand_accent_strip`. That converts `people/show`, `people/index` and `organizations/index` in passing — a one-line swap each.

⚠️ #2392 (org profile) adds a sixth copy; it should adopt the partial when it rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)