### PR TITLE
Bring the public-facing pages into the AWBW brand

### DIFF
--- a/app/helpers/title_display_helper.rb
+++ b/app/helpers/title_display_helper.rb
@@ -1,6 +1,9 @@
 module TitleDisplayHelper
+  # `display: true` sets the title in the brand serif — for a page's own heading.
+  # Card and row titles keep the sans so dense lists stay readable.
   def title_with_badges(record, font_size: "text-lg", record_title: nil,
-                        show_hidden_badge: true, display_windows_type: false)
+                        show_hidden_badge: true, display_windows_type: false,
+                        display: false)
     fragments = []
     home_page = controller_name == "home" || controller_path.start_with?("home/")
 
@@ -98,7 +101,7 @@ module TitleDisplayHelper
     title_row = content_tag(
       :span,
       title_content.html_safe,
-      class: "#{font_size} font-semibold text-gray-900 leading-tight"
+      class: "#{font_size} leading-tight #{display ? "font-display text-primary" : "font-semibold text-gray-900"}"
     )
 
     # ---- Combine rows intelligently ----

--- a/app/views/community_news/index.html.erb
+++ b/app/views/community_news/index.html.erb
@@ -1,33 +1,26 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">News</h2>
-        <p class="text-gray-600">Find recent newsletters and other community postings</p>
-      </div>
+<% actions = capture do %>
+  <% if allowed_to?(:new?, CommunityNews) %>
+    <%= link_to "New community news",
+                new_community_news_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :community_news, eyebrow: "Community", title: "News",
+                     subtitle: "Find recent newsletters and other community postings",
+                     actions: actions } do %>
+  <%= render "search_boxes" %>
 
-      <div class="text-right">
-        <% if allowed_to?(:new?, CommunityNews) %>
-          <%= link_to "New community news",
-                      new_community_news_path,
-                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-        <% end %>
-      </div>
-    </div>
+  <%= render "shared/filtered_to", record: @author, clear_path: community_news_index_path %>
 
-    <%= render "search_boxes" %>
+  <%= render "community_news_count" %>
 
-    <%= render "shared/filtered_to", record: @author, clear_path: community_news_index_path %>
+  <% result_src = community_news_index_path + "?" + request.query_string %>
 
-    <%= render "community_news_count" %>
-
-    <% result_src = community_news_index_path + "?" + request.query_string %>
-
-    <%= turbo_frame_tag "community_news_results", src: result_src do %>
-      <%= render "results_skeleton" %>
-    <% end %>
-  </div>
-</div>
+  <%= turbo_frame_tag "community_news_results", src: result_src do %>
+    <%= render "results_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/community_news/show.html.erb
+++ b/app/views/community_news/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
 <% community_news_url   = community_news_url(@community_news) %>
 <% community_news_title = ERB::Util.url_encode(@community_news.title) %>
-<div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
+<%= render layout: "shared/show_page", locals: { domain: :community_news } do %>
       <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Community news", community_news_index_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @community_news) %>
@@ -17,16 +17,16 @@
       </div>
 
       <!-- Header Row -->
-      <div class="w-full bg-white rounded-lg shadow-md p-6 space-y-6">
-        <div class="max-w-3xl mx-auto px-4 py-10 text-gray-800">
+      <div class="w-full space-y-6 rounded-lg bg-white p-6 shadow-md">
+        <div class="mx-auto max-w-3xl px-4 py-10 text-gray-800">
 
           <!-- Title -->
-          <div class="font-bold my-6 text-gray-900 leading-tight">
-            <%= title_with_badges(@community_news, font_size: "text-3xl") %>
+          <div class="my-6 leading-tight font-bold text-gray-900">
+            <%= title_with_badges(@community_news, font_size: "text-3xl", display: true) %>
           </div>
 
           <!-- Meta Data (exact screenshot style) -->
-          <div class="text-sm text-gray-600 space-y-0.5 mb-6">
+          <div class="mb-6 space-y-0.5 text-sm text-gray-600">
             <p><strong>By:</strong>
               <%= credited_author_link(@community_news) %>
             </p>
@@ -42,9 +42,9 @@
           </div>
 
           <!-- Share Section -->
-          <h3 class="font-semibold text-lg mb-3">Share this news:</h3>
+          <h3 class="mb-3 text-lg font-semibold">Share this news:</h3>
 
-          <div class="flex space-x-4 mb-6">
+          <div class="mb-6 flex space-x-4">
 
             <!-- Facebook -->
             <%= link_to "https://www.facebook.com/sharer/sharer.php?u=#{community_news_url}",
@@ -77,9 +77,9 @@
           </div>
 
           <!-- Footer Copy (matches screenshot) -->
-          <div class="text-sm text-gray-500 leading-relaxed border-t border-gray-300 pt-6">
+          <div class="border-t border-gray-300 pt-6 text-sm leading-relaxed text-gray-500">
             <%= render "shared/organization_footer" %>
           </div>
         </div>
       </div>
-</div>
+<% end %>

--- a/app/views/contact_us/index.html.erb
+++ b/app/views/contact_us/index.html.erb
@@ -3,7 +3,9 @@
 
 <% profile_return_path = (edit_person_path(current_user.person, anchor: "affiliations") if @return_to == "person_edit" && current_user&.person) %>
 <div class="px-4 py-8 sm:px-6 lg:px-8">
-<div class="mx-auto w-full max-w-7xl rounded-xl border border-gray-200 bg-white p-6 shadow" id="contact-us-container">
+<div class="border-primary/10 mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border bg-white shadow-sm" id="contact-us-container">
+  <%= render "shared/brand_accent_strip" %>
+  <div class="p-6">
       <% if profile_return_path %>
         <div class="mb-3">
           <%= link_to profile_return_path, class: "text-sm #{eyebrow_link_class}" do %>
@@ -13,9 +15,9 @@
       <% end %>
       <!-- Header -->
       <header class="space-y-4">
-        <h2 class="text-3xl font-bold tracking-tight text-gray-900">
+        <h1 class="text-primary font-display text-3xl tracking-tight">
           Contact us
-        </h2>
+        </h1>
         <p class="max-w-2xl text-lg leading-relaxed text-gray-600">
           We welcome you to contact us with any questions. We are here to help.
         </p>
@@ -303,5 +305,6 @@
           <%= render "portal_contact_info" %>
         </div>
       <% end %>
+  </div>
     </div>
 </div>

--- a/app/views/contact_us/index.html.erb
+++ b/app/views/contact_us/index.html.erb
@@ -2,7 +2,6 @@
 <%= render "shared/public_welcome_banner" unless @from_story_share %>
 
 <% profile_return_path = (edit_person_path(current_user.person, anchor: "affiliations") if @return_to == "person_edit" && current_user&.person) %>
-<div class="px-4 py-8 sm:px-6 lg:px-8">
 <div class="border-primary/10 mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border bg-white shadow-sm" id="contact-us-container">
   <%= render "shared/brand_accent_strip" %>
   <div class="p-6">
@@ -307,4 +306,3 @@
       <% end %>
   </div>
     </div>
-</div>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "public") %>
 
-<div class="max-w-2xl mx-auto px-4">
+<div class="mx-auto max-w-2xl px-4">
   <div class="flex flex-wrap items-center gap-2 pt-4">
     <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
@@ -16,36 +16,36 @@
   </div>
 </div>
 
-<div class="max-w-2xl mx-auto pb-12 pt-6 px-4">
+<div class="mx-auto max-w-2xl px-4 pt-6 pb-12">
 
-  <div class="text-center mb-8">
-    <h1 class="font-black text-green-800 leading-tight text-4xl sm:text-5xl mb-5" style="font-family: Lato, sans-serif">
+  <div class="mb-8 text-center">
+    <h1 class="text-primary mb-5 font-display text-4xl leading-tight sm:text-5xl">
       <%= link_to @event.title, event_path(@event), class: "hover:underline decoration-2 underline-offset-4" %>
     </h1>
-    <div class="font-bold text-blue-900 uppercase text-2xl sm:text-3xl mb-4" style="font-family: Lato, sans-serif">
+    <div class="text-primary mb-4 text-2xl font-bold uppercase sm:text-3xl">
       <%= @event.times(display_day: true, display_date: true, styled: true) %>
     </div>
   </div>
 
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
 
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div>
-          <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> Form</h2>
+          <h2 class="text-xl leading-tight font-semibold tracking-wide"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> Form</h2>
           <p class="text-sm text-blue-200">Use this form to pay for one or more other attendees.</p>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
