### PR TITLE
Sortable forms index with role column and kebab actions menu

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -147,21 +147,25 @@ class FormsController < ApplicationController
 
   private
 
-  # Sorts the standalone forms for the index frame. Direction is whitelisted to
-  # "asc"/"desc", so it's safe to interpolate into the order clause. Count
-  # columns join their association and order by the aggregate.
+  # Sorts the standalone forms for the index frame. Count columns join their
+  # association and order by the aggregate; direction is a symbol resolved from
+  # the whitelisted param, never interpolated into raw SQL.
   def sorted_forms
-    scope = Form.standalone
+    direction = @sort_direction == "desc" ? :desc : :asc
     case @sort
     when "role"
-      scope.reorder(Arel.sql("role #{@sort_direction}")).order(:name)
+      Form.standalone.reorder(role: direction, name: :asc)
     when "fields"
-      scope.left_joins(:form_fields).group(:id).reorder(Arel.sql("COUNT(form_fields.id) #{@sort_direction}"))
+      order_by_count(Form.standalone.left_joins(:form_fields), Arel.sql("COUNT(form_fields.id)"), direction)
     when "submissions"
-      scope.left_joins(:form_submissions).group(:id).reorder(Arel.sql("COUNT(form_submissions.id) #{@sort_direction}"))
+      order_by_count(Form.standalone.left_joins(:form_submissions), Arel.sql("COUNT(form_submissions.id)"), direction)
     else
-      scope.reorder(Arel.sql("name #{@sort_direction}"))
+      Form.standalone.reorder(name: direction)
     end
+  end
+
+  def order_by_count(scope, count_expr, direction)
+    scope.group(:id).reorder(direction == :desc ? count_expr.desc : count_expr.asc)
   end
 
   # Custom section header ids that were present on the page but left unchecked,

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -2,9 +2,18 @@ class FormsController < ApplicationController
   before_action :set_form, only: %i[show results edit update destroy copy reorder_field reorder_fields edit_sections update_sections]
   before_action :set_dashboard_event, only: %i[show edit edit_sections update update_sections]
 
+  SORTABLE_COLUMNS = %w[name role fields submissions].freeze
+
   def index
     authorize!
-    @forms = Form.standalone.order(:name)
+    if turbo_frame_request?
+      @sort = SORTABLE_COLUMNS.include?(params[:sort]) ? params[:sort] : "name"
+      @sort_direction = params[:direction] == "desc" ? "desc" : "asc"
+      @forms = sorted_forms
+      render :forms_results
+    else
+      render :index
+    end
   end
 
   # Reference page for the field identifiers that wire a question to backend
@@ -137,6 +146,23 @@ class FormsController < ApplicationController
   end
 
   private
+
+  # Sorts the standalone forms for the index frame. Direction is whitelisted to
+  # "asc"/"desc", so it's safe to interpolate into the order clause. Count
+  # columns join their association and order by the aggregate.
+  def sorted_forms
+    scope = Form.standalone
+    case @sort
+    when "role"
+      scope.reorder(Arel.sql("role #{@sort_direction}")).order(:name)
+    when "fields"
+      scope.left_joins(:form_fields).group(:id).reorder(Arel.sql("COUNT(form_fields.id) #{@sort_direction}"))
+    when "submissions"
+      scope.left_joins(:form_submissions).group(:id).reorder(Arel.sql("COUNT(form_submissions.id) #{@sort_direction}"))
+    else
+      scope.reorder(Arel.sql("name #{@sort_direction}"))
+    end
+  end
 
   # Custom section header ids that were present on the page but left unchecked,
   # i.e. the custom sections the user chose to remove.

