### PR TITLE
Put the sign-in and password pages on one branded card

### DIFF
--- a/app/views/devise/_auth_card.html.erb
+++ b/app/views/devise/_auth_card.html.erb
@@ -1,0 +1,28 @@
+<%# Shared shell for the sign-in / password / confirmation pages: the AWBW logo
+    over a white card topped by the brand rule, with a serif heading and the
+    form supplied as a block. Keeps every auth screen on one layout.
+    locals: title; optional subtitle, and links: false for pages served outside a
+    Devise controller, where `devise_mapping` is not defined. %>
+<div class="flex items-center justify-center px-4">
+  <div class="border-primary/10 mt-8 w-full max-w-md overflow-hidden rounded-2xl border bg-white shadow-lg">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="p-8">
+      <%= render "layouts/mailer/logo" %>
+
+      <h1 class="text-primary font-display mb-2 text-center text-3xl"><%= title %></h1>
+      <% if local_assigns[:subtitle].present? %>
+        <p class="mb-6 text-center text-gray-600"><%= subtitle %></p>
+      <% else %>
+        <div class="mb-6"></div>
+      <% end %>
+
+      <%= yield %>
+
+      <% if local_assigns.fetch(:links, true) %>
+        <div class="border-primary/10 mt-6 border-t pt-5 text-center">
+          <%= render "devise/shared/links" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,36 +1,20 @@
-<div class="flex items-center justify-center px-4">
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 mt-8">
+<% content_for(:page_bg_class, "public") %>
+<%= render layout: "devise/auth_card",
+           locals: { title: "Resend confirmation",
+                     subtitle: "We'll email you another confirmation link." } do %>
+  <%= simple_form_for(resource,
+                      as: resource_name,
+                      url: user_confirmation_path,
+                      html: { method: :post }) do |f| %>
+    <%#= render "shared/errors", resource: f.object # don't show this bc it tells user if email not found %>
 
-    <%= render "layouts/mailer/logo" %>
-
-    <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">
-      Resend confirmation instructions
-    </h2>
-
-    <%= simple_form_for(resource,
-                        as: resource_name,
-                        url: user_confirmation_path,
-                        html: { method: :post }) do |f| %>
-      <%#= render "shared/errors", resource: f.object # don't show this bc it tells user if email not found %>
-
-      <div class="mb-4">
-        <%= f.label :email,
-                    class: "block font-medium text-gray-700 mb-1" %>
-
-        <%= f.email_field :email,
-                          autofocus: true,
-                          class: "w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div class="action-buttons mt-8 flex justify-center gap-3">
-        <%= f.submit "Resend confirmation instructions",
-                     class: "btn btn-primary" %>
-      </div>
-    <% end %>
-
-    <div class="mt-6 text-center text-gray-600">
-      <%= render "devise/shared/links" %>
+    <div class="mb-4">
+      <%= f.label :email, class: "block font-medium text-gray-700 mb-1" %>
+      <%= f.email_field :email, autofocus: true, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
     </div>
 