-    <div class="px-6 sm:px-8 py-7">
-      <div class="flex items-start gap-3 bg-blue-50 border border-blue-200 text-blue-900 rounded-lg px-4 py-3 mb-6">
+    <div class="px-6 py-7 sm:px-8">
+      <div class="mb-6 flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-blue-900">
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
-        <div class="text-sm space-y-2">
+        <div class="space-y-2 text-sm">
           <p><strong>Use this form to pay for other people who are attending.</strong> That includes
             paying for one or more other attendees — and you can add yourself too, if you're attending
             and want to cover yourself and others in a single payment.</p>
@@ -55,7 +55,7 @@
         </div>
       </div>
       <% if flash[:alert] %>
-        <div class="flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6">
+        <div class="mb-6 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
           <span><%= flash[:alert] %></span>
         </div>
@@ -74,12 +74,12 @@
           payer_fields = %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees]
         %>
 
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+        <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
           <% @form_fields.each do |field| %>
             <% next if field.field_identifier == "bulk_payment_attendees" %>
 
             <% if field.group_header? %>
-              <div class="md:col-span-12 pt-7 pb-4">
+              <div class="pt-7 pb-4 md:col-span-12">
                 <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
                   <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
@@ -95,12 +95,12 @@
               %>
               <div class="<%= field.grid_span_class %>">
                 <div class="mb-5">
-                  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5" for="<%= field_id %>">
+                  <label class="rich-label mb-1.5 block text-sm font-semibold text-gray-700" for="<%= field_id %>">
                     <%= form_label_html(field.name) %>
                     <% if field.required %><span class="text-red-500">*</span><% end %>
                   </label>
                   <% if field.subtitle.present? %>
-                    <p class="rich-label text-xs text-gray-500 mb-1.5"><%= form_label_html(field.subtitle) %></p>
+                    <p class="rich-label mb-1.5 text-xs text-gray-500"><%= form_label_html(field.subtitle) %></p>
                   <% end %>
                   <%
                     html_type = case field.field_identifier
@@ -120,16 +120,16 @@
                          <%= "required" if field.required %>
                          <%= raw(extra_attrs.join(" ")) %>>
                   <% if field.hint_text.present? %>
-                    <p class="rich-label text-xs text-gray-500 mt-1.5"><%= form_label_html(field.hint_text) %></p>
+                    <p class="rich-label mt-1.5 text-xs text-gray-500"><%= form_label_html(field.hint_text) %></p>
                   <% end %>
                   <% if field.free_form_text? && field.min_words.to_i.positive? %>
-                    <p class="text-left text-xs text-gray-500 mt-1.5">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
+                    <p class="mt-1.5 text-left text-xs text-gray-500">Minimum of <%= field.min_words %> <%= "word".pluralize(field.min_words) %>.</p>
                   <% end %>
                   <% if field.free_form_text? && field.max_characters.to_i.positive? %>
-                    <p class="text-left text-xs text-gray-500 mt-1.5">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
+                    <p class="mt-1.5 text-left text-xs text-gray-500">Maximum of <%= field.max_characters %> <%= "character".pluralize(field.max_characters) %>.</p>
                   <% end %>
                   <% if error %>
-                    <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
+                    <p class="mt-1.5 flex items-center gap-1.5 text-xs text-red-600">
                       <i class="fa-solid fa-circle-exclamation"></i><%= strip_tags(field.name) %> <%= error %>
                     </p>
                   <% end %>
@@ -143,13 +143,13 @@
               %>
               <div class="<%= field.grid_span_class %>">
                 <div class="mb-5">
-                  <label class="rich-label block text-sm font-semibold text-gray-700 mb-1.5">
+                  <label class="rich-label mb-1.5 block text-sm font-semibold text-gray-700">
                     <%= form_label_html(field.name) %>
                     <% if field.required %><span class="text-red-500">*</span><% end %>
                   </label>
-                  <div class="flex flex-wrap gap-2 mt-1">
+                  <div class="mt-1 flex flex-wrap gap-2">
                     <% field.form_field_answer_options.includes(:answer_option).each do |ffao| %>
-                      <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> px-3 py-2.5 cursor-pointer hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50 transition">
+                      <label class="inline-flex items-center gap-2 rounded-lg border <%= error ? 'border-red-400' : 'border-gray-300' %> cursor-pointer px-3 py-2.5 transition hover:border-blue-400 has-[:checked]:border-blue-600 has-[:checked]:bg-blue-50">
                         <input type="radio"
                                name="bulk_payment[form_fields][<%= field.id %>]"
                                value="<%= ffao.answer_option.name %>"
@@ -161,7 +161,7 @@
                     <% end %>
                   </div>
                   <% if error %>
-                    <p class="flex items-center gap-1.5 text-xs text-red-600 mt-1.5">
+                    <p class="mt-1.5 flex items-center gap-1.5 text-xs text-red-600">
                       <i class="fa-solid fa-circle-exclamation"></i>Payment method is required
                     </p>
                   <% end %>
@@ -175,10 +175,10 @@
           <div>
 
             <template data-bulk-payment-attendees-target="template">
-              <div class="flex items-start gap-3 mb-3" data-bulk-payment-attendees-target="row">
-                <div class="flex-1 grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div class="mb-3 flex items-start gap-3" data-bulk-payment-attendees-target="row">
+                <div class="grid flex-1 grid-cols-1 gap-3 md:grid-cols-3">
                   <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_first_name">Attendee first name</label>
+                    <label class="mb-1.5 block text-sm font-semibold text-gray-700" for="attendee_INDEX_first_name">Attendee first name</label>
                     <input type="text"
                            name="bulk_payment[attendees][INDEX][first_name]"
                            id="attendee_INDEX_first_name"
@@ -186,7 +186,7 @@
                            class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
                   </div>
                   <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_last_name">Attendee last name</label>
+                    <label class="mb-1.5 block text-sm font-semibold text-gray-700" for="attendee_INDEX_last_name">Attendee last name</label>
                     <input type="text"
                            name="bulk_payment[attendees][INDEX][last_name]"
                            id="attendee_INDEX_last_name"
@@ -194,7 +194,7 @@
                            class="w-full rounded-lg border border-gray-300 bg-white px-3.5 py-2.5 text-sm text-gray-900 shadow-sm transition hover:border-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 focus:outline-none">
                   </div>
                   <div>
-                    <label class="block text-sm font-semibold text-gray-700 mb-1.5" for="attendee_INDEX_email">Attendee email</label>
+                    <label class="mb-1.5 block text-sm font-semibold text-gray-700" for="attendee_INDEX_email">Attendee email</label>
                     <input type="email"
                            name="bulk_payment[attendees][INDEX][email]"
                            id="attendee_INDEX_email"
@@ -204,7 +204,7 @@
                 </div>
                 <button type="button"
                         data-action="bulk-payment-attendees#removeRow"
-                        class="mt-7 inline-flex items-center justify-center w-8 h-8 rounded-full text-gray-400 hover:text-red-600 hover:bg-red-50 transition cursor-pointer">
+                        class="mt-7 inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-gray-400 transition hover:bg-red-50 hover:text-red-600">
                   <i class="fa-solid fa-xmark"></i>
                 </button>
               </div>
@@ -218,7 +218,7 @@
 
             <button type="button"
                     data-action="bulk-payment-attendees#addRow"
-                    class="inline-flex items-center gap-2 text-sm font-semibold text-blue-700 hover:text-blue-800 transition cursor-pointer mt-2">
+                    class="mt-2 inline-flex cursor-pointer items-center gap-2 text-sm font-semibold text-blue-700 transition hover:text-blue-800">
               <i class="fa-solid fa-plus"></i> Add attendee
             </button>
           </div>
@@ -230,7 +230,7 @@
             <i class="fa-regular fa-circle-check"></i>Submit
           <% end %>
           <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">
-            <i class="fa-solid fa-lock"></i>Your information is kept private. Fields marked <span class="text-red-500 font-medium">*</span> are required.
+            <i class="fa-solid fa-lock"></i>Your information is kept private. Fields marked <span class="font-medium text-red-500">*</span> are required.
           </p>
         </div>
 

--- a/app/views/events/bulk_payment_form_submissions/show.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-3xl mx-auto px-4 pt-4">
+<div class="mx-auto max-w-3xl px-4 pt-4">
   <%# Primary back link is the payer's ticket, available only for slug-based
       submissions. Admins arriving from the bulk payments dashboard
       (return_to=bulk_payments) also get a link back there, with their
@@ -19,21 +19,21 @@
   </div>
 </div>
 
-<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+<div class="mx-auto max-w-3xl px-4 pt-6 pb-12">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl font-semibold tracking-wide leading-tight">Payment submission</h1>
+          <h1 class="text-xl leading-tight font-semibold tracking-wide">Payment submission</h1>
           <p class="text-sm text-blue-200"><%= @event.title %></p>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
