### PR TITLE
Retry public registration on InnoDB deadlock

### DIFF
--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,6 +2,13 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
+    # This public form runs one large, multi-table transaction. Two concurrent
+    # submissions from the same registrant (a double-click or browser retry) can
+    # deadlock in InnoDB. A deadlock fully rolls back the losing transaction, so
+    # retrying from the top is safe — the retry sees the winner's committed
+    # registration and takes the idempotent "existing" path.
+    MAX_DEADLOCK_RETRIES = 2
+
     # Well-known field_identifier of the "magic" CE question seeded onto the
     # registration form. Answering it "Yes" creates a ContinuingEducationRegistration
     # (hours come from the event). Kept here so the seed, service, and specs agree.
@@ -68,6 +75,33 @@ module EventRegistrationServices
     end
 
     def call
+      attempt = 0
+      begin
+        run
+      rescue ActiveRecord::Deadlocked
+        attempt += 1
+        retry if attempt <= MAX_DEADLOCK_RETRIES
+        Result.new(success?: false, event_registration: nil,
+                   errors: [ "We hit a temporary conflict saving your registration. Please try again." ])
+      end
+    rescue FormSubmission::UnreadableUpload => e
+      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
+    rescue ActiveRecord::ValueTooLong => e
+      Result.new(success?: false, event_registration: nil, errors: [ too_long_message(e) ])
+    rescue ActiveRecord::RecordInvalid => e
+      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
+    rescue ActiveRecord::RecordNotUnique => e
+      if e.message.include?("registrant_id")
+        Result.new(success?: false, event_registration: nil,
+                   errors: [ "You are already registered for this event." ])
+      else
+        Result.new(success?: false, event_registration: nil, errors: [ e.message ])
+      end
+    end
+
+    private
+
+    def run
       ActiveRecord::Base.transaction do
         person = find_or_create_person
         sync_person_profile(person)
@@ -127,22 +161,7 @@ module EventRegistrationServices
 
         Result.new(success?: true, event_registration: event_registration, form_submission: submission, errors: [])
       end
-    rescue FormSubmission::UnreadableUpload => e
-      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
-    rescue ActiveRecord::ValueTooLong => e
-      Result.new(success?: false, event_registration: nil, errors: [ too_long_message(e) ])
-    rescue ActiveRecord::RecordInvalid => e
-      Result.new(success?: false, event_registration: nil, errors: [ e.message ])
-    rescue ActiveRecord::RecordNotUnique => e
-      if e.message.include?("registrant_id")
-        Result.new(success?: false, event_registration: nil,
-                   errors: [ "You are already registered for this event." ])
-      else
-        Result.new(success?: false, event_registration: nil, errors: [ e.message ])
-      end
     end
-
-    private
 
     # Turn a database "Data too long for column 'city'" failure into a friendly,
     # form-level message. We can't always map the column back to a single form

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -1185,4 +1185,39 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(organization.addresses.find_by(city: "Reno")).to be_present
     end
   end
+
+  describe "deadlock retries" do
+    let(:params) { base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com") }
+
+    def service
+      described_class.new(event: event, registration_form: form, form_params: params)
+    end
+
+    it "retries the transaction and succeeds after a transient deadlock" do
+      subject = service
+      attempts = 0
+      allow(subject).to receive(:run).and_wrap_original do |original|
+        attempts += 1
+        raise ActiveRecord::Deadlocked, "deadlock" if attempts == 1
+        original.call
+      end
+
+      result = subject.call
+
+      expect(result.success?).to be true
+      expect(attempts).to eq(2)
+      expect(Person.find_by(email: "sam@example.com")).to be_present
+    end
+
+    it "gives up after the retry limit and returns a friendly failure" do
+      subject = service
+      allow(subject).to receive(:run).and_raise(ActiveRecord::Deadlocked.new("deadlock"))
+
+      result = subject.call
+
+      expect(result.success?).to be false
+      expect(result.errors.first).to match(/temporary conflict/i)
+      expect(subject).to have_received(:run).exactly(described_class::MAX_DEADLOCK_RETRIES + 1).times
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained retry/error-handling change in one service, covered by specs

Retries the public event-registration transaction when two concurrent submissions from the same registrant deadlock in InnoDB — so a double-click or browser retry no longer 500s a would-be registrant.

### What is the goal of this PR and why is this important?
A Honeybadger `ActiveRecord::Deadlocked` fired from `PublicRegistration` on this unauthenticated form. Concurrent submissions from the same registrant contend on one large multi-table transaction and deadlock, costing us the registration.

### How did you approach the change?
- Extracted the transaction into a private `run` and wrapped `call` in a bounded deadlock retry (`MAX_DEADLOCK_RETRIES = 2`); a deadlock fully rolls back the loser, so the retry re-runs and takes the idempotent "existing" path.
- On exhausting retries, returns a friendly failure Result instead of a raw 500.

### Anything else to add?
Trade-off: the exhausted-retry case is swallowed into a friendly Result, so a *persistent* deadlock (surviving 3 attempts) no longer reaches Honeybadger — happy to re-raise instead if you'd rather keep that signal.