-  </div>
-</div>
+    <div class="action-buttons mt-6 flex justify-center">
+      <%= f.submit "Resend confirmation instructions", class: "btn btn-primary w-full justify-center" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
-<div class="flex items-center justify-center">
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg mt-8 p-8">
-    <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">Set your password</h2>
-
+<% content_for(:page_bg_class, "public") %>
+<%= render layout: "devise/auth_card",
+           locals: { title: "Set your password",
+                     subtitle: "Choose a new password for your account." } do %>
     <%= simple_form_for(resource,
                         as: resource_name,
                         url: password_path(resource_name),
@@ -13,7 +13,7 @@
 
       <!-- NEW PASSWORD -->
       <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="user_password">New password <abbr title="required">*</abbr></label>
+        <label class="password required mb-1 block font-medium text-gray-700" for="user_password">New password <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password,
                                class: "w-full form-control form-input password-field pr-10 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
@@ -30,12 +30,12 @@
             <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
-        <p class="text-sm text-gray-500 mt-1">Password must be at least 5 characters long</p>
+        <p class="mt-1 text-sm text-gray-500">Password must be at least 5 characters long</p>
       </div>
 
       <!-- CONFIRM PASSWORD -->
       <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="user_password_confirmation">Confirm new password <abbr title="required">*</abbr></label>
+        <label class="password required mb-1 block font-medium text-gray-700" for="user_password_confirmation">Confirm new password <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password_confirmation,
                                class: "w-full form-control form-input password-field pr-10 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
@@ -59,9 +59,4 @@
       </div>
 
     <% end %>
-
-    <div class="mt-6 text-center text-sm">
-      <%= render "devise/shared/links" %>
-    </div>
-  </div>
-</div>
+<% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,28 +1,17 @@
-<div class="flex items-center justify-center px-4">
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 mt-8">
+<% content_for(:page_bg_class, "public") %>
+<%= render layout: "devise/auth_card",
+           locals: { title: "Forgot your password?",
+                     subtitle: "We'll email you a link to set a new one." } do %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: f.object %>
 
-    <%= render "layouts/mailer/logo" %>
-
-    <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">
-      Forgot your password?
-    </h2>
-
-    <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= render "devise/shared/error_messages", resource: f.object %>
-
-      <div class="mb-4">
-        <%= f.label :email, class: "block font-medium text-gray-700 mb-1" %>
-        <%= f.email_field :email, autofocus: true,
-                          class: "w-full rounded-lg border border-gray-300 px-3 py-2 shadow-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
-      </div>
-
-      <div class="action-buttons mt-8 flex justify-center gap-3">
-        <%= f.submit "Email me reset password instructions", class: "btn btn-primary" %>
-      </div>
-    <% end %>
-
-    <div class="mt-6 text-center text-gray-600">
-      <%= render "devise/shared/links" %>
+    <div class="mb-4">
+      <%= f.label :email, class: "block font-medium text-gray-700 mb-1" %>
+      <%= f.email_field :email, autofocus: true, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
     </div>
-  </div>
-</div>
+
+    <div class="action-buttons mt-6 flex justify-center">
+      <%= f.submit "Email me reset password instructions", class: "btn btn-primary w-full justify-center" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,55 +1,42 @@
-<div class="flex items-center justify-center">
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg mt-8 p-8">
+<% content_for(:page_bg_class, "public") %>
+<%= render layout: "devise/auth_card", locals: { title: "Welcome back!", subtitle: "Sign in to the AWBW Portal." } do %>
+  <%= simple_form_for(resource, url: session_path(resource_name)) do |f| %>
+    <% if resource.errors.any? %>
+      <%= render 'shared/errors', resource: resource %>
+    <% end %>
 
-    <%= render "layouts/mailer/logo" %>
-
-    <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">
-      Welcome to our Portal
-    </h2>
-
-    <%= simple_form_for(resource, url: session_path(resource_name)) do |f| %>
-      <% if resource.errors.any? %>
-        <%= render 'shared/errors', resource: resource %>
-      <% end %>
-
-      <%= f.input :email,
-                  autofocus: true,
-                  required: true,
-                  input_html: { class: "w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 shadow-sm" } %>
-      <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="user_password">Password <abbr title="required">*</abbr></label>
-        <div class="relative">
-          <%= f.password_field :password,
-                  class: "w-full form-control form-input password-field pr-10 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
-                  required: true,
-                  minlength: 5,
-                  autofocus: true,
-                  autocomplete: "current-password",
-                  autocorrect: "off",
-                  autocapitalize: "off",
-                  spellcheck: "false",
-                  data: { password_toggle_target: "input" } %>
-          <button
-            type="button"
-            class="toggle-password"
-            data-action="password-toggle#toggle"
-            aria-label="Toggle password visibility">
-            <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
-            <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
-          </button>
-        </div>
+    <%= f.input :email,
+                autofocus: true,
+                required: true,
+                input_html: { class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" } %>
+    <div data-controller="password-toggle" class="input password required mb-4">
+      <label class="password required mb-1 block font-medium text-gray-700" for="user_password">Password <abbr title="required">*</abbr></label>
+      <div class="relative">
+        <%= f.password_field :password,
+                class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none form-control form-input password-field pr-10",
+                required: true,
+                minlength: 5,
+                autocomplete: "current-password",
+                autocorrect: "off",
+                autocapitalize: "off",
+                spellcheck: "false",
+                data: { password_toggle_target: "input" } %>
+        <button
+          type="button"
+          class="toggle-password"
+          data-action="password-toggle#toggle"
+          aria-label="Toggle password visibility">
+          <i class="fa fa-eye" data-password-toggle-target="eyeOpen"></i>
+          <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
+        </button>
       </div>
+    </div>
 
-      <% if devise_mapping.rememberable? %>
-        <%= f.input :remember_me, as: :boolean, label: "Remember me" %>
-      <% end %>
-      <div class="text-center">
-        <%= f.button :submit, "Log in", class: "btn btn-primary" %>
-      </div>
-
+    <% if devise_mapping.rememberable? %>
+      <%= f.input :remember_me, as: :boolean, label: "Remember me" %>
     <% end %>
     <div class="mt-6 text-center">
-      <%= render "devise/shared/links" %>
+      <%= f.button :submit, "Log in", class: "btn btn-primary w-full justify-center" %>
     </div>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "actions-link-text text-black-300 hover:underline" %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: "actions-link-text text-primary text-sm hover:underline" %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "actions-link-text text-black-300 hover:underline" %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "actions-link-text text-primary text-sm hover:underline" %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "actions-link-text text-black-300 hover:underline" %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "actions-link-text text-primary text-sm hover:underline" %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "actions-link-text text-black-300 hover:underline" %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "actions-link-text text-primary text-sm hover:underline" %><br />
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), class: "actions-link-text text-black-300 hover:underline" %><br />
+    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider), class: "actions-link-text text-primary text-sm hover:underline" %><br />
   <% end -%>
 <% end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,16 +1,17 @@
