### PR TITLE
Bring the home page into the AWBW brand, on real brand colour scales

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -24,22 +24,105 @@
      `primary`, green is `success`, orange is `accent`. These add the rest, the
      cream page surface, and the display serif used for headlines. */
   --color-brand-cream: #fcfaeb;
-  --color-brand-gold: #ffcb05;
-  --color-brand-gold-dark: #e0b205;
-  --color-brand-magenta: #992a5b;
-  --color-brand-purple: #41006c;
-  --color-brand-teal: #008d80;
   --font-display: "Fraunces", "Lato", serif;
 
-  /* Pale surfaces for per-domain sections. Green, yellow and peach are the
-     guide's own background swatches; navy, magenta and purple are matched to
-     them in lightness off the corresponding brand colour. */
-  --color-brand-tint-green: #e7f0c6;
-  --color-brand-tint-yellow: #ffefc7;
-  --color-brand-tint-peach: #ffddcf;
-  --color-brand-tint-navy: #dde5f6;
-  --color-brand-tint-magenta: #f7dde8;
-  --color-brand-tint-purple: #e9def3;
+  /* Each brand colour as a full 50–950 scale, so it is used exactly like a
+     stock Tailwind colour: `bg-brand-navy-50`, `text-brand-navy-700`,
+     `border-brand-navy-300`. Generated off Tailwind's own OKLCH curve for the
+     nearest hue family, re-hued to the brand colour and rescaled so the brand
+     hex lands exactly on the step noted above each ramp. Chroma is never
+     pushed past the reference family, which keeps the very dark purple from
+     going neon in its mid tones. */
+  /* Navy — brand #24479e sits at 800. */
+  --color-brand-navy-50: #f2f5fc;
+  --color-brand-navy-100: #e1e9f9;
+  --color-brand-navy-200: #cad9f6;
+  --color-brand-navy-300: #a8c1f4;
+  --color-brand-navy-400: #7a9fed;
+  --color-brand-navy-500: #5682e6;
+  --color-brand-navy-600: #3967d9;
+  --color-brand-navy-700: #2a55c4;
+  --color-brand-navy-800: #24479e;
+  --color-brand-navy-900: #253f7b;
+  --color-brand-navy-950: #19284b;
+
+  /* Yellow — brand #ffcb05 sits at 400. */
+  --color-brand-yellow-50: #fffbea;
+  --color-brand-yellow-100: #fff5c7;
+  --color-brand-yellow-200: #ffea91;
+  --color-brand-yellow-300: #ffda4c;
+  --color-brand-yellow-400: #ffcb05;
+  --color-brand-yellow-500: #e6b704;
+  --color-brand-yellow-600: #bd9500;
+  --color-brand-yellow-700: #907000;
+  --color-brand-yellow-800: #755b00;
+  --color-brand-yellow-900: #624d08;
+  --color-brand-yellow-950: #392b02;
+
+  /* Green — brand #4e8324 sits at 700. */
+  --color-brand-green-50: #f3ffed;
+  --color-brand-green-100: #e4fed6;
+  --color-brand-green-200: #ccfcb0;
+  --color-brand-green-300: #adf67c;
+  --color-brand-green-400: #8fe849;
+  --color-brand-green-500: #7ad030;
+  --color-brand-green-600: #60a722;
+  --color-brand-green-700: #4e8324;
+  --color-brand-green-800: #3f6722;
+  --color-brand-green-900: #385822;
+  --color-brand-green-950: #1f3310;
+
+  /* Magenta — brand #992a5b sits at 800. */
+  --color-brand-magenta-50: #fcf2f5;
+  --color-brand-magenta-100: #fce8ee;
+  --color-brand-magenta-200: #fbd1de;
+  --color-brand-magenta-300: #faabc6;
+  --color-brand-magenta-400: #f474a5;
+  --color-brand-magenta-500: #eb5293;
+  --color-brand-magenta-600: #d73880;
+  --color-brand-magenta-700: #b82d6c;
+  --color-brand-magenta-800: #992a5b;
+  --color-brand-magenta-900: #7e284c;
+  --color-brand-magenta-950: #4d152d;
+
+  /* Orange — brand #d56027 sits at 600. */
+  --color-brand-orange-50: #fff6f2;
+  --color-brand-orange-100: #ffeae1;
+  --color-brand-orange-200: #ffd3c1;
+  --color-brand-orange-300: #fdb597;
+  --color-brand-orange-400: #f18e63;
+  --color-brand-orange-500: #eb7946;
+  --color-brand-orange-600: #d56027;
+  --color-brand-orange-700: #b04d1c;
+  --color-brand-orange-800: #893d19;
+  --color-brand-orange-900: #6c3319;
+  --color-brand-orange-950: #371607;
+
+  /* Purple — brand #41006c sits at 950. */
+  --color-brand-purple-50: #f9f5ff;
+  --color-brand-purple-100: #f2e8ff;
+  --color-brand-purple-200: #e8d5ff;
+  --color-brand-purple-300: #d8b4ff;
+  --color-brand-purple-400: #c17dff;
+  --color-brand-purple-500: #af48ff;
+  --color-brand-purple-600: #9e11fa;
+  --color-brand-purple-700: #8800da;
+  --color-brand-purple-800: #7116b3;
+  --color-brand-purple-900: #5b1b8f;
+  --color-brand-purple-950: #41006c;
+
+  /* Teal — brand #008d80 sits at 600. */
+  --color-brand-teal-50: #f1fdfb;
+  --color-brand-teal-100: #cffaf2;
+  --color-brand-teal-200: #a0f3e6;
+  --color-brand-teal-300: #62e8d6;
+  --color-brand-teal-400: #20cfbd;
+  --color-brand-teal-500: #0eb5a5;
+  --color-brand-teal-600: #008d80;
+  --color-brand-teal-700: #127167;
+  --color-brand-teal-800: #135951;
+  --color-brand-teal-900: #154842;
+  --color-brand-teal-950: #062925;
 
   /* Social network brand colors, used for the hover fill on share/follow
      buttons. Instagram is a three-stop gradient rather than a single fill. */