--- a/app/views/forms/_results_skeleton.html.erb
+++ b/app/views/forms/_results_skeleton.html.erb
@@ -1,0 +1,30 @@
+<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+  <table class="w-full border-collapse">
+    <thead class="bg-gray-100 animate-pulse">
+      <tr>
+        <% 5.times do %>
+          <th class="px-4 py-2 text-left">
+            <div class="h-4 w-20 rounded bg-gray-200"></div>
+          </th>
+        <% end %>
+        <th class="px-4 py-2">
+          <div class="h-4 w-6 ml-auto rounded bg-gray-200"></div>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-200 animate-pulse">
+      <% 3.times do %>
+        <tr>
+          <% 5.times do %>
+            <td class="px-4 py-3">
+              <div class="h-4 w-16 rounded bg-gray-200"></div>
+            </td>
+          <% end %>
+          <td class="px-4 py-3 text-right">
+            <div class="h-6 w-6 ml-auto rounded bg-gray-200"></div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/forms/forms_results.html.erb
+++ b/app/views/forms/forms_results.html.erb
@@ -1,0 +1,83 @@
+<%= turbo_frame_tag :forms_results do %>
+  <% sort_link = sort_header_link(frame: "forms_results", path: ->(p) { forms_path(p) }) %>
+  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+    <table class="w-full border-collapse">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("name", "Name") %></th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("role", "Role") %></th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Availability</th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("fields", "Fields") %></th>
+          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700"><%= sort_link.call("submissions", "Submissions") %></th>
+          <th class="px-4 py-2"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200">
+        <% @forms.each do |form| %>
+          <tr id="form_<%= form.id %>" class="scroll-mt-24 hover:bg-gray-50">
+            <td class="px-4 py-2 text-sm font-medium text-gray-900">
+              <%= form.display_name %>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-600"><%= form_role_label(form) %></td>
+            <%# A public link and an event form are mutually exclusive — an
+                event-connected form is never offered publicly — so at most one
+                chip applies. %>
+            <td class="px-4 py-2 text-sm text-gray-600">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <% if form.publicly_fillable? %>
+                  <%= link_to public_form_path(form.slug), target: "_blank", rel: "noopener",
+                              class: "inline-flex items-center gap-1.5 rounded-md bg-green-50 px-2 py-0.5 text-green-700 font-medium hover:bg-green-100" do %>
+                    <i class="fa-solid fa-link text-xs"></i>/f/<%= form.slug %>
+                  <% end %>
+                <% end %>
+                <% if form.events.size.positive? %>
+                  <span class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+                    <i class="fa-solid fa-calendar-day"></i>Event form
+                  </span>
+                  <%= link_to pluralize(form.events.size, "event"), events_path(form_id: form.id), class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
+                <% end %>
+                <% unless form.publicly_fillable? || form.events.size.positive? %>
+                  <span class="inline-flex items-center rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500">Not published</span>
+                <% end %>
+              </div>
+            </td>
+            <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_fields.size %></td>
+            <td class="px-4 py-2 text-sm text-gray-600">
+              <% submissions_count = form.form_submissions.size %>
+              <% if submissions_count.positive? %>
+                <%= link_to submissions_count, form_submissions_path(form_id: form.id, return_to: "forms"),
+                            class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
+              <% else %>
+                0
+              <% end %>
+            </td>
+            <td class="px-4 py-2 text-right text-sm">
+              <% dropdown_id = "form-actions-menu-#{form.id}" %>
+              <% item_class = "block whitespace-nowrap px-4 py-2 text-sm text-gray-700 hover:bg-gray-50" %>
+              <div data-controller="dropdown" class="relative inline-block text-left">
+                <button type="button"
+                        data-action="dropdown#toggle"
+                        data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
+                        class="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                        aria-label="Form actions">
+                  <i class="fa-solid fa-ellipsis-vertical"></i>
+                </button>
+                <div id="<%= dropdown_id %>"
+                     data-dropdown-target="content"
+                     class="hidden absolute right-0 z-10 mt-1 min-w-[160px] rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                  <%= link_to "Results", results_form_path(form), class: item_class %>
+                  <%= link_to "View", form_path(form), class: item_class %>
+                  <%= link_to "Edit", edit_form_path(form), class: item_class %>
+                  <% if allowed_to?(:copy?, form) %>
+                    <%= link_to "Copy", copy_form_path(form), class: item_class,
+                                data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
+                  <% end %>
+                </div>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -16,74 +16,9 @@
     </div>
   </div>
 
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-    <table class="w-full border-collapse">
-      <thead class="bg-gray-100">
-        <tr>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Fields</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Events</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Availability</th>
-          <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Submissions</th>
-          <th class="px-4 py-2"></th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200">
-        <% @forms.each do |form| %>
-          <tr id="form_<%= form.id %>" class="scroll-mt-24 hover:bg-gray-50">
-            <td class="px-4 py-2 text-sm font-medium text-gray-900">
-              <%= form.display_name %>
-            </td>
-            <td class="px-4 py-2 text-sm text-gray-600"><%= form.form_fields.size %></td>
-            <td class="px-4 py-2 text-sm text-gray-600">
-              <% if form.events.size.positive? %>
-                <%= link_to form.events.size, events_path(form_id: form.id), class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
-              <% else %>
-                0
-              <% end %>
-            </td>
-            <%# A public link and an event form are mutually exclusive — an
-                event-connected form is never offered publicly — so at most one
-                chip applies. %>
-            <td class="px-4 py-2 text-sm text-gray-600">
-              <div class="flex flex-wrap items-center gap-1.5">
-                <% if form.publicly_fillable? %>
-                  <%= link_to public_form_path(form.slug), target: "_blank", rel: "noopener",
-                              class: "inline-flex items-center gap-1.5 rounded-md bg-green-50 px-2 py-0.5 text-green-700 font-medium hover:bg-green-100" do %>
-                    <i class="fa-solid fa-link text-xs"></i>/f/<%= form.slug %>
-                  <% end %>
-                <% end %>
-                <% if form.events.size.positive? %>
-                  <span class="inline-flex items-center gap-1.5 rounded-md <%= DomainTheme.bg_class_for(:forms) %> px-2 py-0.5 text-xs <%= DomainTheme.text_class_for(:forms, intensity: 700) %>">
-                    <i class="fa-solid fa-calendar-day"></i>Event form
-                  </span>
-                <% end %>
-                <% unless form.publicly_fillable? || form.events.size.positive? %>
-                  <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-500">Not published</span>
-                <% end %>
-              </div>
-            </td>
-            <td class="px-4 py-2 text-sm text-gray-600">
-              <% submissions_count = form.form_submissions.size %>
-              <% if submissions_count.positive? %>
-                <%= link_to submissions_count, form_submissions_path(form_id: form.id, return_to: "forms"),
-                            class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
-              <% else %>
-                0
-              <% end %>
-            </td>
-            <td class="space-x-3 px-4 py-2 text-right text-sm">
-              <%= link_to "Results", results_form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
-              <%= link_to "View", form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
-              <%= link_to "Edit", edit_form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
-              <% if allowed_to?(:copy?, form) %>
-                <%= link_to "Copy", copy_form_path(form), class: "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline",
-                            data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+  <% result_src = forms_path + "?" + request.query_string %>
+
+  <%= turbo_frame_tag :forms_results, src: result_src, data: { turbo: "temporary" } do %>
+    <%= render "results_skeleton" %>
+  <% end %>
 </div>

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -8,16 +8,30 @@ RSpec.describe "Forms", type: :request do
     context "as admin" do
       before { sign_in admin }
 