-<h2>Resend unlock instructions</h2>
+<% content_for(:page_bg_class, "public") %>
+<%= render layout: "devise/auth_card",
+           locals: { title: "Resend unlock instructions",
+                     subtitle: "We'll email you a link to unlock your account." } do %>
+  <%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: f.object %>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: f.object %>
+    <div class="mb-4">
+      <%= f.label :email, class: "block font-medium text-gray-700 mb-1" %>
+      <%= f.email_field :email, autofocus: true, class: "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
-  </div>
-
-  <div class="action-buttons mt-8 flex justify-center gap-3">
-    <%= f.submit "Resend unlock instructions" %>
-  </div>
+    <div class="action-buttons mt-6 flex justify-center">
+      <%= f.submit "Resend unlock instructions", class: "btn btn-primary w-full justify-center" %>
+    </div>
+  <% end %>
 <% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -1,6 +1,7 @@
-<div class="flex items-center justify-center">
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg mt-8 p-8">
-    <h2 class="text-2xl font-semibold text-center text-gray-800 mb-6">Change your current password</h2>
+<%= render layout: "devise/auth_card",
+           locals: { title: "Change your password",
+                     subtitle: "Pick a new password for your account.",
+                     links: false } do %>
     <%= render partial: "password_errors", locals: { user: @user } %>
     <%= simple_form_for :user,
                         url: update_password_path,
@@ -8,7 +9,7 @@
                         html: { class: "space-y-4" } do |f| %>
       <!-- CURRENT PASSWORD -->
       <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="user_current_password">Current password <abbr title="required">*</abbr></label>
+        <label class="password required mb-1 block font-medium text-gray-700" for="user_current_password">Current password <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :current_password,
                                class: "w-full form-control form-input password-field pr-10 rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
@@ -26,7 +27,7 @@
           </button>
         </div>
       </div>
-      <p class="text-gray-500 text-sm mt-1">
+      <p class="mt-1 text-sm text-gray-500">
         Don't remember your password?
         <%= link_to "Log out and reset it.",
                     destroy_user_session_path(reset_password: true),
@@ -37,8 +38,8 @@
                     } %>
       </p>
       <!-- NEW PASSWORD -->
-      <div data-controller="password-toggle" class="input password required mb-4 mt-6 pt-6">
-        <label class="password required block font-medium mb-1 text-gray-700" for="change-password-new-password">New password <abbr title="required">*</abbr></label>
+      <div data-controller="password-toggle" class="input password required mt-6 mb-4 pt-6">
+        <label class="password required mb-1 block font-medium text-gray-700" for="change-password-new-password">New password <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password,
                                id: "change-password-new-password",
@@ -56,11 +57,11 @@
             <svg data-password-toggle-target="eyeClosed" style="display:none" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 10c3 4 6.5 6 10 6s7-2 10-6"/><path d="M7.5 14l-1.5 3"/><path d="M12 16v3"/><path d="M16.5 14l1.5 3"/></svg>
           </button>
         </div>
-        <p class="text-sm text-gray-500 mt-1">Password must be at least 5 characters long</p>
+        <p class="mt-1 text-sm text-gray-500">Password must be at least 5 characters long</p>
       </div>
       <!-- CONFIRM PASSWORD -->
       <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="change-password-new-password-confirmation">New password confirmation <abbr title="required">*</abbr></label>