@@ -73,14 +156,10 @@
 
 /* Used to generate classes from `domain_theme.rb`*/
 
-@source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
-@source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
-@source inline("ring-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300,400,500}");
-@source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
-
-/* Per-domain brand surfaces (generated from DomainTheme::BRAND_SURFACES, which
-   lives in lib/ and is not scanned) */
-@source inline("bg-brand-tint-{green,yellow,peach,navy,magenta,purple}");
+@source inline("{hover:,}bg-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink,brand-navy,brand-yellow,brand-green,brand-magenta,brand-orange,brand-purple,brand-teal}-{50,{100..900..100},950}");
+@source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink,brand-navy,brand-yellow,brand-green,brand-magenta,brand-orange,brand-purple,brand-teal}-{200,300}");
+@source inline("ring-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink,brand-navy,brand-yellow,brand-green,brand-magenta,brand-orange,brand-purple,brand-teal}-{200,300,400,500}");
+@source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink,brand-navy,brand-yellow,brand-green,brand-magenta,brand-orange,brand-purple,brand-teal}-{50,{100..900..100},950}");
 
 /* Per-field form layout widths (generated from FormField::WIDTH_GRID_SPANS, which
    lives in a model file Tailwind does not scan) */

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -19,13 +19,27 @@
   --color-transparent: transparent;
   --font-telefon: "Telefon Bold", sans-serif;
 
-  /* AWBW marketing brand tokens (matches awbw.org). The navy is `primary`; these
-     add the warm cream surface, gold call-to-action, and the display serif used
-     for headlines. Themed pages (e.g. the person profile) build on these. */
-  --color-brand-cream: #faf6ea;
-  --color-brand-gold: #f6c445;
-  --color-brand-gold-dark: #e7ad25;
+  /* AWBW brand palette, taken from app/assets/images/brand/awbw-brand-guide.pdf.
+     Three of the guide's six brand colours already exist above: navy is
+     `primary`, green is `success`, orange is `accent`. These add the rest, the
+     cream page surface, and the display serif used for headlines. */
+  --color-brand-cream: #fcfaeb;
+  --color-brand-gold: #ffcb05;
+  --color-brand-gold-dark: #e0b205;
+  --color-brand-magenta: #992a5b;
+  --color-brand-purple: #41006c;
+  --color-brand-teal: #008d80;
   --font-display: "Fraunces", "Lato", serif;
+
+  /* Pale surfaces for per-domain sections. Green, yellow and peach are the
+     guide's own background swatches; navy, magenta and purple are matched to
+     them in lightness off the corresponding brand colour. */
+  --color-brand-tint-green: #e7f0c6;
+  --color-brand-tint-yellow: #ffefc7;
+  --color-brand-tint-peach: #ffddcf;
+  --color-brand-tint-navy: #dde5f6;
+  --color-brand-tint-magenta: #f7dde8;
+  --color-brand-tint-purple: #e9def3;
 
   /* Social network brand colors, used for the hover fill on share/follow
      buttons. Instagram is a three-stop gradient rather than a single fill. */
