### PR TITLE
Fix workshops index crash when searching + sorting by popularity

### DIFF
--- a/app/services/workshop_search_service.rb
+++ b/app/services/workshop_search_service.rb
@@ -154,10 +154,10 @@ class WorkshopSearchService
       .joins("LEFT JOIN action_text_rich_texts ON action_text_rich_texts.record_id = workshops.id " \
              "AND action_text_rich_texts.record_type = 'Workshop'")
       .where(conditions, spaced: "%#{spaced}%", spaceless: "%#{spaceless}%")
-      .select("workshops.id")
+      .reselect("workshops.id")
 
     # Isolated in an id subquery so the person joins don't collide with the text joins.
-    by_person = search_by_author_name(@workshops, params[:query]).select("workshops.id")
+    by_person = search_by_author_name(@workshops, params[:query]).reselect("workshops.id")
 
     @workshops = @workshops.where(id: by_text).or(@workshops.where(id: by_person)).distinct
   end
@@ -170,7 +170,7 @@ class WorkshopSearchService
     # Credited-author name match (explicit author + legacy full_name + creator),
     # shared via AuthorCreditable#by_credited_person_name. Isolated in an id
     # subquery so its person joins don't collide with the current scope's joins.
-    workshops.where(id: workshops.by_credited_person_name(author_name).select("workshops.id"))
+    workshops.where(id: workshops.by_credited_person_name(author_name).reselect("workshops.id"))
   end
 
   def search_by_categories(workshops, categories)

--- a/spec/services/workshop_search_service_spec.rb
+++ b/spec/services/workshop_search_service_spec.rb
@@ -112,6 +112,20 @@ RSpec.describe WorkshopSearchService, type: :service do
       end
     end
 
+    context "sorting by popularity while searching" do
+      # with_bookmarks_count adds a multi-column select; the id subqueries must
+      # emit a single column or MySQL raises "Operand should contain 1 column(s)".
+      it "counts results without a multi-column subquery error" do
+        service = WorkshopSearchService.new({ sort: "popularity", query: "Keyword" }, user: user).call
+        expect { service.workshops.unscope(:select, :order).count }.not_to raise_error
+      end
+
+      it "does not error when combining popularity sort with an author-name search" do
+        service = WorkshopSearchService.new({ sort: "popularity", author_name: "Keyword" }, user: user).call
+        expect { service.workshops.unscope(:select, :order).count }.not_to raise_error
+      end
+    end
+
     context "sorting by author" do
       let!(:workshop_aaron) do
         person = create(:person, first_name: "Aaron", last_name: "Adams")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained query-building fix with a focused regression test

Fixes the workshops index `500` (`Operand should contain 1 column(s)`) that hit facilitators whenever a text or author search was combined with the "most popular" sort.

### What is the goal of this PR and why is this important?
`sort=popularity` applies `with_bookmarks_count`, which adds a multi-column `SELECT`. The id subqueries in `WorkshopSearchService` then appended `.select("workshops.id")` (which stacks on top of that select), so `WHERE id IN (<subquery>)` emitted several columns and MySQL rejected it — crashing the index page (surfaced via Ahoy's result-count query).

### How did you approach the change?
Switched the three id subqueries from `.select("workshops.id")` to `.reselect("workshops.id")` so each subquery emits exactly one column regardless of the outer scope's select.

### Anything else to add?
Added two regression specs (popularity + query, popularity + author name) asserting the count no longer raises. Full service spec is green and RuboCop is clean.