### PR TITLE
Fix the affiliation badge spec failing after 5pm Pacific

### DIFF
--- a/spec/requests/people_affiliation_status_badges_spec.rb
+++ b/spec/requests/people_affiliation_status_badges_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 # The server-rendered half of the affiliation editor's status badges. The live
 # half (badges following the start date as it's edited) is spec/system/upcoming_badge_spec.rb.
 RSpec.describe "Affiliation status badges on the person edit form", type: :request do
-  let(:admin) { create(:user, :admin) }
+  # Requests render in the signed-in user's zone (ApplicationController
+  # #set_time_zone_from_user), so pin it to the spec process's own zone —
+  # otherwise "starts today" straddles a date boundary depending on the hour.
+  # Same guard as the live half in spec/system/upcoming_badge_spec.rb.
+  let(:admin) { create(:user, :admin, time_zone: Time.zone.name) }
   let(:person) { create(:person) }
   let(:org) { create(:organization) }
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line spec change, but the reasoning matters more than the diff

`spec/requests/people_affiliation_status_badges_spec.rb` is failing on `main` right now, and has been failing every evening. It is a time-of-day flake, not a real regression — the app code is correct.

### What's happening
`ApplicationController` wraps every request in the viewer's zone:

```ruby
around_action :set_time_zone_from_user   # user zone, default Pacific
```

The spec builds its dates in the test default of **UTC**. Between **00:00 and 07:00 UTC** (17:00–00:00 Pacific) those two disagree about what "today" is, so:

- Spec creates the row with `start_date: Date.current` → **2026-08-29** (UTC's today)
- View evaluates `start_date > Date.current` in Pacific, where today is **2026-08-28**
- `2026-08-29 > 2026-08-28` → the row renders as **Upcoming**

The view is right. To a viewer in Pacific, a row dated tomorrow *is* upcoming. The spec was asserting UTC's "today" against Pacific's.

### The fix
Pin the viewer's zone to the spec process's own, which is **the guard the live half of this feature already uses** in `spec/system/upcoming_badge_spec.rb` — its comment even names `set_time_zone_from_user`:

```ruby
let(:admin) { create(:user, :admin, time_zone: Time.zone.name) }
```

### How I confirmed it isn't a regression
It fails identically on a clean checkout of `origin/main`, and on a branch whose only diff is two unrelated view files. I traced it by dumping the model's computed flags (all four rows correct) against the rendered DOM (`StartsToday` showing both badges) — the split told me the view was evaluating in a different zone.

I first fixed this with `travel_to` a fixed moment, then switched to the zone-pinning approach so both halves of this feature guard it the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)