@@ -63,6 +77,10 @@
 @source inline("{hover:,}border-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300}");
 @source inline("ring-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{200,300,400,500}");
 @source inline("{hover:,}text-{indigo,purple,teal,violet,orange,rose,blue,sky,emerald,slate,lime,stone,amber,green,yellow,gray,cyan,fuchsia,pink}-{50,{100..900..100},950}");
+
+/* Per-domain brand surfaces (generated from DomainTheme::BRAND_SURFACES, which
+   lives in lib/ and is not scanned) */
+@source inline("bg-brand-tint-{green,yellow,peach,navy,magenta,purple}");
 
 /* Per-field form layout widths (generated from FormField::WIDTH_GRID_SPANS, which
    lives in a model file Tailwind does not scan) */

--- a/app/views/home/_community_news.html.erb
+++ b/app/views/home/_community_news.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Community News" %>
-
-<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:community_news) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Announcements and updates" %>
-
-    <%= turbo_frame_tag "home_community_news", src: home_community_news_index_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
-      <%= render "community_news_cards_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Announcements and updates",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_community_news", src: home_community_news_index_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
+    <%= render "community_news_cards_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/_events.html.erb
+++ b/app/views/home/_events.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Upcoming Events" %>
-
-<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:events) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Workshops, trainings and more" %>
-
-    <%= turbo_frame_tag "home_events", src: home_events_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
-      <%= render "events_cards_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Workshops, trainings and more",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_events", src: home_events_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
+    <%= render "events_cards_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/_home_section_header.html.erb
+++ b/app/views/home/_home_section_header.html.erb
@@ -1,7 +1,0 @@
-<div class="mb-8">
-  <h2 class="text-3xl font-semibold text-gray-900"><%= title %></h2>
-
-  <% if defined?(subtitle) && subtitle.present? %>
-    <p class="text-gray-600 mt-1"><%= subtitle %></p>
-  <% end %>
-</div>

--- a/app/views/home/_resources.html.erb
+++ b/app/views/home/_resources.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Popular Resources" %>
-
-<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:resources) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Tools to support your work" %>
-
-    <%= turbo_frame_tag "home_resources", src: home_resources_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
-      <%= render "resources_cards_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Tools to support your work",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_resources", src: home_resources_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
+    <%= render "resources_cards_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/_section.html.erb
+++ b/app/views/home/_section.html.erb
@@ -1,0 +1,16 @@
+<%# Shared chrome for a home-page section: the brand rule at the boundary, the
+    section's surface, its heading, and the caller's lazy frame as a block.
+    locals: title, subtitle (optional), surface (defaults to white). %>
+<% surface = local_assigns[:surface].presence || "bg-white" %>
+<section class="<%= surface %>">
+  <%= render "shared/brand_accent_strip" %>
+  <div class="mx-auto max-w-6xl px-4 py-10">
+    <div class="mb-8">
+      <h2 class="text-primary font-display text-3xl"><%= title %></h2>
+      <% if local_assigns[:subtitle].present? %>
+        <p class="mt-1 text-gray-600"><%= subtitle %></p>
+      <% end %>
+    </div>
+    <%= yield %>
+  </div>
+</section>

--- a/app/views/home/_stories.html.erb
+++ b/app/views/home/_stories.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Highlighted Stories" %>
-
-<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:stories) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Voices from our community" %>
-
-    <%= turbo_frame_tag "home_stories", src: home_stories_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
-      <%= render "stories_cards_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Voices from our community",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_stories", src: home_stories_path, loading: :lazy, data: {controller: "prefetch-lazy"} do %>
+    <%= render "stories_cards_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/_video_recordings.html.erb
+++ b/app/views/home/_video_recordings.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Video Gallery" %>
-
-<section class="py-10 <%= DomainTheme.bg_class_for(:video_recordings) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Inspiration in motion" %>
-
-    <%= turbo_frame_tag "home_video_gallery", src: home_video_recordings_path, loading: :lazy, data: { controller: "prefetch-lazy" } do %>
-      <%= render "video_gallery_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Inspiration in motion",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_video_gallery", src: home_video_recordings_path, loading: :lazy, data: { controller: "prefetch-lazy" } do %>
+    <%= render "video_gallery_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/_workshops.html.erb
+++ b/app/views/home/_workshops.html.erb
@@ -1,13 +1,9 @@
 <% title ||= "Featured Workshops" %>