-    <div class="px-6 sm:px-8 py-7">
+    <div class="px-6 py-7 sm:px-8">
       <%= render "form_submissions/submission", submission: @submission %>
     </div>
   </div>

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -36,7 +36,8 @@
   <!-- Ticket Container -->
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
     <!-- Ticket Header -->
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0"><%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %></div>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,63 +1,53 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h1 class="text-2xl font-semibold mb-2">Events</h1>
-
-        <p class="text-gray-600 max-w-2xl">
-          Join us for our virtual events including art workshops, facilitator trainings and other opportunities to create, connect and be in community
-        </p>
-      </div>
-      <div class="text-right text-end">
-        <% if allowed_to?(:new?, Event) %>
-          <div class="admin-only bg-blue-100 flex flex-wrap items-center justify-end gap-4">
-            <%= link_to "Reports",
-                        reports_events_path(return_to: "events"),
-                        class: "whitespace-nowrap text-sm #{eyebrow_link_class} px-2 py-1" %>
-            <%= link_to "New event",
-                        new_event_path,
-                        class: "whitespace-nowrap btn btn-secondary-outline" %>
-          </div>
-        <% end %>
-      </div>
+<% actions = capture do %>
+  <% if allowed_to?(:new?, Event) %>
+    <div class="admin-only flex flex-wrap items-center justify-end gap-4 bg-blue-100">
+      <%= link_to "Reports",
+                  reports_events_path(return_to: "events"),
+                  class: "whitespace-nowrap text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to "New event",
+                  new_event_path,
+                  class: "whitespace-nowrap btn btn-secondary-outline" %>
     </div>
-    <!-- Divider -->
-    <div class="w-full mt-6">
-      <hr class="border-gray-300 mb-6">
-    </div>
-
-    <% if params[:form_id].present? && (filtered_form = Form.find_by(id: params[:form_id])) %>
-      <div class="flex items-center justify-between gap-3 mb-6 rounded-lg bg-blue-50 border border-blue-200 px-4 py-2.5 text-sm text-blue-800">
-        <span class="inline-flex items-center gap-2">
-          <i class="fa-solid fa-filter text-blue-500"></i>
-          Showing events using form: <span class="font-semibold"><%= filtered_form.display_name %></span>
-        </span>
-        <%= link_to "Clear filter", events_path, class: "inline-flex items-center gap-1.5 font-medium text-blue-700 hover:text-blue-900" %>
-      </div>
-    <% end %>
-
-    <% archived_events = @archived_events.to_a %>
-    <% if @events.any? %>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <% @events.each do |event| %>
-          <%= render "card", event: event %>
-        <% end %>
-      </div>
-
-    <% elsif archived_events.none? %>
-      <!-- Empty State -->
-      <div class="text-center py-12 text-gray-500">
-        No events available.
-      </div>
-    <% end %>
-
-    <% if archived_events.any? %>
-      <%= render "archived_events", events: archived_events %>
-    <% end %>
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :events, eyebrow: "Programs", title: "Events",
+                     subtitle: "Join us for our virtual events including art workshops, facilitator trainings and other opportunities to create, connect and be in community",
+                     actions: actions } do %>
+  <!-- Divider -->
+  <div class="mt-6 w-full">
+    <hr class="mb-6 border-gray-300">
   </div>
-</div>
 
+  <% if params[:form_id].present? && (filtered_form = Form.find_by(id: params[:form_id])) %>
+    <div class="mb-6 flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-2.5 text-sm text-blue-800">
+      <span class="inline-flex items-center gap-2">
+        <i class="fa-solid fa-filter text-blue-500"></i>
+        Showing events using form: <span class="font-semibold"><%= filtered_form.display_name %></span>
+      </span>
+      <%= link_to "Clear filter", events_path, class: "inline-flex items-center gap-1.5 font-medium text-blue-700 hover:text-blue-900" %>
+    </div>
+  <% end %>
+
+  <% archived_events = @archived_events.to_a %>
+  <% if @events.any? %>
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <% @events.each do |event| %>
+        <%= render "card", event: event %>
+      <% end %>
+    </div>
+
+  <% elsif archived_events.none? %>
+    <!-- Empty State -->
+    <div class="py-12 text-center text-gray-500">
+      No events available.
+    </div>
+  <% end %>
+
+  <% if archived_events.any? %>
+    <%= render "archived_events", events: archived_events %>
+  <% end %>
+<% end %>

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -3,7 +3,7 @@
 <%# ---- SOCIAL SHARE SIDEBAR ---- %>
 <%= render "events/social_share_sidebar", share_url: event_url(@event), share_title: @event.title %>
 
-<div class="max-w-3xl mx-auto px-4">
+<div class="mx-auto max-w-3xl px-4">
   <div class="flex flex-wrap items-center gap-2 pt-4">
     <%= link_to event_path(@event), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
@@ -19,28 +19,28 @@
   </div>
 </div>
 
-<div class="max-w-3xl mx-auto pb-12 pt-6 px-4">
+<div class="mx-auto max-w-3xl px-4 pt-6 pb-12">
 
   <%# ---- EVENT HEADER ---- %>
-  <div class="text-center mb-8">
+  <div class="mb-8 text-center">
     <%# Organization logo leads the page so the publisher's identity (and the
         "art transforming trauma" tagline) establishes trust before the event
         and the registration ask. The color tagline lockup reads on the white
         page; the white reversed mark no longer appears in the purple card. %>
     <%= image_tag("logo-with-tagline.png", alt: "A Window Between Worlds — art transforming trauma", class: "mx-auto mb-6 block h-12 w-auto") %>
     <% if @event.respond_to?(:pre_title) && @event.pre_title.present? %>
-      <p class="text-lg sm:text-xl font-bold uppercase tracking-[0.2em] text-accent mb-3" style="font-family: 'Telefon Bold', sans-serif"><%= @event.pre_title %></p>
+      <p class="text-lg sm:text-xl font-bold uppercase tracking-[0.2em] text-accent mb-3"><%= @event.pre_title %></p>
     <% end %>
-    <h1 class="font-black text-green-800 leading-tight text-4xl sm:text-5xl mb-5" style="font-family: Lato, sans-serif">
+    <h1 class="font-display text-primary leading-tight text-4xl sm:text-5xl mb-5">
       <%= link_to @event.title, event_path(@event), class: "hover:underline decoration-2 underline-offset-4" %>
     </h1>
 
     <%# Date is upper-cased for hero emphasis (no weekday, includes the year);
         the time line keeps natural case so am/pm read lowercase. %>
-    <div class="font-bold text-blue-900 uppercase text-2xl sm:text-3xl" style="font-family: Lato, sans-serif">
+    <div class="font-bold text-primary uppercase text-2xl sm:text-3xl">
       <%= event_dates_label(@event) %>
     </div>
-    <div class="font-bold text-blue-900 text-lg sm:text-xl mt-2 mb-4" style="font-family: Lato, sans-serif">
+    <div class="font-bold text-primary text-lg sm:text-xl mt-2 mb-4">
       <%= event_times_label(@event) %>
     </div>
 
@@ -68,18 +68,18 @@
   </div>
 
   <%# ---- REGISTRATION FORM CARD ---- %>
-  <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
+  <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
 
     <%# Card Header %>
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="min-w-0">
-        <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= @registration_form.display_name %></h2>
+        <h2 class="text-xl leading-tight font-semibold tracking-wide"><%= @registration_form.display_name %></h2>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <%# Card Body %>
-    <div class="px-6 sm:px-8 py-7">
+    <div class="px-6 py-7 sm:px-8">
       <% if @event.autoshow_registration_details? %>
         <%= render "events/public_registrations/details", event: @event %>
       <% end %>
@@ -88,7 +88,7 @@
       <%# The error flash band carries the form-errors controller so it scrolls
           itself into view on connect after a failed submit. %>
       <% if flash[:alert] %>
-        <div role="alert" class="scroll-mt-24 flex items-start gap-3 bg-red-50 border border-red-200 text-red-800 rounded-lg px-4 py-3 mb-6" data-controller="form-errors">
+        <div role="alert" class="mb-6 flex scroll-mt-24 items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-800" data-controller="form-errors">
           <i class="fa-solid fa-circle-exclamation mt-0.5 text-red-500"></i>
           <span><%= flash[:alert] %></span>
         </div>
@@ -117,7 +117,7 @@
           end
         %>
 
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+        <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
           <% @form_fields.each do |field| %>
             <% if field.group_header? %>
               <%= render "events/public_registrations/group_header", field: field %>