-      it "lists standalone forms" do
+      let(:frame_headers) { { "Turbo-Frame" => "forms_results" } }
+
+      it "renders the index shell" do
         create(:form, :standalone, name: "My Form")
         get forms_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "lists standalone forms in the results frame" do
+        create(:form, :standalone, name: "My Form")
+        get forms_path, headers: frame_headers
         expect(response).to have_http_status(:success)
         expect(response.body).to include("My Form")
       end
 
+      it "shows the form role in the results frame" do
+        create(:form, :standalone, name: "New Job Form", role: "new_job")
+        get forms_path, headers: frame_headers
+        expect(response.body).to include("New Job")
+      end
+
       it "shows the public link for a published form" do
         create(:form, :standalone, name: "Volunteer", slug: "volunteer", published: true)
-        get forms_path
+        get forms_path, headers: frame_headers
         expect(response.body).to include(public_form_path("volunteer"))
         expect(response.body).to include("/f/volunteer")
       end
@@ -25,27 +39,41 @@ RSpec.describe "Forms", type: :request do
       it "marks an event-connected unpublished form as an event form, not 'Not published'" do
         form = create(:form, :standalone, name: "Reg Form")
         EventForm.create!(form: form, event: create(:event), role: "registration")
-        get forms_path
+        get forms_path, headers: frame_headers
         expect(response.body).to include("Event form")
       end
 
       it "shows only the event-form chip, not a public link, when a published form is connected to an event" do
         form = create(:form, :standalone, name: "Dual Form", slug: "dual", published: true)
         EventForm.create!(form: form, event: create(:event), role: "registration")
-        get forms_path
+        get forms_path, headers: frame_headers
         expect(response.body).not_to include("/f/dual")
         expect(response.body).to include("Event form")
       end
 
       it "marks a standalone form with no events and no public link as not published" do
         create(:form, :standalone, name: "Orphan Form")
-        get forms_path
+        get forms_path, headers: frame_headers
         expect(response.body).to include("Not published")
       end
 
+      it "orders forms by name ascending by default" do
+        create(:form, :standalone, name: "Zebra")
+        create(:form, :standalone, name: "Alpha")
+        get forms_path, headers: frame_headers
+        expect(response.body.index("Alpha")).to be < response.body.index("Zebra")
+      end
+
+      it "sorts by name descending when requested" do
+        create(:form, :standalone, name: "Zebra")
+        create(:form, :standalone, name: "Alpha")
+        get forms_path(sort: "name", direction: "desc"), headers: frame_headers
+        expect(response.body.index("Zebra")).to be < response.body.index("Alpha")
+      end
+
       it "has no Delete link" do
-        form = create(:form, :standalone, name: "My Form")
-        get forms_path
+        create(:form, :standalone, name: "My Form")
+        get forms_path, headers: frame_headers
         expect(response.body).not_to include(">Delete<")
       end
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained controller sorting + one index page reworked into a lazy frame

Facilitators manage a growing list of standalone forms, so the forms index now shows each form's role, sorts by clicking a column header, and tucks the per-row actions into a kebab menu to keep the table scannable.

### What is the goal of this PR and why is this important?
- Surface each form's **Role** so the list is scannable at a glance.
- Make column headers **click-to-sort** (Name, Role, Fields, Submissions), matching the community news pattern.
- Move **Results / View / Edit / Copy** into a **⋮ kebab menu** per row.

### How did you approach the change?
- Converted the index to the lazy Turbo-frame pattern (`forms_results` frame + skeleton); the controller sorts in a whitelisted `sorted_forms` (count columns join their association, direction is a symbol — no raw SQL interpolation).
- Reused the existing `sort_header_link` helper and `dropdown` Stimulus controller — no new JS.
- Reworked the Availability column: the events count moved next to the "Event form" chip (now reads "4 events"), and the info chips ("Event form", "Not published") are outlined/neutral so they read as info, not clickable links.

### Anything else to add?
No system spec covers the kebab/sort interaction yet; request-spec coverage was added for role display and name sorting.