-
-<section class="<%# mt-6 %> py-10 <%= DomainTheme.bg_class_for(:workshops) %>">
-  <div class="max-w-6xl mx-auto px-4">
-    <%= render "home/home_section_header",
-               title: title,
-               subtitle: "Spotlights from our curriculum" %>
-
-    <%= turbo_frame_tag "home_workshops", src: home_workshops_path(bust_cache: params[:bust_cache].presence) do %>
-      <%= render "workshops_cards_skeleton" %>
-    <% end %>
-  </div>
-</section>
+<%= render layout: "home/section",
+           locals: { title: title,
+                     subtitle: "Spotlights from our curriculum",
+                     surface: local_assigns[:surface] } do %>
+  <%= turbo_frame_tag "home_workshops", src: home_workshops_path(bust_cache: params[:bust_cache].presence) do %>
+    <%= render "workshops_cards_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,11 @@
 <% content_for(:full_width, true) %>
 <%= render "shared/public_welcome_banner" %>
 
-<%= render "home/workshops", title: "Featured Workshops" %>
-<%= render "home/community_news" %>
-<%= render "home/resources", title: "Popular Resources" %>
-<%= render "home/events" %>
-<%= render "home/stories" %>
-<%= render "home/video_recordings" %>
+<%# Sections alternate cream and white, the way awbw.org does — the colour lives
+    in the cards, not the band behind them. %>
+<%= render "home/workshops", title: "Featured Workshops", surface: "bg-brand-cream" %>
+<%= render "home/community_news", surface: "bg-white" %>
+<%= render "home/resources", title: "Popular Resources", surface: "bg-brand-cream" %>
+<%= render "home/events", surface: "bg-white" %>
+<%= render "home/stories", surface: "bg-brand-cream" %>
+<%= render "home/video_recordings", surface: "bg-white" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:full_width, true) %>
 <%= render "shared/public_welcome_banner" %>
 
-<%# Each section keeps its own colour, drawn from the AWBW brand palette rather
-    than Tailwind's stock hues — see DomainTheme::BRAND_SURFACES. %>
-<%= render "home/workshops", title: "Featured Workshops", surface: DomainTheme.brand_surface_for(:workshops) %>
-<%= render "home/community_news", surface: DomainTheme.brand_surface_for(:community_news) %>
-<%= render "home/resources", title: "Popular Resources", surface: DomainTheme.brand_surface_for(:resources) %>
-<%= render "home/events", surface: DomainTheme.brand_surface_for(:events) %>
-<%= render "home/stories", surface: DomainTheme.brand_surface_for(:stories) %>
-<%= render "home/video_recordings", surface: DomainTheme.brand_surface_for(:video_recordings) %>
+<%# Each section keeps its own colour, resolved through DomainTheme like
+    everywhere else in the app — these six domains sit on the brand palette. %>
+<%= render "home/workshops", title: "Featured Workshops", surface: DomainTheme.bg_class_for(:workshops, intensity: 100) %>
+<%= render "home/community_news", surface: DomainTheme.bg_class_for(:community_news, intensity: 100) %>
+<%= render "home/resources", title: "Popular Resources", surface: DomainTheme.bg_class_for(:resources, intensity: 100) %>
+<%= render "home/events", surface: DomainTheme.bg_class_for(:events, intensity: 100) %>
+<%= render "home/stories", surface: DomainTheme.bg_class_for(:stories, intensity: 100) %>
+<%= render "home/video_recordings", surface: DomainTheme.bg_class_for(:video_recordings, intensity: 100) %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:full_width, true) %>
 <%= render "shared/public_welcome_banner" %>
 
-<%# Sections alternate cream and white, the way awbw.org does — the colour lives
-    in the cards, not the band behind them. %>
-<%= render "home/workshops", title: "Featured Workshops", surface: "bg-brand-cream" %>
-<%= render "home/community_news", surface: "bg-white" %>
-<%= render "home/resources", title: "Popular Resources", surface: "bg-brand-cream" %>
-<%= render "home/events", surface: "bg-white" %>
-<%= render "home/stories", surface: "bg-brand-cream" %>
-<%= render "home/video_recordings", surface: "bg-white" %>
+<%# Each section keeps its own colour, drawn from the AWBW brand palette rather
+    than Tailwind's stock hues — see DomainTheme::BRAND_SURFACES. %>
+<%= render "home/workshops", title: "Featured Workshops", surface: DomainTheme.brand_surface_for(:workshops) %>
+<%= render "home/community_news", surface: DomainTheme.brand_surface_for(:community_news) %>
+<%= render "home/resources", title: "Popular Resources", surface: DomainTheme.brand_surface_for(:resources) %>
+<%= render "home/events", surface: DomainTheme.brand_surface_for(:events) %>
+<%= render "home/stories", surface: DomainTheme.brand_surface_for(:stories) %>
+<%= render "home/video_recordings", surface: DomainTheme.brand_surface_for(:video_recordings) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -30,7 +30,7 @@
             No user!
             <%= link_to "Create user",
                           new_user_path(person_id: @person.id),