@@ -135,11 +135,11 @@
 
         <% if @scholarship_form && @scholarship_form.form_fields.any? %>
           <div class="mt-8 rounded-xl border border-blue-100 bg-blue-50/50 px-5 py-6">
-            <h3 class="flex items-center gap-2.5 text-lg font-bold text-purple-900 mb-5">
+            <h3 class="mb-5 flex items-center gap-2.5 text-lg font-bold text-purple-900">
               <i class="fa-solid fa-hand-holding-heart text-accent"></i><%= @scholarship_form.display_name %>
             </h3>
             <%= render "forms/header", form: @scholarship_form, event: @event %>
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+            <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
               <% @scholarship_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% if field.group_header? %>
                   <%# Skip a section header that just repeats the form name shown as the title above %>
@@ -158,7 +158,7 @@
 
         <% if @continuing_education_form && @continuing_education_form.form_fields.any? %>
           <div class="mt-8 rounded-xl border border-teal-100 bg-teal-50/50 px-5 py-6">
-            <h3 class="flex items-center gap-2.5 text-lg font-bold text-teal-900 mb-5">
+            <h3 class="mb-5 flex items-center gap-2.5 text-lg font-bold text-teal-900">
               <i class="fa-solid fa-certificate text-teal-600"></i><%= @continuing_education_form.display_name %>
             </h3>
             <%= render "forms/header", form: @continuing_education_form, event: @event %>
@@ -166,19 +166,19 @@
               <dl class="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <% if @event.ce_hours_request_deadline %>
                   <div class="rounded-lg border border-teal-200 bg-white px-3 py-2">
-                    <dt class="text-xs font-medium uppercase tracking-wide text-teal-700">Request CE credit by</dt>
+                    <dt class="text-xs font-medium tracking-wide text-teal-700 uppercase">Request CE credit by</dt>
                     <dd class="mt-0.5 text-sm font-semibold text-gray-900"><%= @event.ce_hours_request_deadline.strftime("%B %-d, %Y") %></dd>
                   </div>
                 <% end %>
                 <% if @event.ce_payment_due_deadline %>
                   <div class="rounded-lg border border-teal-200 bg-white px-3 py-2">
-                    <dt class="text-xs font-medium uppercase tracking-wide text-teal-700">Payment due by</dt>
+                    <dt class="text-xs font-medium tracking-wide text-teal-700 uppercase">Payment due by</dt>
                     <dd class="mt-0.5 text-sm font-semibold text-gray-900"><%= @event.ce_payment_due_deadline.strftime("%B %-d, %Y") %></dd>
                   </div>
                 <% end %>
               </dl>
             <% end %>
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+            <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
               <% @continuing_education_form.form_fields.reorder(position: :asc).each do |field| %>
                 <% if field.group_header? %>
                   <% next if field.name.to_s.strip.casecmp?(@continuing_education_form.display_name.to_s.strip) %>
@@ -200,7 +200,7 @@
             <i class="fa-regular fa-circle-check"></i>Register
           <% end %>
           <p class="mt-3 flex items-center justify-center gap-1.5 text-xs text-gray-400">
-            <i class="fa-solid fa-lock"></i>Your information is kept private. Fields marked <span class="text-red-500 font-medium">*</span> are required.
+            <i class="fa-solid fa-lock"></i>Your information is kept private. Fields marked <span class="font-medium text-red-500">*</span> are required.
           </p>
         </div>
 

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -38,7 +38,8 @@
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
@@ -48,7 +49,6 @@
           <p class="text-sm text-blue-200"><%= @event.title %></p>
         </div>
       </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
     </div>
 
     <%# Card Body %>
@@ -89,7 +89,8 @@
     <div id="scholarship-application" class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8 scroll-mt-24">
 
       <%# Card Header %>
-      <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-5">
+      <%= render "shared/brand_accent_strip" %>
+      <div class="bg-primary text-white px-6 sm:px-8 py-5">
         <div class="flex items-center gap-3">
           <i class="fa-solid fa-hand-holding-heart text-accent text-xl"></i>
           <div class="flex-1">
@@ -97,7 +98,6 @@
             <p class="text-sm text-blue-200"><%= @scholarship_form.display_name %></p>
           </div>
         </div>
-        <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
       </div>
 
       <%# Card Body %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,13 +10,13 @@
 <% end %>
 
 <% if @preview %>
-  <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
+  <div class="mb-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
     <span><span class="font-medium">Preview</span> — unsaved changes</span>
     <button onclick="window.close()" class="btn btn-secondary-outline btn-sm">Close preview</button>
   </div>
 <% else %>
 <!-- Top Right Actions -->
-<div class="flex flex-wrap items-center gap-2 mb-4">
+<div class="mb-4 flex flex-wrap items-center gap-2">
   <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <div class="ml-auto flex flex-wrap gap-1">
   <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -39,25 +39,25 @@
 
 <%# ---- HEADER CONTENT ---- %>
 <% if @event.rhino_header.present? %>
-  <div class="rhino-centered prose max-w-none prose-img:max-w-full prose-img:w-full prose-strong:text-inherit prose-em:text-inherit mb-4">
+  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
     <%= @event.rhino_header %>
   </div>
 <% end %>
 
 <%# ---- TITLE ---- %>
 <% if @event.autoshow_title %>
-  <div class="text-center mb-4 max-w-2xl mx-auto">
+  <div class="mx-auto mb-4 max-w-2xl text-center">
     <% if @event.pre_title.present? %>
-      <p class="text-base font-semibold font-telefon text-gray-700 mb-2" style="font-family: 'Telefon Bold', sans-serif; font-size: 42px"><%= @event.pre_title %></p>
+      <p class="mb-2 font-telefon text-base font-semibold text-gray-700" style="font-size: 42px"><%= @event.pre_title %></p>
     <% end %>
-    <h1 class="font-bold text-green-800" style="font-family: Lato, sans-serif; font-size: 53px"><%= @event.title %></h1>
+    <h1 class="text-primary font-display" style="font-size: 53px"><%= @event.title %></h1>
   </div>
 <% end %>
 
 <%# ---- EVENT DETAILS (conditional on autoshow) ---- %>
-<div class="text-center space-y-2 mb-4">
+<div class="mb-4 space-y-2 text-center">
   <% if @event.autoshow_pre_date_text && @event.pre_date_text.present? %>
-    <div class="font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif; font-size: 24px"><%= @event.pre_date_text %></div>
+    <div class="text-primary font-bold uppercase" style="font-size: 24px"><%= @event.pre_date_text %></div>
   <% end %>
 
   <% if @event.autoshow_date || @event.autoshow_time %>
@@ -65,12 +65,12 @@
         time sits smaller below in natural case so am/pm read lowercase. %>
     <div>
       <% if @event.autoshow_date %>
-        <div class="font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif; font-size: 35px">
+        <div class="text-primary font-bold uppercase" style="font-size: 35px">
           <%= event_dates_label(@event) %>
         </div>
       <% end %>
       <% if @event.autoshow_time %>
-        <div class="font-bold text-blue-900 mt-2" style="font-family: Lato, sans-serif; font-size: 24px">
+        <div class="text-primary mt-2 font-bold" style="font-size: 24px">
           <%= event_times_label(@event) %>
         </div>
       <% end %>
@@ -78,7 +78,7 @@
   <% end %>
 
   <% if @event.autoshow_cost && @event.labelled_cost %>
-    <div class="text-xl font-bold text-blue-900 uppercase" style="font-family: Lato, sans-serif"><%= @event.labelled_cost %></div>
+    <div class="text-primary text-xl font-bold uppercase"><%= @event.labelled_cost %></div>
   <% end %>
 
   <% if @event.autoshow_location && @event.location.present? %>
@@ -118,7 +118,7 @@
 
 <%# ---- DESCRIPTION ---- %>
 <% if @event.rhino_description.present? %>
-  <div class="prose max-w-none prose-img:max-w-full prose-img:w-full prose-strong:text-inherit prose-em:text-inherit mb-12">
+  <div class="mb-12 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
     <%= @event.rhino_description %>
   </div>
 <% end %>
@@ -129,7 +129,7 @@
 </div>
 
 <% if @preview %>
-  <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-lg px-4 py-3 mt-4 flex items-center justify-between">
+  <div class="mt-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
     <span><span class="font-medium">Preview</span> — unsaved changes</span>
     <button onclick="window.close()" class="btn btn-secondary-outline btn-sm">Close preview</button>
   </div>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -4,7 +4,9 @@
     the wrapper restores the layout's gutters at a wider bound. %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="<%= DomainTheme.bg_class_for(:events) %> <%= DomainTheme.border_class_for(:events, intensity: 200) %> overflow-hidden rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip" %>