+        <label class="password required mb-1 block font-medium text-gray-700" for="change-password-new-password-confirmation">New password confirmation <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password_confirmation,
                                id: "change-password-new-password-confirmation",
@@ -84,5 +85,4 @@
         <%= f.submit "Change Password", class: "btn btn-primary" %>
       </div>
     <% end %>
-  </div>
-</div>
+<% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2500,3 +2500,15 @@
     headings are in the brand serif. Sections, order and cards are unchanged.
   pro_tips:
     - "The section colours, the cream page background, and the rainbow rule now use the exact values from the AWBW brand guide."
+
+- name: "Sign-in and password pages in the AWBW brand"
+  area: people
+  display_status: public_facing
+  released_on: 2026-08-28
+  action_path: "/users/sign_in"
+  summary: >-
+    Signing in, resetting a password, and the confirmation and unlock pages now
+    share one branded card — AWBW logo, rainbow rule, serif heading. Form submit
+    buttons across the whole portal are brand navy instead of a generic blue.
+  pro_tips:
+    - "Every form's submit button was being forced to a non-brand blue by a leftover setting; they now use the brand button the views already asked for."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2505,6 +2505,7 @@
   area: people
   display_status: public_facing
   released_on: 2026-08-28
+  pr_number: 2399
   action_path: "/users/sign_in"
   summary: >-
     Signing in, resetting a password, and the confirmation and unlock pages now

--- a/config/initializers/simple_form_tailwind.rb
+++ b/config/initializers/simple_form_tailwind.rb
@@ -2,7 +2,7 @@
 
 SimpleForm.setup do |config|
   # Default button class
-  config.button_class = "px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 focus:ring focus:ring-blue-300 focus:outline-none"
+  config.button_class = "btn btn-primary"
 
   # Default wrapper for Tailwind
   config.wrappers :tailwind_form, class: "mb-4" do |b|

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe "page_bg_class alignment with policies" do
 
     # ─── admin-or-auth (policy: authenticated?) ───
     "app/views/organizations/index.html.erb"           => "admin-or-auth",
+    "app/views/devise/sessions/new.html.erb"            => "public",
+    "app/views/devise/passwords/new.html.erb"           => "public",
+    "app/views/devise/passwords/edit.html.erb"          => "public",
+    "app/views/devise/confirmations/new.html.erb"       => "public",
+    "app/views/devise/unlocks/new.html.erb"             => "public",
     "app/views/people/index.html.erb"                  => "admin-or-auth",
     "app/views/workshop_logs/index.html.erb"           => "admin-or-auth",
     "app/views/features/index.html.erb"                => "admin-or-auth",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only restyle, but it changes a global simple_form default that affects every submit button in the app

Signing in, resetting a password, and the confirmation and unlock pages now share one branded card, and form buttons across the portal are brand navy instead of a generic blue.

### The blue button wasn't the view's fault
`config/initializers/simple_form_tailwind.rb` hard-coded

```
config.button_class = "px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg …"
```

**46 of the app's 47 `f.button :submit` calls already pass `btn btn-primary`** — and `bg-blue-600` is a *utility*, so it beat the `.btn-primary` *component* class every time. Every form in the app was rendering a non-brand blue button while its view asked for navy. `button_class` is now `btn btn-primary`; views passing their own variant still win, since those component classes are defined later in `buttons.css`.

This is the wide-reaching part of the PR — worth a look.

### One shared auth card
Each devise screen had its own copy of the same `max-w-md` white card. They now render through `devise/_auth_card`: AWBW logo, rainbow rule, `font-display` heading, subtitle, one shared field style, full-width submit.

Covers sign in · forgot password · set password · resend confirmation · resend unlock · change password.

`links: false` exists because `devise_mapping` is only defined inside a Devise controller — the change-password page is served by `UsersController` and 500s without it.

### Smaller fixes found along the way
- `devise/shared/_links` used `text-black-300`, which isn't a Tailwind colour, so every auth link rendered unstyled.
- The sign-in email field used `focus:border-indigo-500 focus:ring-indigo-500`, the lone outlier from the documented `focus:border-blue-500 focus:ring-blue-200` convention.
- `devise/registrations/{new,edit}` are untouched: `:registerable` isn't in the User model's devise modules, so those views are unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)