-                          class: "rounded-full bg-brand-gold hover:bg-brand-gold-dark text-primary px-3 py-1" %>
+                          class: "rounded-full bg-brand-yellow-400 hover:bg-brand-yellow-500 text-primary px-3 py-1" %>
           </div>
         <% end %>
         <%= link_to "Home", root_path, class: "text-sm text-white/80 hover:text-white px-2 py-1" %>
@@ -39,7 +39,7 @@
         <% end %>
         <% if allowed_to?(:edit?, @person) %>
           <%= link_to edit_person_path(@person),
-                        class: "admin-only inline-flex items-center gap-1.5 text-sm font-semibold rounded-full bg-brand-gold hover:bg-brand-gold-dark text-primary px-4 py-1.5 shadow-sm transition" do %>
+                        class: "admin-only inline-flex items-center gap-1.5 text-sm font-semibold rounded-full bg-brand-yellow-400 hover:bg-brand-yellow-500 text-primary px-4 py-1.5 shadow-sm transition" do %>
             <i class="fa-solid fa-pen text-xs"></i> Edit
           <% end %>
         <% end %>
@@ -72,12 +72,12 @@
           <% if @person.facilitator_since_date.present? %>
             <p class="mt-1 text-sm text-white/70">
               Facilitator since
-              <span class="text-brand-gold font-semibold"><%= @person.facilitator_since_date.strftime("%B %Y") %></span>
+              <span class="text-brand-yellow-400 font-semibold"><%= @person.facilitator_since_date.strftime("%B %Y") %></span>
             </p>
           <% elsif @person.affiliated_since_date.present? %>
             <p class="mt-1 text-sm text-white/70">
               Affiliated since
-              <span class="text-brand-gold font-semibold"><%= @person.affiliated_since_date.strftime("%B %Y") %></span>
+              <span class="text-brand-yellow-400 font-semibold"><%= @person.affiliated_since_date.strftime("%B %Y") %></span>
             </p>
           <% end %>
         <% end %>
@@ -87,11 +87,11 @@
           <% if email.present? %>
             <% if @person.profile_show_email? %>
               <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
-                <i class="fa-solid fa-envelope text-xs text-white/60"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-brand-gold" %><!--email_on-->
+                <i class="fa-solid fa-envelope text-xs text-white/60"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-brand-yellow-400" %><!--email_on-->
               </span>
             <% elsif allowed_to?(:manage?, Person) %>
               <span class="admin-only inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
-                <i class="fa-solid fa-envelope text-xs text-white/60"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-brand-gold" %><!--email_on-->
+                <i class="fa-solid fa-envelope text-xs text-white/60"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-brand-yellow-400" %><!--email_on-->
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
@@ -110,7 +110,7 @@
           <% phone = @person.phone_number || @person.user&.phone %>
           <% if @person.profile_show_phone? && phone.present? %>
             <span class="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-white/90">
-              <i class="fa-solid fa-phone text-xs text-white/60"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-brand-gold" %>
+              <i class="fa-solid fa-phone text-xs text-white/60"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-brand-yellow-400" %>
             </span>
           <% end %>
           <% if @person.profile_show_social_media? %>

--- a/app/views/shared/_brand_accent_strip.html.erb
+++ b/app/views/shared/_brand_accent_strip.html.erb
@@ -1,2 +1,2 @@
 <%# The AWBW rainbow rule that tops a branded page card (matches awbw.org). %>
-<div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+<div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#ffcb05,#992a5b,#41006c,#24479e)]"></div>

--- a/app/views/shared/_public_welcome_banner.html.erb
+++ b/app/views/shared/_public_welcome_banner.html.erb
@@ -1,16 +1,19 @@
 <% unless user_signed_in? %>