+  <div class="p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Event", event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -30,7 +32,7 @@
       <% if @event.start_date.present? %>
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
-      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+      <h1 class="font-display text-primary mt-2 flex items-center justify-center gap-2 text-3xl">
         <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
         Meet the staff
       </h1>
@@ -38,5 +40,6 @@
   </div>
 
   <%= render "events/staff_cards", event_staffs: @event_staffs %>
+  </div>
 </div>
 </div>

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -1,42 +1,36 @@
 <% content_for(:page_bg_class, "public") %>
 <%= render "shared/public_welcome_banner" %>
 
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-4">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold">FAQs</h2>
-        <p class="text-gray-600 mt-2">Find answers to common questions here. If you don't see what you need, please reach out to us at <%= mail_to ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"), class: "text-blue-600 hover:text-blue-800" %>.</p>
-      </div>
+<% actions = capture do %>
+  <% if allowed_to?(:new?, Faq) %>
+    <%= link_to "New FAQ",
+                new_faq_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<% subtitle = capture do %>
+  Find answers to common questions here. If you don't see what you need, please reach out to us at <%= mail_to ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"), class: "text-blue-600 hover:text-blue-800" %>.
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :faqs, eyebrow: "Support", title: "FAQs",
+                     subtitle: subtitle, actions: actions } do %>
+  <!-- Filter form -->
+  <div class="mt-4"><%= render "search_boxes" %></div>
 
-      <div class="text-right">
-        <% if allowed_to?(:new?, Faq) %>
-          <%= link_to "New FAQ",
-                      new_faq_path,
-                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-        <% end %>
-      </div>
-    </div>
-
-    <!-- Filter form -->
-    <div class="mt-4"><%= render "search_boxes" %></div>
-
-    <!-- Inner White Card -->
-    <div class="bg-white rounded-lg shadow-md p-6 mt-4">
-      <div
-        class="animate-fade"
-        data-controller="sortable"
-        data-sortable-url-value="<%= faq_path(id: ":id") %>"
-        data-testid="faq-list"
-      >
-        <% if @faqs.present? %>
-          <%= render partial: "faq", collection: @faqs, as: :faq %>
-          <div class="pagination flex justify-center mt-12"><%= tailwind_paginate @faqs %></div>
-        <% else %>
-          <p class="text-start text-gray-500 mt-6">No FAQs found.</p>
-        <% end %>
-      </div>
+  <!-- Inner White Card -->
+  <div class="mt-4 rounded-lg bg-white p-6 shadow-md">
+    <div
+      class="animate-fade"
+      data-controller="sortable"
+      data-sortable-url-value="<%= faq_path(id: ":id") %>"
+      data-testid="faq-list"
+    >
+      <% if @faqs.present? %>
+        <%= render partial: "faq", collection: @faqs, as: :faq %>
+        <div class="pagination mt-12 flex justify-center"><%= tailwind_paginate @faqs %></div>
+      <% else %>
+        <p class="mt-6 text-start text-gray-500">No FAQs found.</p>
+      <% end %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/faqs/show.html.erb
+++ b/app/views/faqs/show.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<%= render layout: "shared/show_page", locals: { domain: :faqs } do %>
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "FAQs", faqs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @faq) %>
           <%= link_to "Edit", edit_faq_path(@faq), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-3xl">
         <%= @faq.class.model_name.human %>
         Details
       </h1>
@@ -16,4 +16,4 @@
           <%= render @faq, hide_options: true %>
         </div>
       </div>
-</div>
+<% end %>

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -12,7 +12,8 @@
   </div>
 
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <h1 class="text-xl leading-tight font-semibold tracking-wide"><%= @form.display_name %></h1>
       <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>

--- a/app/views/public_forms/thank_you.html.erb
+++ b/app/views/public_forms/thank_you.html.erb
@@ -5,17 +5,20 @@
     <%= image_tag("logo-with-tagline.png", alt: "A Window Between Worlds — art transforming trauma", class: "mx-auto mb-6 block h-12 w-auto") %>
   </div>
 
-  <div class="overflow-hidden rounded-2xl bg-white px-6 py-12 text-center shadow-xl ring-1 ring-black/5 sm:px-10">
+  <div class="overflow-hidden rounded-2xl bg-white text-center shadow-xl ring-1 ring-black/5">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="px-6 py-12 sm:px-10">
     <span class="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 text-green-600">
       <i class="fa-solid fa-circle-check text-3xl" aria-hidden="true"></i>
     </span>
-    <h1 class="mb-2 text-2xl font-bold text-gray-900">Thank you!</h1>
+    <h1 class="text-primary mb-2 font-display text-3xl">Thank you!</h1>
     <p class="text-gray-600">
       Your response to <span class="font-semibold text-gray-900"><%= @form.display_name %></span> has been submitted.
     </p>
     <div class="mt-8">
       <%= link_to "Submit another response", public_form_path(@form.slug),
                   class: "inline-flex items-center gap-2 rounded-xl border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50" %>
+    </div>
     </div>
   </div>
 </div>

--- a/app/views/resources/index.html.erb
+++ b/app/views/resources/index.html.erb
@@ -1,37 +1,29 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header Row -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Resources</h2>
-        <p class="text-gray-600">Search for handouts, templates and toolkits to support your work</p>
-      </div>
+<% actions = capture do %>
+  <% if allowed_to?(:new?, Resource) %>
+    <%= link_to "New Resource",
+                new_resource_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :resources, eyebrow: "Library", title: "Resources",
+                     subtitle: "Search for handouts, templates and toolkits to support your work",
+                     actions: actions } do %>
+  <!-- Search Form -->
+  <div class="w-full"><%= render "search_boxes" %></div>
 
-      <div class="text-right">
-        <% if allowed_to?(:new?, Resource) %>
-          <%= link_to "New Resource",
-                      new_resource_path,
-                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-        <% end %>
-      </div>
-    </div>
+  <!-- Divider -->
+  <div class="mt-6 w-full"><hr class="mb-6 border-gray-300"></div>
 
-    <!-- Search Form -->
-    <div class="w-full"><%= render "search_boxes" %></div>
+  <%= render "shared/filtered_to", record: @author, clear_path: resources_path %>
 
-    <!-- Divider -->
-    <div class="w-full mt-6"><hr class="border-gray-300 mb-6"></div>
+  <!-- Results Table -->
+  <% result_src = resources_path + "?" + request.query_string %>
 
-    <%= render "shared/filtered_to", record: @author, clear_path: resources_path %>
-
-    <!-- Results Table -->
-    <% result_src = resources_path + "?" + request.query_string %>
-
-    <%= turbo_frame_tag :resources_results, src: result_src, autoscroll: "start", data: {turbo: "temporary"} do %>
-      <%= render "results_skeleton" %>
-    <% end %>
-  </div>
-</div>
+  <%= turbo_frame_tag :resources_results, src: result_src, autoscroll: "start", data: {turbo: "temporary"} do %>
+    <%= render "results_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
+<%= render layout: "shared/show_page", locals: { domain: :resources } do %>
       <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Resources", resources_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @resource) %>
@@ -18,16 +18,16 @@
                     download: true if @resource.downloadable_asset&.file&.attached? %>
       </div>
       <!-- Resource Card -->
-      <div class="bg-white rounded-lg shadow-md p-6 mb-4 space-y-6">
+      <div class="mb-4 space-y-6 rounded-lg bg-white p-6 shadow-md">
         <!-- Title -->
-        <div class="font-semibold text-gray-900 mb-2">
-          <%= title_with_badges(@resource, font_size: "text-3xl") %>
+        <div class="mb-2 font-semibold text-gray-900">
+          <%= title_with_badges(@resource, font_size: "text-3xl", display: true) %>
           <%#= "(#{@resource.windows_type&.short_name})" if @resource.windows_type %>
         </div>
         <!-- Author and Date -->
         <div class="flex flex-col gap-1">
           <% unless @resource.toolkit_and_form? %>
-            <div class="flex items-center text-gray-600 text-sm gap-2">
+            <div class="flex items-center gap-2 text-sm text-gray-600">
               <span>
                 <%= credited_author_link(@resource, class: "hover:underline") %>
               </span>
@@ -44,7 +44,7 @@
         <div class="flex justify-end">
           <%= render "assets/primary_image_picker", owner: @resource %>
         </div>
-        <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
+        <div id="upload-progress" class="mt-2 hidden h-1 w-full overflow-hidden rounded bg-gray-200">
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
         <!-- Assets -->
@@ -55,4 +55,4 @@
       <!-- Mentions -->
       <%= render "shared/show_mentions_list", mentions: @mentioners, heading: "Mentioned by" %>
       <%= render "shared/show_mentions_list", mentions: @mentionees, heading: "Mentions in this Resource" %>
