### PR TITLE
Include unpublished events as registrant transfer destinations

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -514,12 +514,13 @@ class EventRegistrationsController < ApplicationController
       edit: (cell if reopen), anchor: cell)
   end
 
-  # Events a registrant can be transferred into: published events of the same
-  # format as the one they're leaving — an on-demand event only transfers to
-  # another on-demand event, and a scheduled (non-on-demand) event only to
-  # another scheduled event — excluding the source event, most recent first.
+  # Events a registrant can be transferred into: events of the same format as
+  # the one they're leaving — an on-demand event only transfers to another
+  # on-demand event, and a scheduled (non-on-demand) event only to another
+  # scheduled event — whether or not they're published, excluding the source
+  # event, most recent first.
   def transfer_destination_events
-    Event.where(published: true, on_demand: @event_registration.event.on_demand)
+    Event.where(on_demand: @event_registration.event.on_demand)
          .where.not(id: @event_registration.event_id)
          .order(start_date: :desc)
   end

--- a/config/features.yml
+++ b/config/features.yml
@@ -41,6 +41,14 @@
   pro_tips:
     - "Presentation only — every section, badge, and permission on the profile works exactly as before."
 
+- name: "Transfer registrants into unpublished events"
+  area: registration
+  display_status: admin_facing
+  released_on: 2026-08-28
+  summary: >-
+    The transfer-out destination list now includes same-format events that aren't
+    published yet, so a registrant can be moved into an event that's still being set up.
+
 - name: "Transferred-in attendance days are preserved"
   area: registration
   display_status: admin_facing

--- a/spec/requests/event_registrations_spec.rb
+++ b/spec/requests/event_registrations_spec.rb
@@ -878,6 +878,14 @@ RSpec.describe "EventRegistrations", type: :request do
           expect(response.body).not_to include("<option value=\"#{other_format.id}\"")
         end
 
+        it "offers same-format events even when they aren't published" do
+          unpublished = create(:event, title: "Unpublished Destination", published: false, on_demand: false)
+
+          get transfer_event_registration_path(source)
+
+          expect(response.body).to include("<option value=\"#{unpublished.id}\"")
+        end
+
         it "offers only other on-demand events when transferring out of one" do
           on_demand = create(:event, title: "Source On-Demand", on_demand: true)
           on_demand_source = create(:event_registration, event: on_demand, status: "transferred_out")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line filter change to transfer-target scope, plus a test

Facilitators can now transfer a registrant into a same-format event that isn't published yet — useful when the destination event is still being set up.

- Dropped the `published: true` filter from `transfer_destination_events`; same-format (`on_demand`) matching and source-event exclusion are unchanged.
- The `process_transfer` server-side guard reuses that method, so unpublished destinations are accepted there too.
- Added a request spec covering an unpublished destination; seeded a `config/features.yml` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)