-  <div class="bg-white px-8 py-6 mt-6 mb-6 flex items-center justify-center gap-5">
-    <div class="h-20 w-20 shrink-0 rounded-full overflow-hidden">
-      <%= image_tag "logo-circle.png", class: "h-full w-full object-cover", alt: "AWBW logo" %>
-    </div>
-    <div class="max-w-lg">
-      <h2 class="text-xl font-semibold text-primary mb-1">Welcome to the AWBW Portal!</h2>
-      <p class="text-gray-600">
-        We invite you to explore our public content below.
-        Windows Facilitators,
-        <%= link_to "log in", new_user_session_path, class: "font-medium text-primary underline hover:text-primary/80" %>
-        for access to all our curriculum and resources.
-      </p>
+  <div class="bg-brand-cream">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="mx-auto flex max-w-6xl items-center justify-center gap-5 px-4 py-8">
+      <div class="h-20 w-20 shrink-0 overflow-hidden rounded-full">
+        <%= image_tag "logo-circle.png", class: "h-full w-full object-cover", alt: "AWBW logo" %>
+      </div>
+      <div class="max-w-lg">
+        <h2 class="text-primary mb-1 font-display text-3xl">Welcome to the AWBW Portal!</h2>
+        <p class="text-gray-600">
+          We invite you to explore our public content below.
+          Windows Facilitators,
+          <%= link_to "log in", new_user_session_path, class: "font-medium text-primary underline hover:text-primary/80" %>
+          for access to all our curriculum and resources.
+        </p>
+      </div>
     </div>
   </div>
 <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2495,9 +2495,10 @@
   pr_number: 2394
   action_path: "/"
   summary: >-
-    The portal home page now reads like awbw.org: sections alternate cream and
-    white with the rainbow rule marking each boundary, and section headings are
-    in the brand serif. The sections, their order, and the cards inside them are
+    The portal home page now reads like awbw.org: each section keeps its own
+    colour, but drawn from the official AWBW brand palette instead of stock
+    web colours, with the rainbow rule marking each boundary and headings in
+    the brand serif. The sections, their order, and the cards inside them are
     unchanged.
   pro_tips:
-    - "The colour that used to tint each whole band now lives in the cards, which is how the marketing site handles it."
+    - "The section colours, the cream page background, and the rainbow rule now use the exact values from the AWBW brand guide."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2495,10 +2495,8 @@
   pr_number: 2394
   action_path: "/"
   summary: >-
-    The portal home page now reads like awbw.org: each section keeps its own
-    colour, but drawn from the official AWBW brand palette instead of stock
-    web colours, with the rainbow rule marking each boundary and headings in
-    the brand serif. The sections, their order, and the cards inside them are
-    unchanged.
+    The portal home page now reads like awbw.org: section colours come from the
+    official AWBW brand palette, the rainbow rule marks each boundary, and
+    headings are in the brand serif. Sections, order and cards are unchanged.
   pro_tips:
     - "The section colours, the cream page background, and the rainbow rule now use the exact values from the AWBW brand guide."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2492,6 +2492,7 @@
   area: content
   display_status: public_facing
   released_on: 2026-08-28
+  pr_number: 2394
   action_path: "/"
   summary: >-
     The portal home page now reads like awbw.org: sections alternate cream and

--- a/config/features.yml
+++ b/config/features.yml
@@ -2487,3 +2487,16 @@
     cream ticket body. Nothing moved; only the styling changed.
   pro_tips:
     - "Registrants see this, so it's the most public-facing page in the portal — preview it from an event's dashboard with \"Sample ticket\"."
+
+- name: "Home page in the AWBW brand"
+  area: content
+  display_status: public_facing
+  released_on: 2026-08-28
+  action_path: "/"
+  summary: >-
+    The portal home page now reads like awbw.org: sections alternate cream and
+    white with the rainbow rule marking each boundary, and section headings are
+    in the brand serif. The sections, their order, and the cards inside them are
+    unchanged.
+  pro_tips:
+    - "The colour that used to tint each whole band now lives in the cards, which is how the marketing site handles it."

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -73,6 +73,19 @@ module DomainTheme
     affiliated_person:        :slate
   }
 
+  # Pale AWBW-brand surfaces for pages that tint a whole band per domain (the
+  # home page's sections). Tailwind's stock palette doesn't reach the brand
+  # hues, so these are theme tokens from `application.tailwind.css` rather than
+  # palette steps — add any new one to that file's `@source inline` safelist too.
+  BRAND_SURFACES = {
+    workshops:        "bg-brand-tint-navy",
+    community_news:   "bg-brand-tint-peach",
+    resources:        "bg-brand-tint-purple",
+    events:           "bg-brand-tint-green",
+    stories:          "bg-brand-tint-magenta",
+    video_recordings: "bg-brand-tint-yellow"
+  }.freeze
+
   # Ordered palette of colours offered as user-pickable swatches (e.g. the
   # callout colour dropdown). A curated subset of the full theme palette that
   # reads well as tinted boxes — add a colour here once and every picker updates.