-</div>
+<% end %>

--- a/app/views/shared/_brand_accent_strip.html.erb
+++ b/app/views/shared/_brand_accent_strip.html.erb
@@ -1,2 +1,4 @@
-<%# The AWBW rainbow rule that tops a branded page card (matches awbw.org). %>
-<div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#ffcb05,#992a5b,#41006c,#24479e)]"></div>
+<%# The AWBW rainbow rule that tops a branded page card (matches awbw.org).
+    Pass rounded: true when the card is not clipping its own overflow, so the
+    rule still follows the card's rounded top corners. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,#4e8324,#d56027,#ffcb05,#992a5b,#41006c,#24479e)]"></div>

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -1,0 +1,26 @@
+<%# Shared shell for an index page: the brand card (rainbow rule, rounded corners,
+    soft domain border) over the domain's own tint, then the serif title with an
+    optional eyebrow, subtitle and right-hand actions, and the page body as a block.
+    locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
+    actions (captured markup), surface (defaults to the domain's 50 tint). %>
+<% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
+<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip" %>
+  <div class="w-full p-6">
+    <div class="mb-6 flex items-start justify-between gap-4">
+      <div class="pr-6">
+        <% if local_assigns[:eyebrow].present? %>
+          <span class="text-2xs font-semibold tracking-widest uppercase <%= DomainTheme.text_class_for(domain, intensity: 700) %>"><%= eyebrow %></span>
+        <% end %>
+        <h1 class="text-primary font-display text-3xl"><%= title %></h1>
+        <% if local_assigns[:subtitle].present? %>
+          <div class="mt-2 max-w-3xl text-gray-600"><%= subtitle %></div>
+        <% end %>
+      </div>
+      <% if local_assigns[:actions].present? %>
+        <div class="flex flex-wrap items-center justify-end gap-3 text-right"><%= actions %></div>
+      <% end %>
+    </div>
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -4,8 +4,8 @@
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
     actions (captured markup), surface (defaults to the domain's 50 tint). %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
-<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip", rounded: true %>
   <div class="w-full p-6">
     <div class="mb-6 flex items-start justify-between gap-4">
       <div class="pr-6">

--- a/app/views/shared/_public_welcome_banner.html.erb
+++ b/app/views/shared/_public_welcome_banner.html.erb
@@ -1,5 +1,8 @@
 <% unless user_signed_in? %>
-  <div class="bg-brand-cream">
+  <%# The home page is a stack of full-bleed bands, so the banner stays edge to
+      edge there. Everywhere else it sits above rounded cards, so it becomes one. %>
+  <% full_bleed = content_for?(:full_width) %>
+  <div class="bg-brand-cream overflow-hidden <%= "border-primary/10 mb-6 rounded-2xl border shadow-sm" unless full_bleed %>">
     <%= render "shared/brand_accent_strip" %>
     <div class="mx-auto flex max-w-6xl items-center justify-center gap-5 px-4 py-8">
       <div class="h-20 w-20 shrink-0 overflow-hidden rounded-full">

--- a/app/views/shared/_show_page.html.erb
+++ b/app/views/shared/_show_page.html.erb
@@ -3,7 +3,7 @@
     supplied as a block. Mirrors `shared/_index_page` for the listing pages.
     locals: domain (a DomainTheme key); optional surface, extra_class. %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
-<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= local_assigns[:extra_class] %> mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= local_assigns[:extra_class] %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip", rounded: true %>
   <div class="p-6"><%= yield %></div>
 </div>

--- a/app/views/shared/_show_page.html.erb
+++ b/app/views/shared/_show_page.html.erb
@@ -1,0 +1,9 @@
+<%# Shared shell for a public show page: the brand card (rainbow rule, rounded
+    corners, soft domain border) over the domain's own tint, with the page body
+    supplied as a block. Mirrors `shared/_index_page` for the listing pages.
+    locals: domain (a DomainTheme key); optional surface, extra_class. %>
+<% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
+<div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= local_assigns[:extra_class] %> mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip" %>
+  <div class="p-6"><%= yield %></div>
+</div>

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -1,38 +1,31 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="community-news-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Stories</h2>
-        <p class="text-gray-600">Check out stories from Windows Facilitators around the world and the healing they make possible through art</p>
-      </div>
+<% actions = capture do %>
+  <% if allowed_to?(:import?, Story) %>
+    <%= link_to "Import",
+                new_story_import_path,
+                class: "admin-only font-medium text-blue-700 hover:text-blue-900 hover:underline" %>
+  <% end %>
+  <% if allowed_to?(:new?, Story) %>
+    <%= link_to "New Story",
+                new_story_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :stories, eyebrow: "Community", title: "Stories",
+                     subtitle: "Check out stories from Windows Facilitators around the world and the healing they make possible through art",
+                     actions: actions } do %>
+  <%= render "search_boxes" %>
 
-      <div class="text-right text-end flex flex-wrap items-center justify-end gap-3">
-        <% if allowed_to?(:import?, Story) %>
-          <%= link_to "Import",
-                      new_story_import_path,
-                      class: "admin-only font-medium text-blue-700 hover:text-blue-900 hover:underline" %>
-        <% end %>
-        <% if allowed_to?(:new?, Story) %>
-          <%= link_to "New Story",
-                      new_story_path,
-                      class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-        <% end %>
-      </div>
-    </div>
+  <%= render "shared/filtered_to", record: @author, clear_path: stories_path %>
 
-    <%= render "search_boxes" %>
+  <%= render "stories_count" %>
 
-    <%= render "shared/filtered_to", record: @author, clear_path: stories_path %>
+  <% result_src = stories_path + "?" + request.query_string %>
 
-    <%= render "stories_count" %>
-
-    <% result_src = stories_path + "?" + request.query_string %>
-
-    <%= turbo_frame_tag "stories_results", src: result_src do %>
-      <%= render "results_skeleton" %>
-    <% end %>
-  </div>
-</div>
+  <%= turbo_frame_tag "stories_results", src: result_src do %>
+    <%= render "results_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -2,9 +2,9 @@
 <% story_title = ERB::Util.url_encode(@story.title) %>
 
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
+<%= render layout: "shared/show_page", locals: { domain: :stories } do %>
       <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Stories", stories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @story) %>
@@ -18,15 +18,15 @@
       </div>
 
       <!-- Story Card -->
-      <div class="bg-white rounded-lg shadow-md p-6 space-y-2">
+      <div class="space-y-2 rounded-lg bg-white p-6 shadow-md">
 
         <!-- Title -->
-        <div class="font-semibold text-gray-900 mb-2">
-          <%= title_with_badges(@story, font_size: "text-3xl") %>
+        <div class="mb-2 font-semibold text-gray-900">
+          <%= title_with_badges(@story, font_size: "text-3xl", display: true) %>
         </div>
 
         <!-- Meta Data (exact screenshot style) -->
-        <div class="text-sm text-gray-600 space-y-0.5">
+        <div class="space-y-0.5 text-sm text-gray-600">
           <p><strong>Story by:</strong>
             <%= credited_author_link(@story) %>
           </p>
@@ -49,7 +49,7 @@
           <% end %>
         </div>
 
-        <div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
+        <div id="upload-progress" class="mt-2 hidden h-1 w-full overflow-hidden rounded bg-gray-200">
           <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
         </div>
         <div id="hero-image" class="relative">
@@ -65,9 +65,9 @@
         </div>
 
         <!-- Share Section -->
-        <h3 class="font-semibold text-lg mb-3">Share this Story:</h3>
+        <h3 class="mb-3 text-lg font-semibold">Share this Story:</h3>
 
-        <div class="flex space-x-4 mb-6">
+        <div class="mb-6 flex space-x-4">
 
           <!-- Facebook -->
           <%= link_to "https://www.facebook.com/sharer/sharer.php?u=#{story_url}",
@@ -99,8 +99,8 @@
 
         </div>
 
-        <div class="text-sm text-gray-500 leading-relaxed border-t border-gray-300 pt-6">
+        <div class="border-t border-gray-300 pt-6 text-sm leading-relaxed text-gray-500">
           <%= render "shared/organization_footer" %>
         </div>
       </div>
-</div>
+<% end %>

--- a/app/views/taggings/index.html.erb
+++ b/app/views/taggings/index.html.erb
@@ -9,19 +9,12 @@
      filtered_categories.map { |c| "#{c.category_type&.name&.titleize}: #{c.name}" }.join(", ").presence
 %>
 
-<div class="taggings-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:tags) %> rounded-xl border border-gray-200 p-6 shadow">
+<%= render layout: "shared/index_page",
+           locals: { domain: :tags, eyebrow: "Browse", title: "Taggings",
+                     subtitle: "Content tagged by sector or thematic category." } do %>
 
   <!-- HEADER -->
   <div class="mb-10 w-full">
-    <div class="mb-6">
-      <h1 class="mb-2 text-3xl font-semibold text-gray-900">
-        Taggings
-      </h1>
-
-      <p class="max-w-2xl text-gray-600">
-        Content tagged by sector or thematic category.
-      </p>
-    </div>
 
     <!-- ACTIVE FILTERS -->
     <% if sector_names.present? || category_full_names.present? || @category_names_all.present? %>
@@ -118,7 +111,7 @@
     <% end %>
 
   </div>
-</div>
+<% end %>
 
 <!-- STAFF TAGS (internal, admin-only) -->
 <% if allowed_to?(:index?, StaffTag) && @staff_tags.present? %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,20 +1,12 @@
 <% content_for(:page_bg_class, "public") %>
 <%= render "shared/public_welcome_banner" %>
 
-<div class="tags-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:tags) %> rounded-xl border border-gray-200 p-6 shadow">
-  <!-- HEADER -->
+<% subtitle = capture do %>
+  Browse workshops, resources, and stories using our tagging system. For a more precise search, use <a href="#explore-by-combination" class="font-semibold text-blue-600 hover:text-blue-800">Explore by combination</a> to apply multiple filters at once.
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :tags, eyebrow: "Browse", title: "Tags", subtitle: subtitle } do %>
   <div class="mb-10 w-full">
-    <div class="mb-10 flex items-start justify-between gap-6">
-      <!-- Title + subtitle -->
-      <div>
-        <h2 class="mb-2 text-2xl font-semibold">
-          Tags
-        </h2>
-        <p class="max-w-2xl text-gray-600">
-          Browse workshops, resources, and stories using our tagging system. For a more precise search, use <a href="#explore-by-combination" class="font-semibold text-blue-600 hover:text-blue-800">Explore by combination</a> to apply multiple filters at once.
-        </p>
-      </div>
-    </div>
 
     <div class="space-y-6">
       <!-- SECTORS -->
@@ -90,6 +82,6 @@
       <% end %>
     </div>
   </div>
-</div>
+<% end %>
 
 <%= render "taggings/explore_by_combination" %>

--- a/app/views/video_recordings/index.html.erb
+++ b/app/views/video_recordings/index.html.erb
@@ -1,53 +1,36 @@
 <% content_for(:page_bg_class, "public") %>
 <%= render "shared/public_welcome_banner" %>
 
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:video_recordings, intensity: @video_type == "instructional" ? 100 : 50) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">
-          <% if @video_type == "instructional" %>
-            Instructional videos
-          <% else %>
-            Videos
-          <% end %>
-        </h2>
+<% instructional = @video_type == "instructional" %>
+<% actions = capture do %>
+  <% if instructional %>
+    <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% end %>
+  <% if allowed_to?(:new?, VideoRecording) %>
+    <%= link_to "New #{VideoRecording.model_name.human.downcase}",
+                 new_video_recording_path,
+                 class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<% subtitle = if instructional
+     user_signed_in? ?
+       "Our library of step-by-step instructional videos designed to support your journey" :
+       "Step-by-step instructional videos to help you get the most out of our platform"
+   else
+     user_signed_in? ?
+       "Explore videos from the community showcasing impact and inspiring stories" :
+       "A library of videos designed to introduce you to our work and the real-world impact shared by the community we serve"
+   end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :video_recordings, eyebrow: "Library",
+                     title: instructional ? "Instructional videos" : "Videos",
+                     subtitle: subtitle, actions: actions,
+                     surface: DomainTheme.bg_class_for(:video_recordings, intensity: instructional ? 100 : 50) } do %>
+  <%= render "search_boxes" %>
 
-        <p class="text-gray-600 max-w-4xl">
-          <% if @video_type == "instructional" %>
-            <% if user_signed_in? %>
-              Our library of step-by-step instructional videos designed to support your journey
-            <% else %>
-              Step-by-step instructional videos to help you get the most out of our platform
-            <% end %>
-          <% else %>
-            <% if user_signed_in? %>
-              Explore videos from the community showcasing impact and inspiring stories
-            <% else %>
-              A library of videos designed to introduce you to our work and the real-world impact shared&nbsp;by the community we serve
-            <% end %>
-          <% end %>
-        </p>
-      </div>
+  <% result_src = video_recordings_path + "?" + request.query_string %>
 
-      <div class="text-right space-y-2">
-        <% if @video_type == "instructional" %>
-          <%= link_to "See all Videos", video_recordings_path(video_type: "all"), class: "block text-sm #{eyebrow_link_class} px-2 py-1" %>
-        <% end %>
-        <% if allowed_to?(:new?, VideoRecording) %>
-          <%= link_to "New #{VideoRecording.model_name.human.downcase}",
-                       new_video_recording_path,
-                       class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-        <% end %>
-      </div>
-    </div>
-
-    <%= render "search_boxes" %>
-
-    <% result_src = video_recordings_path + "?" + request.query_string %>
-
-    <%= turbo_frame_tag "video_recordings_results", src: result_src do %>
-      <%= render "results_skeleton" %>
-    <% end %>
-  </div>
-</div>
+  <%= turbo_frame_tag "video_recordings_results", src: result_src do %>
+    <%= render "results_skeleton" %>
+  <% end %>
+<% end %>

--- a/app/views/video_recordings/show.html.erb
+++ b/app/views/video_recordings/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:video_recordings, intensity: @video_recording.is_instructional? ? 100 : 50) %> border border-gray-200 rounded-xl shadow p-6">
+<%= render layout: "shared/show_page", locals: { domain: :video_recordings, surface: DomainTheme.bg_class_for(:video_recordings, intensity: @video_recording.is_instructional? ? 100 : 50) } do %>
       <!-- Top Right Utility Links -->
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if @video_recording.is_instructional? %>
           <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -18,11 +18,11 @@
       </div>
 
       <!-- Resource Card -->
-      <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
+      <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
 
         <!-- Title -->
-        <div class="font-semibold text-gray-900 my-6">
-          <%= title_with_badges(@video_recording, font_size: "text-3xl") %>
+        <div class="my-6 font-semibold text-gray-900">
+          <%= title_with_badges(@video_recording, font_size: "text-3xl", display: true) %>
         </div>
 
         <!-- Embedded Video -->
@@ -56,4 +56,4 @@
         </div>
 
       </div>
-</div>
+<% end %>

--- a/app/views/workshop_variations/index.html.erb
+++ b/app/views/workshop_variations/index.html.erb
@@ -1,18 +1,14 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
+<% actions = capture do %>
+  <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
+              new_workshop_variation_path,
+              class: "btn btn-primary-outline" %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :workshop_variations, eyebrow: "Curriculum",
+                     title: WorkshopVariation.model_name.human.pluralize,
+                     actions: actions } do %>
   <div class="space-y-6">
-    <!-- Header -->
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-semibold text-gray-900">
-        <%= WorkshopVariation.model_name.human.pluralize %>
-      </h1>
-      <div class="flex gap-2">
-        <%= link_to "New #{WorkshopVariation.model_name.human.downcase}",
-                    new_workshop_variation_path,
-                    class: "btn btn-primary-outline" %>
-      </div>
-    </div>
-
     <%= render "search_boxes" %>
 
     <%= render "shared/filtered_to", record: @author, clear_path: workshop_variations_path %>
@@ -25,4 +21,4 @@
       <%= render "results_skeleton" %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/workshop_variations/show.html.erb
+++ b/app/views/workshop_variations/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
+<%= render layout: "shared/show_page", locals: { domain: :workshop_variations } do %>
 
-    <div class="flex flex-wrap justify-end gap-2 mb-4">
+    <div class="mb-4 flex flex-wrap justify-end gap-2">
       <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "Workshop", workshop_path(@workshop_variation.workshop, anchor: "workshop-variations"),
                   class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -13,7 +13,7 @@
 
 
     <!-- Resource Card -->
-    <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
+    <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
       <div class="workshop">
         Workshop: <%= link_to("#{@workshop_variation.workshop.name} (#{@workshop_variation.workshop.windows_type&.short_name || 'Combined'})",
                                workshop_path(@workshop_variation.workshop), class: "btn btn-secondary-outline") %>
@@ -32,12 +32,12 @@
       <% end %>
 
       <!-- Title -->