@@ -95,6 +108,11 @@ module DomainTheme
 
   def self.color_for(key)
     COLORS[key.to_sym] || :gray
+  end
+
+  # Pale brand surface for a domain, falling back to the cream page surface.
+  def self.brand_surface_for(key)
+    BRAND_SURFACES[key.to_sym] || "bg-brand-cream"
   end
 
   # Full colour swatch (role => Tailwind class) for a raw base colour.

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -1,14 +1,17 @@
 module DomainTheme
   # New colors must be added to the inline source in `application.tailwind.css`
   # for tailwind to generate the classes
+  # Domains on the AWBW brand palette use a `brand-*` scale (defined in
+  # application.tailwind.css); the rest still use Tailwind's stock hues. Both
+  # work the same way here — the helpers below just interpolate the name.
   COLORS = {
-    workshops:                :indigo,
+    workshops:                :"brand-navy",
     workshop_variations:      :purple,
     workshop_logs:            :teal,
-    resources:                :violet,
-    community_news:           :orange,
-    stories:                  :fuchsia,
-    events:                   :teal,
+    resources:                :"brand-purple",
+    community_news:           :"brand-orange",
+    stories:                  :"brand-magenta",
+    events:                   :"brand-teal",
     people:                   :cyan,
     organizations:            :emerald,
     quotes:                   :slate,
@@ -21,7 +24,7 @@ module DomainTheme
 
     forms:                    :purple,
     faqs:                     :pink,
-    video_recordings:         :sky,
+    video_recordings:         :"brand-yellow",
 
     workshop_ideas:           :indigo,
     workshop_variation_ideas: :purple,
@@ -73,19 +76,6 @@ module DomainTheme
     affiliated_person:        :slate
   }
 
-  # Pale AWBW-brand surfaces for pages that tint a whole band per domain (the
-  # home page's sections). Tailwind's stock palette doesn't reach the brand
-  # hues, so these are theme tokens from `application.tailwind.css` rather than
-  # palette steps — add any new one to that file's `@source inline` safelist too.
-  BRAND_SURFACES = {
-    workshops:        "bg-brand-tint-navy",
-    community_news:   "bg-brand-tint-peach",
-    resources:        "bg-brand-tint-purple",
-    events:           "bg-brand-tint-green",
-    stories:          "bg-brand-tint-magenta",
-    video_recordings: "bg-brand-tint-yellow"
-  }.freeze
-
   # Ordered palette of colours offered as user-pickable swatches (e.g. the
   # callout colour dropdown). A curated subset of the full theme palette that
   # reads well as tinted boxes — add a colour here once and every picker updates.
@@ -108,11 +98,6 @@ module DomainTheme
 
   def self.color_for(key)
     COLORS[key.to_sym] || :gray
-  end
-
-  # Pale brand surface for a domain, falling back to the cream page surface.
-  def self.brand_surface_for(key)
-    BRAND_SURFACES[key.to_sym] || "bg-brand-cream"
   end
 
   # Full colour swatch (role => Tailwind class) for a raw base colour.

--- a/spec/lib/domain_theme_spec.rb
+++ b/spec/lib/domain_theme_spec.rb
@@ -15,19 +15,26 @@ RSpec.describe DomainTheme do
         .to eq("bg-gray-50")
     end
 
+    it "builds the same class shape for a brand-palette domain" do
+      expect(DomainTheme.bg_class_for(:workshops)).to eq("bg-brand-navy-50")
+      expect(DomainTheme.bg_class_for(:workshops, intensity: 700)).to eq("bg-brand-navy-700")
+      expect(DomainTheme.text_class_for(:stories, intensity: 700)).to eq("text-brand-magenta-700")
+      expect(DomainTheme.border_class_for(:events)).to eq("border-brand-teal-300")
+    end
+
     it "supports intensity overrides" do
-      expect(DomainTheme.bg_class_for(:events, intensity: 100))
-        .to eq("bg-teal-100")
+      expect(DomainTheme.bg_class_for(:people, intensity: 100))
+        .to eq("bg-cyan-100")
     end
 
     it "supports hover classes for 100's" do