-      <%= title_with_badges(@workshop_variation, font_size: "text-3xl",
+      <%= title_with_badges(@workshop_variation, font_size: "text-3xl", display: true,
                             record_title: "#{@workshop_variation.name} (#{@workshop_variation.windows_type&.short_name || 'Combined'})") %>
 
       <!-- Author and Date -->
       <div class="flex flex-col gap-1">
-        <div class="flex items-center text-gray-600 text-sm gap-2">
+        <div class="flex items-center gap-2 text-sm text-gray-600">
           <span>
             <%= credited_author_link(@workshop_variation, class: "hover:underline") %>
           </span>
@@ -52,7 +52,7 @@
 
       <!-- URL -->
       <% if @workshop_variation.youtube_url.present? %>
-        <div class="prose mx-auto leading-relaxed text-gray-800 text-left">
+        <div class="mx-auto text-left prose leading-relaxed text-gray-800">
           <%= link_to @workshop_variation.youtube_url, @workshop_variation.youtube_url, target: "_blank",
                       rel: "noopener noreferrer",
                       class: "text-blue-600 hover:underline break-words" %>
@@ -63,4 +63,4 @@
       <!-- Main Text -->
       <%= @workshop_variation.rhino_body %>
     </div>
-</div>
+<% end %>

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -1,30 +1,23 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% content_for(:page_bg_class, "public") %>
-<div class="workshops-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
-  <!-- Header -->
-  <div class="w-full">
-    <div class="flex items-start justify-between mb-6">
-      <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Workshops</h2>
-
-        <p class="text-gray-700">
-          Search by emotional theme, materials needed, ease of set-up, and more.
-          <br>
-          We encourage Windows Facilitator creativity and innovation. If you adapt and improve workshops, please <%= link_to "share your ideas with us", new_workshop_variation_idea_path, class: "text-blue-500" %>!
-        </p>
-      </div>
-
-      <% if allowed_to?(:new?, Workshop) %>
-        <%= link_to "New workshop",
-                    new_workshop_path,
-                    class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-      <% end %>
-    </div>
-  </div>
-
+<% actions = capture do %>
+  <% if allowed_to?(:new?, Workshop) %>
+    <%= link_to "New workshop",
+                new_workshop_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
+  <% end %>
+<% end %>
+<% subtitle = capture do %>
+  Search by emotional theme, materials needed, ease of set-up, and more.
+  <br>
+  We encourage Windows Facilitator creativity and innovation. If you adapt and improve workshops, please <%= link_to "share your ideas with us", new_workshop_variation_idea_path, class: "text-blue-500" %>!
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :workshops, eyebrow: "Curriculum", title: "Workshops",
+                     subtitle: subtitle, actions: actions } do %>
   <!-- Divider -->
-  <div class="w-full"><hr class="border-gray-300 mb-6"></div>
+  <div class="w-full"><hr class="mb-6 border-gray-300"></div>
 
   <!-- Search Form -->
   <div class="w-full">
@@ -35,15 +28,15 @@
       <%= hidden_field_tag :author_id, params[:author_id] if params[:author_id].present? %>
       <%= render "filters" %>
 
-      <div><hr class="border-gray-300 my-6"></div>
+      <div><hr class="my-6 border-gray-300"></div>
 
       <div class="mt-6"><%= render "filters_applied" %></div>
 
-      <div><hr class="border-gray-300 my-6"></div>
+      <div><hr class="my-6 border-gray-300"></div>
 
       <!-- Sort Options -->
       <div class="flex flex-wrap items-center gap-x-4 gap-y-2 font-medium">
-        <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">
+        <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">
           Sort by
         </h3>
 
@@ -62,4 +55,4 @@
       <%= render "results_skeleton" %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
-<div class="workshop-show max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6 print:border-none print:shadow-none">
+<%= render layout: "shared/show_page", locals: { domain: :workshops, extra_class: "workshop-show print:border-none print:shadow-none" } do %>
   <div class="flex flex-col gap-6">
     <!-- Main Workshop Show -->
     <div id="show" class="flex-1">
@@ -20,4 +20,4 @@
       </script>
     </div>
   </div>
-</div>
+<% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2518,9 +2518,11 @@
   area: content
   display_status: public_facing
   released_on: 2026-08-28
+  pr_number: 2398
   summary: >-
-    Every public listing page — workshops, resources, stories, news, events,
-    videos, FAQs — now carries the awbw.org look, and each keeps its own colour
-    drawn from the AWBW brand palette. Filters, columns and content are unchanged.
+    The public pages now carry the awbw.org look: every listing keeps its own
+    colour from the AWBW brand palette, and the registration and payment pages
+    get the same navy header the ticket has. Content and filters are unchanged.
   pro_tips:
     - "FAQs and workshop variations join the brand palette, so every public listing now uses an official AWBW colour."
+    - "The public event page, registration form and bulk payment pages lose the old purple header and green headline."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2513,3 +2513,14 @@
     buttons across the whole portal are brand navy instead of a generic blue.
   pro_tips:
     - "Every form's submit button was being forced to a non-brand blue by a leftover setting; they now use the brand button the views already asked for."
+
+- name: "Public pages in the AWBW brand"
+  area: content
+  display_status: public_facing
+  released_on: 2026-08-28
+  summary: >-
+    Every public listing page — workshops, resources, stories, news, events,
+    videos, FAQs — now carries the awbw.org look, and each keeps its own colour
+    drawn from the AWBW brand palette. Filters, columns and content are unchanged.
+  pro_tips:
+    - "FAQs and workshop variations join the brand palette, so every public listing now uses an official AWBW colour."

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -17,7 +17,7 @@ module DomainTheme
     quotes:                   :slate,
     grants:                   :green,
 
-    tags:                     :lime,
+    tags:                     :"brand-green",
     sectors:                  :lime,
     categories:               :lime,
     category_types:            :lime,

--- a/lib/domain_theme.rb
+++ b/lib/domain_theme.rb
@@ -6,7 +6,7 @@ module DomainTheme
   # work the same way here — the helpers below just interpolate the name.
   COLORS = {
     workshops:                :"brand-navy",
-    workshop_variations:      :purple,
+    workshop_variations:      :"brand-navy",
     workshop_logs:            :teal,
     resources:                :"brand-purple",
     community_news:           :"brand-orange",
@@ -23,7 +23,7 @@ module DomainTheme
     category_types:            :lime,
 
     forms:                    :purple,
-    faqs:                     :pink,
+    faqs:                     :"brand-green",
     video_recordings:         :"brand-yellow",
 
     workshop_ideas:           :indigo,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only restyle across every public page; extracts two shared shells and moves three domains onto the brand palette

Every public-facing page now carries the awbw.org look, and each keeps its own colour — from the AWBW brand palette rather than a stock Tailwind hue.

Scope was set by auditing every view with a public `page_bg_class` (`public` and `admin-or-public-or-authpublished`), not by picking pages. 43 total; 5 deliberately excluded, listed at the bottom.

### Two shared shells
The listing pages and the content show pages each repeated one markup shape, so they become `shared/_index_page` and `shared/_show_page`, rendered with `layout:` (the pattern `home/_section` and `events/callouts/_callout_page` already use).

Both keep **the domain tint as the card surface**, so the per-model colour stays visible, and add the branded chrome: rainbow rule, `rounded-2xl`, soft domain border, `font-display` title.

- **Listings** — workshops · workshop variations · resources · stories · community news · events · FAQs · video recordings · tags · taggings
- **Show pages** — workshops · workshop variations · resources · stories · community news · FAQs · video recordings

### Registration, payment and utility pages
The registration flow still had the purple gradient header and hard-coded `Lato`/`text-green-800` hero the ticket shed in #2393, so the flow read as two different products. Same treatment now: public event page, public registration form and confirmation, public forms, bulk-payment new/show/ticket, contact us, event staff page, form thank-you.

### Three domains joined the brand palette
| Domain | Was | Now |
|---|---|---|
| faqs | `pink` | `brand-green` |
| workshop_variations | `purple` | `brand-navy` (pairs it with workshops) |
| tags | `lime` | `brand-green` |

All seven brand scales are in use. `faqs` and `tags` share green — the brand has seven hues and the public surface needs nine, so the two utility domains pair up.

### One helper change worth a look
`title_with_badges` renders **both** page titles and card/row titles. Applying the serif wholesale would have restyled every card and table row, so it gains an opt-in `display:` flag that the five show pages pass. Dense lists keep the sans.

### Deliberately not included
- **`events/invoices/show`, `registrations/invoice`, `registrations/receipt`** — printable financial documents; print fidelity is its own problem.
- **`story_shares/index` and `show`** — a separate microsite with its own `<html>` layout, its own font link (Lato only, no Fraunces) and its own `body` font rule. `font-display` would silently fall back there. Rebranding it is a distinct project.
- **Admin `forms/*`** — five more purple headers, but not public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)