-      expect(DomainTheme.bg_class_for(:stories, intensity: 200, hover: true))
-        .to eq("hover:bg-fuchsia-300")
+      expect(DomainTheme.bg_class_for(:people, intensity: 200, hover: true))
+        .to eq("hover:bg-cyan-300")
     end
 
     it "supports hover classes for 50" do
-      expect(DomainTheme.bg_class_for(:stories, intensity: 50, hover: true))
-        .to eq("hover:bg-fuchsia-100")
+      expect(DomainTheme.bg_class_for(:people, intensity: 50, hover: true))
+        .to eq("hover:bg-cyan-100")
     end
 
     it "defines a color for every taggable home type" do
@@ -39,7 +46,7 @@ RSpec.describe DomainTheme do
 
   describe ".text_class_for" do
     it "returns the correct Tailwind text class for a domain" do
-      expect(DomainTheme.text_class_for(:workshops)).to eq("text-indigo-800")
+      expect(DomainTheme.text_class_for(:organizations)).to eq("text-emerald-800")
     end
 
     it "supports intensity overrides" do
@@ -59,7 +66,7 @@ RSpec.describe DomainTheme do
 
   describe ".color_for" do
     it "returns configured color symbols" do
-      expect(DomainTheme.color_for(:workshops)).to eq(:indigo)
+      expect(DomainTheme.color_for(:people)).to eq(:cyan)
     end
 
     it "symbolizes string keys" do

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -7,9 +7,7 @@ RSpec.describe "Home", type: :request do
 
       expect(response).to have_http_status(:ok)
 
-      section_titles = response.body
-        .scan(%r{<h2 class="text-3xl font-semibold text-gray-900">(.*?)</h2>}m)
-        .flatten.map(&:strip)
+      section_titles = Nokogiri::HTML(response.body).css("section h2").map { |h2| h2.text.strip }
       expect(section_titles).not_to be_empty, "Expected to find section titles in h2 tags"
 
       section_titles.each do |title|


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 adds a brand colour system and re-points six domains onto it, so the blast radius is every page that themes those domains

The AWBW brand colours are now first-class Tailwind colours with full intensity scales, and the home page uses them the same way every other page uses `DomainTheme`.

### Brand colours as real scales
A flat `--color-brand-gold` can't do `-50` / `-700` / `hover:`, so each brand hue now has a full **50–950 ramp**:

`brand-navy` · `brand-yellow` · `brand-green` · `brand-magenta` · `brand-orange` · `brand-purple` · `brand-teal`

- Generated off **Tailwind's own OKLCH curve** for the nearest hue family, re-hued to the brand colour and rescaled so the brand hex lands exactly on one step (navy at 800, yellow at 400, green at 700, magenta at 800, orange at 600, purple at 950, teal at 600).
- Chroma is capped at the reference family's, which stops the very dark brand purple (`#41006C`) going neon in its mid tones.
- `bg-brand-navy-50`, `text-brand-magenta-700`, `border-brand-teal-300`, `hover:bg-brand-yellow-500` all work. Verified against a real Vite build — 198 brand utilities emitted.

### DomainTheme treats them like any other colour
Six domains moved onto the brand palette, so they're consistent **everywhere**, not just on the home page:

| Domain | Was | Now |
|---|---|---|
| workshops | `indigo` | `brand-navy` |
| community_news | `orange` | `brand-orange` |
| resources | `violet` | `brand-purple` |
| events | `teal` | `brand-teal` |
| stories | `fuchsia` | `brand-magenta` |
| video_recordings | `sky` | `brand-yellow` |

The helpers needed no change — they interpolate the colour name, so `brand-navy` just works. The other 45 domain keys still use stock Tailwind hues; finishing that migration is a separate, deliberate pass.

`--color-brand-gold` / `-dark` are gone, folded into `brand-yellow-400` / `-500`.

### Home page
Sections keep a colour each, now resolved through `DomainTheme.bg_class_for(key, intensity: 100)` like everywhere else. Six near-identical section wrappers became one `home/_section` partial rendered with `layout:`; `_home_section_header` folded in and removed. Order, titles, subtitles, lazy frames and `prefetch-lazy` unchanged.

### Two spec changes worth a look
- `spec/lib/domain_theme_spec.rb` used `:workshops`/`:events`/`:stories` as vehicles for testing intensity and hover mechanics, so it broke when those domains changed hue. It now uses domains that aren't on the brand palette, plus a new example asserting a brand-palette domain builds the same class shape.
- `spec/requests/home_spec.rb` asserted section titles by matching a literal class string. Its intent is a copy rule — *titles must be two words* — so it now selects `section h2` via Nokogiri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)