### PR TITLE
Bring the admin and staff-only pages into the AWBW brand

### DIFF
--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -51,7 +51,7 @@
   <% end %>
 
   <!-- Activities Table -->
-  <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
+  <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm blur-on-submit">
     <table class="responsive-table min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50 text-xs tracking-wider text-gray-600 uppercase">
       <tr>

--- a/app/views/admin/ahoy_activities/charts.html.erb
+++ b/app/views/admin/ahoy_activities/charts.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
       <div class="mb-2 flex flex-wrap items-center gap-y-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
           <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -13,7 +13,7 @@
       </div>
 
       <div class="mb-6 flex items-baseline gap-3 leading-none">
-        <h1 class="text-2xl leading-none font-semibold text-gray-900">Charts</h1>
+        <h1 class="text-primary font-display text-2xl leading-none font-semibold">Charts</h1>
       </div>
 
       <div class="mb-6 flex min-h-10 flex-wrap items-start justify-between gap-3 text-sm">
@@ -46,7 +46,7 @@
       </div>
 
       <section>
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <% has_users = @audience_labels.include?("users")
              has_staff = @audience_labels.include?("staff")
              audience_note = if has_users && has_staff
@@ -131,7 +131,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Engagement patterns</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= link_to admin_activities_visits_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
@@ -158,7 +158,7 @@
               </div>
             <% end %>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-2 text-sm font-semibold text-gray-700">Avg activities per visit</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 tabular-nums"><%= @avg_events_per_visit %></div>
@@ -192,14 +192,14 @@
             <% end %>
 
             <div class="flex flex-col gap-4">
-              <div class="flex-1 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+              <div class="border-primary/10 flex-1 rounded-2xl border bg-white p-4 shadow-sm">
                 <h3 class="mb-1 text-sm font-semibold text-gray-700">Avg session duration</h3>
                 <div class="flex flex-col items-center justify-center py-2">
                   <div class="text-3xl font-bold text-gray-900 tabular-nums"><%= @avg_session_minutes %></div>
                   <div class="mt-1 text-xs text-gray-400">Minutes per session</div>
                 </div>
               </div>
-              <div class="flex-1 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+              <div class="border-primary/10 flex-1 rounded-2xl border bg-white p-4 shadow-sm">
                 <h3 class="mb-1 text-sm font-semibold text-gray-700">Public activities</h3>
                 <div class="flex flex-col items-center justify-center py-2">
                   <div class="text-3xl font-bold text-gray-900 tabular-nums"><%= @public_events_pct %>%</div>
@@ -269,7 +269,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Workshop analytics</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= chart_card("Workshop search: category types") { bar_chart(@ws_category_types) } %>
@@ -286,7 +286,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Resource analytics</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= chart_card("Resource search: keywords") { bar_chart(@rs_keywords) } %>
@@ -297,7 +297,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Tag analytics</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= link_to tags_path, class: "group relative bg-white border border-gray-200 rounded-xl shadow-sm p-6 hover:bg-blue-50 hover:border-blue-300 hover:shadow-md transition-all" do %>
@@ -316,7 +316,7 @@
               </div>
             <% end %>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-2 text-sm font-semibold text-gray-700">Tagging searches</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@tagging_searches) %></div>
@@ -329,7 +329,7 @@
 
             <%= chart_card("Tagging search origin") { pie_chart(@tagging_search_origin) } %>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm md:col-span-2 xl:col-span-2">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm md:col-span-2 xl:col-span-2">
               <h3 class="mb-4 text-sm font-semibold text-gray-700">Top filter combinations</h3>
               <ul class="space-y-1 text-sm text-gray-700">
                 <% @top_filter_combos.each do |label, count| %>
@@ -346,7 +346,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Content discovery</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= chart_card("Content types people view most") do %>
@@ -376,17 +376,17 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Content creation</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-2 text-sm font-semibold text-gray-700">Ideas submitted</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@ideas_submitted) %></div>
               </div>
             </div>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-2 text-sm font-semibold text-gray-700">Ideas promoted</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@ideas_promoted) %></div>
@@ -394,14 +394,14 @@
               </div>
             </div>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-2 text-sm font-semibold text-gray-700">Avg ideas per person</h3>
               <div class="flex flex-col items-center justify-center py-4">
                 <div class="text-5xl font-bold text-gray-900 tabular-nums"><%= @avg_ideas_per_person %></div>
               </div>
             </div>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-4 text-sm font-semibold text-gray-700">Total content created</h3>
               <ul class="space-y-1 text-sm text-gray-700">
                 <% @total_generated_content.each do |row| %>
@@ -426,7 +426,7 @@
               </ul>
             </div>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-4 text-sm font-semibold text-gray-700">User-generated content</h3>
               <ul class="space-y-1 text-sm text-gray-700">
                 <% @user_generated_content.each do |label, count, promoted| %>
@@ -442,7 +442,7 @@
               </ul>
             </div>
 
-            <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
               <h3 class="mb-4 text-sm font-semibold text-gray-700">Admin-generated content</h3>
               <ul class="space-y-1 text-sm text-gray-700">
                 <% @admin_generated_content.each do |row| %>
@@ -467,7 +467,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Referrals & technical</h2>
           <div class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
             <%= chart_card("Top referrer → landing pages") do %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-primary/10 rounded-2xl shadow-sm p-6">
 
       <div class="flex flex-wrap items-center gap-y-2 mb-2">
         <%# Scoped to a person (from their edit page's History card, or the filter) —
@@ -21,7 +21,7 @@
       </div>
 
       <div class="flex items-baseline gap-3 mb-6 leading-none">
-        <h1 class="text-2xl font-semibold text-gray-900 leading-none">Activities</h1>
+        <h1 class="font-display text-2xl font-semibold text-primary leading-none">Activities</h1>
         <%= render "count" %>
       </div>
 
@@ -29,7 +29,7 @@
         <%= render "admin/shared/active_filters_subheader" %>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mb-6">
+      <div class="bg-white border border-primary/10 rounded-2xl shadow-sm p-6 mb-6">
         <%# Selects submit on change and the text boxes debounce-submit as you type,
             all into the activity_results frame — the filter form stays put (and
             focused) while just the rows swap. %>

--- a/app/views/admin/ahoy_activities/show.html.erb
+++ b/app/views/admin/ahoy_activities/show.html.erb
@@ -1,29 +1,29 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
 
       <!-- Header -->
-      <div class="flex items-center justify-between mb-6">
-        <h1 class="text-2xl font-semibold text-gray-900">Activity detail</h1>
+      <div class="mb-6 flex items-center justify-between">
+        <h1 class="text-primary font-display text-2xl font-semibold">Activity detail</h1>
         <%= link_to "Back to Activities",
                     admin_activities_events_path,
                     class: "text-indigo-600 hover:underline text-sm" %>
       </div>
 
       <!-- Activity Info -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mb-6">
+      <div class="border-primary/10 mb-6 rounded-2xl border bg-white p-6 shadow-sm">
         <dl class="divide-y divide-gray-100 text-sm">
-          <div class="py-3 flex items-baseline gap-4">
-            <dt class="text-gray-500 font-medium w-28 shrink-0">Activity name</dt>
+          <div class="flex items-baseline gap-4 py-3">
+            <dt class="w-28 shrink-0 font-medium text-gray-500">Activity name</dt>
             <dd class="text-gray-900"><%= @event.name %></dd>
           </div>
 
-          <div class="py-3 flex items-baseline gap-4">
-            <dt class="text-gray-500 font-medium w-28 shrink-0">Time</dt>
+          <div class="flex items-baseline gap-4 py-3">
+            <dt class="w-28 shrink-0 font-medium text-gray-500">Time</dt>
             <dd class="text-gray-900"><%= @event.time.in_time_zone.strftime("%Y-%m-%d %H:%M:%S %Z") %></dd>
           </div>
 
-          <div class="py-3 flex items-baseline gap-4">
-            <dt class="text-gray-500 font-medium w-28 shrink-0">User</dt>
+          <div class="flex items-baseline gap-4 py-3">
+            <dt class="w-28 shrink-0 font-medium text-gray-500">User</dt>
             <dd>
               <% if @event.user %>
                 <%= link_to @event.user.full_name,
@@ -35,8 +35,8 @@
             </dd>
           </div>
 
-          <div class="py-3 flex items-baseline gap-4">
-            <dt class="text-gray-500 font-medium w-28 shrink-0">Visit ID</dt>
+          <div class="flex items-baseline gap-4 py-3">
+            <dt class="w-28 shrink-0 font-medium text-gray-500">Visit ID</dt>
             <dd>
               <%= link_to @event.visit_id,
                           admin_activities_visits_path(visit_id: @event.visit_id),
@@ -45,8 +45,8 @@
           </div>
 
           <% if @event.resource_type.present? %>
-            <div class="py-3 flex items-baseline gap-4">
-              <dt class="text-gray-500 font-medium w-28 shrink-0">Resource</dt>
+            <div class="flex items-baseline gap-4 py-3">
+              <dt class="w-28 shrink-0 font-medium text-gray-500">Resource</dt>
               <dd class="text-gray-900">
                 <% if @resource_path %>
                   <%= link_to "#{@event.resource_type}.find(#{@event.resource_id})",
@@ -62,8 +62,8 @@
       </div>
 
       <!-- Properties -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-4">Properties</h2>
+      <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
+        <h2 class="mb-4 text-lg font-semibold text-gray-900">Properties</h2>
 
         <% if @event.properties.present? && @event.properties.any? %>
           <%
@@ -77,15 +77,15 @@
           <dl class="divide-y divide-gray-100">
             <% ordered_keys.each do |key|
               value = @event.properties[key] %>
-              <div class="py-3 flex items-baseline gap-4">
-                <dt class="text-sm font-medium text-gray-500 w-36 shrink-0"><%= key %></dt>
+              <div class="flex items-baseline gap-4 py-3">
+                <dt class="w-36 shrink-0 text-sm font-medium text-gray-500"><%= key %></dt>
                 <dd class="text-sm text-gray-900">
                   <% if key == "resource_title" && @resource_path %>
                     <%= link_to value.to_s.delete('"'), @resource_path, class: "text-indigo-600 hover:underline" %>
                   <% elsif value.nil? %>
                     <span class="text-gray-400 italic">nil</span>
                   <% elsif value.is_a?(Hash) || value.is_a?(Array) %>
-                    <pre class="bg-gray-50 rounded-lg p-3 overflow-x-auto text-xs"><%= JSON.pretty_generate(value).delete('"') %></pre>
+                    <pre class="overflow-x-auto rounded-lg bg-gray-50 p-3 text-xs"><%= JSON.pretty_generate(value).delete('"') %></pre>
                   <% else %>
                     <%= value.to_s.delete('"') %>
                   <% end %>
@@ -94,7 +94,7 @@
             <% end %>
           </dl>
         <% else %>
-          <p class="text-gray-400 italic text-sm">No properties</p>
+          <p class="text-sm text-gray-400 italic">No properties</p>
         <% end %>
       </div>
 </div>

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
 
-      <div class="flex flex-wrap items-center gap-y-2 mb-2">
+      <div class="mb-2 flex flex-wrap items-center gap-y-2">
         <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
           <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fas fa-arrow-left"></i>
@@ -13,24 +13,24 @@
         </div>
       </div>
 
-      <div class="flex items-baseline gap-3 mb-6 leading-none">
-        <h1 class="text-2xl font-semibold text-gray-900 leading-none">Visits</h1>
-        <span class="text-sm text-gray-500 leading-none"><%= @visits.total_entries %> total</span>
+      <div class="mb-6 flex items-baseline gap-3 leading-none">
+        <h1 class="text-primary font-display text-2xl leading-none font-semibold">Visits</h1>
+        <span class="text-sm leading-none text-gray-500"><%= @visits.total_entries %> total</span>
       </div>
 
-      <div class="mb-6 text-sm min-h-10">
+      <div class="mb-6 min-h-10 text-sm">
         <%= render "admin/shared/active_filters_subheader" %>
       </div>
 
       <!-- Filters -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mb-6">
+      <div class="border-primary/10 mb-6 rounded-2xl border bg-white p-6 shadow-sm">
         <%= form_with url: request.path, method: :get, local: true do %>
 
-          <div class="flex flex-wrap lg:flex-nowrap gap-4">
+          <div class="flex flex-wrap gap-4 lg:flex-nowrap">
 
             <!-- User Filter -->
-            <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
+            <div class="min-w-0 flex-1">
+              <label class="mb-1 block text-sm font-medium text-gray-600">
                 User
               </label>
               <%= text_field_tag :user_search,
@@ -40,13 +40,13 @@
             </div>
 
             <!-- Audience -->
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
             </div>
 
             <!-- Time Period -->
-            <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
+            <div class="min-w-0 flex-1">
+              <label class="mb-1 block text-sm font-medium text-gray-600">
                 Time Period
               </label>
               <%= select_tag :time_period,
@@ -58,8 +58,8 @@
             </div>
 
             <!-- Date From -->
-            <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
+            <div class="min-w-0 flex-1">
+              <label class="mb-1 block text-sm font-medium text-gray-600">
                 From
               </label>
               <%= date_field_tag :from, params[:from],
@@ -67,8 +67,8 @@
             </div>
 
             <!-- Date To -->
-            <div class="flex-1 min-w-0">
-              <label class="block text-sm font-medium text-gray-600 mb-1">
+            <div class="min-w-0 flex-1">
+              <label class="mb-1 block text-sm font-medium text-gray-600">
                 To
               </label>
               <%= date_field_tag :to, params[:to],
@@ -78,7 +78,7 @@
           </div>
 
           <!-- Quick Ranges -->
-          <div class="flex items-center gap-3 mt-6 text-sm">
+          <div class="mt-6 flex items-center gap-3 text-sm">
             <span class="text-gray-500">Quick:</span>
             <% safe_params = params.slice(:user_id, :user_search, :from, :to).to_unsafe_h %>
             <%= link_to "24h",
@@ -103,9 +103,9 @@
       </div>
 
       <!-- Table -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
         <table class="min-w-full divide-y divide-gray-200 text-sm">
-          <thead class="bg-gray-50 text-gray-600 uppercase tracking-wider text-xs">
+          <thead class="bg-gray-50 text-xs tracking-wider text-gray-600 uppercase">
           <tr>
             <th class="px-4 py-3 text-left">ID</th>
             <th class="px-4 py-3 text-left">Started</th>
@@ -118,12 +118,12 @@
 
           <tbody class="divide-y divide-gray-100">
           <% @visits.each do |visit| %>
-            <tr class="hover:bg-gray-50 transition">
+            <tr class="transition hover:bg-gray-50">
               <td class="px-4 py-3 text-gray-700">
                 <%= visit.id %>
               </td>
 
-              <td class="px-4 py-3 text-gray-500 whitespace-nowrap">
+              <td class="px-4 py-3 whitespace-nowrap text-gray-500">
                 <%= visit.started_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
               </td>
 
@@ -146,7 +146,7 @@
                             admin_activities_events_path(visit_id: visit.id) %>
               </td>
 
-              <td class="px-4 py-3 text-gray-500 max-w-xs">
+              <td class="max-w-xs px-4 py-3 text-gray-500">
                 <%= visit.user_agent %>
               </td>
             </tr>
@@ -155,7 +155,7 @@
         </table>
       </div>
 
-      <div class="flex justify-center mt-8">
+      <div class="mt-8 flex justify-center">
         <%= tailwind_paginate @visits %>
       </div>
 </div>

--- a/app/views/admin/analytics/index.html.erb
+++ b/app/views/admin/analytics/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-2 flex flex-wrap items-center gap-y-2">
     <% if allowed_to?(:index?, with: Admin::HomePolicy) %>
       <%= link_to admin_path, class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -13,7 +13,7 @@
   </div>
 
   <div class="mb-6 flex items-baseline gap-3 leading-none">
-    <h1 class="text-2xl leading-none font-semibold text-gray-900">Counts</h1>
+    <h1 class="text-primary font-display text-2xl leading-none font-semibold">Counts</h1>
   </div>
 
   <div class="mb-6 flex min-h-10 flex-wrap items-start justify-between gap-3 text-sm">
@@ -44,7 +44,7 @@
 
       <!-- Summary -->
       <section>
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">
             View counts
           </h2>
@@ -52,7 +52,7 @@
           <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
             <% @summary.each do |label, data| %>
               <%= link_to polymorphic_path(label.to_s.classify.constantize), class: "block group" do %>
-                <div class="<%= DomainTheme.bg_class_for(label) %> relative min-h-[120px] rounded-xl border border-gray-200 p-5 shadow-sm transition hover:shadow-md">
+                <div class="<%= DomainTheme.bg_class_for(label) %> border-primary/10 relative min-h-[120px] rounded-2xl border p-5 shadow-sm transition hover:shadow-md">
                   <i class="fa-solid fa-arrow-up-right-from-square text-2xs absolute top-3 right-3 text-gray-400 transition-colors group-hover:text-blue-600"></i>
                   <div class="pr-4 text-xs font-semibold tracking-wide text-gray-500 uppercase">
                     <%= label.to_s.humanize %>
@@ -78,7 +78,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Workshops</h2>
           <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
             <%= render "admin/analytics/popular_list",
@@ -101,7 +101,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Resources</h2>
           <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
             <%= render "admin/analytics/popular_list",
@@ -127,7 +127,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800"><%= CommunityNews.model_name.human.pluralize %></h2>
           <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
             <%= render "admin/analytics/popular_list",
@@ -150,7 +150,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Stories</h2>
           <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
             <%= render "admin/analytics/popular_list",
@@ -173,7 +173,7 @@
       </section>
 
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">Other</h2>
           <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
             <%= render "admin/analytics/popular_list",
@@ -229,7 +229,7 @@
 
       <!-- Zero Engagement -->
       <section class="mt-6">
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <h2 class="mb-4 text-lg font-semibold text-gray-800">
             No engagement
           </h2>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,27 +1,27 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
     <section>
-      <div class="flex flex-col items-start mb-4">
-        <h1 class="text-2xl font-semibold text-gray-900">Admin home</h1>
+      <div class="mb-4 flex flex-col items-start">
+        <h1 class="text-primary font-display text-2xl font-semibold">Admin home</h1>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+      <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
       <div class="flex flex-col gap-6 md:flex-row">
         <!-- Column 1 -->
-        <div class="flex flex-col gap-2 flex-1">
+        <div class="flex flex-1 flex-col gap-2">
           Admin-generated
           <% @system_cards.each do |card| %>
             <a href="<%= card[:path] %>"
-               class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+               class="flex items-center gap-6 rounded-lg border border-gray-200 shadow-lg
                       <%= card[:bg_color] %> <%= card[:text_color] %>
-                      <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
-              <div class="text-2xl text-gray-700 flex-shrink-0">
+                      <%= card[:hover_bg_color] %> px-4 py-1 transition-colors transition-shadow duration-300">
+              <div class="flex-shrink-0 text-2xl text-gray-700">
                 <!--            <i class="fa-solid <%#= card[:icon] %>" aria-hidden="true"></i>-->
                 <%= card[:icon] %>
               </div>
 
               <div class="flex-1">
-                <h3 class="text-lg font-bold text-gray-800 break-words">
+                <h3 class="text-lg font-bold break-words text-gray-800">
                   <%= card[:title] %>
                 </h3>
               </div>
@@ -31,16 +31,16 @@
         </div>
 
         <!-- Column 2 -->
-        <div class="flex flex-col gap-2 flex-1">
+        <div class="flex flex-1 flex-col gap-2">
           User-generated
           <% @user_content_cards.each do |card| %>
             <% if card[:disabled] %>
-              <div class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+              <div class="border-primary/10 flex items-center gap-6 rounded-2xl border shadow-lg
                       <%= card[:bg_color] %> <%= card[:text_color] %>
-                      px-4 py-1 cursor-not-allowed opacity-60"
+                      cursor-not-allowed px-4 py-1 opacity-60"
                    title="Not built yet"
                    aria-disabled="true">
-                <div class="text-2xl flex-shrink-0">
+                <div class="flex-shrink-0 text-2xl">
                   <%= card[:icon] %>
                 </div>
 
@@ -50,15 +50,15 @@
               </div>
             <% else %>
               <a href="<%= card[:path] %>"
-                 class="flex items-center gap-6 rounded-lg shadow-lg border border-gray-200
+                 class="flex items-center gap-6 rounded-lg border border-gray-200 shadow-lg
                         <%= card[:bg_color] %> <%= card[:text_color] %>
-                        <%= card[:hover_bg_color] %> transition-colors transition-shadow duration-300 px-4 py-1">
-                <div class="text-2xl text-gray-700 flex-shrink-0">
+                        <%= card[:hover_bg_color] %> px-4 py-1 transition-colors transition-shadow duration-300">
+                <div class="flex-shrink-0 text-2xl text-gray-700">
                   <%= card[:icon] %>
                 </div>
 
                 <div class="flex-1">
-                  <h3 class="text-lg font-bold text-gray-800 break-words"><%= card[:title] %></h3>
+                  <h3 class="text-lg font-bold break-words text-gray-800"><%= card[:title] %></h3>
                 </div>
               </a>
             <% end %>
@@ -67,22 +67,22 @@
       </div>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mt-6">
+      <div class="border-primary/10 mt-6 rounded-2xl border bg-white p-6 shadow-sm">
         Base data
-       <div class="flex flex-wrap gap-4 mt-3">
+       <div class="mt-3 flex flex-wrap gap-4">
           <% @reference_cards.each do |card| %>
             <a href="<%= card[:path] %>"
-             class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200
+             class="flex items-center gap-3 rounded-lg border border-gray-200 shadow-lg
               <%= card[:bg_color] %> <%= card[:text_color] %>
               <%= card[:hover_bg_color] %>
-              transition-colors transition-shadow duration-300 px-4 py-1 flex-1">
+              flex-1 px-4 py-1 transition-colors transition-shadow duration-300">
 
-              <div class="text-lg text-gray-700 flex-shrink-0">
+              <div class="flex-shrink-0 text-lg text-gray-700">
                 <%= card[:icon] %>
               </div>
 
               <div>
-                <h3 class="text-sm font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
+                <h3 class="text-sm font-bold whitespace-nowrap text-gray-800"><%= card[:title] %></h3>
               </div>
 
             </a>
@@ -90,17 +90,17 @@
         </div>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 mt-6">
+      <div class="border-primary/10 mt-6 rounded-2xl border bg-white p-6 shadow-sm">
         Additional data
-       <div class="columns-1 sm:columns-2 md:columns-3 gap-2 mt-3">
+       <div class="mt-3 columns-1 gap-2 sm:columns-2 md:columns-3">
           <% @additional_data_cards.each do |card| %>
             <% if card[:disabled] %>
-              <div class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200 mb-2 break-inside-avoid
+              <div class="border-primary/10 mb-2 flex break-inside-avoid items-center gap-3 rounded-2xl border shadow-lg
                 <%= card[:bg_color] %> <%= card[:text_color] %>
-                px-4 py-1 cursor-not-allowed opacity-60"
+                cursor-not-allowed px-4 py-1 opacity-60"
                    title="Not built yet"
                    aria-disabled="true">
-                <div class="text-lg flex-shrink-0">
+                <div class="flex-shrink-0 text-lg">
                   <%= card[:icon] %>
                 </div>
 
@@ -110,17 +110,17 @@
               </div>
             <% else %>
               <a href="<%= card[:path] %>"
-               class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200 mb-2 break-inside-avoid
+               class="mb-2 flex break-inside-avoid items-center gap-3 rounded-lg border border-gray-200 shadow-lg
                 <%= card[:bg_color] %> <%= card[:text_color] %>
                 <%= card[:hover_bg_color] %>
-                transition-colors transition-shadow duration-300 px-4 py-1">
+                px-4 py-1 transition-colors transition-shadow duration-300">
 
-                <div class="text-lg text-gray-700 flex-shrink-0">
+                <div class="flex-shrink-0 text-lg text-gray-700">
                   <%= card[:icon] %>
                 </div>
 
                 <div>
-                  <h3 class="text-sm font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
+                  <h3 class="text-sm font-bold whitespace-nowrap text-gray-800"><%= card[:title] %></h3>
                 </div>
               </a>
             <% end %>
@@ -128,32 +128,32 @@
         </div>
       </div>
 
-      <div class="flex flex-col md:flex-row gap-6 mt-6">
-        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 md:w-1/2">
+      <div class="mt-6 flex flex-col gap-6 md:flex-row">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm md:w-1/2">
           Deprecated data
-         <div class="columns-1 sm:columns-2 gap-2 mt-3">
+         <div class="mt-3 columns-1 gap-2 sm:columns-2">
             <% @deprecated_data_cards.each do |card| %>
               <a href="<%= card[:path] %>"
-               class="flex items-center gap-3 rounded-lg shadow-lg border border-gray-200 mb-2 break-inside-avoid
+               class="mb-2 flex break-inside-avoid items-center gap-3 rounded-lg border border-gray-200 shadow-lg
                 <%= card[:bg_color] %> <%= card[:text_color] %>
                 <%= card[:hover_bg_color] %>
-                transition-colors transition-shadow duration-300 px-4 py-1">
+                px-4 py-1 transition-colors transition-shadow duration-300">
 
-                <div class="text-lg text-gray-700 flex-shrink-0">
+                <div class="flex-shrink-0 text-lg text-gray-700">
                   <%= card[:icon] %>
                 </div>
 
                 <div>
-                  <h3 class="text-sm font-bold text-gray-800 whitespace-nowrap"><%= card[:title] %></h3>
+                  <h3 class="text-sm font-bold whitespace-nowrap text-gray-800"><%= card[:title] %></h3>
                 </div>
               </a>
             <% end %>
           </div>
         </div>
 
-        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 md:w-1/2">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm md:w-1/2">
           Actions
-          <div class="flex flex-wrap gap-2 mt-3">
+          <div class="mt-3 flex flex-wrap gap-2">
             <% if allowed_to?(:create?, Feature) %>
               <%= button_to import_features_path,
                             class: "btn btn-primary-outline",
@@ -168,23 +168,5 @@
     </section>
 </div>
 
-<div class="hidden
-    bg-black
-    bg-gray-50 bg-gray-100 bg-gray-200 bg-gray-500
-
-    bg-red-800
-    bg-sky-100 bg-sky-200 hover:bg-sky-200
-    bg-cyan-50 bg-cyan-100 bg-cyan-200 bg-cyan-500
-    bg-pink-50 bg-pink-100 bg-pink-200 bg-pink-500
-    bg-yellow-50 bg-yellow-100 bg-yellow-200
-
-    text-gray-50 text-transparent
-    text-blue-800
-    text-green-800 text-green-200
-    text-indigo-800
-    text-orange-800
-    text-pink-800
-    text-purple-800
-    text-red-800
-    text-yellow-800">
+<div class="hidden bg-black bg-cyan-50 bg-cyan-100 bg-cyan-200 bg-cyan-500 bg-gray-50 bg-gray-100 bg-gray-200 bg-gray-500 bg-pink-50 bg-pink-100 bg-pink-200 bg-pink-500 bg-red-800 bg-sky-100 bg-sky-200 bg-yellow-50 bg-yellow-100 bg-yellow-200 text-blue-800 text-gray-50 text-green-200 text-green-800 text-indigo-800 text-orange-800 text-pink-800 text-purple-800 text-red-800 text-transparent text-yellow-800 hover:bg-sky-200">
 </div>

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -24,7 +24,7 @@
      expired ? "bg-blue-50! text-blue-500! border-blue-200!" : "bg-blue-100! text-blue-700! font-semibold border-blue-300!"
    end %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if back_path %>
       <%= link_to back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -37,7 +37,7 @@
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="mb-1 text-2xl font-semibold tracking-tight text-gray-900">Edit affiliation</h1>
+  <h1 class="text-primary mb-1 font-display text-2xl font-semibold tracking-tight">Edit affiliation</h1>
   <p class="mb-6 text-sm text-gray-500">
     <%= @affiliation.person&.full_name %> at <%= @affiliation.organization&.name %>
   </p>

--- a/app/views/allocations/allocations_results.html.erb
+++ b/app/views/allocations/allocations_results.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :allocations_results do %>
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm blur-on-submit">
     <% if @allocations.any? %>
       <% total = @allocations.respond_to?(:total_entries) ? @allocations.total_entries : @allocations.size %>
       <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">

--- a/app/views/allocations/index.html.erb
+++ b/app/views/allocations/index.html.erb
@@ -3,7 +3,7 @@
 <% if @allocatable %>
   <%# ---- Focused view for a single allocatable — chrome modeled on the edit
       scholarship page (back link, centered title with event/registrant context). ---- %>
-  <div class="mx-auto max-w-5xl <%= DomainTheme.bg_class_for(:payments) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+  <div class="mx-auto max-w-5xl <%= DomainTheme.bg_class_for(:payments) %> border border-primary/10 rounded-2xl shadow-sm p-4 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
       <% if @allocatable.is_a?(EventRegistration) && params[:return_to] == "bulk_payments" %>
         <%# Re-expand the originating submission's row and scroll to it on return. %>
@@ -43,7 +43,7 @@
       <%# ---- Scoped header: makes explicit that this lists only the allocations
           tied to this one registration, with the registrant + event named. ---- %>
       <div class="mb-8 text-center">
-        <h1 class="flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-black">
+        <h1 class="font-display flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-primary">
           <i class="fa-solid fa-money-bill-transfer <%= DomainTheme.text_class_for(:payments, intensity: 600) %>"></i>
           Allocations
         </h1>
@@ -62,7 +62,7 @@
       </div>
     <% elsif @allocatable.is_a?(ContinuingEducationRegistration) %>
       <div class="mb-8 text-center">
-        <h1 class="flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-black">
+        <h1 class="font-display flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-primary">
           <i class="fa-solid fa-money-bill-transfer <%= DomainTheme.text_class_for(:payments, intensity: 600) %>"></i>
           Allocations
         </h1>
@@ -122,14 +122,14 @@
 <% else %>
   <%# ---- Searchable list of every allocation — chrome modeled on the manage
       registrants index (left-aligned title, filter form, results table). ---- %>
-  <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:payments) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:payments) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
       <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
 
     <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900">All allocations</h1>
+        <h1 class="font-display text-2xl font-semibold text-primary">All allocations</h1>
         <p class="text-gray-600 mt-1">Payments, discounts, and scholarships applied across registrations</p>
       </div>
     </div>

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -1,17 +1,17 @@
-<div class="max-w-2xl mx-auto" data-controller="search-type-select">
-  <h1 class="text-2xl font-bold mb-6">New Allocation</h1>
+<div class="mx-auto max-w-2xl" data-controller="search-type-select">
+  <h1 class="text-primary mb-6 font-display text-2xl font-bold">New Allocation</h1>
   <%= simple_form_for @allocation, url: allocations_path do |f| %>
     <%= f.hidden_field :source_type %>
     <%= f.hidden_field :source_id %>
     <% source = @source || (@allocation.source if @allocation.source.present?) %>
     <% if source.present? && source.is_a?(Payment) %>
-      <div class="mb-4 p-4 bg-gray-50 rounded-lg">
+      <div class="mb-4 rounded-lg bg-gray-50 p-4">
         <p class="text-sm font-medium text-gray-700">From Payment</p>
         <p class="text-lg text-gray-900"><%= dollars_from_cents(source.amount_cents) %></p>
         <p class="text-sm text-gray-500">Remaining: <%= dollars_from_cents(source.amount_cents_remaining) %></p>
       </div>
     <% else %>
-      <div class="mb-4 p-4 bg-red-50 rounded-lg">
+      <div class="mb-4 rounded-lg bg-red-50 p-4">
         <p class="text-sm font-medium text-red-700">Error: No payment source found</p>
       </div>
     <% end %>
@@ -35,8 +35,8 @@
     </template>
     <div data-search-type-select-target="pickerContainer">
       <div>
-        <label class="text-sm font-medium text-gray-500 mb-1 block italic">Select Allocatable Type</label>
-        <div class="w-full bg-gray-100 border border-gray-300 rounded-lg px-3 py-2 cursor-not-allowed min-h-[2.2rem]"></div>
+        <label class="mb-1 block text-sm font-medium text-gray-500 italic">Select Allocatable Type</label>
+        <div class="min-h-[2.2rem] w-full cursor-not-allowed rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"></div>
       </div>
     </div>
     <%= f.input :amount_dollars, label: "Amount ($)", input_html: { min: 0, step: 0.01, placeholder: "0.00", data: { controller: "currency-input", action: "currency-input#format" } } %>

--- a/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
+++ b/app/views/author_credit_divergences/author_credit_divergences_results.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :author_credit_divergences_results do %>
   <% if @result.empty? && divergence_filters_applied? %>
-    <div class="rounded-lg border border-gray-200 bg-white p-8 text-center">
+    <div class="rounded-2xl border border-primary/10 bg-white p-8 text-center">
       <i class="fa-solid fa-filter-circle-xmark text-3xl text-gray-400 mb-3"></i>
       <p class="text-gray-700 font-medium">Nothing matches these filters.</p>
       <p class="text-sm text-gray-500 mt-1">
@@ -103,7 +103,7 @@
         <p class="text-sm text-gray-600 mb-3"><%= pluralize(@result.creator.size, "person") %> to confirm.</p>
         <div class="space-y-6">
           <% @result.creator.each do |group| %>
-            <div class="rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="rounded-2xl border border-primary/10 bg-white shadow-sm">
               <div class="border-b border-gray-200 px-4 py-3">
                 <%= link_to group.person.full_name, person_path(group.person),
                             target: "_blank", rel: "noopener", title: "Opens in a new tab",

--- a/app/views/author_credit_divergences/index.html.erb
+++ b/app/views/author_credit_divergences/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <section class="w-full">
-    <div class="flex flex-col items-start mb-4">
-      <h1 class="text-3xl font-bold text-gray-900 my-2">Author credit divergences</h1>
-      <p class="text-sm text-gray-600 max-w-3xl">
+    <div class="mb-4 flex flex-col items-start">
+      <h1 class="text-primary my-2 font-display text-3xl font-bold">Author credit divergences</h1>
+      <p class="max-w-3xl text-sm text-gray-600">
         Content whose credit doesn't resolve cleanly through a person's profile &mdash; either the
         stored preference drifted, or the credit isn't coming from an <code>author_id</code> at all.
         An <code>author_id</code> is the only path that follows the person's profile, links to it,

--- a/app/views/banners/edit.html.erb
+++ b/app/views/banners/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
-          <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:banners) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+          <div class="mb-4 flex flex-wrap justify-end gap-2">
             <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "Banners", banners_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "View", banner_path(@banner), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
-          <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @banner.class.model_name.human.downcase %></h1>
+          <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @banner.class.model_name.human.downcase %></h1>
 
           <div class="space-y-6">
             <div class="mt-4">

--- a/app/views/banners/index.html.erb
+++ b/app/views/banners/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:banners) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             📣 <%= Banner.model_name.human.pluralize %> (<%= @banners_count %>)
           </h1>
           <div class="flex gap-2">
@@ -18,15 +18,15 @@
           <table class="w-full border-collapse border border-gray-200">
             <thead class="bg-gray-100">
             <tr>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-[60px]">Content</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">Published</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">Actions</th>
+              <th class="w-[60px] px-4 py-2 text-left text-sm font-semibold text-gray-700">Content</th>
+              <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">Published</th>
+              <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
             </tr>
             </thead>
 
             <tbody class="divide-y divide-gray-200">
             <% @banners.each do |banner| %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <tr class="transition-colors duration-150 hover:bg-gray-50">
                 <td class="px-4 py-2 text-sm text-gray-800"><%= h(banner.content) %></td>
                 <td class="px-4 py-2 text-center">
                   <% if banner.published? %>
@@ -37,7 +37,7 @@
                 </td>
 
                 <!-- Actions -->
-                <td class="px-4 py-2 flex justify-center gap-2">
+                <td class="flex justify-center gap-2 px-4 py-2">
                   <%= link_to 'Edit', edit_banner_path(banner), class: "btn btn-secondary-outline" %>
                 </td>
               </tr>
@@ -49,7 +49,7 @@
 
         <!-- Empty state -->
         <% unless @banners.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= Banner.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>

--- a/app/views/banners/new.html.erb
+++ b/app/views/banners/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New <%= @banner.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:banners) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New <%= @banner.class.model_name.human.downcase %></h1>
         </div>
 
-        <div class="border-b border-gray-300 mb-6"></div>
+        <div class="mb-6 border-b border-gray-300"></div>
 
         <div class="space-y-6">
           <div class="mt-4">

--- a/app/views/banners/show.html.erb
+++ b/app/views/banners/show.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:banners) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:banners) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Banners", banners_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @banner) %>
           <%= link_to "Edit", edit_banner_path(@banner), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         <%= @banner.class.model_name.human %> details
       </h1>
 
       <div class="space-y-6">
         <div class="mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+          <div class="mb-3 grid grid-cols-1 gap-4 md:grid-cols-2">
 
                           <div class="mb-3">
                 <p class="font-bold text-gray-700">Content:</p>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-  <h1 class="text-2xl font-semibold text-gray-900 mb-4">Bookmarks</h1>
-  <div class="border-b border-gray-300 mb-6"></div>
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <h1 class="text-primary mb-4 font-display text-2xl font-semibold">Bookmarks</h1>
+  <div class="mb-6 border-b border-gray-300"></div>
   <div class="mt-4 pt-4">
     <%= render "search_boxes", url: bookmarks_path, frame_id: "bookmarks_results" %>
 

--- a/app/views/bookmarks/personal.html.erb
+++ b/app/views/bookmarks/personal.html.erb
@@ -1,6 +1,6 @@
-<div class="max-w-6xl mx-auto px-4 py-8">
-  <div class="max-w-6xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
-    <h1 class="text-2xl font-semibold text-gray-900 mb-4">
+<div class="mx-auto max-w-6xl px-4 py-8">
+  <div class="border-primary/10 mx-auto max-w-6xl rounded-2xl border bg-white p-6 shadow-sm">
+    <h1 class="text-primary mb-4 font-display text-2xl font-semibold">
       <%= @viewing_self ? "My" : "#{@user_name}'s" %> Bookmarks
     </h1>
 

--- a/app/views/bookmarks/tally.html.erb
+++ b/app/views/bookmarks/tally.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-      <h1 class="text-2xl font-bold mb-4">Bookmarks tally</h1>
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <h1 class="text-primary mb-4 font-display text-2xl font-bold">Bookmarks tally</h1>
 
       <!-- Filter form -->
       <%= form_tag('/bookmarks/tally', method: :get, class: "space-y-4", data: { controller: "collection" }) do %>
@@ -10,7 +10,7 @@
       <div class="rounded-xl bg-white p-6">
       <div class="flex gap-4">
         <div class="flex-1 bg-gray-100 p-4">
-          <table class="w-full border border-gray-200 rounded-lg shadow-sm">
+          <table class="w-full rounded-lg border border-gray-200 shadow-sm">
             <thead>
               <tr>
                 <th colspan="2" class="bg-gray-400 px-4 py-2 text-white">Bookmarks</th>
@@ -45,7 +45,7 @@
           </table>
         </div>
         <div class="flex-1 p-4">
-          <table class="w-full border border-gray-200 bg-gray-300 rounded-lg shadow-sm">
+          <table class="w-full rounded-lg border border-gray-200 bg-gray-300 shadow-sm">
             <thead>
               <tr>
                 <th colspan="2" class="bg-gray-400 px-4 py-2 text-white">Workshops led (via logs)</th>

--- a/app/views/bulk_payments/bulk_payments_results.html.erb
+++ b/app/views/bulk_payments/bulk_payments_results.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <% if @submissions.any? %>
-    <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm">
       <table class="w-full border-collapse">
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">

--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="w-full">
     <div class="mb-4">
       <%= link_to admin_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -64,7 +64,7 @@
 
     <% result_src = bulk_payments_path(request.query_parameters) %>
     <%= turbo_frame_tag :bulk_payments_results, src: result_src, data: { turbo: "temporary" } do %>
-      <div class="rounded-xl border border-gray-200 bg-white py-16 text-center text-gray-400 shadow-sm">
+      <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center text-gray-400 shadow-sm">
         <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
         <p class="mt-2 text-sm">Loading submissions…</p>
       </div>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:categories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Categories", categories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Taggings", taggings_path(category_names_all: @category.name), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "View", category_path(@category), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @category.class.model_name.human.downcase %></h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @category.class.model_name.human.downcase %></h1>
 
   <div class="space-y-6">
     <div class="mt-4">

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:categories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
 
     <!-- Header -->
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-semibold text-gray-900">
+    <div class="mb-6 flex items-center justify-between">
+      <h1 class="text-primary font-display text-2xl font-semibold">
         <%= Category.model_name.human.pluralize %> (<%= @count_display %>)
       </h1>
       <div class="flex gap-2">
@@ -26,25 +26,25 @@
           <table class="w-full table-fixed border-collapse border border-gray-200">
             <thead class="bg-gray-100">
               <tr>
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/3">
+              <th class="w-1/3 px-4 py-2 text-left text-sm font-semibold text-gray-700">
                 Order&nbsp;&nbsp;&nbsp;&nbsp;Name
               </th>
 
-              <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/4">
+              <th class="w-1/4 px-4 py-2 text-left text-sm font-semibold text-gray-700">
                 Type
               </th>
 
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">
+              <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">
                 Published
               </th>
 
               <% if params[:admin] %>
-                <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">
+                <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">
                   Position
                 </th>
               <% end %>
 
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">
+              <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">
                 Actions
               </th>
             </tr>
@@ -58,29 +58,29 @@
                 <tr class="<%= "bg-gray-200" unless category.published? %> <%= category.published? ? "hover:bg-gray-100" : "hover:bg-gray-50" %>
                   transition-colors duration-150"
                 data-sortable-id="<%= category.id %>">
-                <td class="px-4 py-2 text-md text-gray-800 truncate font-bold">
+                <td class="truncate px-4 py-2 text-md font-bold text-gray-800">
                   <span class="px-4">
                     <i class="fa-solid fa-sort cursor-move text-gray-400 hover:text-gray-600"
                        data-sortable-handle=""></i>
                   </span>
                   <%= category.name %>
                   <% if category.description.present? %>
-                    <i class="fa-solid fa-circle-info ml-1 text-sm font-normal text-gray-400 hover:text-blue-600 cursor-help"
+                    <i class="fa-solid fa-circle-info ml-1 cursor-help text-sm font-normal text-gray-400 hover:text-blue-600"
                        title="<%= category.description %>"></i>
                   <% end %>
                 </td>
 
-                <td class="px-4 py-2 text-sm text-gray-800 truncate">
+                <td class="truncate px-4 py-2 text-sm text-gray-800">
                   <%= category.category_type&.name || "—" %>
                 </td>
 
                 <td class="px-4 py-2 text-center">
                   <% if category.published? %>
-                    <span class="inline-block px-2 py-1 text-xs font-semibold text-green-800 bg-green-100 rounded">
+                    <span class="inline-block rounded bg-green-100 px-2 py-1 text-xs font-semibold text-green-800">
                       Yes
                     </span>
                   <% else %>
-                    <span class="inline-block px-2 py-1 text-xs font-semibold text-gray-700 bg-gray-200 rounded">
+                    <span class="inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-700">
                       No
                     </span>
                   <% end %>
@@ -108,7 +108,7 @@
           </table>
         <% else %>
           <!-- Empty state -->
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= Category.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>
@@ -116,7 +116,7 @@
     </div>
 
     <!-- Pagination -->
-    <div class="pagination flex justify-center mt-12">
+    <div class="pagination mt-12 flex justify-center">
       <%= tailwind_paginate @categories %>
     </div>
 

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New <%= @category.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:categories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New <%= @category.class.model_name.human.downcase %></h1>
         </div>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form", category: @category %>
           </div>
         </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:categories) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:categories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Categories", categories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @category) %>
           <%= link_to "Edit", edit_category_path(@category), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         <%= @category.class.model_name.human %> details
       </h1>
 
       <div class="space-y-6">
         <div class="mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-3">
+          <div class="mb-3 grid grid-cols-1 gap-4 md:grid-cols-3">
 
               <div class="mb-3">
                 <p class="font-bold text-gray-700">Name:</p>

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="mx-auto max-w-5xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Category Types", category_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", category_type_path(@category_type), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit <%= @category_type.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @category_type.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
-  <div class="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="admin-only bg-blue-100 rounded p-6">
-      <div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:category_types, intensity: 100) %>
-        border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
+  <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
+    <div class="admin-only rounded bg-blue-100 p-6">
+      <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:category_types, intensity: 100) %>
+        border-primary/10 rounded-2xl border p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= CategoryType.model_name.human.pluralize %> (<%= @count_display %>)
           </h1>
           <div class="flex gap-2">
@@ -17,7 +17,7 @@
           </div>
         </div>
 
-        <div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+        <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
@@ -27,14 +27,14 @@
                 <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Story specific</th>
                 <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Profile specific</th>
                 <th class="px-4 py-2 text-left text-sm font-medium text-gray-700">Categories count</th>
-                <th class="px-4 py-2 text-left text-sm font-medium text-gray-700 w-32">Actions</th>
+                <th class="w-32 px-4 py-2 text-left text-sm font-medium text-gray-700">Actions</th>
               </tr>
             </thead>
 
             <tbody class="divide-y divide-gray-100">
               <% @category_types.each do |category_type| %>
               <tr>
-                <td class="px-4 py-2 text-gray-700 text-base font-bold">
+                <td class="px-4 py-2 text-base font-bold text-gray-700">
                   <%= category_type.name %>
                 </td>
 
@@ -87,13 +87,13 @@
 
         <!-- Empty state -->
         <% unless @category_types.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= CategoryType.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>
 
         <!-- Pagination -->
-        <div class="pagination flex justify-center mt-12">
+        <div class="pagination mt-12 flex justify-center">
           <%= tailwind_paginate @category_types %>
         </div>
       </div>

--- a/app/views/category_types/new.html.erb
+++ b/app/views/category_types/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">New <%= @category_type.class.model_name.human.downcase %></h1>
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+      <div class="mb-3 flex items-center justify-between">
+        <h1 class="text-primary font-display text-2xl font-semibold">New <%= @category_type.class.model_name.human.downcase %></h1>
       </div>
 
-      <div class="border-b border-gray-300 mb-6"></div>
+      <div class="mb-6 border-b border-gray-300"></div>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -1,40 +1,40 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="max-w-5xl mx-auto bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Category types", category_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Categories", categories_path(category_type_id: @category_type.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Edit", edit_category_type_path(@category_type), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         Category type details: <%= @category_type.name %>
       </h1>
 
-      <div class="flex items-center gap-6 mt-2 mb-2">
+      <div class="mt-2 mb-2 flex items-center gap-6">
         <p class="text-gray-700">
           <span class="font-bold">Published:</span>
           <% if @category_type.published? %>
-            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+            <span class="fa fa-check-circle ml-1 text-green-500"></span>
           <% else %>
-            <span class="text-gray-400 ml-1">--</span>
+            <span class="ml-1 text-gray-400">--</span>
           <% end %>
         </p>
         <p class="text-gray-700">
           <span class="font-bold">Story specific:</span>
           <% if @category_type.story_specific? %>
-            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+            <span class="fa fa-check-circle ml-1 text-green-500"></span>
           <% else %>
-            <span class="text-gray-400 ml-1">--</span>
+            <span class="ml-1 text-gray-400">--</span>
           <% end %>
         </p>
         <p class="text-gray-700">
           <span class="font-bold">Profile specific:</span>
           <% if @category_type.profile_specific? %>
-            <span class="fa fa-check-circle text-green-500 ml-1"></span>
+            <span class="fa fa-check-circle ml-1 text-green-500"></span>
           <% else %>
-            <span class="text-gray-400 ml-1">--</span>
+            <span class="ml-1 text-gray-400">--</span>
           <% end %>
         </p>
         <p class="text-gray-700">
@@ -44,19 +44,19 @@
       </div>
 
       <!-- Associated Categories -->
-      <div class="pt-6 border-t border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900 mb-3">
+      <div class="border-t border-gray-200 pt-6">
+        <h2 class="mb-3 text-lg font-semibold text-gray-900">
           Associated Categories
         </h2>
 
         <% if @category_type.categories.any? %>
           <ul class="space-y-2">
             <% @category_type.categories.order(:position, :name).each do |category| %>
-              <li class="bg-gray-50 border border-gray-200 rounded-md px-4 py-2">
+              <li class="rounded-md border border-gray-200 bg-gray-50 px-4 py-2">
                 <%= link_to taggings_path(category_names_all: category.name),
                             class: "font-medium text-gray-900 hover:text-blue-600" do %>
                   <%= category.name %>
-                  <span class="text-sm text-gray-500 ml-2">(<%= category.categorizable_items.count %> taggings)</span>
+                  <span class="ml-2 text-sm text-gray-500">(<%= category.categorizable_items.count %> taggings)</span>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -5,17 +5,17 @@
   <% end %>
 </div>
 
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
   <div class="<%= DomainTheme.bg_class_for(:comments, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:comments) %> px-8 py-3">
     <div class="flex items-center gap-2">
       <i class="fa-solid fa-comments <%= DomainTheme.text_class_for(:comments, intensity: 700) %>"></i>
-      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> uppercase tracking-wide">Comments</span>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> tracking-wide uppercase">Comments</span>
     </div>
   </div>
 
-  <div class="p-4 sm:p-8 space-y-6">
+  <div class="space-y-6 p-4 sm:p-8">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
-      <h1 class="text-2xl font-semibold text-gray-900">All comments</h1>
+      <h1 class="text-primary font-display text-2xl font-semibold">All comments</h1>
       <p class="text-sm text-gray-500"><%= pluralize(@total_count, "comment") %></p>
     </div>
 

--- a/app/views/community_news/edit.html.erb
+++ b/app/views/community_news/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-          <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:community_news) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+          <div class="mb-4 flex flex-wrap justify-end gap-2">
             <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "Community News", community_news_index_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <% if @community_news.reference_url.present? %>
@@ -10,7 +10,7 @@
             <%= link_to "View", community_news_path(@community_news, no_redirect: true),
                         class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
-          <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @community_news.class.model_name.human.downcase %></h1>
+          <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @community_news.class.model_name.human.downcase %></h1>
 
           <div class="space-y-6">
             <div class="mt-4">

--- a/app/views/community_news/new.html.erb
+++ b/app/views/community_news/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:community_news) %> border border-gray-200 rounded-xl shadow p-6">
-          <div class="flex items-center justify-between mb-3">
-            <h1 class="text-2xl font-semibold text-gray-900">New <%= @community_news.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:community_news) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+          <div class="mb-3 flex items-center justify-between">
+            <h1 class="text-primary font-display text-2xl font-semibold">New <%= @community_news.class.model_name.human.downcase %></h1>
           </div>
 
-          <div class="border-b border-gray-300 mb-6"></div>
+          <div class="mb-6 border-b border-gray-300"></div>
 
           <div class="space-y-6">
             <div class="mt-4">

--- a/app/views/continuing_education_registrations/continuing_education_registrations_results.html.erb
+++ b/app/views/continuing_education_registrations/continuing_education_registrations_results.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag :continuing_education_registrations_results do %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden blur-on-submit">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm blur-on-submit">
     <% if @ce_registrations.any? %>
       <% total = @ce_registrations.respond_to?(:total_entries) ? @ce_registrations.total_entries : @ce_registrations.size %>
-      <div class="flex flex-wrap items-center justify-between gap-2 px-6 py-4 border-b border-gray-100">
+      <div class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-100 px-6 py-4">
         <p class="text-sm text-gray-500"><%= total %> CE registration<%= "s" if total != 1 %></p>
         <p class="text-sm text-gray-500">
           <%= number_with_precision(@ce_total_hours, precision: 1, strip_insignificant_zeros: true) %> hours
@@ -11,47 +11,47 @@
         </p>
       </div>
 
-      <div class="overflow-x-auto animate-fade">
+      <div class="animate-fade overflow-x-auto">
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Registrant</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">License</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Hours</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Cost</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Payment</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Certificate</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Registrant</th>
+              <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Event</th>
+              <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">License</th>
+              <th class="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">Hours</th>
+              <th class="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">Cost</th>
+              <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Payment</th>
+              <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Certificate</th>
+              <th class="px-4 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">Actions</th>
             </tr>
           </thead>
 
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody class="divide-y divide-gray-200 bg-white">
             <% @ce_registrations.each do |ce| %>
               <% ce = ce.decorate %>
               <% registration = ce.event_registration %>
               <% payment = ce.payment_status_badge %>
               <% certificate = ce.certificate_badge %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
-                <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">
+              <tr class="transition-colors duration-150 hover:bg-gray-50">
+                <td class="px-4 py-3 text-sm font-medium whitespace-nowrap text-gray-900">
                   <%= link_to registration.registrant.full_name, continuing_education_registration_path(ce), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top" } %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">
+                <td class="px-4 py-3 text-sm whitespace-nowrap text-gray-700">
                   <%= registration.event.title %>
                   <% if registration.event.start_date.present? %>
                     <span class="block text-xs text-gray-400"><%= registration.event.decorate.times(display_day: true, display_date: true) %></span>
                   <% end %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700"><%= ce.license_label %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-700 tabular-nums"><%= number_with_precision(ce.hours, precision: 1, strip_insignificant_zeros: true) %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm text-gray-900 tabular-nums"><%= dollars_from_cents(ce.cost_cents) %></td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm">
+                <td class="px-4 py-3 text-sm whitespace-nowrap text-gray-700"><%= ce.license_label %></td>
+                <td class="px-4 py-3 text-right text-sm whitespace-nowrap text-gray-700 tabular-nums"><%= number_with_precision(ce.hours, precision: 1, strip_insignificant_zeros: true) %></td>
+                <td class="px-4 py-3 text-right text-sm whitespace-nowrap text-gray-900 tabular-nums"><%= dollars_from_cents(ce.cost_cents) %></td>
+                <td class="px-4 py-3 text-sm whitespace-nowrap">
                   <%= render "shared/badge", label: payment.label, classes: payment.classes, icon: payment.icon %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-sm">
+                <td class="px-4 py-3 text-sm whitespace-nowrap">
                   <%= render "shared/badge", label: certificate.label, classes: certificate.classes, icon: certificate.icon %>
                 </td>
-                <td class="px-4 py-3 whitespace-nowrap text-right text-sm font-medium">
+                <td class="px-4 py-3 text-right text-sm font-medium whitespace-nowrap">
                   <%= link_to "Edit", edit_continuing_education_registration_path(ce, return_to: "ce_index"), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top" } %>
                 </td>
               </tr>
@@ -60,11 +60,11 @@
         </table>
       </div>
     <% else %>
-      <p class="text-gray-500 text-center py-8">There are no CE registrations that match your search. Please try again.</p>
+      <p class="py-8 text-center text-gray-500">There are no CE registrations that match your search. Please try again.</p>
     <% end %>
   </div>
 
   <% if @ce_registrations.respond_to?(:total_pages) && @ce_registrations.total_pages > 1 %>
-    <div class="pagination flex justify-center mt-6"><%= tailwind_paginate @ce_registrations %></div>
+    <div class="pagination mt-6 flex justify-center"><%= tailwind_paginate @ce_registrations %></div>
   <% end %>
 <% end %>

--- a/app/views/continuing_education_registrations/edit.html.erb
+++ b/app/views/continuing_education_registrations/edit.html.erb
@@ -2,7 +2,7 @@
 <% registration = @ce_registration.event_registration %>
 <% license = @ce_registration.professional_license %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + secondary links, matching the scholarship edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>

--- a/app/views/continuing_education_registrations/index.html.erb
+++ b/app/views/continuing_education_registrations/index.html.erb
@@ -1,21 +1,21 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <%# Top-left menu: jump to the cross-event CE sign-ins. %>
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to signins_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-clipboard-check text-xs"></i> CE sign-ins
     <% end %>
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <div class="flex items-center gap-3 mb-6">
+  <div class="mb-6 flex items-center gap-3">
     <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
       <i class="fa-solid fa-certificate"></i>
     </span>
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">CE registrations</h1>
-      <p class="text-gray-600 mt-1">Continuing-education registrations across every event</p>
+      <h1 class="text-primary font-display text-2xl font-semibold">CE registrations</h1>
+      <p class="mt-1 text-gray-600">Continuing-education registrations across every event</p>
     </div>
   </div>
 

--- a/app/views/continuing_education_registrations/new.html.erb
+++ b/app/views/continuing_education_registrations/new.html.erb
@@ -2,7 +2,7 @@
 <% registration = @event_registration %>
 <% event = registration.event %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + Home, matching the CE edit page. %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to ce_registration_return_path(registration), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>

--- a/app/views/continuing_education_registrations/show.html.erb
+++ b/app/views/continuing_education_registrations/show.html.erb
@@ -5,7 +5,7 @@
 <% payment = ce.payment_status_badge %>
 <% certificate = ce.certificate_badge %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back to the CE registrations index + Edit / Home. %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>

--- a/app/views/dedupes/index.html.erb
+++ b/app/views/dedupes/index.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(@dedupe[:domain]) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(@dedupe[:domain]) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
 
     <!-- Eyebrow + header -->
     <div>
       <%= link_to "← #{@dedupe[:model_label_plural]}", url_for(action: :index),
                   class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <h1 class="mt-2 text-2xl font-semibold text-gray-900">
+      <h1 class="text-primary mt-2 font-display text-2xl font-semibold">
         Dedupe <%= @dedupe[:model_label_plural].downcase %>
       </h1>
       <p class="mt-1 text-gray-500">
@@ -58,7 +58,7 @@
         <div class="space-y-4">
           <% @possible_duplicate_groups.each do |group| %>
             <% keep_record = group.records.first %>
-            <div class="rounded-xl border border-gray-200 bg-white p-4">
+            <div class="border-primary/10 rounded-2xl border bg-white p-4">
               <div class="mb-2 flex items-start justify-between gap-4">
                 <h3 class="font-semibold text-gray-900">
                   <%= group.label.presence || "(no name)" %>
@@ -101,7 +101,7 @@
         </div>
       </div>
     <% else %>
-      <div class="rounded-xl border border-gray-200 bg-white py-10 text-center">
+      <div class="border-primary/10 rounded-2xl border bg-white py-10 text-center">
         <i class="fa-solid fa-circle-check mb-2 text-3xl text-emerald-500"></i>
         <p class="text-gray-600">No likely duplicate <%= @dedupe[:model_label_plural].downcase %> detected.</p>
       </div>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(@dedupe[:domain]) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(@dedupe[:domain]) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
 
     <!-- Eyebrow + header -->
@@ -7,7 +7,7 @@
       <div>
         <%= link_to "← Back to dedupe", url_for(action: :dedupe_index),
                     class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-        <h1 class="mt-2 text-2xl font-semibold text-gray-900">
+        <h1 class="text-primary mt-2 font-display text-2xl font-semibold">
           Preview <%= @dedupe[:model_label].downcase %> merge
         </h1>
         <p class="mt-1 text-gray-500">

--- a/app/views/discounts/show.html.erb
+++ b/app/views/discounts/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to "← Allocations", allocations_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
 
-    <h1 class="text-2xl font-semibold text-gray-900">Discount</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Discount</h1>
 
     <% if @discount.allocations.first&.allocatable.present? %>
       <% alloc = @discount.allocations.first.allocatable %>
-      <p class="text-gray-600 mt-1"><%= alloc.registrant.full_name %> — <%= alloc.event.title %></p>
+      <p class="mt-1 text-gray-600"><%= alloc.registrant.full_name %> — <%= alloc.event.title %></p>
     <% end %>
   </div>
 

--- a/app/views/event_registration_imports/create.html.erb
+++ b/app/views/event_registration_imports/create.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-5xl <%= DomainTheme.bg_class_for(:event_registrations) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-5xl <%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-4 flex flex-wrap justify-start gap-2">
     <%= link_to "← Choose a different file", new_event_registration_import_path(event_id: @event.id),
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="mb-1 text-3xl font-semibold tracking-tight text-gray-900">
+  <h1 class="text-primary mb-1 font-display text-3xl font-semibold tracking-tight">
     Preview import
   </h1>
   <p class="mb-6 text-gray-600">
@@ -24,7 +24,7 @@
       [ "Rows", @result.rows_processed ],
       [ "Skipped", @result.skipped.size ]
     ].each do |label, count| %>
-      <div class="rounded-lg border border-gray-200 bg-white p-3 text-center">
+      <div class="border-primary/10 rounded-2xl border bg-white p-3 text-center">
         <div class="text-2xl font-semibold text-gray-900"><%= count %></div>
         <div class="text-xs text-gray-500"><%= label %></div>
       </div>
@@ -38,7 +38,7 @@
     No emails are sent.
   </p>
 
-  <div class="mb-6 overflow-hidden rounded-lg border border-gray-200 bg-white">
+  <div class="border-primary/10 mb-6 overflow-hidden rounded-2xl border bg-white">
     <div class="overflow-x-auto">
       <table class="min-w-full text-sm">
         <thead class="bg-gray-50 text-xs tracking-wide text-gray-500 uppercase">
@@ -103,7 +103,7 @@
     </div>
   </div>
 
-  <div class="rounded-lg border border-gray-200 bg-white p-6">
+  <div class="border-primary/10 rounded-2xl border bg-white p-6">
     <%= form_with url: confirm_event_registration_import_path, method: :post do |f| %>
       <%= f.hidden_field :signed_id, value: @blob.signed_id %>
       <%= f.hidden_field :event_id, value: @event.id %>

--- a/app/views/event_registration_imports/new.html.erb
+++ b/app/views/event_registration_imports/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-4 flex flex-wrap justify-start gap-2">
     <%= link_to "← Registrants", (@event ? registrants_event_path(@event) : events_path),
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="mb-3 text-3xl font-semibold tracking-tight text-gray-900">
+  <h1 class="text-primary mb-3 font-display text-3xl font-semibold tracking-tight">
     Import registrants
   </h1>
   <p class="mb-6 text-gray-600">

--- a/app/views/event_registrations/confirm.html.erb
+++ b/app/views/event_registrations/confirm.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="max-w-2xl mx-auto">
-    <div class="flex items-center mb-6">
-      <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-green-100">
+<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mx-auto max-w-2xl">
+    <div class="mb-6 flex items-center">
+      <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-green-100">
         <svg class="h-5 w-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
         </svg>
       </div>
-      <h1 class="ml-3 text-xl font-semibold text-gray-900">Registration created</h1>
+      <h1 class="text-primary ml-3 font-display text-xl font-semibold">Registration created</h1>
     </div>
 
-    <div class="bg-white rounded-lg p-4 mb-6">
+    <div class="mb-6 rounded-lg bg-white p-4">
       <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <dt class="text-gray-500">Registrant</dt>
-        <dd class="text-gray-900 font-medium"><%= @person.full_name %></dd>
+        <dd class="font-medium text-gray-900"><%= @person.full_name %></dd>
         <dt class="text-gray-500">Email</dt>
         <dd class="text-gray-900"><%= @person.preferred_email.presence || "No email on file" %></dd>
         <dt class="text-gray-500">Event</dt>
@@ -21,11 +21,11 @@
         <dt class="text-gray-500">Account status</dt>
         <dd>
           <% if @user.nil? %>
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700">No user account</span>
+            <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">No user account</span>
           <% elsif @user.confirmed_at.present? %>
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">Confirmed</span>
+            <span class="inline-flex items-center rounded bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Confirmed</span>
           <% else %>
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">Unconfirmed</span>
+            <span class="inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">Unconfirmed</span>
           <% end %>
         </dd>
       </dl>
@@ -40,7 +40,7 @@
       <p class="text-sm font-medium text-gray-700">Optional follow-up actions:</p>
 
       <% if @user.nil? && @person.preferred_email.present? %>
-        <label class="flex items-start gap-3 p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
+        <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 hover:bg-gray-50">
           <%= check_box_tag :create_user, "1", false, class: "mt-0.5" %>
           <div>
             <span class="text-sm font-medium text-gray-900">Create user account</span>
@@ -50,7 +50,7 @@
       <% end %>
 
       <% if @user.nil? || @user&.confirmed_at.nil? %>
-        <label class="flex items-start gap-3 p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
+        <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 hover:bg-gray-50">
           <%= check_box_tag :send_invite, "1", false, class: "mt-0.5" %>
           <div>
             <span class="text-sm font-medium text-gray-900">Send system invite email</span>
@@ -66,7 +66,7 @@
       <% end %>
 
       <% if @person.preferred_email.present? %>
-        <label class="flex items-start gap-3 p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
+        <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 hover:bg-gray-50">
           <%= check_box_tag :send_confirmation_email, "1", false, class: "mt-0.5" %>
           <div>
             <span class="text-sm font-medium text-gray-900">Send registration confirmation email</span>
@@ -75,7 +75,7 @@
         </label>
       <% end %>
 
-      <label class="flex items-start gap-3 p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
+      <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 hover:bg-gray-50">
         <%= check_box_tag :send_admin_fyi, "1", false, class: "mt-0.5" %>
         <div>
           <span class="text-sm font-medium text-gray-900">Send admin notification email</span>
@@ -83,7 +83,7 @@
         </div>
       </label>
 
-      <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
+      <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
         <% skip_path = @return_to == "registrants" ? registrants_event_row_path(@event_registration.event, @event_registration.id) : registration_ticket_path(@event_registration.slug) %>
         <%= link_to "Skip", skip_path, class: "btn btn-secondary-outline" %>
         <button type="submit" class="btn btn-primary">Send selected</button>

--- a/app/views/event_registrations/edit.html.erb
+++ b/app/views/event_registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + secondary links, matching the event pages. When the
       admin arrived from the bulk payments page, the back link returns there with
       the originating submission re-expanded instead of the registrants roster. %>

--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
           <!-- Header -->
           <div class="mb-6 flex items-center justify-between">
-            <h1 class="text-2xl font-semibold text-gray-900">
+            <h1 class="text-primary font-display text-2xl font-semibold">
               <%= EventRegistration.model_name.human.pluralize %> (<%= @event_registrations_count %>)
             </h1>
             <div class="flex gap-2">

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -11,9 +11,9 @@
       <%= link_to "← Back to registrants", registrants_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
   </div>
-  <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+  <div class="bg-white rounded-2xl shadow-lg border border-primary/10 p-6">
     <div class="flex items-start justify-between gap-3 mb-2">
-      <h1 class="text-2xl font-bold text-gray-900">Linked organizations &amp; affiliations</h1>
+      <h1 class="font-display text-2xl font-bold text-primary">Linked organizations &amp; affiliations</h1>
       <%= link_to edit_affiliations_path, data: { turbo_frame: "_top" },
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700 shrink-0 mt-1.5" do %>
         Edit <%= @person.first_name.presence || @person.full_name %>'s affiliations
@@ -41,7 +41,7 @@
         <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500">Registration form submission</h2>
         <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform [[open]_&]:rotate-180"></i>
       </summary>
-      <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+      <div class="bg-gray-50 border border-primary/10 rounded-2xl p-4">
         <% present_entries = @submitted_entries.select { |entry| entry[:org_name].present? || entry[:position].present? } %>
         <% if present_entries.any? %>
           <% multiple = present_entries.size > 1 %>
@@ -81,7 +81,7 @@
         below. === %>
     <% org_swatch = DomainTheme.swatch(:green) %>
     <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Registration-linked organizations</h2>
-    <div class="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-8">
+    <div class="bg-gray-50 border border-primary/10 rounded-2xl p-4 mb-8">
       <% if @linked_organizations.any? %>
         <ul class="space-y-2 mb-4">
           <% @linked_organizations.each do |org| %>

--- a/app/views/event_registrations/new.html.erb
+++ b/app/views/event_registrations/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link, matching the event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to event_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Registrations
     <% end %>
@@ -10,8 +10,8 @@
   </div>
 
   <%# Title block %>
-  <div class="text-center mb-8">
-    <h1 class="flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-black">
+  <div class="mb-8 text-center">
+    <h1 class="text-primary flex items-center justify-center gap-3 font-display text-3xl font-extrabold sm:text-4xl">
       <i class="fa-solid fa-user-plus <%= DomainTheme.text_class_for(:event_registrations, intensity: 600) %>"></i>
       New registration
     </h1>

--- a/app/views/event_registrations/transfer.html.erb
+++ b/app/views/event_registrations/transfer.html.erb
@@ -16,13 +16,13 @@
   <% end %>
 </div>
 
-<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:event_registrations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mx-auto max-w-2xl space-y-6">
     <div class="flex items-center">
       <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-purple-100">
         <i class="fa-solid fa-right-from-bracket text-purple-600"></i>
       </div>
-      <h1 class="ml-3 text-xl font-semibold text-gray-900">Manage transfer</h1>
+      <h1 class="text-primary ml-3 font-display text-xl font-semibold">Manage transfer</h1>
     </div>
 
     <div class="rounded-lg bg-white p-4">
@@ -52,14 +52,14 @@
       <%# Plain-language "here's what happens to their data" block so an admin
           knowingly consents. The chain-collapse warning shows only when the reg
           being transferred is itself a transfer-in. (#1944) %>
-      <div class="mb-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <div class="border-primary/10 mb-4 rounded-2xl border bg-gray-50 p-3">
         <p class="mb-2 text-xs font-semibold text-gray-700">What recording this transfer will do:</p>
         <div class="grid gap-3 sm:grid-cols-2">
           <div class="rounded-md border border-gray-200 bg-white p-3">
             <p class="text-xs font-semibold text-gray-800">
               <i class="fa-solid fa-right-from-bracket text-gray-400"></i> This registration
             </p>
-            <p class="mb-2 truncate text-2xs text-gray-500" title="<%= source.event.title %>">
+            <p class="text-2xs mb-2 truncate text-gray-500" title="<%= source.event.title %>">
               <%= source.event.decorate.title_with_month_year %>
             </p>
             <ul class="list-disc space-y-1 pl-4 text-xs text-gray-600">
@@ -74,7 +74,7 @@
             <p class="text-xs font-semibold text-gray-800">
               <i class="fa-solid fa-right-to-bracket text-gray-400"></i> New registration
             </p>
-            <p class="mb-2 text-2xs text-gray-500">the event you pick</p>
+            <p class="text-2xs mb-2 text-gray-500">the event you pick</p>
             <ul class="list-disc space-y-1 pl-4 text-xs text-gray-600">
               <li>Created fresh — track attendance here</li>
               <li>Gets a copy of the linked organizations</li>

--- a/app/views/events/attendance.html.erb
+++ b/app/views/events/attendance.html.erb
@@ -5,7 +5,7 @@
 <% event = @event.decorate %>
 
 <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-6 shadow">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
     <%# Sign-ins has no tab of its own, so nothing in the subnav is marked current. %>
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% case params[:return_to] %>
@@ -93,7 +93,7 @@
               <span class="text-xs text-gray-400">Total <%= attendance_duration_label(@report.total_minutes(row)) %></span>
             </div>
 
-            <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <div class="overflow-hidden rounded-2xl border border-primary/10 bg-white">
               <div class="grid items-center gap-x-3 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500 border-b border-gray-100"
                    style="grid-template-columns: minmax(11rem,1.2fr) 3fr minmax(5rem,auto)">
                 <div>Day</div>
@@ -132,7 +132,7 @@
             <span class="text-xs text-gray-400"><%= @report.registrations_present_on(date) %> of <%= @report.reported_registrations.size %> signed in</span>
           </div>
 
-          <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+          <div class="overflow-hidden rounded-2xl border border-primary/10 bg-white">
             <div class="grid items-center gap-x-3 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500 border-b border-gray-100"
                  style="grid-template-columns: <%= @report.ce_only? ? "minmax(9rem,1.2fr) minmax(6rem,0.8fr) 3fr minmax(5rem,auto)" : "minmax(9rem,1.4fr) 3fr minmax(5rem,auto)" %>">
               <div>Name</div>

--- a/app/views/events/attendees.html.erb
+++ b/app/views/events/attendees.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-4 sm:p-6">
     <%# The report KPIs drill in here carrying both return_to and (when scoped)
         event_id, so an explicit origin wins over the event fallback — otherwise a
         report drill-in would bounce the user to that event's dashboard instead of

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, "Bulk payments — #{@event.title}") %>
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <% if params[:return_to] == "bulk_payments_index" %>
@@ -12,7 +12,7 @@
   </div>
 
   <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
-    <h1 class="text-2xl font-semibold text-gray-900">Bulk payments</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Bulk payments</h1>
     <div class="flex items-center gap-3">
       <%= link_to event_invoice_path(@event),
                   class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
@@ -31,7 +31,7 @@
       <% end %>
     </div>
   <% else %>
-    <div class="rounded-lg border border-gray-200 bg-white py-16 text-center">
+    <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center">
       <i class="fa-regular fa-receipt mb-3 text-4xl text-gray-300"></i>
       <p class="text-gray-500">No bulk payment submissions yet.</p>
     </div>

--- a/app/views/events/confirm_reminder.html.erb
+++ b/app/views/events/confirm_reminder.html.erb
@@ -1,23 +1,23 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <%# Top bar: eyelash + sub-nav, matching the other event pages. The eyebrow
       returns to the recipient picker so the admin can adjust the selection. %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Recipients", preview_reminder_event_path(@event, mode: (@invite_mode ? "invite" : nil), custom_subject: @custom_subject, custom_message: @custom_message, hide_event_card: (@hide_event_card ? "1" : "0"), hide_ticket_button: (@hide_ticket_button ? "1" : "0")), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
   <div class="mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900"><%= @invite_mode ? "Send Portal invite emails" : "Send bulk emails" %></h1>
-    <p class="text-gray-600 mt-1">
+    <h1 class="text-primary font-display text-2xl font-semibold"><%= @invite_mode ? "Send Portal invite emails" : "Send bulk emails" %></h1>
+    <p class="mt-1 text-gray-600">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
   </div>
 
   <% count = @event_registrations.size %>
-  <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+  <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
     <div class="flex items-start gap-2">
-      <i class="fa-solid fa-circle-info text-blue-500 mt-0.5"></i>
+      <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
       <div class="text-sm text-blue-800">
         <% if @invite_mode %>
           <p class="font-medium">You're about to invite <%= count %> <%= "person".pluralize(count) %>.</p>
@@ -30,23 +30,23 @@
     </div>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-lg p-4 mb-6">
-    <h2 class="text-lg font-semibold text-gray-800 mb-3">Recipients <span class="text-gray-400 font-normal">(<%= count %>)</span></h2>
+  <div class="border-primary/10 mb-6 rounded-2xl border bg-white p-4">
+    <h2 class="mb-3 text-lg font-semibold text-gray-800">Recipients <span class="font-normal text-gray-400">(<%= count %>)</span></h2>
 
-    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated names</h3>
-    <p class="text-sm text-gray-700 mb-4 break-words">
+    <h3 class="mb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">Comma-separated names</h3>
+    <p class="mb-4 text-sm break-words text-gray-700">
       <%= @event_registrations.map { |reg| reg.registrant.full_name }.join(", ") %>
     </p>
 
-    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Comma-separated emails</h3>
-    <p class="text-sm text-gray-700 mb-4 break-words">
+    <h3 class="mb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">Comma-separated emails</h3>
+    <p class="mb-4 text-sm break-words text-gray-700">
       <%= @event_registrations.map { |reg| reg.registrant.preferred_email }.join(", ") %>
     </p>
 
-    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">Full list</h3>
-    <ul class="columns-1 sm:columns-2 gap-x-8 text-sm">
+    <h3 class="mb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">Full list</h3>
+    <ul class="columns-1 gap-x-8 text-sm sm:columns-2">
       <% @event_registrations.each do |reg| %>
-        <li class="break-inside-avoid mb-1">
+        <li class="mb-1 break-inside-avoid">
           <span class="text-gray-900"><%= reg.registrant.full_name %></span>
           <span class="text-gray-400">&lt;<%= reg.registrant.preferred_email %>&gt;</span>
         </li>
@@ -54,26 +54,26 @@
     </ul>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-lg overflow-hidden mb-6">
-    <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
-      <p class="text-xs font-semibold uppercase tracking-wide text-gray-500">Subject</p>
+  <div class="border-primary/10 mb-6 overflow-hidden rounded-2xl border bg-white">
+    <div class="border-b border-gray-200 bg-gray-50 px-4 py-3">
+      <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Subject</p>
       <p class="text-sm font-medium text-gray-900"><%= @reminder_subject %></p>
       <%# Name the omission explicitly — the preview below shows an absence, which
           is easy to miss when you're scanning for what's there. %>
       <% if @hide_event_card && !@invite_mode %>
-        <p class="text-xs text-gray-500 mt-1.5">
+        <p class="mt-1.5 text-xs text-gray-500">
           <i class="fa-solid fa-eye-slash text-gray-400"></i>
           Event details box hidden — the date, time, cost, and location won't be in this email.
         </p>
       <% end %>
       <% if @hide_ticket_button && !@invite_mode %>
-        <p class="text-xs text-gray-500 mt-1.5">
+        <p class="mt-1.5 text-xs text-gray-500">
           <i class="fa-solid fa-eye-slash text-gray-400"></i>
           "View ticket" button hidden — this email won't link to the registrant's ticket.
         </p>
       <% end %>
     </div>
-    <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif;">
+    <div class="email-preview max-h-[70vh] overflow-auto p-4" style="font-family: Lato, sans-serif;">
       <%= raw @reminder_preview_html %>
     </div>
   </div>

--- a/app/views/events/dashboard.html.erb
+++ b/app/views/events/dashboard.html.erb
@@ -3,9 +3,9 @@
     the wrapper restores the layout's gutters at a wider bound. %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4 print:hidden">
     <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :dashboard %>
   </div>
@@ -31,7 +31,7 @@
           <%= @event.date_range %>
         </p>
       <% end %>
-      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+      <h1 class="font-display text-3xl font-bold text-primary mt-2 flex items-center justify-center gap-2">
         <i class="fa-solid fa-chart-simple <%= DomainTheme.text_class_for(:events, intensity: 600) %>"></i>
         Dashboard
       </h1>
@@ -42,8 +42,8 @@
       free registration AND no CE fees or scholarships (a free event can still
       charge for CE). %>
   <% if @dashboard.free? && @dashboard.cont_ed_total_cents.zero? && @dashboard.scholarship_total_cents.zero? %>
-    <div class="bg-white rounded-xl border border-gray-200 p-4 text-center text-sm text-gray-500 mb-4">
-      <i class="fa-solid fa-tag text-gray-400 mr-1"></i> Free event — no payments or scholarships
+    <div class="border-primary/10 mb-4 rounded-2xl border bg-white p-4 text-center text-sm text-gray-500">
+      <i class="fa-solid fa-tag mr-1 text-gray-400"></i> Free event — no payments or scholarships
     </div>
   <% else %>
     <%# Money reads as an equation: Grand total = Registration fees + Scholarships allocated + Continuing education fees.
@@ -53,7 +53,7 @@
         stay visible.
         Each addend owns Paid/Allocated + Outstanding sub-rows (nested inside its card).
         Grand total is a full-width hero; the three addends sit in a row beneath it. %>
-    <div class="space-y-3 sm:space-y-4 mb-4">
+    <div class="mb-4 space-y-3 sm:space-y-4">
       <%# Grand total — full-width headline read as an inline equation:
           $grand = $registration + $scholarships + $cont_ed. Left-aligned; the headline
           figure dominates while the addends stay muted, and the row wraps on mobile. %>
@@ -66,11 +66,11 @@
            "leading-tight rounded-lg border border-transparent px-3 py-2 transition-colors hover:bg-#{color}-50 hover:border-#{color}-300"
          end %>
       <div class="rounded-xl border <%= DomainTheme.border_class_for(:event_dashboard, intensity: 200) %> <%= DomainTheme.bg_class_for(:event_dashboard, intensity: 50) %> p-4 shadow-sm">
-        <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_dashboard, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+        <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:event_dashboard, intensity: 600) %> text-xs font-semibold tracking-wide uppercase">
           <i class="fa-solid fa-coins"></i>
           <span>Grand total</span>
         </div>
-        <div class="mt-2 flex flex-col lg:flex-row lg:items-start lg:justify-between gap-x-6 gap-y-3">
+        <div class="mt-2 flex flex-col gap-x-6 gap-y-3 lg:flex-row lg:items-start lg:justify-between">
           <%# The equation stays on one line at every width: below lg the per-addend
               labels collapse so it reads as numbers only ($grand = $reg + $sch + $ce),
               with a compact label key beneath; the full labels return inline at lg+.
@@ -82,18 +82,18 @@
                     title: "View the event revenue report" %>
               <span class="text-2xl font-light text-gray-300 select-none">=</span>
               <%= link_to registrants_event_path(@event), class: addend_class.call(:payments), title: "Manage registrations" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></p>
-                <p class="hidden lg:block text-xs text-gray-500">Registration fees</p>
+                <p class="text-lg font-semibold sm:text-xl <%= DomainTheme.text_class_for(:payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></p>
+                <p class="hidden text-xs text-gray-500 lg:block">Registration fees</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
               <%= link_to recipients_event_path(@event), class: addend_class.call(:scholarships), title: "View scholarships" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></p>
-                <p class="hidden lg:block text-xs text-gray-500">Scholarships</p>
+                <p class="text-lg font-semibold sm:text-xl <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></p>
+                <p class="hidden text-xs text-gray-500 lg:block">Scholarships</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
               <%= link_to registrants_event_path(@event, ce_status: "registered"), class: "#{addend_class.call(:continuing_education)} whitespace-nowrap", title: "View registrants with continuing education" do %>
-                <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></p>
-                <p class="hidden lg:block text-xs text-gray-500">CE fees</p>
+                <p class="text-lg font-semibold sm:text-xl <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></p>
+                <p class="hidden text-xs text-gray-500 lg:block">CE fees</p>
               <% end %>
               <span class="text-2xl font-light text-gray-300 select-none">+</span>
               <% if @dashboard.unallocated_bulk_payment_cents.positive? %>
@@ -101,16 +101,16 @@
                     amber-bordered card with a warning icon, since unallocated bulk
                     payment money still needs action. %>
                 <%= link_to bulk_payments_event_path(@event), class: "whitespace-nowrap leading-tight rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 hover:bg-amber-100 transition-colors", title: "Allocate bulk payments" do %>
-                  <p class="flex items-center gap-1.5 text-lg sm:text-xl font-semibold text-amber-700 tabular-nums">
+                  <p class="flex items-center gap-1.5 text-lg font-semibold text-amber-700 tabular-nums sm:text-xl">
                     <i class="fa-solid fa-circle-exclamation"></i>
                     <%= dollars_from_cents(@dashboard.unallocated_bulk_payment_cents) %>
                   </p>
-                  <p class="hidden lg:block text-xs text-gray-500">Unallocated bulk payments</p>
+                  <p class="hidden text-xs text-gray-500 lg:block">Unallocated bulk payments</p>
                 <% end %>
               <% else %>
                 <%= link_to bulk_payments_event_path(@event), class: addend_class.call(:bulk_payments), title: "View bulk payments" do %>
-                  <p class="text-lg sm:text-xl font-semibold <%= DomainTheme.text_class_for(:bulk_payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.unallocated_bulk_payment_cents) %></p>
-                  <p class="hidden lg:block text-xs text-gray-500">Bulk payments</p>
+                  <p class="text-lg font-semibold sm:text-xl <%= DomainTheme.text_class_for(:bulk_payments, intensity: 600) %> tabular-nums"><%= dollars_from_cents(@dashboard.unallocated_bulk_payment_cents) %></p>
+                  <p class="hidden text-xs text-gray-500 lg:block">Bulk payments</p>
                 <% end %>
               <% end %>
             </div>
@@ -121,7 +121,7 @@
               cont ed paid), what's still owed, and the fee revenue earned
               (registration + cont ed, excluding scholarships). Collected + due =
               monies made. Kept neutral grey so the equation stays the focus. %>
-          <div class="lg:shrink-0 lg:border-l lg:border-gray-200 lg:pl-6 flex flex-col gap-1 text-xs text-gray-500">
+          <div class="flex flex-col gap-1 text-xs text-gray-500 lg:shrink-0 lg:border-l lg:border-gray-200 lg:pl-6">
             <span class="flex items-center justify-between gap-3">
               <span>Collected</span>
               <span class="font-semibold text-gray-500 tabular-nums"><%= dollars_from_cents(@dashboard.collected_cents) %></span>
@@ -130,7 +130,7 @@
               <span>Due</span>
               <span class="font-semibold text-gray-500 tabular-nums"><%= dollars_from_cents(@dashboard.due_cents) %></span>
             </span>
-            <span class="flex items-center justify-between gap-3 mt-1 pt-1 border-t border-gray-200">
+            <span class="mt-1 flex items-center justify-between gap-3 border-t border-gray-200 pt-1">
               <span class="font-bold text-gray-700">Monies</span>
               <span class="font-bold text-gray-700 tabular-nums"><%= dollars_from_cents(@dashboard.monies_made_cents) %></span>
             </span>
@@ -140,12 +140,12 @@
 
       <%# The three addends: Registration fees + Scholarships + Continuing education fees. Each owns
           paid/completed + outstanding sub-rows that expand to the registrants behind the figure. %>
-      <div class="flex flex-col md:flex-row md:flex-wrap md:items-stretch gap-3 md:gap-4">
+      <div class="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-stretch md:gap-4">
         <%# Payments = Paid + Outstanding %>
-        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
-          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <details class="group/card flex-1 rounded-xl border md:min-w-[16rem] <%= DomainTheme.border_class_for(:payments, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
-              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:payments, intensity: 600) %> text-xs font-semibold tracking-wide uppercase">
                 <i class="fa-solid fa-sack-dollar"></i>
                 <span>Registration fees</span>
               </div>
@@ -158,14 +158,14 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></span>
+                <span class="text-2xl font-bold sm:text-3xl <%= DomainTheme.text_class_for(:payments, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.registration_subtotal_cents) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
-          <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
+          <div class="mt-3 space-y-1 border-t border-gray-100 pt-3">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.received_cents,
                   count: @dashboard.paid_count, registrants: @dashboard.paid_registrants,
@@ -182,10 +182,10 @@
         </details>
 
         <%# Scholarships = Completed + Outstanding %>
-        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
-          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <details class="group/card flex-1 rounded-xl border md:min-w-[16rem] <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
-              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %> text-xs font-semibold tracking-wide uppercase">
                 <i class="fa-solid fa-graduation-cap"></i>
                 <span>Scholarships</span>
               </div>
@@ -198,13 +198,13 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></span>
+                <span class="text-2xl font-bold sm:text-3xl <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.scholarship_total_cents) %></span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
-          <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
+          <div class="mt-3 space-y-1 border-t border-gray-100 pt-3">
             <%= render "dashboard_money_row", label: "Scholarships", icon: "fa-graduation-cap",
                   amount_cents: @dashboard.scholarship_total_cents,
                   count: @dashboard.scholarship_registrants.size, registrants: @dashboard.scholarship_registrants,
@@ -214,10 +214,10 @@
         </details>
 
         <%# Continuing education fees = Paid + Outstanding %>
-        <details class="group/card flex-1 md:min-w-[16rem] rounded-xl border <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
-          <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+        <details class="group/card flex-1 rounded-xl border md:min-w-[16rem] <%= DomainTheme.border_class_for(:continuing_education, intensity: 200) %> bg-white p-4 shadow-sm">
+          <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
             <div class="flex items-center justify-between gap-2">
-              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold uppercase tracking-wide">
+              <div class="flex items-center gap-1.5 <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %> text-xs font-semibold tracking-wide uppercase">
                 <i class="fa-solid fa-award"></i>
                 <span>CE fees</span>
               </div>
@@ -230,14 +230,14 @@
             </div>
             <div class="mt-2 flex items-center justify-between gap-2">
               <p class="break-words">
-                <span class="text-2xl sm:text-3xl font-bold <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></span>
+                <span class="text-2xl font-bold sm:text-3xl <%= DomainTheme.text_class_for(:continuing_education, intensity: 700) %> tabular-nums"><%= dollars_from_cents(@dashboard.cont_ed_total_cents) %></span>
                 <span class="text-xs text-gray-500">including due</span>
               </p>
               <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
             </div>
           </summary>
 
-          <div class="mt-3 pt-3 border-t border-gray-100 space-y-1">
+          <div class="mt-3 space-y-1 border-t border-gray-100 pt-3">
             <%= render "dashboard_money_row", label: "Paid", icon: "fa-money-bill-wave",
                   amount_cents: @dashboard.cont_ed_paid_cents,
                   count: @dashboard.cont_ed_paid_count, registrants: @dashboard.cont_ed_paid_registrants,
@@ -357,8 +357,8 @@
       </div>
     </details>
 
-    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
-      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+    <details class="group/card rounded-xl border bg-white <%= DomainTheme.border_class_for(:organizations, intensity: 200) %> p-4 shadow-sm">
+      <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <%= render "headcount_header", color_key: :organizations, icon: "fa-building",
                 count: @dashboard.organization_count, label: "Organizations",
@@ -367,20 +367,20 @@
         </div>
         <% program_counts = @dashboard.program_status_counts %>
         <% program_status_ids = @dashboard.program_status_registrant_ids %>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: program_status_ids[:new].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: program_status_ids[:ongoing].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: program_status_ids[:reinstated].join("-").presence || "0") %></p>
+        <p class="mt-1 text-xs text-gray-500"><%= render "stat_link", label: "#{program_counts[:new]} new", path: registrants_event_path(@event, registrant_ids: program_status_ids[:new].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:ongoing]} ongoing", path: registrants_event_path(@event, registrant_ids: program_status_ids[:ongoing].join("-").presence || "0") %> · <%= render "stat_link", label: "#{program_counts[:reinstated]} reinstated", path: registrants_event_path(@event, registrant_ids: program_status_ids[:reinstated].join("-").presence || "0") %></p>
       </summary>
-      <div class="mt-3 pt-3 border-t border-gray-100">
+      <div class="mt-3 border-t border-gray-100 pt-3">
         <% if @dashboard.organizations.any? %>
-          <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
+          <ul class="max-h-64 space-y-1 overflow-y-auto text-xs text-gray-700">
             <% @dashboard.organizations.each do |organization| %>
-              <li class="group/rowlink flex items-center gap-1.5 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50">
+              <li class="group/rowlink -mx-1 flex items-center gap-1.5 rounded px-1 py-0.5 hover:bg-gray-50">
                 <%= link_to registrants_event_path(@event, registrant_ids: @dashboard.organization_registrant_ids_by_org.fetch(organization.id, []).to_a.join("-")), class: "flex items-center justify-between gap-2 flex-1 min-w-0", title: "Registrants from #{organization.name}" do %>
-                  <span class="flex items-center gap-1.5 min-w-0">
+                  <span class="flex min-w-0 items-center gap-1.5">
                     <%= organization.decorate.program_status_badge(@dashboard.program_status_by_organization[organization.id]) %>
                     <%= organization.decorate.high_profile_icon %>
-                    <span class="truncate min-w-0 group-hover/rowlink:underline"><%= organization.name %></span>
+                    <span class="min-w-0 truncate group-hover/rowlink:underline"><%= organization.name %></span>
                   </span>
-                  <span class="text-xs text-gray-500 shrink-0"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
+                  <span class="shrink-0 text-xs text-gray-500"><%= @dashboard.organization_counts.fetch(organization.id, 0) %></span>
                 <% end %>
                 <%= link_to organization_path(organization), class: "shrink-0 flex h-7 items-center text-white group-hover/rowlink:text-gray-500", title: "View #{organization.name} profile" do %>
                   <i class="fa-solid fa-arrow-up-right-from-square text-2xs"></i>
@@ -394,24 +394,24 @@
       </div>
     </details>
 
-    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
-      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+    <details class="group/card rounded-xl border bg-white <%= DomainTheme.border_class_for(:sectors, intensity: 200) %> p-4 shadow-sm">
+      <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <%= render "headcount_header", color_key: :sectors, icon: "fa-layer-group",
                 count: @dashboard.sectors.size, label: "Sectors",
                 path: registrants_event_path(@event, registrant_ids: @dashboard.sector_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: "#{@dashboard.primary_sector_count} primary", path: registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids.join("-").presence || "0") %> · <%= render "stat_link", label: "#{@dashboard.additional_sector_count} additional", path: registrants_event_path(@event, registrant_ids: @dashboard.additional_sector_registrant_ids.join("-").presence || "0") %></p>
+        <p class="mt-1 text-xs text-gray-500"><%= render "stat_link", label: "#{@dashboard.primary_sector_count} primary", path: registrants_event_path(@event, registrant_ids: @dashboard.primary_sector_registrant_ids.join("-").presence || "0") %> · <%= render "stat_link", label: "#{@dashboard.additional_sector_count} additional", path: registrants_event_path(@event, registrant_ids: @dashboard.additional_sector_registrant_ids.join("-").presence || "0") %></p>
       </summary>
-      <div class="mt-3 pt-3 border-t border-gray-100">
+      <div class="mt-3 border-t border-gray-100 pt-3">
         <% if @dashboard.sectors.any? %>
-          <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
+          <ul class="max-h-64 space-y-1 overflow-y-auto text-xs text-gray-700">
             <% @dashboard.sectors.each do |sector| %>
               <li>
                 <%= link_to registrants_event_path(@event, sector: sector.id), class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50", title: sector.name do %>
-                  <span class="truncate min-w-0 group-hover/rowlink:underline"><%= sector.name %></span>
-                  <span class="flex items-center gap-2 shrink-0">
+                  <span class="min-w-0 truncate group-hover/rowlink:underline"><%= sector.name %></span>
+                  <span class="flex shrink-0 items-center gap-2">
                     <span class="text-xs text-gray-500"><%= @dashboard.sector_counts.fetch(sector.id, 0) %></span>
                     <i class="fa-solid fa-arrow-up-right-from-square text-2xs text-white group-hover/rowlink:text-gray-500"></i>
                   </span>
@@ -425,24 +425,24 @@
       </div>
     </details>
 
-    <details class="group/card bg-white rounded-xl border <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
-      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
+    <details class="group/card rounded-xl border bg-white <%= DomainTheme.border_class_for(:addresses, intensity: 200) %> p-4 shadow-sm">
+      <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
         <div class="flex items-center justify-between gap-2">
           <%= render "headcount_header", color_key: :addresses, icon: "fa-location-dot",
                 count: @dashboard.states.size, label: "States",
                 path: registrants_event_path(@event, registrant_ids: @dashboard.state_registrant_ids.join("-")) %>
           <i class="fa-solid fa-chevron-down text-gray-400 transition-transform group-open/card:rotate-180"></i>
         </div>
-        <p class="text-xs text-gray-500 mt-1"><%= render "stat_link", label: pluralize(@dashboard.countries.size, "country"), path: registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-").presence || "0") %></p>
+        <p class="mt-1 text-xs text-gray-500"><%= render "stat_link", label: pluralize(@dashboard.countries.size, "country"), path: registrants_event_path(@event, registrant_ids: @dashboard.country_registrant_ids.join("-").presence || "0") %></p>
       </summary>
-      <div class="mt-3 pt-3 border-t border-gray-100">
+      <div class="mt-3 border-t border-gray-100 pt-3">
         <% if @dashboard.states.any? %>
-          <ul class="space-y-1 text-xs text-gray-700 max-h-64 overflow-y-auto">
+          <ul class="max-h-64 space-y-1 overflow-y-auto text-xs text-gray-700">
             <% @dashboard.states.each do |state| %>
               <li>
                 <%= link_to registrants_event_path(@event, state: state), class: "group/rowlink flex items-center justify-between gap-2 rounded px-1 -mx-1 py-0.5 hover:bg-gray-50" do %>
                   <span class="group-hover/rowlink:underline"><%= state %></span>
-                  <span class="flex items-center gap-2 shrink-0">
+                  <span class="flex shrink-0 items-center gap-2">
                     <span class="text-xs text-gray-500"><%= @dashboard.state_counts.fetch(state, 0) %></span>
                     <i class="fa-solid fa-arrow-up-right-from-square text-2xs text-white group-hover/rowlink:text-gray-500"></i>
                   </span>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :edit %>
   </div>
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
       Edit event: <%= @event.title %>
     </h1>
     <button type="submit" form="event-form"
@@ -17,7 +17,7 @@
     </button>
   </div>
   <div class="space-y-6">
-    <div class="bg-white rounded mt-4 p-6">
+    <div class="mt-4 rounded bg-white p-6">
       <%= render "form" %>
       <%= render "shared/audit_info", resource: @event %>
     </div>

--- a/app/views/events/edit_staff.html.erb
+++ b/app/views/events/edit_staff.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 
-<div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6 sm:p-8">
+<div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6 sm:p-8">
   <%# Eyebrow returns to wherever the editor was opened from: a registrant's (or
       the sample's) staff callout page, else the admin staff roster. Kept in sync
       with EventsController#update_staff's post-save redirect. %>
@@ -15,7 +15,7 @@
 
   <div class="mb-8">
     <p class="text-sm font-semibold uppercase tracking-wide <%= DomainTheme.text_class_for(:events) %>">Manage staff</p>
-    <h1 class="text-2xl font-bold text-gray-900 mt-1"><%= @event.title %></h1>
+    <h1 class="font-display text-2xl font-bold text-primary mt-1"><%= @event.title %></h1>
     <p class="text-gray-500 mt-1 text-sm">Connect people to this event and set their role. Use the toggle to mark who is expected to attend.</p>
   </div>
 

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -1,20 +1,20 @@
-<div class="max-w-5xl mx-auto px-4 pt-4">
+<div class="mx-auto max-w-5xl px-4 pt-4">
   <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     &larr; Back to registrants
   <% end %>
 
-  <h1 class="text-lg font-semibold text-gray-800 mt-3">
+  <h1 class="text-primary mt-3 font-display text-lg font-semibold">
     <%= @person.name %> &mdash; <%= @event.title %>
   </h1>
 </div>
 
-<div class="max-w-5xl mx-auto pb-12 pt-4 px-4 space-y-10">
+<div class="mx-auto max-w-5xl space-y-10 px-4 pt-4 pb-12">
   <% @form_submissions.each do |submission| %>
     <% form_fields = submission.form.form_fields.reorder(position: :asc) %>
     <% responses = submission.form_answers.index_by(&:form_field_id) %>
 
     <div>
-      <div class="pb-1.5 border-b-2 border-gray-300 mb-5">
+      <div class="mb-5 border-b-2 border-gray-300 pb-1.5">
         <h2 class="text-lg font-semibold text-gray-900"><%= submission.form.name %></h2>
         <p class="text-xs text-gray-500">Submitted <%= submission.created_at.strftime("%B %d, %Y at %l:%M %P") %></p>
       </div>
@@ -39,13 +39,13 @@
 
       <% sections.each do |section| %>
         <% if section[:name].present? %>
-          <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mt-5 mb-2"><%= section[:name] %></h3>
+          <h3 class="mt-5 mb-2 text-xs font-semibold tracking-wider text-gray-500 uppercase"><%= section[:name] %></h3>
         <% end %>
         <div class="divide-y divide-gray-100">
           <% section[:fields].each do |field, response| %>
             <div class="flex gap-4 py-1.5">
               <div class="w-1/3 shrink-0 text-xs text-gray-500"><%= display_question_label(field, response) %></div>
-              <div class="text-sm text-gray-900 whitespace-pre-line"><%= render "shared/form_answer_value", field: field, response: response %></div>
+              <div class="text-sm whitespace-pre-line text-gray-900"><%= render "shared/form_answer_value", field: field, response: response %></div>
             </div>
           <% end %>
         </div>
@@ -57,7 +57,7 @@
         <% if attendees.any? %>
           <div class="mt-3 space-y-1.5">
             <% attendees.each do |attendee| %>
-              <div class="flex items-center gap-2 text-sm text-gray-900 bg-gray-50 rounded px-3 py-1.5">
+              <div class="flex items-center gap-2 rounded bg-gray-50 px-3 py-1.5 text-sm text-gray-900">
                 <span class="font-medium"><%= attendee["first_name"] %> <%= attendee["last_name"] %></span>
                 <span class="text-gray-500"><%= attendee["email"] %></span>
               </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
       New <%= @event.class.model_name.human.downcase %>
     </h1>
   </div>
   <div class="space-y-6">
-    <div class="bg-white rounded mt-4 p-6">
+    <div class="mt-4 rounded bg-white p-6">
       <%= render "form" %>
     </div>
   </div>

--- a/app/views/events/onboarding.html.erb
+++ b/app/views/events/onboarding.html.erb
@@ -1,16 +1,16 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <% content_for(:full_width, true) %>
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow m-2 p-4">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 m-2 rounded-2xl border p-4 shadow-sm">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :registrants %>
   </div>
 
-  <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">Onboarding</h1>
-      <p class="text-gray-600 mt-1">
+      <h1 class="text-primary font-display text-2xl font-semibold">Onboarding</h1>
+      <p class="mt-1 text-gray-600">
         <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
       </p>
     </div>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% label, return_path = participation_return_link %>
       <%= link_to label, return_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -74,7 +74,7 @@
           stacked column per year. %>
       <section class="mb-8">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Attendance by year</h2>
-        <div class="rounded-xl border border-gray-200 bg-white p-4">
+        <div class="rounded-2xl border border-primary/10 bg-white p-4">
           <%= column_chart @report.chart_series, stacked: true, thousands: ",",
                 colors: [ "#2563eb", "#d97706", "#dc2626" ], height: "260px", library: { borderRadius: 4 } %>
         </div>
@@ -147,13 +147,13 @@
                     <%# Each outcome links to this event's registrants filtered to that status.
                         Inline grid-template-columns (like the revenue table) so all seven
                         outcomes sit in one row without relying on a generated grid-cols-7. %>
-                    <div class="grid gap-x-4 gap-y-2 text-sm py-2"
+                    <div class="grid gap-x-4 gap-y-2 py-2 text-sm"
                          style="grid-template-columns: repeat(7, minmax(0, 1fr))">
                       <% EventParticipationReport::STATUS_LABELS.each do |status, label| %>
                         <%= link_to attendees_events_path(event_id: row.event.id, attendance_status: status, event_type: EventRegistration::FILTER_ALL, return_to: "participation"),
                               class: "flex items-baseline justify-between gap-2 rounded px-1 -mx-1 hover:bg-white transition-colors" do %>
-                          <span class="text-gray-500 whitespace-nowrap"><%= label %></span>
-                          <span class="tabular-nums text-gray-800"><%= number_with_delimiter(row.count_for(status)) %></span>
+                          <span class="whitespace-nowrap text-gray-500"><%= label %></span>
+                          <span class="text-gray-800 tabular-nums"><%= number_with_delimiter(row.count_for(status)) %></span>
                         <% end %>
                       <% end %>
                     </div>
@@ -175,19 +175,19 @@
           </details>
         <% end %>
 
-        <div class="grid items-center gap-x-3 px-3 py-3 mt-2 bg-gray-200 border border-gray-300 rounded-lg text-base font-bold text-gray-900"
+        <div class="mt-2 grid items-center gap-x-3 rounded-lg border border-gray-300 bg-gray-200 px-3 py-3 text-base font-bold text-gray-900"
              style="grid-template-columns: var(--part-cols)">
-          <div class="uppercase tracking-wide text-xs text-gray-600">All years</div>
+          <div class="text-xs tracking-wide text-gray-600 uppercase">All years</div>
           <div class="text-right tabular-nums">
             <%= number_with_delimiter(@report.unique_people) %>
             <% if @report.attended_seats != @report.unique_people %>
               <span class="text-xs font-normal text-gray-500">(<%= number_with_delimiter(@report.attended_seats) %> seats)</span>
             <% end %>
           </div>
-          <div class="text-right tabular-nums text-amber-700"><%= number_with_delimiter(@report.count_for("incomplete_attendance")) %></div>
-          <div class="text-right tabular-nums text-red-600"><%= number_with_delimiter(@report.count_for("no_show")) %></div>
-          <div class="text-right tabular-nums text-purple-700"><%= number_with_delimiter(@report.count_other) %></div>
-          <div class="text-right tabular-nums text-gray-700"><%= number_with_delimiter(@report.total_registrations) %></div>
+          <div class="text-right text-amber-700 tabular-nums"><%= number_with_delimiter(@report.count_for("incomplete_attendance")) %></div>
+          <div class="text-right text-red-600 tabular-nums"><%= number_with_delimiter(@report.count_for("no_show")) %></div>
+          <div class="text-right text-purple-700 tabular-nums"><%= number_with_delimiter(@report.count_other) %></div>
+          <div class="text-right text-gray-700 tabular-nums"><%= number_with_delimiter(@report.total_registrations) %></div>
         </div>
 
         <p class="mt-3 text-xs text-gray-500">
@@ -199,7 +199,7 @@
         </p>
       </section>
     <% else %>
-      <div class="text-center py-12 text-gray-500">
+      <div class="py-12 text-center text-gray-500">
         No events match this filter yet — once trainings run and attendance is recorded, you'll see participation by year here.
       </div>
     <% end %>

--- a/app/views/events/preview_reminder.html.erb
+++ b/app/views/events/preview_reminder.html.erb
@@ -1,23 +1,23 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Registrants", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: nil %>
   </div>
 
   <div class="mb-4">
-    <h1 class="text-2xl font-semibold text-gray-900">
+    <h1 class="text-primary font-display text-2xl font-semibold">
       <%= @invite_mode ? "Send Portal invite emails" : "Send bulk emails" %>
     </h1>
-    <p class="text-gray-600 mt-1">
+    <p class="mt-1 text-gray-600">
       <%= @event.title %><% if @event.start_date.present? %> &bull; <%= @event.date_range %><% end %>
     </p>
   </div>
 
   <%# Banner: what this page does, plus a plain link to the other mode. %>
-  <div class="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-6 flex items-baseline gap-2.5 text-sm text-gray-600">
-    <i class="fa-solid fa-circle-info text-gray-400 shrink-0"></i>
+  <div class="border-primary/10 mb-6 flex items-baseline gap-2.5 rounded-2xl border bg-gray-50 px-4 py-3 text-sm text-gray-600">
+    <i class="fa-solid fa-circle-info shrink-0 text-gray-400"></i>
     <p>
       <% if @invite_mode %>
         You're sending the standard Portal invite (confirmation) email to registrants
@@ -31,15 +31,15 @@
   </div>
   <% if @event_registrations.empty? %>
     <% if @invite_mode %>
-      <p class="text-gray-600 mb-4">Every registrant with an email already has a portal account — there's no one to invite.</p>
+      <p class="mb-4 text-gray-600">Every registrant with an email already has a portal account — there's no one to invite.</p>
     <% else %>
-      <p class="text-gray-600 mb-4">There are no registrants with an email address to send a reminder to.</p>
+      <p class="mb-4 text-gray-600">There are no registrants with an email address to send a reminder to.</p>
     <% end %>
     <%= link_to "Back to registrants", registrants_event_path(@event), class: "btn btn-secondary-outline" %>
   <% else %>
-    <h2 class="text-lg font-semibold text-gray-800 mb-2 pb-2 border-b border-gray-200">Recipients</h2>
+    <h2 class="mb-2 border-b border-gray-200 pb-2 text-lg font-semibold text-gray-800">Recipients</h2>
     <% if @invite_mode %>
-      <p class="text-gray-600 mb-3">
+      <p class="mb-3 text-gray-600">
         Only registrants with no Portal account yet are listed — a Portal invite
         (confirmation) email is for people who can't sign in. Filters keep everyone
         in the list and check
@@ -48,7 +48,7 @@
         <code class="font-mono">amy--aisha</code>).
       </p>
     <% else %>
-      <p class="text-gray-600 mb-3">
+      <p class="mb-3 text-gray-600">
         Choose who will receive this reminder. Filters keep everyone in the list and
         check the matches. Separate multiple values with
         <code class="font-mono">'--'</code> to match multiple values (e.g.
@@ -88,11 +88,11 @@
         </div>
       <% else %>
         <div class="my-14">
-          <h2 class="text-lg font-semibold text-gray-800 mb-6 pb-2 border-b border-gray-200">Email draft</h2>
-          <div class="bg-white border border-gray-200 rounded-lg p-6 pb-8 space-y-6">
+          <h2 class="mb-6 border-b border-gray-200 pb-2 text-lg font-semibold text-gray-800">Email draft</h2>
+          <div class="border-primary/10 space-y-6 rounded-2xl border bg-white p-6 pb-8">
             <div>
-              <h3 class="font-semibold text-gray-700 mb-2">Subject</h3>
-              <p class="text-gray-600 mb-2">
+              <h3 class="mb-2 font-semibold text-gray-700">Subject</h3>
+              <p class="mb-2 text-gray-600">
                 The subject line recipients will see. Edit it as you like — leave it as is to use the default.
               </p>
               <%= text_field_tag :custom_subject, @custom_subject,
@@ -100,15 +100,15 @@
                     data: { reminder_preview_target: "subjectInput", action: "input->reminder-preview#updateSubject" } %>
             </div>
             <div>
-              <h3 class="font-semibold text-gray-700 mb-2">Message</h3>
-              <p class="text-gray-600 mb-2">
+              <h3 class="mb-2 font-semibold text-gray-700">Message</h3>
+              <p class="mb-2 text-gray-600">
                 The intro shown near the top of the reminder, above the event details. Edit it or clear it as you like.
               </p>
               <%= text_area_tag :custom_message, @custom_message,
                     rows: 4,
                     class: "w-full rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono bg-white",
                     data: { reminder_preview_target: "input", action: "input->reminder-preview#update" } %>
-              <p class="text-xs text-gray-400 mt-1.5">
+              <p class="mt-1.5 text-xs text-gray-400">
                 Accepts basic HTML — bold, italics, links, lists, and line breaks.
               </p>
             </div>
@@ -119,7 +119,7 @@
                       data: { reminder_preview_target: "eventCardToggle", action: "reminder-preview#toggleEventCard" } %>
                 Hide the event details box
               </label>
-              <p class="text-xs text-gray-400 mt-1.5 ml-6">
+              <p class="mt-1.5 ml-6 text-xs text-gray-400">
                 Leaves out the grey box with the event's date, time, cost, and location.
               </p>
               <%# The toggle's only feedback is the preview below, which a screen
@@ -143,8 +143,8 @@
       <% end %>
       <% if @reminder_preview_html.present? %>
         <div class="mb-6">
-          <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">Preview (sample registrant)</h2>
-          <div class="border border-gray-200 rounded-lg bg-white overflow-hidden">
+          <h2 class="mb-3 border-b border-gray-200 pb-2 text-lg font-semibold text-gray-800">Preview (sample registrant)</h2>
+          <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white">
             <div class="border-b border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700">
               <span class="font-semibold text-gray-500">Subject:</span>
               <% if @invite_mode %>
@@ -153,7 +153,7 @@
                 <span data-reminder-preview-target="subjectPreview"><%= @custom_subject %></span>
               <% end %>
             </div>
-            <div class="email-preview overflow-auto max-h-[70vh] p-4" style="font-family: Lato, sans-serif; zoom: 0.6;">
+            <div class="email-preview max-h-[70vh] overflow-auto p-4" style="font-family: Lato, sans-serif; zoom: 0.6;">
               <%= raw @reminder_preview_html %>
             </div>
           </div>

--- a/app/views/events/program_statuses.html.erb
+++ b/app/views/events/program_statuses.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
         <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/events/recipients.html.erb
+++ b/app/views/events/recipients.html.erb
@@ -13,9 +13,9 @@
     the wrapper restores the layout's gutters at a wider bound. %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
-<div class="bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="border-primary/10 rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4 print:hidden">
     <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= render "events/subnav", event: @event, current: :scholarships %>
   </div>
@@ -67,8 +67,8 @@
         charts panel) survives — same rule as the roster's chip. %>
     <% drill_ins = AttendeesActiveFilters.new(params, chip_params: %w[ registrant_ids ]).chips %>
     <% if drill_ins.any? %>
-      <div class="flex flex-wrap items-center gap-2 mb-4 print:hidden">
-        <span class="text-xs font-semibold uppercase text-gray-500 tracking-wide">Applied</span>
+      <div class="mb-4 flex flex-wrap items-center gap-2 print:hidden">
+        <span class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Applied</span>
         <% drill_ins.each do |filter| %>
           <span class="inline-flex items-center gap-1.5 rounded-full border border-fuchsia-200 bg-fuchsia-50 px-3 py-1 text-xs font-medium text-fuchsia-700">
             <%= filter[:label] %>
@@ -89,8 +89,8 @@
          data-panel-toggle-target="panel" data-panel-toggle-name="recipients">
       <%# Title shares a row with the controls (show/hide scholarship status,
           group by funder, expand/collapse all). %>
-      <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
-        <h2 class="text-xl font-bold flex items-center gap-2 <%= DomainTheme.text_class_for(:scholarships) %>">
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+        <h2 class="flex items-center gap-2 text-xl font-bold <%= DomainTheme.text_class_for(:scholarships) %>">
           <i class="fa-solid fa-user-graduate"></i>
           Recipients
         </h2>
@@ -128,7 +128,7 @@
           <%# Expand / collapse all %>
           <button type="button" data-action="expandable-cards#toggleAll"
                   class="inline-flex items-center gap-2 text-sm font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> hover:<%= DomainTheme.text_class_for(:scholarships) %>">
-            <i class="fa-solid fa-chevron-down transition-transform rotate-180" data-expandable-cards-target="icon"></i>
+            <i class="fa-solid fa-chevron-down rotate-180 transition-transform" data-expandable-cards-target="icon"></i>
             <span data-expandable-cards-target="label">Collapse all</span>
           </button>
         </div>
@@ -148,7 +148,7 @@
             <section class="break-inside-avoid">
               <%# Bold, dark-fuchsia funder band so each group's header stands out.
                   The funder name links to the funder's profile (org or person). %>
-              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-fuchsia-800 px-4 py-2.5 mb-4 text-white">
+              <div class="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-fuchsia-800 px-4 py-2.5 text-white">
                 <i class="fa-solid fa-hand-holding-heart text-fuchsia-200"></i>
                 <h2 class="text-lg font-bold tracking-tight">
                   <% if group.funder && allowed_to?(:show?, group.funder) %>
@@ -185,21 +185,21 @@
       <% end %>
     </div>
   <% else %>
-    <div class="text-center py-12 text-gray-500">
+    <div class="py-12 text-center text-gray-500">
       No scholarship recipients yet.
     </div>
   <% end %>
 
   <%# ---- Shout outs: registrants who opted in, with their shout-out text ---- %>
   <% if @dashboard.shoutouts.any? %>
-    <div id="shout-outs" class="scroll-mt-24 mt-10 break-inside-avoid">
+    <div id="shout-outs" class="mt-10 scroll-mt-24 break-inside-avoid">
       <% recipient_shoutout_options = @dashboard.scholarship_applicants.filter_map { |person|
            reg_id = @dashboard.registration_id_by_registrant[person.id]
            next unless reg_id
            label = person.email.present? ? "#{person.name} (#{person.email})" : person.name
            [ label, reg_id ]
          } %>
-      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
         <%= render "events/section_heading", title: "Shout outs", icon: "fa-bullhorn",
               theme: :scholarships, panel: "shoutouts", open: true, margin: "" %>
         <%# Search a scholarship recipient and feature them: this flags their
@@ -223,11 +223,11 @@
         <% end %>
       </div>
       <div data-panel-toggle-target="panel" data-panel-toggle-name="shoutouts"
-           class="bg-white border <%= DomainTheme.border_class_for(:scholarships) %> rounded-xl shadow-sm divide-y divide-gray-100">
+           class="border bg-white <%= DomainTheme.border_class_for(:scholarships) %> divide-y divide-gray-100 rounded-xl shadow-sm">
         <% @dashboard.shoutouts.each do |shoutout| %>
           <% org_link_class = "text-sm font-semibold #{DomainTheme.text_class_for(:scholarships, intensity: 700)} hover:#{DomainTheme.text_class_for(:scholarships)} hover:underline" %>
-          <div class="flex items-start gap-3 px-5 py-4 break-inside-avoid">
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 flex-1 min-w-0">
+          <div class="flex break-inside-avoid items-start gap-3 px-5 py-4">
+            <div class="grid min-w-0 flex-1 grid-cols-1 gap-3 sm:grid-cols-3">
             <%# Organization on the left, linked to its website when it has one,
                 otherwise to its profile page. %>
             <div class="sm:col-span-1">
@@ -242,7 +242,7 @@
             </div>
             <%# Recipient name on the right, bold and linked to their profile, with
                 their primary sector and age group in parens, then their shout-out text. %>
-            <div class="sm:col-span-2 text-sm text-gray-700">
+            <div class="text-sm text-gray-700 sm:col-span-2">
               <%= link_to shoutout.recipient.name, person_path(shoutout.recipient),
                           class: "font-semibold text-gray-900 hover:underline" %>
               <% meta = [ shoutout.sector, shoutout.age_group ].compact_blank %>

--- a/app/views/events/registrants.html.erb
+++ b/app/views/events/registrants.html.erb
@@ -3,7 +3,7 @@
     of the screen; the wrapper restores the layout's gutters at a wider bound. %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
   <%# Top bar: eyebrow + sub-nav, matching the other event pages. %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <% if params[:return_to] == "scholarships" %>
@@ -35,7 +35,7 @@
       <% if @event.start_date.present? %>
         <p class="text-sm text-gray-500 mt-1"><%= @event.date_range %></p>
       <% end %>
-      <h1 class="text-3xl font-bold text-gray-900 mt-2 flex items-center justify-center gap-2">
+      <h1 class="font-display text-3xl font-bold text-primary mt-2 flex items-center justify-center gap-2">
         <i class="fa-solid fa-users <%= DomainTheme.text_class_for(:event_registrations, intensity: 800) %>"></i>
         Manage registrations
       </h1>

--- a/app/views/events/reports.html.erb
+++ b/app/views/events/reports.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6">
       <% if @filter_event %>
         <%= link_to "← #{@filter_event.title}", dashboard_event_path(@filter_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -29,7 +29,7 @@
       <%= hidden_field_tag :return_to, params[:return_to] %>
       <div class="flex flex-wrap items-end gap-4">
         <div class="w-full sm:w-40">
-          <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" for="period">Time period</label>
+          <label class="mb-1 block text-xs font-semibold tracking-wide text-gray-500 uppercase" for="period">Time period</label>
           <%= select_tag :period,
                 options_for_select([ [ "This year", "this_year" ], [ "Last year", "last_year" ], [ "All time", "all_time" ] ], @period),
                 class: "w-full bg-white border border-gray-300 rounded-lg px-3 py-2 focus:ring-blue-500 focus:border-blue-500",

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
         <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -73,7 +73,7 @@
       <%# Revenue over time: fees + funded scholarships vs org subsidy, one stacked column per year. %>
       <section class="mb-8">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Revenue by year</h2>
-        <div class="rounded-xl border border-gray-200 bg-white p-4">
+        <div class="rounded-2xl border border-primary/10 bg-white p-4">
           <%= column_chart @report.chart_series, stacked: true, prefix: "$", thousands: ",",
                 colors: [ "#2563eb", "#c026d3", "#dc2626" ], height: "260px", library: { borderRadius: 4 } %>
         </div>
@@ -190,7 +190,7 @@
         </p>
       </section>
     <% else %>
-      <div class="text-center py-12 text-gray-500">
+      <div class="py-12 text-center text-gray-500">
         No paid events yet — once events run, you'll see revenue by year here.
       </div>
     <% end %>

--- a/app/views/events/roster.html.erb
+++ b/app/views/events/roster.html.erb
@@ -9,7 +9,7 @@
     the wrapper restores the layout's gutters at a wider bound. %>
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
-<div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-4 sm:p-6">
   <%# Top bar: back link + sub-nav, matching the other event pages %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">
     <%= link_to "← Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -134,7 +134,7 @@
           </span>
         </div>
       <% end %>
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <div class="bg-white border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
         <%= render "events/registrant_roster", roster: @dashboard, registrants: @roster_registrants, row_return_to: "roster", show_attendance_status: true, program_status_event: @event %>
       </div>
     </div>

--- a/app/views/events/scholarships.html.erb
+++ b/app/views/events/scholarships.html.erb
@@ -3,7 +3,7 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>
         <%= link_to "← Dashboard", dashboard_event_path(params[:event_id]), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/events/signins.html.erb
+++ b/app/views/events/signins.html.erb
@@ -5,7 +5,7 @@
 <% content_for(:page_title, title) %>
 
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
-  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-gray-200 rounded-xl shadow p-6">
+  <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= render "events/report_subnav", current: :signins %>

--- a/app/views/faqs/edit.html.erb
+++ b/app/views/faqs/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:faqs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-4 flex flex-wrap justify-end gap-2">
           <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "FAQs", faqs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "View", faq_path(@faq), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
-        <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+        <h1 class="text-primary mb-3 font-display text-2xl font-semibold">
           Edit <%= @faq.class.model_name.human.downcase %>
         </h1>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @faq %>

--- a/app/views/faqs/new.html.erb
+++ b/app/views/faqs/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:faqs) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">
+<div class="<%= DomainTheme.bg_class_for(:faqs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             New <%= @faq.class.model_name.human.downcase %>
           </h1>
         </div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form" %>
           </div>

--- a/app/views/features/edit.html.erb
+++ b/app/views/features/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto w-full max-w-3xl rounded-xl border border-gray-200 bg-white p-6 shadow">
+<div class="border-primary/10 mx-auto w-full max-w-3xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Features & tips", features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "View", feature_path(@feature), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit feature</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit feature</h1>
   <%= render "form", feature: @feature %>
   <%= render "shared/audit_info", resource: @feature %>
   <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>

--- a/app/views/features/index.html.erb
+++ b/app/views/features/index.html.erb
@@ -1,17 +1,17 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 
-<div class="w-full max-w-7xl mx-auto bg-gray-50 border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap items-start justify-between gap-4 mb-4">
+<div class="border-primary/10 mx-auto w-full max-w-7xl rounded-2xl border bg-gray-50 p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap items-start justify-between gap-4">
     <div class="pr-6">
-      <h1 class="text-2xl font-semibold text-gray-900">Features &amp; tips</h1>
-      <p class="text-gray-600 mt-2 max-w-2xl">
+      <h1 class="text-primary font-display text-2xl font-semibold">Features &amp; tips</h1>
+      <p class="mt-2 max-w-2xl text-gray-600">
         Everything the portal can do, newest first. Search by name or tip, narrow by area,
         audience, or date — then open a feature for the full walkthrough and pro tips.
       </p>
     </div>
 
     <% if allowed_to?(:create?, Feature) %>
-      <div class="admin-only bg-blue-100 flex flex-wrap items-center justify-end gap-2 rounded-lg p-2">
+      <div class="admin-only flex flex-wrap items-center justify-end gap-2 rounded-lg bg-blue-100 p-2">
         <%= link_to new_feature_path, class: "btn btn-primary-outline" do %>
           <i class="fa-solid fa-plus"></i> New feature
         <% end %>

--- a/app/views/features/new.html.erb
+++ b/app/views/features/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="w-full max-w-3xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="border-primary/10 mx-auto w-full max-w-3xl rounded-2xl border bg-white p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Features & tips", features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">New feature</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">New feature</h1>
   <%= render "form", feature: @feature %>
 </div>

--- a/app/views/features/show.html.erb
+++ b/app/views/features/show.html.erb
@@ -1,18 +1,18 @@
 <% content_for(:page_bg_class, "admin-or-authpublished") %>
 
-<div class="w-full max-w-3xl mx-auto">
+<div class="mx-auto w-full max-w-3xl">
   <div class="mb-3">
     <%= link_to features_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left"></i> Features &amp; tips
     <% end %>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-xl shadow overflow-hidden">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
     <div class="bg-<%= @feature.area_color %>-100 border-b border-<%= @feature.area_color %>-300 px-6 py-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="flex items-center gap-2">
           <i class="fa-solid <%= @feature.area_icon %> text-<%= @feature.area_color %>-700"></i>
-          <span class="text-sm font-semibold text-<%= @feature.area_color %>-900 uppercase tracking-wide">
+          <span class="text-sm font-semibold text-<%= @feature.area_color %>-900 tracking-wide uppercase">
             <%= @feature.area_label %>
           </span>
         </div>
@@ -29,13 +29,13 @@
 
     <div class="p-6">
       <div class="flex items-start justify-between gap-3">
-        <h1 class="text-2xl font-semibold text-gray-900"><%= @feature.name %></h1>
-        <span class="text-sm text-gray-500 whitespace-nowrap shrink-0 mt-1">
+        <h1 class="text-primary font-display text-2xl font-semibold"><%= @feature.name %></h1>
+        <span class="mt-1 shrink-0 text-sm whitespace-nowrap text-gray-500">
           <i class="fa-regular fa-calendar"></i> <%= @feature.released_label %>
         </span>
       </div>
 
-      <p class="text-gray-600 mt-2"><%= @feature.summary %></p>
+      <p class="mt-2 text-gray-600"><%= @feature.summary %></p>
 
       <div class="mt-4 flex flex-wrap gap-2">
         <% if @feature.action_path.present? %>
@@ -58,11 +58,11 @@
       </div>
 
       <% if @feature.pro_tips_list.any? %>
-        <div class="mt-5 rounded-lg bg-amber-50 border border-amber-200 p-4">
-          <p class="text-sm font-semibold text-amber-800 uppercase tracking-wide mb-2">
+        <div class="mt-5 rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <p class="mb-2 text-sm font-semibold tracking-wide text-amber-800 uppercase">
             <i class="fa-solid fa-lightbulb"></i> <%= "Pro tip".pluralize(@feature.pro_tips_list.size) %>
           </p>
-          <ul class="list-disc list-inside space-y-1 text-amber-900">
+          <ul class="list-inside list-disc space-y-1 text-amber-900">
             <% @feature.pro_tips_list.each do |tip| %>
               <li><%= tip %></li>
             <% end %>
@@ -71,13 +71,13 @@
       <% end %>
 
       <% if @feature.rhino_description.present? %>
-        <div class="prose max-w-none mt-6">
+        <div class="mt-6 max-w-none prose">
           <%= @feature.rhino_description %>
         </div>
       <% end %>
 
       <% if allowed_to?(:update?, @feature) %>
-        <div class="mt-8 pt-4 border-t border-gray-200 flex flex-wrap gap-2">
+        <div class="mt-8 flex flex-wrap gap-2 border-t border-gray-200 pt-4">
           <%= link_to "Edit", edit_feature_path(@feature), class: "admin-only bg-blue-100 btn btn-primary-outline" %>
           <%= button_to "Delete", feature_path(@feature), method: :delete,
                         class: "admin-only bg-blue-100 btn btn-danger-outline",

--- a/app/views/fm_archives/index.html.erb
+++ b/app/views/fm_archives/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-semibold text-gray-900">FileMaker Archive</h1>
+    <div class="mb-6 flex items-center justify-between">
+      <h1 class="text-primary font-display text-2xl font-semibold">FileMaker Archive</h1>
     </div>
 
     <div class="flex flex-wrap gap-2">
@@ -13,7 +13,7 @@
     </div>
 
     <% if @records %>
-      <div class="rounded-xl bg-white p-6 overflow-x-auto">
+      <div class="overflow-x-auto rounded-xl bg-white p-6">
         <table class="w-full border-collapse border border-gray-200 text-sm">
           <thead>
             <tr class="bg-gray-100">
@@ -33,7 +33,7 @@
           </tbody>
         </table>
 
-        <div class="pagination flex justify-center mt-8">
+        <div class="pagination mt-8 flex justify-center">
           <%= tailwind_paginate @records, params: { table: @selected } %>
         </div>
       </div>

--- a/app/views/fm_archives/show.html.erb
+++ b/app/views/fm_archives/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
-    <div class="flex items-center justify-between mb-6">
+    <div class="mb-6 flex items-center justify-between">
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900"><%= @record.class.name %></h1>
+        <h1 class="text-primary font-display text-2xl font-semibold"><%= @record.class.name %></h1>
         <p class="text-sm text-gray-500">FM ID: <%= @record.fm_id %> &middot; Key: <%= @record.fm_key_name %></p>
       </div>
       <%= link_to "Back to list", fm_archives_path(table: @record.class.table_name.sub("fm_", "")), class: "btn btn-primary-outline" %>
@@ -12,9 +12,9 @@
     <div class="rounded-xl bg-white p-6">
       <dl class="divide-y divide-gray-200">
         <% @record.data.each do |key, value| %>
-          <div class="py-3 grid grid-cols-3 gap-4">
+          <div class="grid grid-cols-3 gap-4 py-3">
             <dt class="text-sm font-medium text-gray-500"><%= key %></dt>
-            <dd class="text-sm text-gray-900 col-span-2 break-words">
+            <dd class="col-span-2 text-sm break-words text-gray-900">
               <% link_target = @record.class::FM_LINKS[key] %>
               <% if link_target && value.present? %>
                 <%= link_to value, fm_archive_path(value, table: link_target.sub("fm_", "")), class: "text-primary hover:underline" %>
@@ -31,10 +31,10 @@
 
     <% if @backlinks.any? %>
       <div class="rounded-xl bg-white p-6">
-        <h2 class="text-lg font-semibold mb-4">Related Records</h2>
+        <h2 class="mb-4 text-lg font-semibold">Related Records</h2>
         <% @backlinks.each do |label, info| %>
           <%= turbo_frame_tag "backlink_#{info[:table]}", class: "block py-3 border-b border-gray-200 last:border-0" do %>
-            <h3 class="text-sm font-medium text-gray-500 mb-2"><%= label %> (<%= info[:records].total_entries %>)</h3>
+            <h3 class="mb-2 text-sm font-medium text-gray-500"><%= label %> (<%= info[:records].total_entries %>)</h3>
             <div class="flex flex-wrap gap-1">
               <% info[:records].each do |record| %>
                 <%= link_to record.fm_id, fm_archive_path(record.fm_id, table: info[:table].sub("fm_", "")),

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <% if @form_answers.any? %>
-    <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm">
       <table class="w-full border-collapse">
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="form-answers-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="form-answers-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-2xl border border-primary/10 p-6 shadow-sm">
   <div class="w-full">
     <div class="mb-6 flex items-start gap-4">
       <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
@@ -77,7 +77,7 @@
 
     <% result_src = form_answers_path(request.query_parameters) %>
     <%= turbo_frame_tag :form_answers_results, src: result_src, data: { turbo: "temporary" } do %>
-      <div class="rounded-xl border border-gray-200 bg-white py-16 text-center text-gray-400 shadow-sm">
+      <div class="rounded-2xl border border-primary/10 bg-white py-16 text-center text-gray-400 shadow-sm">
         <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
         <p class="mt-2 text-sm">Loading answers…</p>
       </div>

--- a/app/views/form_submissions/form_submissions_results.html.erb
+++ b/app/views/form_submissions/form_submissions_results.html.erb
@@ -19,7 +19,7 @@
       <%= render "shared/column_toggle_switch", group: "submitted", label: "Submitted date", on: true %>
       <%= render "shared/column_toggle_switch", group: "user_account", label: "User account", on: false %>
     </div>
-    <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm">
       <table class="w-full border-collapse">
         <thead>
           <tr class="border-b border-gray-200 bg-gray-50 text-left text-sm text-gray-600">

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="form-submissions-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="form-submissions-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-2xl border border-primary/10 p-6 shadow-sm">
   <div class="w-full">
     <% if params[:return_to] == "form_results" && @form %>
       <div class="mb-4">
@@ -157,7 +157,7 @@
 
     <% result_src = form_submissions_path(request.query_parameters) %>
     <%= turbo_frame_tag :form_submissions_results, src: result_src, data: { turbo: "temporary" } do %>
-      <div class="rounded-xl border border-gray-200 bg-white py-16 text-center text-gray-400 shadow-sm">
+      <div class="rounded-2xl border border-primary/10 bg-white py-16 text-center text-gray-400 shadow-sm">
         <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
         <p class="mt-2 text-sm">Loading submissions…</p>
       </div>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -14,9 +14,9 @@
       <%= link_to "← Back to submission", form_submission_path(@form_submission), class: "text-sm #{eyebrow_link_class}" %>
     <% end %>
   </div>
-  <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+  <div class="bg-white rounded-2xl shadow-lg border border-primary/10 p-6">
     <div class="flex items-start justify-between gap-3 mb-2">
-      <h1 class="text-2xl font-bold text-gray-900">Linked organization &amp; affiliations</h1>
+      <h1 class="font-display text-2xl font-bold text-primary">Linked organization &amp; affiliations</h1>
       <%= link_to edit_affiliations_path, data: { turbo_frame: "_top" },
                   class: "inline-flex items-center gap-1 text-sm text-gray-500 underline hover:text-gray-700 shrink-0 mt-1.5" do %>
         Edit <%= @person.first_name.presence || @person.full_name %>'s affiliations
@@ -27,7 +27,7 @@
     <%# === What the person submitted — the source answer admins reconcile
         against, rendered grey/neutral like the registration editor. %>
     <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3"><%= @form_submission.form.display_name %> submission</h2>
-    <div class="bg-gray-50 border border-gray-200 rounded-lg p-4 mb-8">
+    <div class="bg-gray-50 border border-primary/10 rounded-2xl p-4 mb-8">
       <% if @submitted_org_name.present? || @submitted_position.present? %>
         <%= link_to form_submission_path(@form_submission),
                     target: "_blank", rel: "noopener",
@@ -52,7 +52,7 @@
         green to stand apart, like the registration editor's linked cards. %>
     <% org_swatch = DomainTheme.swatch(:green) %>
     <h2 class="text-sm font-bold uppercase tracking-wide text-gray-500 mb-3">Linked organization</h2>
-    <div class="bg-gray-50 border border-gray-200 rounded-xl p-4 mb-8">
+    <div class="bg-gray-50 border border-primary/10 rounded-2xl p-4 mb-8">
       <% if @matched_organization %>
         <ul class="space-y-2 mb-4">
           <li class="relative flex items-start justify-between gap-3 <%= org_swatch[:bg] %> border <%= org_swatch[:border] %> rounded-lg p-3 transition hover:border-green-300 hover:shadow-sm">

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -39,7 +39,7 @@
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-xl leading-tight font-semibold tracking-wide">Form submission</h1>
+          <h1 class="text-primary font-display text-xl leading-tight font-semibold tracking-wide">Form submission</h1>
           <p class="text-sm text-blue-200"><%= @form_submission.form.name %></p>
         </div>
       </div>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -24,7 +24,7 @@
           </div>
           <div>
             <p class="text-xs font-medium tracking-[0.2em] text-purple-200 uppercase">Edit</p>
-            <h1 class="text-2xl leading-tight font-bold tracking-tight"><%= @form.display_name %></h1>
+            <h1 class="text-primary font-display text-2xl leading-tight font-bold tracking-tight"><%= @form.display_name %></h1>
           </div>
         </div>
 
@@ -109,7 +109,7 @@
       <%# Only a standalone form with no event connection can be published publicly;
           an event-connected form stays tied to its event. %>
       <% if @form.event_connected? %>
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
           <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
             <i class="fa-solid fa-link text-purple-700"></i>
             <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Share with a public link</h2>
@@ -177,7 +177,7 @@
                 placeholder: "e.g. <strong>Welcome!</strong> Please complete all fields below.",
                 class: "w-full flex-1 rounded border-gray-300 shadow-sm px-3 py-2 text-sm font-mono" %>
         </div>
-        <div class="lg:w-72 shrink-0 rounded-lg bg-gray-50 border border-gray-200 p-4 text-xs">
+        <div class="lg:w-72 shrink-0 rounded-2xl bg-gray-50 border border-primary/10 p-4 text-xs">
           <p class="font-semibold text-gray-700 mb-1">Available placeholders</p>
           <p class="text-gray-500 mb-3">Filled from the event when the form is shown.</p>
           <dl class="space-y-3">
@@ -273,7 +273,7 @@
       </div>
     </details>
 
-    <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+    <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
       <div class="flex items-center gap-3">
         <% if allowed_to?(:destroy?, @form) %>
           <% if @form.event_forms.none? %>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -21,7 +21,7 @@
           </div>
           <div>
             <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit sections</p>
-            <h1 class="text-2xl font-bold tracking-tight leading-tight"><%= @form.display_name %></h1>
+            <h1 class="font-display text-2xl font-bold tracking-tight leading-tight text-primary"><%= @form.display_name %></h1>
           </div>
         </div>
 
@@ -50,7 +50,7 @@
 
     <div class="px-4 sm:px-6 py-6">
   <%= form_with url: update_sections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+    <div class="bg-white border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
       <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
         <i class="fa-solid fa-list-check text-purple-700"></i>
         <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
@@ -115,7 +115,7 @@
       </div>
     </div>
 
-    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+    <div class="bg-white border border-primary/10 rounded-2xl shadow-sm p-6">
       <div class="flex items-center gap-3">
         <%= f.submit "Save changes", class: "btn btn-primary cursor-pointer" %>
         <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "btn btn-secondary" %>

--- a/app/views/forms/forms_results.html.erb
+++ b/app/views/forms/forms_results.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :forms_results do %>
   <% sort_link = sort_header_link(frame: "forms_results", path: ->(p) { forms_path(p) }) %>
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
     <table class="w-full border-collapse">
       <thead class="bg-gray-100">
         <tr>
@@ -64,7 +64,7 @@
                 </button>
                 <div id="<%= dropdown_id %>"
                      data-dropdown-target="content"
-                     class="hidden absolute right-0 z-10 mt-1 min-w-[160px] rounded-md border border-gray-200 bg-white py-1 shadow-lg">
+                     class="absolute right-0 z-10 mt-1 hidden min-w-[160px] rounded-md border border-gray-200 bg-white py-1 shadow-lg">
                   <%= link_to "Results", results_form_path(form), class: item_class %>
                   <%= link_to "View", form_path(form), class: item_class %>
                   <%= link_to "Edit", edit_form_path(form), class: item_class %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6 flex items-start justify-between">
     <div class="pr-6">
-      <h1 class="mb-2 text-2xl font-semibold">Forms</h1>
+      <h1 class="text-primary mb-2 font-display text-2xl font-semibold">Forms</h1>
       <p class="max-w-2xl text-gray-600">Reusable forms for event registrations and other submissions</p>
     </div>
     <div class="text-end text-right">

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div>
           <p class="text-xs font-medium tracking-[0.2em] text-purple-200 uppercase">New form</p>
-          <h1 class="text-2xl leading-tight font-bold tracking-tight">Create a form</h1>
+          <h1 class="text-primary font-display text-2xl leading-tight font-bold tracking-tight">Create a form</h1>
         </div>
       </div>
       <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
@@ -21,7 +21,7 @@
 
     <div class="px-4 py-6 sm:px-6">
       <%= form_with url: forms_path, method: :post, class: "space-y-6", data: { controller: "section-filter" } do |f| %>
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
           <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
             <i class="fa-solid fa-gear text-purple-700"></i>
             <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Form details</h2>
@@ -52,7 +52,7 @@
           </div>
         </div>
 
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
           <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
             <i class="fa-solid fa-list-check text-purple-700"></i>
             <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Sections to include</h2>
@@ -67,7 +67,7 @@
                      else "other"
                    end %>
                 <% field_names = FormBuilderService.section_field_names(key) %>
-                <div class="rounded-lg border border-gray-200 px-3 py-2" data-section-role="<%= section_role %>"
+                <div class="border-primary/10 rounded-2xl border px-3 py-2" data-section-role="<%= section_role %>"
                      data-controller="expandable-card" data-expandable-card-expanded-value="false">
                   <div class="flex items-center gap-2">
                     <label class="flex flex-1 cursor-pointer items-center gap-2">
@@ -89,7 +89,7 @@
           </div>
         </div>
 
-        <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <div class="flex items-center gap-3">
             <%= f.submit "Submit", class: "btn btn-primary cursor-pointer" %>
             <%= link_to "Cancel", forms_path, class: "btn btn-secondary-outline" %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -4,7 +4,7 @@
     (matches the roster breakdowns). %>
 <% palette = %w[#3b82f6 #ef4444 #f59e0b #10b981 #6366f1 #ec4899 #14b8a6 #f97316 #8b5cf6 #84cc16 #06b6d4 #eab308 #a855f7 #22c55e #fb7185] %>
 
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-4">
     <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Forms
@@ -17,7 +17,7 @@
         <i class="fa-solid fa-chart-pie text-xl" aria-hidden="true"></i>
       </span>
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900"><%= @form.display_name %> — results</h1>
+        <h1 class="text-primary font-display text-2xl font-semibold"><%= @form.display_name %> — results</h1>
         <p class="mt-1 text-gray-600">Every submission to this form, rolled up question by question.</p>
       </div>
     </div>
@@ -28,21 +28,21 @@
   </div>
 
   <% unless @aggregator.any_submissions? %>
-    <div class="rounded-xl border border-gray-200 bg-white py-16 text-center shadow-sm">
+    <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
       <i class="fa-solid fa-inbox text-3xl text-gray-300" aria-hidden="true"></i>
       <p class="mt-3 text-gray-500">No submissions to this form yet.</p>
     </div>
   <% else %>
     <div class="mb-2 grid grid-cols-3 gap-3">
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <div class="border-primary/10 rounded-2xl border bg-white p-4">
         <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Submissions</div>
         <div class="mt-1 text-2xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@aggregator.submission_count) %></div>
       </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <div class="border-primary/10 rounded-2xl border bg-white p-4">
         <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Respondents</div>
         <div class="mt-1 text-2xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@aggregator.respondent_count) %></div>
       </div>
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
+      <div class="border-primary/10 rounded-2xl border bg-white p-4">
         <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Questions</div>
         <div class="mt-1 text-2xl font-bold text-gray-900 tabular-nums"><%= number_with_delimiter(@aggregator.question_count) %></div>
       </div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </div>
 
-  <div class="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-200">
+  <div class="bg-white rounded-2xl shadow-lg overflow-hidden border border-primary/10">
     <%# Admin chrome wrapping the form preview below. The amber "Preview" badge
         signals this is not the live page (echoing the amber token note inside). %>
     <div class="bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 py-5">
@@ -70,7 +70,7 @@
         has_conditional = @form_fields.any?(&:conditional_visibility?)
       %>
 
-      <div class="mb-6 rounded-lg bg-gray-50 border border-gray-200 p-3">
+      <div class="mb-6 rounded-2xl bg-gray-50 border border-primary/10 p-3">
         <% if has_conditional %>
           <p class="text-xs text-gray-600">This preview shows every field. Highlighted fields are only asked under certain conditions — the conditional logic runs on the live registration form.</p>
         <% else %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -22,7 +22,7 @@
         </div>
         <div>
           <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Reference</p>
-          <h1 class="text-2xl font-bold tracking-tight leading-tight">Smart field settings</h1>
+          <h1 class="font-display text-2xl font-bold tracking-tight leading-tight text-primary">Smart field settings</h1>
         </div>
       </div>
       <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>

--- a/app/views/grants/edit.html.erb
+++ b/app/views/grants/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:grants) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Grants", grants_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "View", grant_path(@grant), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+  <h1 class="text-primary mb-3 font-display text-2xl font-semibold">
     Edit <%= Grant.model_name.human.downcase %>
   </h1>
 
-  <div class="bg-white rounded p-6">
+  <div class="rounded bg-white p-6">
     <div class="mt-4">
       <%= render "form" %>
       <%= render "shared/audit_info", resource: @grant %>

--- a/app/views/grants/index.html.erb
+++ b/app/views/grants/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="grants-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="grants-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:grants) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="w-full">
     <%# Back link to the scholarship that opened this page via its grant "View all". %>
     <% if params[:from_scholarship].present? %>
@@ -8,21 +8,21 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Scholarship
       <% end %>
     <% end %>
-    <div class="flex items-start justify-between gap-6 mb-6">
+    <div class="mb-6 flex items-start justify-between gap-6">
       <div class="flex items-start gap-4">
-        <span class="hidden sm:flex h-12 w-12 shrink-0 items-center justify-center rounded-xl <%= DomainTheme.bg_class_for(:grants, intensity: 100) %> <%= DomainTheme.text_class_for(:grants, intensity: 700) %> shadow-sm">
+        <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:grants, intensity: 100) %> <%= DomainTheme.text_class_for(:grants, intensity: 700) %> shadow-sm">
           <i class="fa-solid fa-hand-holding-dollar text-xl" aria-hidden="true"></i>
         </span>
         <div>
-          <h2 class="text-2xl font-semibold text-gray-900 flex items-center gap-2">
+          <h2 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
             <%= Grant.model_name.human.pluralize %>
             <%= render "count" %>
           </h2>
-          <p class="text-gray-600 mt-1">Funds provided by organizations and people, from which scholarships are awarded.</p>
+          <p class="mt-1 text-gray-600">Funds provided by organizations and people, from which scholarships are awarded.</p>
         </div>
       </div>
 
-      <div class="shrink-0 flex items-center gap-2 text-right text-end">
+      <div class="flex shrink-0 items-center gap-2 text-end text-right">
         <% if allowed_to?(:index?, Scholarship) %>
           <%= link_to scholarships_path, class: "btn btn-primary-outline" do %>
             <i class="fa-solid fa-graduation-cap" aria-hidden="true"></i>

--- a/app/views/grants/new.html.erb
+++ b/app/views/grants/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-2xl font-semibold text-gray-900">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:grants) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-semibold">
       New <%= Grant.model_name.human.downcase %>
     </h1>
   </div>
 
-  <div class="bg-white rounded p-6">
+  <div class="rounded bg-white p-6">
     <div class="mt-4">
       <%= render "form" %>
     </div>

--- a/app/views/grants/show.html.erb
+++ b/app/views/grants/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% grant = @grant.decorate %>
 
-<div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:grants) %> border border-gray-200 rounded-xl shadow p-6 space-y-6">
+<div class="mx-auto max-w-4xl <%= DomainTheme.bg_class_for(:grants) %> border-primary/10 space-y-6 rounded-2xl border p-6 shadow-sm">
   <div>
     <%# Eyebrow returns to wherever the grant was opened from: the scholarships
         index (when linked from a grant group there) or the grants index. %>
@@ -16,11 +16,11 @@
     <% end %>
     <div class="flex items-start justify-between">
       <div>
-        <div class="flex items-center gap-2 flex-wrap">
-          <h1 class="text-2xl font-semibold text-gray-900"><%= grant.name %></h1>
+        <div class="flex flex-wrap items-center gap-2">
+          <h1 class="text-primary font-display text-2xl font-semibold"><%= grant.name %></h1>
           <%= grant.legacy_scholarship_badge %>
         </div>
-        <p class="text-gray-600 mt-1"><%= grant_funder_badge(grant) %></p>
+        <p class="mt-1 text-gray-600"><%= grant_funder_badge(grant) %></p>
       </div>
       <% if allowed_to?(:edit?, @grant) %>
         <%= link_to "Edit", edit_grant_path(@grant), class: "btn btn-primary-outline" %>
@@ -30,14 +30,14 @@
 
   <!-- Photos -->
   <% if @grant.primary_asset&.file&.attached? || @grant.gallery_assets.any? { |asset| asset.file.attached? } %>
-    <div class="bg-white rounded-lg shadow p-5">
+    <div class="rounded-lg bg-white p-5 shadow">
       <%= render "assets/display_assets", resource: @grant, link: true %>
     </div>
   <% end %>
 
   <!-- Budget summary -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
+  <div class="rounded-lg bg-white p-5 shadow">
+    <dl class="grid grid-cols-1 gap-4 text-center sm:grid-cols-3">
       <div>
         <dt class="text-sm font-medium text-gray-500">Funding amount</dt>
         <dd class="mt-1 text-xl font-semibold text-gray-900"><%= grant.amount %></dd>
@@ -56,8 +56,8 @@
   </div>
 
   <!-- Details -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <dl class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+  <div class="rounded-lg bg-white p-5 shadow">
+    <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div>
         <dt class="text-sm font-medium text-gray-500">Funds allocation deadline</dt>
         <dd class="mt-1 text-sm text-gray-900"><%= grant.funds_allocation_deadline %></dd>
@@ -71,7 +71,7 @@
     <% if @grant.description.present? %>
       <div class="mt-4">
         <dt class="text-sm font-medium text-gray-500">Description</dt>
-        <dd class="mt-1 text-sm text-gray-900 whitespace-pre-line"><%= @grant.description %></dd>
+        <dd class="mt-1 text-sm whitespace-pre-line text-gray-900"><%= @grant.description %></dd>
       </div>
     <% end %>
   </div>
@@ -81,9 +81,9 @@
   <% grant_categories = @grant.categories.includes(:category_type).order(Arel.sql("category_types.name, categories.position, categories.name")) %>
   <% if grant_sectors.any? || grant_categories.any? %>
     <% tag_count = grant_sectors.size + grant_categories.size %>
-    <div class="bg-white rounded-lg shadow p-5" data-controller="dropdown">
+    <div class="rounded-lg bg-white p-5 shadow" data-controller="dropdown">
       <button type="button"
-              class="inline-flex items-center gap-2 text-lg font-semibold text-gray-900 hover:text-gray-700 cursor-pointer transition"
+              class="inline-flex cursor-pointer items-center gap-2 text-lg font-semibold text-gray-900 transition hover:text-gray-700"
               data-action="dropdown#toggle"
               data-dropdown-payload-param='[{"grant_tags_content":"hidden"}, {"grant_tags_show_label":"hidden"}, {"grant_tags_hide_label":"hidden"}, {"grant_tags_chevron":"rotate-180"}]'>
         <i id="grant_tags_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200"></i>
@@ -91,7 +91,7 @@
         <span id="grant_tags_hide_label" class="hidden">Hide tags (<%= tag_count %>)</span>
       </button>
 
-      <div id="grant_tags_content" class="hidden mt-4 flex flex-wrap gap-2">
+      <div id="grant_tags_content" class="mt-4 flex hidden flex-wrap gap-2">
         <% grant_sectors.each do |sector| %>
           <%= render "sectors/tagging_label", sector: sector %>
         <% end %>
@@ -103,10 +103,10 @@
   <% end %>
 
   <!-- Eligibility criteria -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-2">Eligibility criteria</h2>
+  <div class="rounded-lg bg-white p-5 shadow">
+    <h2 class="mb-2 text-lg font-semibold text-gray-900">Eligibility criteria</h2>
     <% if @grant.eligibility_criteria_list.any? %>
-      <ul class="list-disc pl-5 space-y-1 text-sm text-gray-800">
+      <ul class="list-disc space-y-1 pl-5 text-sm text-gray-800">
         <% @grant.eligibility_criteria_list.each do |criterion| %>
           <li><%= criterion %></li>
         <% end %>
@@ -117,10 +117,10 @@
   </div>
 
   <!-- Tasks -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-2">Tasks to complete</h2>
+  <div class="rounded-lg bg-white p-5 shadow">
+    <h2 class="mb-2 text-lg font-semibold text-gray-900">Tasks to complete</h2>
     <% if @grant.task_list.any? %>
-      <ul class="list-disc pl-5 space-y-1 text-sm text-gray-800">
+      <ul class="list-disc space-y-1 pl-5 text-sm text-gray-800">
         <% @grant.task_list.each do |task| %>
           <li><%= task %></li>
         <% end %>

--- a/app/views/membership_invoices/edit.html.erb
+++ b/app/views/membership_invoices/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% person = @membership_invoice.person %>
 
-<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-4 shadow sm:p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="mb-1 text-2xl font-bold">Edit membership invoice</h1>
+  <h1 class="text-primary mb-1 font-display text-2xl font-bold">Edit membership invoice</h1>
   <p class="mb-6 text-sm text-gray-500"><%= person.full_name %> &middot; <%= @membership_invoice.decorate.period_range %></p>
 
   <%= simple_form_for @membership_invoice do |f| %>

--- a/app/views/membership_invoices/index.html.erb
+++ b/app/views/membership_invoices/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mx-auto max-w-6xl">
   <div class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold">Membership invoices</h1>
+    <h1 class="text-primary font-display text-2xl font-bold">Membership invoices</h1>
   </div>
 
   <%= render "search_boxes" %>

--- a/app/views/membership_invoices/membership_invoices_results.html.erb
+++ b/app/views/membership_invoices/membership_invoices_results.html.erb
@@ -1,21 +1,21 @@
 <%= turbo_frame_tag :membership_invoices_results do %>
   <% if @membership_invoices.any? %>
-    <div class="overflow-x-auto animate-fade blur-on-submit bg-white border border-gray-200 rounded-xl shadow-sm">
+    <div class="border-primary/10 animate-fade overflow-x-auto rounded-2xl border bg-white shadow-sm blur-on-submit">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Person</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Period</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cost</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Paid</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Person</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Period</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Cost</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Paid</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Status</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="divide-y divide-gray-200 bg-white">
           <% @membership_invoices.each do |membership_invoice| %>
             <% invoice = membership_invoice.decorate %>
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900">
                 <%= link_to invoice.person.full_name, person_path(invoice.person),
                             class: "text-primary hover:text-primary-dark",
                             data: { turbo_frame: "_top" } %>
@@ -23,10 +23,10 @@
                   <span class="block text-xs text-gray-500">Membership cancelled</span>
                 <% end %>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= invoice.period_range %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= invoice.cost %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= invoice.paid %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm">
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-500"><%= invoice.period_range %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= invoice.cost %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= invoice.paid %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap">
                 <%= render "membership_invoices/status_pill", invoice: invoice, linked: true %>
               </td>
             </tr>
@@ -35,7 +35,7 @@
       </table>
     </div>
   <% else %>
-    <p class="text-gray-500 text-center py-6">No membership invoices yet.</p>
+    <p class="py-6 text-center text-gray-500">No membership invoices yet.</p>
   <% end %>
-  <div class="pagination flex justify-center mt-6"><%= tailwind_paginate @membership_invoices %></div>
+  <div class="pagination mt-6 flex justify-center"><%= tailwind_paginate @membership_invoices %></div>
 <% end %>

--- a/app/views/membership_invoices/new.html.erb
+++ b/app/views/membership_invoices/new.html.erb
@@ -1,20 +1,20 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% person = @membership.person %>
 
-<div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="text-2xl font-bold mb-1">Add membership invoice</h1>
-  <p class="text-sm text-gray-500 mb-6"><%= person.full_name %></p>
+  <h1 class="text-primary mb-1 font-display text-2xl font-bold">Add membership invoice</h1>
+  <p class="mb-6 text-sm text-gray-500"><%= person.full_name %></p>
 
   <%= simple_form_for @membership_invoice, url: membership_membership_invoices_path(@membership) do |f| %>
     <%= render "fields", f: f, include_end_date: false %>
 
-    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+    <div class="mt-6 flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", person_memberships_path(person), class: "btn btn-secondary-outline" %>
         <%= f.button :submit, "Add invoice", class: "btn btn-primary" %>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-4 shadow sm:p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="mb-1 text-2xl font-bold">Membership cost</h1>
+  <h1 class="text-primary mb-1 font-display text-2xl font-bold">Membership cost</h1>
   <p class="mb-6 text-sm text-gray-500"><%= @person.full_name %></p>
 
   <%= simple_form_for @membership do |f| %>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -2,17 +2,17 @@
 
 <% active_membership = @memberships.any? { |membership| !membership.cancelled? } %>
 
-<div class="mx-auto max-w-3xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="border-primary/10 mx-auto max-w-3xl rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= @person.full_name %>
     <% end %>
     <%= link_to "All memberships", membership_invoices_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <div class="flex flex-wrap items-end justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-end justify-between gap-2">
     <div>
-      <h1 class="text-2xl font-bold mb-1">Memberships</h1>
+      <h1 class="text-primary mb-1 font-display text-2xl font-bold">Memberships</h1>
       <p class="text-sm text-gray-500"><%= @person.full_name %></p>
     </div>
     <% if !active_membership || params[:admin] == "true" %>
@@ -28,8 +28,8 @@
   <% else %>
     <div class="space-y-6">
       <% @memberships.each do |membership| %>
-        <div class="border border-gray-200 rounded-lg p-3 sm:p-4">
-          <div class="flex flex-wrap items-start justify-between gap-x-6 gap-y-2 mb-3">
+        <div class="border-primary/10 rounded-2xl border p-3 sm:p-4">
+          <div class="mb-3 flex flex-wrap items-start justify-between gap-x-6 gap-y-2">
             <div class="flex flex-wrap gap-x-6 gap-y-1 text-sm">
               <span class="text-gray-600">Cost: <span class="font-medium text-gray-800"><%= membership.cost_label %></span></span>
               <span class="text-gray-600">Status: <span class="font-medium text-gray-800"><%= membership.status_label %></span></span>

--- a/app/views/memberships/new.html.erb
+++ b/app/views/memberships/new.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl bg-white border border-gray-200 rounded-xl shadow p-4 sm:p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-4 shadow-sm sm:p-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to person_memberships_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Membership
     <% end %>
   </div>
 
-  <h1 class="text-2xl font-bold mb-1">New membership</h1>
-  <p class="text-sm text-gray-500 mb-6"><%= @person.full_name %></p>
+  <h1 class="text-primary mb-1 font-display text-2xl font-bold">New membership</h1>
+  <p class="mb-6 text-sm text-gray-500"><%= @person.full_name %></p>
 
   <%= simple_form_for @membership, url: person_memberships_path(@person) do |f| %>
     <%= render "shared/errors", resource: f.object %>
@@ -20,7 +20,7 @@
           input_html: { min: 0, step: 0.01, placeholder: "Standard", class: "bg-white" } %>
 
     <fieldset class="mt-6 border-t border-gray-200 pt-6">
-      <legend class="text-sm font-medium text-gray-700 mb-3">First invoice</legend>
+      <legend class="mb-3 text-sm font-medium text-gray-700">First invoice</legend>
 
       <%= f.simple_fields_for :membership_invoices do |invoice| %>
         <%= invoice.input :start_date,
@@ -37,7 +37,7 @@
       <% end %>
     </fieldset>
 
-    <div class="flex items-center gap-3 border-t border-gray-200 pt-6 mt-6">
+    <div class="mt-6 flex items-center gap-3 border-t border-gray-200 pt-6">
       <div class="ml-auto flex items-center gap-3">
         <%= link_to "Cancel", person_memberships_path(@person), class: "btn btn-secondary-outline" %>
         <%= f.button :submit, "Create membership", class: "btn btn-primary" %>

--- a/app/views/monthly_reports/index.html.erb
+++ b/app/views/monthly_reports/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="w-full max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto w-full max-w-7xl <%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="w-full">
-    <div class="flex items-start justify-between mb-6 gap-4 flex-wrap">
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-4">
       <div class="pr-6">
-        <h2 class="text-2xl font-semibold mb-2">Monthly reports</h2>
+        <h2 class="mb-2 text-2xl font-semibold">Monthly reports</h2>
         <% if @organization %>
           <p class="text-gray-600">
             for <%= link_to @organization.name, edit_organization_path(@organization), class: "text-gray-700 hover:underline font-medium" %>
@@ -13,7 +13,7 @@
         <% end %>
       </div>
 
-      <div class="flex gap-2 items-center text-right">
+      <div class="flex items-center gap-2 text-right">
         <% if @organization %>
           <%= link_to "Back to organization", edit_organization_path(@organization), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>

--- a/app/views/monthly_reports/show.html.erb
+++ b/app/views/monthly_reports/show.html.erb
@@ -3,8 +3,8 @@
 <% teens_total    = @monthly_report.teens_ongoing.to_i + @monthly_report.teens_first_time.to_i %>
 <% adults_total   = @monthly_report.adults_ongoing.to_i + @monthly_report.adults_first_time.to_i %>
 
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end items-center gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, MonthlyReport) %>
       <%= link_to "My Monthly Reports", monthly_reports_path(created_by_id: current_user.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -13,13 +13,13 @@
     <%= render "bookmarks/editable_bookmark_button", resource: @monthly_report %>
   </div>
 
-  <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
-    <div class="font-semibold text-gray-900 mb-2">
-      <h1 class="text-3xl tracking-tight"><%= @monthly_report.title %></h1>
+  <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
+    <div class="mb-2 font-semibold text-gray-900">
+      <h1 class="text-primary font-display text-3xl tracking-tight"><%= @monthly_report.title %></h1>
     </div>
 
-    <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <span class="font-semibold text-gray-700">Submitted by:</span>
           <% if @monthly_report.created_by&.person && allowed_to?(:show?, @monthly_report.created_by.person) %>
@@ -70,16 +70,16 @@
     <!-- Participant counts -->
     <% if children_total > 0 || teens_total > 0 || adults_total > 0 %>
       <div>
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Participant counts</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Participant counts</h2>
         <div class="overflow-x-auto">
-          <table class="min-w-full border border-gray-300 rounded-lg overflow-hidden">
+          <table class="min-w-full overflow-hidden rounded-lg border border-gray-300">
           <thead>
           <tr class="bg-gray-100">
             <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Category</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Children</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Teens</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Adults</th>
-            <th class="px-4 py-2 text-center text-sm font-bold text-gray-800 bg-gray-300 uppercase">Total</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Children</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Teens</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Adults</th>
+            <th class="bg-gray-300 px-4 py-2 text-center text-sm font-bold text-gray-800 uppercase">Total</th>
           </tr>
           </thead>
 
@@ -87,10 +87,10 @@
           <!-- Ongoing -->
           <tr>
             <td class="px-4 py-2 font-medium text-gray-700">Ongoing Participants</td>
-            <td class="text-center bg-blue-100"><%= display_count(@monthly_report.children_ongoing) %></td>
-            <td class="text-center bg-blue-100"><%= display_count(@monthly_report.teens_ongoing) %></td>
-            <td class="text-center bg-blue-100"><%= display_count(@monthly_report.adults_ongoing) %></td>
-            <td class="text-center font-semibold bg-blue-200">
+            <td class="bg-blue-100 text-center"><%= display_count(@monthly_report.children_ongoing) %></td>
+            <td class="bg-blue-100 text-center"><%= display_count(@monthly_report.teens_ongoing) %></td>
+            <td class="bg-blue-100 text-center"><%= display_count(@monthly_report.adults_ongoing) %></td>
+            <td class="bg-blue-200 text-center font-semibold">
               <%= display_count(@monthly_report.children_ongoing.to_i +
                                   @monthly_report.teens_ongoing.to_i +
                                   @monthly_report.adults_ongoing.to_i) %>
@@ -100,10 +100,10 @@
           <!-- First-time -->
           <tr>
             <td class="px-4 py-2 font-medium text-gray-700">First-Time Participants</td>
-            <td class="text-center bg-green-100"><%= display_count(@monthly_report.children_first_time) %></td>
-            <td class="text-center bg-green-100"><%= display_count(@monthly_report.teens_first_time) %></td>
-            <td class="text-center bg-green-100"><%= display_count(@monthly_report.adults_first_time) %></td>
-            <td class="text-center font-semibold bg-green-200">
+            <td class="bg-green-100 text-center"><%= display_count(@monthly_report.children_first_time) %></td>
+            <td class="bg-green-100 text-center"><%= display_count(@monthly_report.teens_first_time) %></td>
+            <td class="bg-green-100 text-center"><%= display_count(@monthly_report.adults_first_time) %></td>
+            <td class="bg-green-200 text-center font-semibold">
               <%= display_count(@monthly_report.children_first_time.to_i +
                                   @monthly_report.teens_first_time.to_i +
                                   @monthly_report.adults_first_time.to_i) %>
@@ -113,10 +113,10 @@
           <!-- Subtotals -->
           <tr class="font-semibold">
             <td class="px-4 py-2 text-right text-sm font-bold text-gray-800 uppercase">Subtotal</td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(children_total) %></td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(teens_total) %></td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(adults_total) %></td>
-            <td class="text-center text-lg font-bold bg-purple-200">
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(children_total) %></td>
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(teens_total) %></td>
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(adults_total) %></td>
+            <td class="bg-purple-200 text-center text-lg font-bold">
               <%= display_count(children_total + teens_total + adults_total) %>
             </td>
           </tr>
@@ -128,7 +128,7 @@
 
     <!-- Sectors -->
     <div>
-      <h2 class="text-lg font-semibold text-gray-800 mb-2">Sectors</h2>
+      <h2 class="mb-2 text-lg font-semibold text-gray-800">Sectors</h2>
       <% if @monthly_report.sectors.any? %>
         <div class="flex flex-wrap gap-1">
           <% @monthly_report.sectors.each do |sector| %>
@@ -142,7 +142,7 @@
 
     <!-- Responses -->
     <div class="space-y-3">
-      <h2 class="text-lg font-semibold text-gray-800 mb-2">Responses</h2>
+      <h2 class="mb-2 text-lg font-semibold text-gray-800">Responses</h2>
       <% if @answers.any? %>
         <% @answers.each do |answer| %>
           <div class="border-b border-gray-200 pb-2">
@@ -158,33 +158,33 @@
     <!-- Uploads -->
     <% if @monthly_report.assets.any? %>
       <div>
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Uploads</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Uploads</h2>
         <%= render "assets/display_assets", resource: @monthly_report, link: true, align: :start %>
       </div>
     <% end %>
 
     <!-- Quotes -->
     <div class="space-y-3">
-      <h2 class="text-lg font-semibold text-gray-800 mb-2">Quotes</h2>
+      <h2 class="mb-2 text-lg font-semibold text-gray-800">Quotes</h2>
       <% if @monthly_report.quotes.any? %>
         <div class="space-y-6">
           <% @monthly_report.quotes.decorate.each do |quote| %>
             <div>
-              <div class="relative bg-gray-100 italic leading-relaxed p-6 rounded-2xl">
-                <div class="font-semibold text-gray-700 italic text-lg">
+              <div class="relative rounded-2xl bg-gray-100 p-6 leading-relaxed italic">
+                <div class="text-lg font-semibold text-gray-700 italic">
                   <%= link_to quote.detail, quote_path(quote.object), class: "hover:underline" %>
-                  <span class="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded-full">
+                  <span class="rounded-full bg-gray-200 px-2 py-1 text-xs text-gray-700">
                     <span class="fa fa-eye-slash"></span>
                     Unpublished
                   </span>
                 </div>
-                <div class="text-gray-700 mt-3">
+                <div class="mt-3 text-gray-700">
                   -- <%= quote.attribution %>
                   <%= "@ " + quote.created_at.strftime("%m-%d-%-Y") %>
                   <%= ("re " + link_to(quote.workshop.title, workshop_path(quote.workshop),
                                        class: "hover:underline") if quote.workshop).to_s.html_safe %>
                 </div>
-                <div class="absolute -bottom-3 left-8 w-0 h-0 border-t-8 border-t-gray-100 border-x-8 border-x-transparent"></div>
+                <div class="absolute -bottom-3 left-8 h-0 w-0 border-x-8 border-t-8 border-x-transparent border-t-gray-100"></div>
               </div>
             </div>
           <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 </div>
 
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
   <div class="<%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:notifications) %> px-8 py-3">
     <div class="flex items-center gap-2">
       <i class="fa-solid fa-bell <%= DomainTheme.text_class_for(:notifications, intensity: 700) %>"></i>
@@ -25,7 +25,7 @@
 
   <div class="p-4 sm:p-8 space-y-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <h1 class="text-2xl font-semibold text-gray-900"><%= t("communications.title") %></h1>
+      <h1 class="font-display text-2xl font-semibold text-primary"><%= t("communications.title") %></h1>
       <% if allowed_to?(:new?, with: NotificationPolicy) %>
         <%= link_to new_notification_path,
                     class: "inline-flex items-center gap-2 rounded-lg #{DomainTheme.bg_class_for(:notifications, intensity: 600)} #{DomainTheme.bg_class_for(:notifications, intensity: 600, hover: true)} px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors" do %>

--- a/app/views/notifications/new.html.erb
+++ b/app/views/notifications/new.html.erb
@@ -5,8 +5,8 @@
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= t("communications.back_link") %>
     <% end %>
   </div>
-  <div class="<%= DomainTheme.bg_class_for(:admin_only) %> rounded-xl border border-gray-200 p-6 shadow">
-  <h1 class="mt-3 mb-1 text-2xl font-semibold text-gray-900"><%= t("communications.new") %></h1>
+  <div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <h1 class="text-primary mt-3 mb-1 font-display text-2xl font-semibold"><%= t("communications.new") %></h1>
   <p class="mb-5 text-sm text-gray-500">
     Log a communication you had with a person by hand (a call, text, or email sent outside the portal).
   </p>

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -16,7 +16,7 @@
   <!-- Header -->
   <div class="flex items-start justify-between gap-4">
     <div>
-      <h1 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
+      <h1 class="text-primary flex items-center gap-2 font-display text-2xl font-semibold">
         <%= t("communications.detail_title") %>
         <%= @notification.decorate.flag_badges %>
       </h1>

--- a/app/views/organization_statuses/edit.html.erb
+++ b/app/views/organization_statuses/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", organization_status_path(@organization_status), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @organization_status.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @organization_status.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/organization_statuses/index.html.erb
+++ b/app/views/organization_statuses/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= OrganizationStatus.model_name.human.pluralize %> (<%= @count_display %>)
           </h1>
           <div class="flex gap-2">
@@ -20,7 +20,7 @@
               <tr>
                 <th class="px-4 py-2">Name</th>
                 <th class="px-4 py-2">Organization count</th>
-                <th class="px-4 py-2 w-32">Actions</th>
+                <th class="w-32 px-4 py-2">Actions</th>
               </tr>
             </thead>
 
@@ -55,13 +55,13 @@
 
         <!-- Empty state -->
         <% unless @organization_statuses.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= OrganizationStatus.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>
 
         <!-- Pagination -->
-        <div class="pagination flex justify-center mt-12">
+        <div class="pagination mt-12 flex justify-center">
           <%= tailwind_paginate @organization_statuses %>
         </div>
   </div>

--- a/app/views/organization_statuses/new.html.erb
+++ b/app/views/organization_statuses/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">New <%= @organization_status.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-3 flex items-center justify-between">
+        <h1 class="text-primary font-display text-2xl font-semibold">New <%= @organization_status.class.model_name.human.downcase %></h1>
       </div>
 
-      <div class="border-b border-gray-300 mb-6"></div>
+      <div class="mb-6 border-b border-gray-300"></div>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/organization_statuses/show.html.erb
+++ b/app/views/organization_statuses/show.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Organization Statuses", organization_statuses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @organization_status) %>
           <%= link_to "Edit", edit_organization_status_path(@organization_status), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         <%= @organization_status.class.model_name.human %> details
       </h1>
 
       <div class="space-y-6">
         <div class="mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+          <div class="mb-3 grid grid-cols-1 gap-4 md:grid-cols-2">
               <div class="mb-3">
                 <p class="font-bold text-gray-700">Name:</p>
                 <p class="text-gray-900"><%= @organization_status.name %></p>
@@ -24,17 +24,16 @@
       </div>
 
       <!-- Associated Organizations -->
-      <div class="pt-6 border-t border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900 mb-3">
+      <div class="border-t border-gray-200 pt-6">
+        <h2 class="mb-3 text-lg font-semibold text-gray-900">
           Associated Organizations
         </h2>
 
         <% if @organization_status.organizations.any? %>
           <ul class="space-y-2">
             <% @organization_status.organizations.order(:name).each do |organization| %>
-              <li class="flex items-center justify-between bg-gray-50
-                   border border-gray-200 rounded-md px-4 py-2">
-          <span class="text-gray-900 font-medium">
+              <li class="flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-4 py-2">
+          <span class="font-medium text-gray-900">
             <%= organization.name %>
           </span>
 

--- a/app/views/organizations/check_duplicates.html.erb
+++ b/app/views/organizations/check_duplicates.html.erb
@@ -18,7 +18,7 @@
           </svg>
         </div>
 
-        <h1 class="ml-4 text-xl font-semibold text-gray-900">Possible duplicate organization</h1>
+        <h1 class="text-primary ml-4 font-display text-xl font-semibold">Possible duplicate organization</h1>
       </div>
 
       <p class="mb-2 text-sm text-gray-600">Checking: <span class="font-medium text-gray-900"><%= @name %></span></p>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
           <div class="mb-2">
             <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -15,7 +15,7 @@
           <%= link_to "Organizations", organizations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "Profile", organization_path(@organization), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
-        <h1 class="mb-3 text-3xl font-semibold tracking-tight text-gray-900">
+        <h1 class="text-primary mb-3 font-display text-3xl font-semibold tracking-tight">
           Edit Organization: <%= truncate(@organization.name, length: 40) %>
         </h1>
         <div class="space-y-6">

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             New <%= @organization.class.model_name.human.downcase %>
           </h1>
         </div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form" %>
           </div>

--- a/app/views/organizations/populations_served.html.erb
+++ b/app/views/organizations/populations_served.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-authpublished") %>
-<div class="<%= DomainTheme.bg_class_for(:organizations) %> border border-gray-200 rounded-xl shadow p-6">
-  <h3 class="text-lg font-semibold text-gray-800 mb-4">Sectors</h3>
-<div class="flex flex-wrap gap-2 mb-6">
+<div class="<%= DomainTheme.bg_class_for(:organizations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <h3 class="mb-4 text-lg font-semibold text-gray-800">Sectors</h3>
+<div class="mb-6 flex flex-wrap gap-2">
   <% @organization.direct_sectors.each do |sector| %>
-    <span class="inline-flex items-center px-4 py-2 bg-white rounded-full border border-gray-200 shadow-sm text-gray-700">
+    <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-gray-700 shadow-sm">
       <%= sector.name %>
     </span>
   <% end %>
 </div>
 
-  <h2 class="text-lg font-semibold text-gray-800 mb-4">
+  <h2 class="mb-4 text-lg font-semibold text-gray-800">
      Sector Distribution for <%= @organization.name %>
   </h2>
 
@@ -17,9 +17,9 @@
     <% if @sectors_by_people.any? %>
       <ul class="space-y-2">
         <% @sectors_by_people.each do |sector, count| %>
-          <li class="flex items-center justify-between p-2 bg-white rounded border border-gray-100 shadow-sm">
+          <li class="flex items-center justify-between rounded border border-gray-100 bg-white p-2 shadow-sm">
             <span><%= sector.name %></span>
-           <span class="text-gray-600 font-medium">
+           <span class="font-medium text-gray-600">
             <%= count %> <%= count == 1 ? "person" : "people" %>
           </span>
           </li>

--- a/app/views/other_responses/index.html.erb
+++ b/app/views/other_responses/index.html.erb
@@ -11,12 +11,12 @@
 <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1 mb-2" do %>
   <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
 <% end %>
-<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-primary/10 rounded-2xl shadow-sm p-6">
   <div class="space-y-6">
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-gray-900">Review “Other” responses</h1>
+        <h1 class="font-display text-2xl font-semibold text-primary">Review “Other” responses</h1>
         <p class="text-sm text-gray-600 mt-1">
           Free-text “Other” answers people typed on forms, grouped by value. Turn a sector into a
           real tag — <span class="font-medium text-gray-700">create</span> a new one or

--- a/app/views/payments/edit.html.erb
+++ b/app/views/payments/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-xl mx-auto">
+<div class="mx-auto max-w-xl">
   <%= link_to "← Payment", payment_path(@payment), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
-  <h1 class="text-2xl font-bold mb-6">Edit Payment</h1>
-  <div class="bg-white rounded border border-gray-200 p-6">
+  <h1 class="text-primary mb-6 font-display text-2xl font-bold">Edit Payment</h1>
+  <div class="rounded border border-gray-200 bg-white p-6">
     <%= simple_form_for @payment, as: :payment, url: payment_path(@payment), method: :patch do |f| %>
       <% payer_label_data = @payment.selected_payer&.compound_search_label %>
       <% designation_label_data = @payment.selected_additional_designation&.compound_search_label %>

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,6 +1,6 @@
-<div class="max-w-6xl mx-auto">
-  <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold">Payments</h1>
+<div class="mx-auto max-w-6xl">
+  <div class="mb-6 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-bold">Payments</h1>
     <div class="flex gap-2"><%= link_to "Add Cash Payment", new_payment_path(type: "CashPayment"), class: "btn btn-secondary" %><%= link_to "Add Check Payment", new_payment_path(type: "CheckPayment"), class: "btn btn-secondary" %><%= link_to "Generate Stripe Link", new_checkout_link_payments_path, class: "btn btn-secondary" %></div>
   </div>
 

--- a/app/views/payments/new_checkout_link.html.erb
+++ b/app/views/payments/new_checkout_link.html.erb
@@ -1,22 +1,22 @@
-<div class="max-w-lg mx-auto">
-  <div class="flex items-center gap-2 mb-6">
+<div class="mx-auto max-w-lg">
+  <div class="mb-6 flex items-center gap-2">
     <%= link_to payments_path, class: "text-sm #{eyebrow_link_class} inline-flex items-center gap-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Payments
     <% end %>
   </div>
 
   <% if @checkout_url %>
-    <div class="bg-white border-2 border-blue-400 rounded-xl p-6 shadow-sm">
-      <h1 class="text-lg font-semibold text-gray-900 mb-1">Stripe Payment Link</h1>
-      <p class="text-sm text-gray-500 mb-4">Send this link to the payer to collect payment:</p>
+    <div class="rounded-xl border-2 border-blue-400 bg-white p-6 shadow-sm">
+      <h1 class="text-primary mb-1 font-display text-lg font-semibold">Stripe Payment Link</h1>
+      <p class="mb-4 text-sm text-gray-500">Send this link to the payer to collect payment:</p>
 
-      <div class="flex items-center gap-2 mb-4">
+      <div class="mb-4 flex items-center gap-2">
         <input type="text" value="<%= @checkout_url %>" readonly
-               class="flex-1 bg-gray-50 rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono"
+               class="flex-1 rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 font-mono text-sm"
                onclick="this.select()" />
         <button type="button"
                 onclick="navigator.clipboard.writeText('<%= j @checkout_url %>').then(() => { this.textContent = 'Copied!'; setTimeout(() => { this.textContent = 'Copy' }, 2000) })"
-                class="inline-flex items-center gap-1.5 rounded-lg bg-gray-700 text-white px-3 py-2 text-sm font-medium hover:bg-gray-800 transition-colors whitespace-nowrap">
+                class="inline-flex items-center gap-1.5 rounded-lg bg-gray-700 px-3 py-2 text-sm font-medium whitespace-nowrap text-white transition-colors hover:bg-gray-800">
           Copy
         </button>
       </div>
@@ -29,14 +29,14 @@
       </div>
     </div>
   <% else %>
-    <div class="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
-      <h1 class="text-lg font-semibold text-gray-900 mb-1">Generate Stripe Checkout Link</h1>
-      <p class="text-sm text-gray-500 mb-4">Create a custom Stripe checkout link with a specified amount.</p>
+    <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
+      <h1 class="text-primary mb-1 font-display text-lg font-semibold">Generate Stripe Checkout Link</h1>
+      <p class="mb-4 text-sm text-gray-500">Create a custom Stripe checkout link with a specified amount.</p>
 
       <%= form_tag create_checkout_link_payments_path, data: { turbo: false } do %>
         <div class="mb-6">
           <%= label_tag :description, "Description", class: "block text-sm font-medium text-gray-700 mb-1" %>
-          <p class="text-xs text-gray-400 mb-1">Displays in checkout</p>
+          <p class="mb-1 text-xs text-gray-400">Displays in checkout</p>
           <%= text_field_tag :description, params[:description], placeholder: "e.g. AWBW Facilitator Training",
                class: "bg-white w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500" %>
         </div>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -1,13 +1,13 @@
-<div class="max-w-2xl mx-auto">
+<div class="mx-auto max-w-2xl">
   <%= link_to "← Payments", payments_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
-  <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold">Payment</h1>
+  <div class="mb-6 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-bold">Payment</h1>
     <div class="flex gap-2">
       <%= link_to "Edit", edit_payment_path(@payment), class: "btn btn-secondary-outline" %>
       <% if @payment.amount_cents_remaining > 0 %>
         <%= link_to "Allocate", new_allocation_path(source_sgid: @payment.to_sgid.to_s), class: "btn btn-primary" %>
         <% if @payment.is_a?(ExternalProcessorPayment) && @payment.pay_charge_id.blank? %>
-          <span class="text-sm text-gray-400 italic flex items-center gap-1">
+          <span class="flex items-center gap-1 text-sm text-gray-400 italic">
             <i class="fa-solid fa-info-circle"></i>
             Must be refunded via the Stripe Dashboard
           </span>
@@ -57,9 +57,9 @@
       <div>
         <dt class="text-sm font-medium text-gray-500">Stripe Receipt</dt>
         <dd class="mt-1 text-sm">
-          <a href="<%= receipt_url %>" target="_blank" rel="noopener" class="text-primary hover:text-primary-dark underline inline-flex items-center gap-1">
+          <a href="<%= receipt_url %>" target="_blank" rel="noopener" class="text-primary hover:text-primary-dark inline-flex items-center gap-1 underline">
             View Receipt
-            <i class="fa-solid fa-arrow-up-right-from-square w-3 h-3"></i>
+            <i class="fa-solid fa-arrow-up-right-from-square h-3 w-3"></i>
           </a>
         </dd>
       </div>
@@ -76,11 +76,11 @@
                   data-dropdown-payload-param='[{"payment-metadata-<%= @payment.id %>":"hidden"}]'
                   class="inline-flex items-center gap-1.5 text-sm font-medium <%= eyebrow_link_class %> cursor-pointer">
             Metadata
-            <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
+            <i class="fa-solid fa-chevron-down h-3 w-3 text-gray-400"></i>
           </button>
           <div id="payment-metadata-<%= @payment.id %>"
                data-dropdown-target="content"
-               class="hidden mt-2 bg-gray-50 border border-gray-200 rounded-lg p-4 font-mono text-xs text-gray-800 whitespace-pre-wrap break-words max-w-full">
+               class="mt-2 hidden max-w-full rounded-lg border border-gray-200 bg-gray-50 p-4 font-mono text-xs break-words whitespace-pre-wrap text-gray-800">
             <%= JSON.pretty_generate(@payment.metadata) %>
           </div>
         </div>
@@ -92,8 +92,8 @@
   </dl>
   <% if @allocations.any? %>
     <div class="mt-8">
-      <h2 class="text-lg font-medium mb-4">Allocations</h2>
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <h2 class="mb-4 text-lg font-medium">Allocations</h2>
+      <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
@@ -141,8 +141,8 @@
   <% end %>
   <% if @refunds.any? %>
     <div class="mt-8">
-      <h2 class="text-lg font-medium mb-4">Refunds</h2>
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+      <h2 class="mb-4 text-lg font-medium">Refunds</h2>
+      <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>

--- a/app/views/people/all_comments.html.erb
+++ b/app/views/people/all_comments.html.erb
@@ -5,17 +5,17 @@
   <% end %>
 </div>
 
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
   <div class="<%= DomainTheme.bg_class_for(:comments, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:comments) %> px-8 py-3">
     <div class="flex items-center gap-2">
       <i class="fa-solid fa-comments <%= DomainTheme.text_class_for(:comments, intensity: 700) %>"></i>
-      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> uppercase tracking-wide">All comments</span>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:comments, intensity: 900) %> tracking-wide uppercase">All comments</span>
     </div>
   </div>
 
-  <div class="p-4 sm:p-8 space-y-6">
+  <div class="space-y-6 p-4 sm:p-8">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
-      <h1 class="text-2xl font-semibold text-gray-900"><%= @person.full_name %></h1>
+      <h1 class="text-primary font-display text-2xl font-semibold"><%= @person.full_name %></h1>
       <p class="text-sm text-gray-500">
         <%= pluralize(@total_count, "comment") %><% if @flagged_count.positive? %> · <span class="font-medium text-orange-600"><%= @flagged_count %> flagged</span><% end %>
       </p>

--- a/app/views/people/check_duplicates.html.erb
+++ b/app/views/people/check_duplicates.html.erb
@@ -18,7 +18,7 @@
           </svg>
         </div>
 
-        <h1 class="ml-4 text-xl font-semibold text-gray-900">Possible duplicate person</h1>
+        <h1 class="text-primary ml-4 font-display text-xl font-semibold">Possible duplicate person</h1>
       </div>
 
       <p class="mb-2 text-sm text-gray-600">

--- a/app/views/people/comments_and_communications.html.erb
+++ b/app/views/people/comments_and_communications.html.erb
@@ -16,7 +16,7 @@
 
 <%# The page keeps the admin-only policy marker, but the card carries the people
     theme so the feed doesn't read as one flat blue wash. %>
-<div class="overflow-hidden rounded-xl border border-gray-200 shadow <%= DomainTheme.bg_class_for(:people, intensity: 50) %>">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm <%= DomainTheme.bg_class_for(:people, intensity: 50) %>">
   <div class="<%= DomainTheme.bg_class_for(:people, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:people) %> px-8 py-3">
     <div class="flex items-center gap-2">
       <i class="fa-solid fa-comments <%= DomainTheme.text_class_for(:people, intensity: 700) %>"></i>
@@ -26,7 +26,7 @@
 
   <div class="space-y-6 p-4 sm:p-8">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
-      <h1 class="text-2xl font-semibold text-gray-900"><%= @person.full_name %></h1>
+      <h1 class="text-primary font-display text-2xl font-semibold"><%= @person.full_name %></h1>
       <p class="text-sm text-gray-500">
         <%= pluralize(@total_count, "entry", plural: "entries") %><% if @flagged_count.positive? %> · <span class="font-medium text-orange-600"><%= @flagged_count %> flagged</span><% end %>
       </p>

--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:people) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
         <div class="sticky top-0 z-10 <%= DomainTheme.bg_class_for(:people) %> pb-3">
           <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
             <div class="mb-2">
@@ -40,7 +40,7 @@
             <%= link_to "People", people_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
             <%= link_to "Profile", person_path(@person), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           </div>
-          <h1 class="text-3xl font-semibold tracking-tight text-gray-900">
+          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
             Edit Person: <%= truncate(@person.name, length: 30) %>
           </h1>
         </div>
@@ -58,7 +58,7 @@
             <div class="mb-2 font-semibold text-gray-700">
               Associated records
             </div>
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
+            <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 shadow-sm">
               <%= render "associated_records", person: @person %>
             </div>
           </div>

--- a/app/views/people/email_addresses.html.erb
+++ b/app/views/people/email_addresses.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← People", people_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="mb-6">
-    <h1 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
+    <h1 class="text-primary flex items-center gap-2 font-display text-2xl font-semibold">
       <i class="fa-solid fa-envelope <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i>
       Email addresses
     </h1>

--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:people) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New <%= @person.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New <%= @person.class.model_name.human.downcase %></h1>
         </div>
 
-        <div class="border-b border-gray-300 mb-6"></div>
+        <div class="mb-6 border-b border-gray-300"></div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form" %>
           </div>

--- a/app/views/people/workshop_logs.html.erb
+++ b/app/views/people/workshop_logs.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="admin-or-owner border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="admin-or-owner border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
   <!-- Header -->
   <div class="<%= DomainTheme.bg_class_for(:workshop_logs, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:workshop_logs, intensity: 300) %> px-8 py-3">
     <div class="flex items-center gap-2">
-      <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:workshop_logs, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
       </svg>
-      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> uppercase tracking-wide">Workshop Logs for <%= @person.full_name %></span>
+      <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:workshop_logs, intensity: 900) %> tracking-wide uppercase">Workshop Logs for <%= @person.full_name %></span>
     </div>
   </div>
 
@@ -22,7 +22,7 @@
       <% first_log = @filtered_logs.first %>
       <% workshop_name = first_log.workshop_title.presence || "Workshop Log" %>
       <% workshop_name += " (#{first_log.windows_type_name})" if first_log.windows_type_name.present? %>
-      <h1 class="text-2xl font-bold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-bold">
         Workshop Logs for
         <% if first_log.workshop.present? %>
           <%= link_to workshop_name, workshop_path(first_log.workshop),
@@ -33,15 +33,15 @@
       </h1>
 
       <!-- Column headers -->
-      <div class="flex items-center gap-2 mb-2">
-        <div class="grid grid-cols-5 gap-2 flex-1 min-w-0">
-          <div class="px-2.5 text-left pl-6 text-xs font-medium text-gray-400">Date</div>
+      <div class="mb-2 flex items-center gap-2">
+        <div class="grid min-w-0 flex-1 grid-cols-5 gap-2">
+          <div class="px-2.5 pl-6 text-left text-xs font-medium text-gray-400">Date</div>
           <div class="px-1.5 text-center text-xs font-medium text-gray-400">Total</div>
           <div class="px-1.5 text-center text-xs font-medium text-gray-400">Adults</div>
           <div class="px-1.5 text-center text-xs font-medium text-gray-400">Teens</div>
           <div class="px-1.5 text-center text-xs font-medium text-gray-400">Children</div>
         </div>
-        <div class="shrink-0 w-20 ml-4"></div>
+        <div class="ml-4 w-20 shrink-0"></div>
       </div>
 
       <!-- Grand totals (top) -->
@@ -56,7 +56,7 @@
     <% else %>
       <!-- All workshops grouped -->
       <% if @grouped_logs.any? %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           <% @grouped_logs.each do |key, logs| %>
             <%= render "people/sections/workshop_log_grouped_card",
                        person: @person, logs: logs %>

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:continuing_education) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
@@ -12,12 +12,12 @@
       <i class="fa-solid fa-id-card"></i>
     </span>
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">Edit license</h1>
+      <h1 class="text-primary font-display text-2xl font-semibold">Edit license</h1>
       <p class="mt-1 text-gray-600">Update this registrant's professional license</p>
     </div>
   </div>
 
-  <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+  <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
     <%= render "form", professional_license: @professional_license %>
   </div>
   <%= render "shared/audit_info", resource: @professional_license %>

--- a/app/views/professional_licenses/index.html.erb
+++ b/app/views/professional_licenses/index.html.erb
@@ -1,26 +1,26 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-certificate text-xs"></i> CE registrations
     <% end %>
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <div class="flex justify-end mb-6">
+  <div class="mb-6 flex justify-end">
     <%= link_to new_professional_license_path, class: "btn btn-primary" do %>
       <i class="fa-solid fa-plus text-xs"></i> New license
     <% end %>
   </div>
 
-  <div class="flex items-center gap-3 mb-6">
+  <div class="mb-6 flex items-center gap-3">
     <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
       <i class="fa-solid fa-id-card"></i>
     </span>
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">Licenses</h1>
-      <p class="text-gray-600 mt-1">Professional licenses on file across all registrants</p>
+      <h1 class="text-primary font-display text-2xl font-semibold">Licenses</h1>
+      <p class="mt-1 text-gray-600">Professional licenses on file across all registrants</p>
     </div>
   </div>
 

--- a/app/views/professional_licenses/new.html.erb
+++ b/app/views/professional_licenses/new.html.erb
@@ -1,23 +1,23 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto <%= DomainTheme.bg_class_for(:continuing_education) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
     <% end %>
   </div>
 
-  <div class="flex items-center gap-3 mb-6">
+  <div class="mb-6 flex items-center gap-3">
     <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
       <i class="fa-solid fa-id-card"></i>
     </span>
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">New license</h1>
-      <p class="text-gray-600 mt-1">Pick a registrant and record their professional license</p>
+      <h1 class="text-primary font-display text-2xl font-semibold">New license</h1>
+      <p class="mt-1 text-gray-600">Pick a registrant and record their professional license</p>
     </div>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+  <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
     <%= render "form", professional_license: @professional_license %>
   </div>
 </div>

--- a/app/views/professional_licenses/professional_licenses_results.html.erb
+++ b/app/views/professional_licenses/professional_licenses_results.html.erb
@@ -1,7 +1,7 @@
 <% sort_base = params.permit(:person_query, :kind, :expired).to_h.symbolize_keys %>
 <% sort_link = sort_header_link(frame: "professional_licenses_results", path: ->(p) { professional_licenses_path(p) }, base: sort_base) %>
 <%= turbo_frame_tag :professional_licenses_results do %>
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm blur-on-submit">
     <% if @professional_licenses.any? %>
       <% total = @professional_licenses.respond_to?(:total_entries) ? @professional_licenses.total_entries : @professional_licenses.size %>
       <div class="flex items-center justify-between border-b border-gray-100 px-6 py-4">

--- a/app/views/quotes/edit.html.erb
+++ b/app/views/quotes/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:quotes) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Quotes", quotes_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", quote_path(@quote), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @quote.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @quote.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:quotes) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:quotes) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
       <div class="space-y-6">
         <!-- Header -->
         <div class="mb-6 flex items-center justify-between">
-          <h1 class="text-2xl font-semibold text-gray-900">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= Quote.model_name.human.pluralize %> (<%= @quotes_count %>)
           </h1>
           <div class="flex gap-2">

--- a/app/views/quotes/new.html.erb
+++ b/app/views/quotes/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:quotes) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-2xl font-semibold text-gray-900">New <%= @quote.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:quotes) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-semibold">New <%= @quote.class.model_name.human.downcase %></h1>
   </div>
 
-  <div class="border-b border-gray-300 mb-6"></div>
+  <div class="mb-6 border-b border-gray-300"></div>
 
   <div class="space-y-6">
     <div class="mt-4">

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -2,7 +2,7 @@
 <% quote_title = ERB::Util.url_encode(@quote.title) %>
 
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:quotes) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:quotes) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
       <!-- Top Right Utility Links -->
       <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -20,12 +20,12 @@
         <div class="mx-auto max-w-3xl px-4 py-10 text-gray-800">
 
           <!-- Title -->
-          <h1 class="mb-2 text-3xl leading-tight font-bold text-gray-900">
+          <h1 class="text-primary mb-2 font-display text-3xl leading-tight font-bold">
             Quote Details
           </h1>
 
           <!-- Card -->
-          <div class="mb-6 space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <div class="border-primary/10 mb-6 space-y-6 rounded-2xl border bg-white p-6 shadow-sm">
             <div>
               <div class="relative rounded-2xl bg-gray-100 p-6 leading-relaxed italic">
                 <div class="text-lg font-semibold text-gray-700 italic">

--- a/app/views/refunds/new.html.erb
+++ b/app/views/refunds/new.html.erb
@@ -1,21 +1,21 @@
-<div class="max-w-2xl mx-auto" data-controller="search-type-select">
-  <h1 class="text-2xl font-bold mb-6">New Refund</h1>
+<div class="mx-auto max-w-2xl" data-controller="search-type-select">
+  <h1 class="text-primary mb-6 font-display text-2xl font-bold">New Refund</h1>
   <%= simple_form_for @refund, url: refunds_path do |f| %>
     <%= f.hidden_field :refundable_type %>
     <%= f.hidden_field :refundable_id %>
     <% if @payment.present? %>
-      <div class="mb-4 p-4 bg-gray-50 rounded-lg">
+      <div class="mb-4 rounded-lg bg-gray-50 p-4">
         <p class="text-sm font-medium text-gray-700">For Payment</p>
         <p class="text-lg text-gray-900"><%= dollars_from_cents(@payment.amount_cents) %></p>
         <p class="text-sm text-gray-500">Remaining: <%= dollars_from_cents(@payment.amount_cents_remaining) %></p>
       </div>
     <% else %>
-      <div class="mb-4 p-4 bg-red-50 rounded-lg">
+      <div class="mb-4 rounded-lg bg-red-50 p-4">
         <p class="text-sm font-medium text-red-700">Error: No payment found</p>
       </div>
     <% end %>
     <% if @payment.is_a?(ExternalProcessorPayment) %>
-      <div class="mb-4 p-4 bg-blue-50 rounded-lg">
+      <div class="mb-4 rounded-lg bg-blue-50 p-4">
         <p class="text-sm text-blue-700">This refund will be processed via Stripe and returned to the original payment method.</p>
       </div>
     <% end %>
@@ -50,8 +50,8 @@
       </template>
       <div data-search-type-select-target="pickerContainer">
         <div>
-          <label class="text-sm font-medium text-gray-500 mb-1 block italic">Select Recipient Type</label>
-          <div class="w-full bg-gray-100 border border-gray-300 rounded-lg px-3 py-2 cursor-not-allowed min-h-[2.2rem]"></div>
+          <label class="mb-1 block text-sm font-medium text-gray-500 italic">Select Recipient Type</label>
+          <div class="min-h-[2.2rem] w-full cursor-not-allowed rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"></div>
         </div>
       </div>
       <div class="mb-4">

--- a/app/views/refunds/show.html.erb
+++ b/app/views/refunds/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to "← Payment", payment_path(@refund.refundable), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
 
-    <h1 class="text-2xl font-semibold text-gray-900">Refund</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Refund</h1>
   </div>
 
   <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-member") %>
 <div class="min-h-screen py-8">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-200 p-6 space-y-6">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="border-primary/10 space-y-6 rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
 
       <!-- Header -->
       <div class="flex items-center justify-between">
-        <h1 class="text-2xl font-semibold text-gray-900">
+        <h1 class="text-primary font-display text-2xl font-semibold">
           <%= @workshop_log.workshop&.title || "Workshop Log" %>
         </h1>
 
@@ -18,7 +18,7 @@
       </div>
 
       <!-- Workshop Info -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-gray-800">
+      <div class="grid grid-cols-1 gap-6 text-sm text-gray-800 md:grid-cols-2">
         <div>
           <p><span class="font-semibold text-gray-700">Person:</span> <%= @workshop_log.created_by&.name || "—" %></p>
           <p><span class="font-semibold text-gray-700">Organization:</span> <%= @workshop_log.organization&.name || "—" %></p>
@@ -36,16 +36,16 @@
 
       <!-- Participant counts -->
       <div>
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Participant counts</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Participant counts</h2>
         <div class="overflow-x-auto">
-          <table class="min-w-full border border-gray-300 rounded-lg overflow-hidden">
+          <table class="min-w-full overflow-hidden rounded-lg border border-gray-300">
             <thead>
             <tr class="bg-gray-100">
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Category</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Children</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Teens</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Adults</th>
-              <th class="px-4 py-2 text-center text-sm font-bold text-gray-800 bg-gray-300 uppercase">Total</th>
+              <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Children</th>
+              <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Teens</th>
+              <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Adults</th>
+              <th class="bg-gray-300 px-4 py-2 text-center text-sm font-bold text-gray-800 uppercase">Total</th>
             </tr>
             </thead>
 
@@ -53,10 +53,10 @@
             <!-- Ongoing -->
             <tr>
               <td class="px-4 py-2 font-medium text-gray-700">Ongoing Participants</td>
-              <td class="text-center bg-blue-100"><%= display_count(@workshop_log.children_ongoing) %></td>
-              <td class="text-center bg-blue-100"><%= display_count(@workshop_log.teens_ongoing) %></td>
-              <td class="text-center bg-blue-100"><%= display_count(@workshop_log.adults_ongoing) %></td>
-              <td class="text-center font-semibold bg-blue-200">
+              <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.children_ongoing) %></td>
+              <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.teens_ongoing) %></td>
+              <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.adults_ongoing) %></td>
+              <td class="bg-blue-200 text-center font-semibold">
                 <%= display_count(@workshop_log.children_ongoing.to_i +
                                     @workshop_log.teens_ongoing.to_i +
                                     @workshop_log.adults_ongoing.to_i) %>
@@ -66,10 +66,10 @@
             <!-- First-time -->
             <tr>
               <td class="px-4 py-2 font-medium text-gray-700">First-Time Participants</td>
-              <td class="text-center bg-green-100"><%= display_count(@workshop_log.children_first_time) %></td>
-              <td class="text-center bg-green-100"><%= display_count(@workshop_log.teens_first_time) %></td>
-              <td class="text-center bg-green-100"><%= display_count(@workshop_log.adults_first_time) %></td>
-              <td class="text-center font-semibold bg-green-200">
+              <td class="bg-green-100 text-center"><%= display_count(@workshop_log.children_first_time) %></td>
+              <td class="bg-green-100 text-center"><%= display_count(@workshop_log.teens_first_time) %></td>
+              <td class="bg-green-100 text-center"><%= display_count(@workshop_log.adults_first_time) %></td>
+              <td class="bg-green-200 text-center font-semibold">
                 <%= display_count(@workshop_log.children_first_time.to_i +
                                     @workshop_log.teens_first_time.to_i +
                                     @workshop_log.adults_first_time.to_i) %>
@@ -82,10 +82,10 @@
             <% adults_total   = @workshop_log.adults_ongoing.to_i + @workshop_log.adults_first_time.to_i %>
             <tr class="font-semibold">
               <td class="px-4 py-2 text-right text-sm font-bold text-gray-800 uppercase">Subtotal</td>
-              <td class="text-center font-bold text-md bg-purple-100"><%= display_count(children_total) %></td>
-              <td class="text-center font-bold text-md bg-purple-100"><%= display_count(teens_total) %></td>
-              <td class="text-center font-bold text-md bg-purple-100"><%= display_count(adults_total) %></td>
-              <td class="text-center text-lg font-bold bg-purple-200">
+              <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(children_total) %></td>
+              <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(teens_total) %></td>
+              <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(adults_total) %></td>
+              <td class="bg-purple-200 text-center text-lg font-bold">
                 <%= display_count(children_total + teens_total + adults_total) %>
               </td>
             </tr>
@@ -97,7 +97,7 @@
       <!-- Responses -->
       <% if @answers.any? %>
         <div class="mt-8 space-y-3">
-          <h2 class="text-lg font-semibold text-gray-800 mb-2">Responses</h2>
+          <h2 class="mb-2 text-lg font-semibold text-gray-800">Responses</h2>
           <% @answers.each do |answer| %>
             <div class="border-b border-gray-200 pb-2">
               <p class="text-sm font-semibold text-gray-700"><%= answer.form_field.name %></p>
@@ -110,25 +110,25 @@
       <!-- Quotes -->
       <% if @workshop_log.quotes.any? %>
         <div class="mt-8 space-y-3">
-          <h2 class="text-lg font-semibold text-gray-800 mb-2">Quotes</h2>
-          <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-6 space-y-6 mb-6">
+          <h2 class="mb-2 text-lg font-semibold text-gray-800">Quotes</h2>
+          <div class="border-primary/10 mb-6 space-y-6 rounded-2xl border bg-white p-6 shadow-sm">
             <% @workshop_log.quotes.decorate.each do |quote| %>
               <div>
-                <div class="relative bg-gray-100 italic leading-relaxed p-6 rounded-2xl">
-                  <div class="font-semibold text-gray-700 italic text-lg">
+                <div class="relative rounded-2xl bg-gray-100 p-6 leading-relaxed italic">
+                  <div class="text-lg font-semibold text-gray-700 italic">
                     <%= link_to quote.detail, quote_path(quote.object), class: "hover:underline" %>
-                    <span class="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded-full">
+                    <span class="rounded-full bg-gray-200 px-2 py-1 text-xs text-gray-700">
                       <span class="fa fa-eye-slash"></span>
                       Unpublished
                     </span>
                   </div>
-                  <div class="text-gray-700 mt-3">
+                  <div class="mt-3 text-gray-700">
                     -- <%= quote.attribution %>
                     <%= "@ " + quote.created_at.strftime("%m-%d-%-Y") %>
                     <%= ("re " + link_to(quote.workshop.title, workshop_path(quote.workshop),
                                          class: "hover:underline") if quote.workshop).to_s.html_safe %>
                   </div>
-                  <div class="absolute -bottom-3 left-8 w-0 h-0 border-t-8 border-t-gray-100 border-x-8 border-x-transparent"></div>
+                  <div class="absolute -bottom-3 left-8 h-0 w-0 border-x-8 border-t-8 border-x-transparent border-t-gray-100"></div>
                 </div>
               </div>
             <% end %>

--- a/app/views/resources/edit.html.erb
+++ b/app/views/resources/edit.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:resources) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Resources", resources_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", resource_path(@resource, no_redirect: true), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-3">Edit <%= @resource.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-3 font-display text-2xl font-semibold">Edit <%= @resource.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
-          <div class="mt-4 bg-white rounded p-3">
+          <div class="mt-4 rounded bg-white p-3">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @resource %>
           </div>

--- a/app/views/resources/new.html.erb
+++ b/app/views/resources/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+<div class="<%= DomainTheme.bg_class_for(:resources) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
             New <%= @resource.class.model_name.human.downcase %>
           </h1>
         </div>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
           </div>
         </div>

--- a/app/views/scholarships/edit.html.erb
+++ b/app/views/scholarships/edit.html.erb
@@ -3,7 +3,7 @@
 <% grant_nav = grant.present? && params[:return_to].in?(%w[ grant_show grant_edit ]) %>
 <% theme = (grant_nav || (@allocatable.blank? && grant.present?)) ? :grants : :scholarships %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> rounded-xl border border-gray-200 p-4 shadow sm:p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + secondary links, matching the registration edit page %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if grant_nav %>

--- a/app/views/scholarships/index.html.erb
+++ b/app/views/scholarships/index.html.erb
@@ -1,22 +1,22 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="scholarships-index max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:scholarships) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="scholarships-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:scholarships) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="w-full">
-    <div class="flex items-start justify-between gap-6 mb-6">
+    <div class="mb-6 flex items-start justify-between gap-6">
       <div class="flex items-start gap-4">
-        <span class="hidden sm:flex h-12 w-12 shrink-0 items-center justify-center rounded-xl <%= DomainTheme.bg_class_for(:scholarships) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> shadow-sm">
+        <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:scholarships) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> shadow-sm">
           <i class="fa-solid fa-graduation-cap text-xl" aria-hidden="true"></i>
         </span>
         <div>
-          <h2 class="text-2xl font-semibold text-gray-900 flex items-center gap-2">
+          <h2 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
             <%= Scholarship.model_name.human.pluralize %>
             <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:scholarships) %> <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %> border <%= DomainTheme.border_class_for(:scholarships, intensity: 200) %> px-2.5 py-0.5 text-sm font-semibold"><%= @scholarships_count %></span>
           </h2>
-          <p class="text-gray-600 mt-1">Awards to facilitators, grouped by funder and grant.</p>
+          <p class="mt-1 text-gray-600">Awards to facilitators, grouped by funder and grant.</p>
         </div>
       </div>
 
-      <div class="shrink-0 text-right text-end">
+      <div class="shrink-0 text-end text-right">
         <%= link_to grants_path, class: "btn btn-primary-outline" do %>
           <i class="fa-solid fa-hand-holding-dollar" aria-hidden="true"></i>
           <%= Grant.model_name.human.pluralize %>
@@ -33,8 +33,8 @@
     <%# Scholarship summary for the trainings in scope, linking to the full report. %>
     <% if @scholarship_report.any? %>
       <div class="mb-8">
-        <div class="flex items-center justify-between mb-3">
-          <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Summary</h3>
+        <div class="mb-3 flex items-center justify-between">
+          <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Summary</h3>
           <%= link_to "Full report →", scholarships_events_path, class: "text-sm font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
         </div>
         <%= render "events/scholarship_kpis", report: @scholarship_report %>
@@ -47,7 +47,7 @@
         <%= render partial: "funder_group", collection: @funder_groups, as: :funder_group %>
       </div>
     <% else %>
-      <div class="bg-white rounded-xl border border-dashed border-gray-300 py-12 text-center">
+      <div class="rounded-xl border border-dashed border-gray-300 bg-white py-12 text-center">
         <i class="fa-solid fa-graduation-cap text-3xl text-gray-300" aria-hidden="true"></i>
         <p class="mt-3 text-gray-500">No scholarships found.</p>
       </div>

--- a/app/views/scholarships/new.html.erb
+++ b/app/views/scholarships/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% theme = @grant ? :grants : :scholarships %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> border border-gray-200 rounded-xl shadow p-4 sm:p-6">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(theme) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: back link + secondary links, matching the registration edit page %>
-  <div class="flex flex-wrap items-center justify-between gap-2 mb-6">
+  <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <% if @grant %>
       <%= link_to (params[:return_to] == "grant_edit" ? edit_grant_path(@grant) : grant_path(@grant)), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Grant

--- a/app/views/scholarships/show.html.erb
+++ b/app/views/scholarships/show.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:events) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to "← Edit scholarship", edit_scholarship_path(@scholarship), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
-    <h1 class="text-2xl font-semibold text-gray-900">Scholarship</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Scholarship</h1>
     <% if @scholarship.recipient.present? %>
       <p class="mt-1 text-gray-600"><%= @scholarship.recipient.full_name %></p>
     <% end %>

--- a/app/views/sectors/edit.html.erb
+++ b/app/views/sectors/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:sectors) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Sectors", sectors_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Taggings", taggings_path(sector_names_all: @sector.name), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", sector_path(@sector), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit sector</h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit sector</h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/sectors/index.html.erb
+++ b/app/views/sectors/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:sectors) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
 
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             Sectors (<%= @count_display %>)
           </h1>
           <div class="flex gap-2">
@@ -29,15 +29,15 @@
               <table class="w-full table-fixed border-collapse border border-gray-200">
                 <thead class="bg-gray-100">
                 <tr>
-                  <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/3">
+                  <th class="w-1/3 px-4 py-2 text-left text-sm font-semibold text-gray-700">
                     Name
                   </th>
 
-                  <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/6">
+                  <th class="w-1/6 px-4 py-2 text-center text-sm font-semibold text-gray-700">
                     Published
                   </th>
 
-                  <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]">
+                  <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700">
                     Actions
                   </th>
                 </tr>
@@ -48,21 +48,21 @@
                   <tr class=" <%= "bg-gray-200" unless sector.published? %>
                     <%= sector.published? ? "hover:bg-gray-100" : "hover:bg-gray-50" %> transition-colors duration-150">
 
-                    <td class="px-4 py-2 text-md text-gray-800 truncate font-bold">
+                    <td class="truncate px-4 py-2 text-md font-bold text-gray-800">
                       <%= sector.name %>
                       <% if sector.description.present? %>
-                        <i class="fa-solid fa-circle-info ml-1 text-sm font-normal text-gray-400 hover:text-blue-600 cursor-help"
+                        <i class="fa-solid fa-circle-info ml-1 cursor-help text-sm font-normal text-gray-400 hover:text-blue-600"
                            title="<%= sector.description %>"></i>
                       <% end %>
                     </td>
 
                     <td class="px-4 py-2 text-center">
                       <% if sector.published? %>
-                        <span class="inline-block px-2 py-1 text-xs font-semibold text-green-800 bg-green-100 rounded">
+                        <span class="inline-block rounded bg-green-100 px-2 py-1 text-xs font-semibold text-green-800">
                           Yes
                         </span>
                       <% else %>
-                        <span class="inline-block px-2 py-1 text-xs font-semibold text-gray-700 bg-gray-200 rounded">
+                        <span class="inline-block rounded bg-gray-200 px-2 py-1 text-xs font-semibold text-gray-700">
                           No
                         </span>
                       <% end %>
@@ -84,7 +84,7 @@
               </table>
             <% else %>
               <!-- Empty state -->
-              <p class="text-gray-500 text-center py-6">
+              <p class="py-6 text-center text-gray-500">
                 No <%= Sector.model_name.human.pluralize.downcase %> found.
               </p>
             <% end %>
@@ -92,7 +92,7 @@
         </div>
 
         <!-- Pagination -->
-        <div class="pagination flex justify-center mt-12">
+        <div class="pagination mt-12 flex justify-center">
           <%= tailwind_paginate @sectors %>
         </div>
 

--- a/app/views/sectors/new.html.erb
+++ b/app/views/sectors/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New sector</h1>
+<div class="<%= DomainTheme.bg_class_for(:sectors) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New sector</h1>
         </div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form", sector: @sector %>
           </div>

--- a/app/views/sectors/show.html.erb
+++ b/app/views/sectors/show.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:sectors) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:sectors) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Sectors", sectors_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @sector) %>
           <%= link_to "Edit", edit_sector_path(@sector), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         Sector details
       </h1>
 
       <div class="space-y-6">
         <div class="mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-3">
+          <div class="mb-3 grid grid-cols-1 gap-4 md:grid-cols-3">
 
               <div class="mb-3">
                 <p class="font-bold text-gray-700">Name:</p>

--- a/app/views/staff_taggings/edit.html.erb
+++ b/app/views/staff_taggings/edit.html.erb
@@ -20,13 +20,13 @@
       <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
 
-    <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit staff tagging</h1>
+    <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit staff tagging</h1>
 
     <%= simple_form_for @staff_tagging,
           url: staff_tagging_path(@staff_tagging, return_to: params[:return_to].presence, origin_id: params[:origin_id].presence, admin: params[:admin].presence),
           method: :patch,
           html: { data: { turbo: false } } do |f| %>
-      <div class="mb-6 rounded-xl border border-gray-200 bg-gray-50 p-4">
+      <div class="border-primary/10 mb-6 rounded-2xl border bg-gray-50 p-4">
         <div class="flex flex-col gap-4 md:flex-row md:items-start">
           <div class="md:w-72">
             <span class="<%= search_label_class %>">Person</span>

--- a/app/views/staff_taggings/index.html.erb
+++ b/app/views/staff_taggings/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="w-full">
     <div class="mb-4">
       <%= link_to "← Staff tags", staff_tags_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/staff_taggings/new.html.erb
+++ b/app/views/staff_taggings/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-    <div class="mx-auto rounded-xl border border-gray-200 bg-white p-6 shadow-lg">
+    <div class="border-primary/10 mx-auto rounded-2xl border bg-white p-6 shadow-lg">
       <div class="mb-4">
         <%= link_to "← Staff taggings", staff_taggings_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="mb-2 text-2xl font-semibold text-gray-900">New staff tagging</h1>
+      <h1 class="text-primary mb-2 font-display text-2xl font-semibold">New staff tagging</h1>
       <p class="mb-6 text-sm text-gray-600">Tag a person with a staff tag.</p>
 
       <%= simple_form_for @staff_tagging, url: staff_taggings_path do |f| %>

--- a/app/views/staff_tags/edit.html.erb
+++ b/app/views/staff_tags/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="mx-auto max-w-5xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
         <%= link_to "← Staff tags", staff_tags_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", staff_tag_path(@staff_tag), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit staff tag</h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit staff tag</h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/staff_tags/index.html.erb
+++ b/app/views/staff_tags/index.html.erb
@@ -2,12 +2,12 @@
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
     <div class="admin-only rounded bg-blue-100 p-6">
-      <div class="mx-auto max-w-7xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+      <div class="border-primary/10 mx-auto max-w-7xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="space-y-6">
         <!-- Header -->
         <div class="mb-6 flex items-start justify-between">
           <div>
-            <h1 class="text-2xl font-semibold text-gray-900">
+            <h1 class="text-primary font-display text-2xl font-semibold">
               Staff tags (<%= @count_display %>)
             </h1>
             <p class="mt-1 max-w-2xl text-sm text-gray-600">
@@ -21,7 +21,7 @@
           </div>
         </div>
 
-        <div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="border-primary/10 overflow-x-auto rounded-2xl border bg-white shadow-sm">
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>

--- a/app/views/staff_tags/new.html.erb
+++ b/app/views/staff_tags/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="mx-auto max-w-5xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center gap-2">
         <%= link_to "← Staff tags", staff_tags_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="mb-3 text-2xl font-semibold text-gray-900">New staff tag</h1>
+      <h1 class="text-primary mb-3 font-display text-2xl font-semibold">New staff tag</h1>
 
       <div class="mb-6 border-b border-gray-300"></div>
 

--- a/app/views/staff_tags/show.html.erb
+++ b/app/views/staff_tags/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen py-8">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-    <div class="mx-auto max-w-5xl rounded-xl border border-gray-200 bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
+    <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
         <%= link_to "← Staff tags", staff_tags_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Edit", edit_staff_tag_path(@staff_tag), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="mb-2 text-2xl font-semibold text-gray-900">
+      <h1 class="text-primary mb-2 font-display text-2xl font-semibold">
         Staff tag: <%= @staff_tag.name %>
       </h1>
 

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:stories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-4 flex flex-wrap justify-end gap-2">
           <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "Stories", stories_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <% if @story.external_url.present? %>
@@ -10,11 +10,11 @@
           <%= link_to "View", story_path(@story, no_redirect: true),
                       class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
-        <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
+        <h1 class="text-primary mb-3 font-display text-3xl font-semibold tracking-tight">
           Edit <%= @story.class.model_name.human.downcase %>
         </h1>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @story %>
           </div>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+<div class="<%= DomainTheme.bg_class_for(:stories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
             New <%= @story.class.model_name.human.downcase %>
           </h1>
         </div>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
           </div>
         </div>

--- a/app/views/story_ideas/edit.html.erb
+++ b/app/views/story_ideas/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Story Ideas", story_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if @story_idea.stories.any? %>
@@ -10,7 +10,7 @@
         <% end %>
         <%= link_to "View", story_idea_path(@story_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @story_idea.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/story_ideas/index.html.erb
+++ b/app/views/story_ideas/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= StoryIdea.model_name.human.pluralize %> (<%= @story_ideas_count %>)
           </h1>
           <div class="flex gap-2">
@@ -30,7 +30,7 @@
               <th class="px-4 py-2 text-center text-sm font-medium text-gray-700">Actions</th>
             </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
+            <tbody class="divide-y divide-gray-200 bg-white">
             <% @story_ideas.each do |story_idea| %>
               <tr class="hover:bg-gray-50">
                 <td>
@@ -51,16 +51,16 @@
                 <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.windows_type&.short_name %></td>
                 <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.workshop_title %></td>
                 <td class="px-4 py-2 text-sm text-gray-800"><%= story_idea.organization&.name %></td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
+                <td class="px-4 py-2 text-center text-sm text-gray-500">
                   <%= story_idea.updated_at.strftime("%b %d, %Y") %>
                 </td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
+                <td class="px-4 py-2 text-center text-sm text-gray-500">
                   <% if story_idea.stories.any? %>
                     <%= link_to "Story", story_path(story_idea.stories.last),
                                 class: "btn btn-secondary-outline" %>
                   <% end %>
                 </td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center">
+                <td class="px-4 py-2 text-center text-sm text-gray-500">
                   <%= link_to "Edit", edit_story_idea_path(story_idea), class: "btn btn-secondary-outline" %>
                 </td>
               </tr>
@@ -73,7 +73,7 @@
 
         <!-- Empty state -->
         <% unless @story_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= StoryIdea.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>

--- a/app/views/story_ideas/new.html.erb
+++ b/app/views/story_ideas/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-2xl font-semibold text-gray-900">New <%= @story_idea.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-semibold">New <%= @story_idea.class.model_name.human.downcase %></h1>
   </div>
 
-  <div class="mb-6 text-gray-700 leading-relaxed">
+  <div class="mb-6 leading-relaxed text-gray-700">
     At A Window Between Worlds, we value every story you share. Your voice helps paint a picture of the positive impact
     of art on people and communities, inspiring others to use art in similarly powerful and far reaching ways.
     <br><br>

--- a/app/views/story_ideas/show.html.erb
+++ b/app/views/story_ideas/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:story_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, StoryIdea) %>
       <%= link_to "Story Ideas", story_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -10,9 +10,9 @@
     <% end %>
   </div>
 
-  <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
-    <div class="font-semibold text-gray-900 mb-2">
-      <h1 class="text-3xl tracking-tight"><%= @story_idea.title %></h1>
+  <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
+    <div class="mb-2 font-semibold text-gray-900">
+      <h1 class="text-primary font-display text-3xl tracking-tight"><%= @story_idea.title %></h1>
     </div>
 
     <% if @story_idea.stories.any? %>
@@ -27,8 +27,8 @@
       </div>
     <% end %>
 
-    <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <span class="font-semibold text-gray-700">Story by:</span>
           <% if @story_idea.created_by&.person && allowed_to?(:show?, @story_idea.created_by.person) %>
@@ -96,9 +96,9 @@
       </div>
 
       <% if @story_idea.sectors.any? %>
-        <div class="mt-3 pt-3 border-t border-gray-200">
+        <div class="mt-3 border-t border-gray-200 pt-3">
           <span class="font-semibold text-gray-700">Sectors:</span>
-          <div class="flex flex-wrap gap-1 mt-1">
+          <div class="mt-1 flex flex-wrap gap-1">
             <% @story_idea.sectors.each do |sector| %>
               <%= render "sectors/tagging_label", sector: sector %>
             <% end %>
@@ -109,7 +109,7 @@
       <% if @story_idea.categories.any? %>
         <div class="mt-2">
           <span class="font-semibold text-gray-700">Categories:</span>
-          <div class="flex flex-wrap gap-1 mt-1">
+          <div class="mt-1 flex flex-wrap gap-1">
             <% @story_idea.categories.each do |cat| %>
               <%= render "categories/tagging_label", category: cat %>
             <% end %>

--- a/app/views/story_imports/create.html.erb
+++ b/app/views/story_imports/create.html.erb
@@ -1,56 +1,56 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-4xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="mx-auto max-w-4xl <%= DomainTheme.bg_class_for(:stories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "← Choose a different file", new_story_import_path,
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-1">
+  <h1 class="text-primary mb-1 font-display text-3xl font-semibold tracking-tight">
     Preview import
   </h1>
-  <p class="text-gray-600 mb-6">
+  <p class="mb-6 text-gray-600">
     Reviewing <span class="font-medium"><%= @filename %></span>.
     Nothing has been saved yet — confirm below to run the import.
   </p>
 
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+  <div class="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
     <% [
          [ "Rows read", @result.rows_processed ],
          [ "Story ideas", @result.ideas_created ],
          [ "Connected stories", @result.stories_created ],
          [ "Rows skipped", @result.skipped.size ]
        ].each do |label, value| %>
-      <div class="bg-white rounded-lg border border-gray-200 p-4 text-center">
+      <div class="border-primary/10 rounded-2xl border bg-white p-4 text-center">
         <div class="text-2xl font-semibold text-gray-900"><%= value %></div>
-        <div class="text-xs text-gray-500 mt-1"><%= label %></div>
+        <div class="mt-1 text-xs text-gray-500"><%= label %></div>
       </div>
     <% end %>
   </div>
 
-  <h2 class="text-lg font-semibold text-gray-900 mb-2">Row-by-row</h2>
-  <p class="text-sm text-gray-500 mb-3">
-    <span class="inline-block w-2 h-2 rounded-full bg-amber-400 align-middle"></span> new record ·
-    <span class="inline-block w-2 h-2 rounded-full bg-gray-400 align-middle"></span> existing (reused) ·
-    <span class="inline-block w-2 h-2 rounded-full bg-blue-400 align-middle"></span> updated
+  <h2 class="mb-2 text-lg font-semibold text-gray-900">Row-by-row</h2>
+  <p class="mb-3 text-sm text-gray-500">
+    <span class="inline-block h-2 w-2 rounded-full bg-amber-400 align-middle"></span> new record ·
+    <span class="inline-block h-2 w-2 rounded-full bg-gray-400 align-middle"></span> existing (reused) ·
+    <span class="inline-block h-2 w-2 rounded-full bg-blue-400 align-middle"></span> updated
   </p>
 
   <% preview_cap = 300 %>
-  <div class="space-y-3 mb-6">
+  <div class="mb-6 space-y-3">
     <% @result.previews.first(preview_cap).each do |p| %>
-      <div class="bg-white rounded-lg border border-gray-200 p-4">
+      <div class="border-primary/10 rounded-2xl border bg-white p-4">
         <div class="flex items-start justify-between gap-3">
           <span class="font-medium text-gray-900"><%= p.title.presence || "(untitled)" %></span>
           <% if p.skipped_reason %>
-            <span class="shrink-0 text-xs font-medium rounded-full bg-gray-100 text-gray-600 px-2 py-0.5">Skipped — <%= p.skipped_reason %></span>
+            <span class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">Skipped — <%= p.skipped_reason %></span>
           <% else %>
-            <span class="shrink-0 text-xs font-medium rounded-full px-2 py-0.5 <%= p.will_publish ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800" %>">
+            <span class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium <%= p.will_publish ? "bg-green-100 text-green-800" : "bg-yellow-100 text-yellow-800" %>">
               <%= p.will_publish ? "Published story" : "Draft story" %><%= " + story idea" if p.creates_idea %>
             </span>
           <% end %>
         </div>
 
         <% unless p.skipped_reason %>
-          <dl class="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 text-sm">
+          <dl class="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 text-sm sm:grid-cols-2">
             <div>
               <dt class="inline text-gray-500">Organization:</dt>
               <dd class="inline text-gray-800">
@@ -83,7 +83,7 @@
             <div class="mt-2 flex flex-wrap items-center gap-1.5">
               <span class="text-xs text-gray-500">Sectors:</span>
               <% p.sectors.each do |name| %>
-                <span class="text-xs rounded-full bg-purple-100 text-purple-800 px-2 py-0.5"><%= name %></span>
+                <span class="rounded-full bg-purple-100 px-2 py-0.5 text-xs text-purple-800"><%= name %></span>
               <% end %>
             </div>
           <% end %>
@@ -92,7 +92,7 @@
             <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
               <span class="text-xs text-gray-500">Categories:</span>
               <% p.categories.each do |label| %>
-                <span class="text-xs rounded-full bg-lime-100 text-lime-800 px-2 py-0.5"><%= label %></span>
+                <span class="rounded-full bg-lime-100 px-2 py-0.5 text-xs text-lime-800"><%= label %></span>
               <% end %>
             </div>
           <% end %>
@@ -106,7 +106,7 @@
           <% end %>
 
           <% if p.warnings.any? %>
-            <ul class="mt-2 text-xs text-yellow-700 list-disc pl-5 space-y-0.5">
+            <ul class="mt-2 list-disc space-y-0.5 pl-5 text-xs text-yellow-700">
               <% p.warnings.first(6).each do |w| %>
                 <li><%= w %></li>
               <% end %>
@@ -121,11 +121,11 @@
   </div>
 
   <% if @result.warnings.any? %>
-    <details class="bg-yellow-50 rounded-lg border border-yellow-200 p-4 mb-6">
+    <details class="mb-6 rounded-lg border border-yellow-200 bg-yellow-50 p-4">
       <summary class="cursor-pointer font-medium text-yellow-800">
         <%= pluralize(@result.warnings.size, "warning") %> across all rows
       </summary>
-      <ul class="mt-3 text-sm text-yellow-800 list-disc pl-5 space-y-1">
+      <ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-yellow-800">
         <% @result.warnings.first(100).each do |line| %>
           <li><%= line %></li>
         <% end %>
@@ -136,10 +136,10 @@
     </details>
   <% end %>
 
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="border-primary/10 rounded-2xl border bg-white p-4">
     <%= form_with url: confirm_story_import_path, method: :post do |f| %>
       <%= f.hidden_field :signed_id, value: @blob.signed_id %>
-      <p class="text-sm text-gray-600 mb-3">
+      <p class="mb-3 text-sm text-gray-600">
         This will create <%= pluralize(@result.ideas_created, "story idea") %>
         and <%= pluralize(@result.stories_created, "connected story") %>.
       </p>

--- a/app/views/story_imports/new.html.erb
+++ b/app/views/story_imports/new.html.erb
@@ -1,20 +1,20 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-3xl mx-auto <%= DomainTheme.bg_class_for(:stories) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="mx-auto max-w-3xl <%= DomainTheme.bg_class_for(:stories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "← Stories", stories_path,
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <h1 class="text-3xl font-semibold text-gray-900 tracking-tight mb-3">
+  <h1 class="text-primary mb-3 font-display text-3xl font-semibold tracking-tight">
     Import stories from CSV
   </h1>
-  <p class="text-gray-600 mb-6">
+  <p class="mb-6 text-gray-600">
     Upload a WordPress Posts Export CSV. We'll create a story idea for every row and a
     connected, published story for rows that were public on WordPress. You'll see a
     preview of exactly what will be created before anything is saved.
   </p>
 
-  <div class="bg-white rounded p-6">
+  <div class="rounded bg-white p-6">
     <%= form_with url: story_import_path, method: :post, multipart: true do |f| %>
       <div class="mb-4">
         <%= f.label :file, "CSV file", class: "block text-sm font-medium text-gray-700 mb-1" %>

--- a/app/views/story_share_admin/show.html.erb
+++ b/app/views/story_share_admin/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="mb-6">
     <%= link_to "← Story Share portal", story_shares_path, class: "text-sm text-purple-700 hover:underline" %>
   </div>
 
-  <h1 class="text-2xl font-bold text-gray-900 mb-2">Story Share admin</h1>
-  <p class="text-gray-600 mb-8">
+  <h1 class="text-primary mb-2 font-display text-2xl font-bold">Story Share admin</h1>
+  <p class="mb-8 text-gray-600">
     Choose which sectors and audience categories appear in the Story Share portal's nav menus,
     and drag to reorder them. The top nav shows the first six sectors; the second nav shows the
     audience categories in this order.

--- a/app/views/taggings/matrix.html.erb
+++ b/app/views/taggings/matrix.html.erb
@@ -1,22 +1,22 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="tags-matrix bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="tags-matrix border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
     <div class="w-full">
       <div class="mb-10">
-        <h1 class="text-3xl font-semibold text-gray-900 mb-2">
+        <h1 class="text-primary mb-2 font-display text-3xl font-semibold">
           Tagging counts
         </h1>
-        <p class="text-gray-600 max-w-2xl">
+        <p class="max-w-2xl text-gray-600">
           Total tagged items by sector and category
         </p>
       </div>
 
       <!-- CARD BODY -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow">
+      <div class="border-primary/10 rounded-2xl border bg-white shadow-sm">
         <div class="overflow-x-auto">
           <table class="min-w-full text-sm">
 
             <!-- TABLE HEADER -->
-            <thead class="bg-gray-50 border-b border-gray-200">
+            <thead class="border-b border-gray-200 bg-gray-50">
             <tr>
               <th class="px-4 py-3 text-left font-semibold text-gray-700">
                 Tag
@@ -68,7 +68,7 @@
             <% end %>
 
             <!-- CATEGORIES HEADER -->
-            <tr class="bg-gray-100 border-t border-gray-200">
+            <tr class="border-t border-gray-200 bg-gray-100">
               <td colspan="<%= Tag::TAGGABLE_META.size + 1 %>"
                   class="px-4 py-2 font-semibold text-gray-700">
                 Categories

--- a/app/views/topic_subscription_types/edit.html.erb
+++ b/app/views/topic_subscription_types/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit topic</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit topic</h1>
   <%= render "form", submit_label: "Save changes" %>
 
   <%# Archive/restore and delete moved off the index — the topic's actions live on

--- a/app/views/topic_subscription_types/index.html.erb
+++ b/app/views/topic_subscription_types/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscription_types) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="max-w-5xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscription_types) %> border border-primary/10 rounded-2xl shadow-sm p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <%= link_to "← Subscriptions", topic_subscriptions_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">Subscription topics</h1>
+      <h1 class="font-display text-2xl font-semibold text-primary">Subscription topics</h1>
       <p class="text-gray-600 mt-1">The topics people can subscribe to. Archive a topic to retire it without losing existing subscriptions.</p>
     </div>
     <%= link_to new_topic_subscription_type_path, class: "btn btn-primary inline-flex items-center gap-1.5" do %>
@@ -16,7 +16,7 @@
     <% end %>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+  <div class="bg-white border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
     <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
       <nav class="inline-flex rounded-lg bg-gray-100 p-0.5 text-sm font-medium" aria-label="Status filter">
         <%= link_to topic_subscription_types_path(status: "active"),

--- a/app/views/topic_subscription_types/new.html.erb
+++ b/app/views/topic_subscription_types/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= link_to "← Subscription topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">New topic</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">New topic</h1>
   <%= render "form", submit_label: "Add topic" %>
 </div>

--- a/app/views/topic_subscriptions/edit.html.erb
+++ b/app/views/topic_subscriptions/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-2xl rounded-xl border border-gray-200 bg-white p-6 shadow">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= render "eyebrow" %>
   </div>
-  <h1 class="mb-6 text-2xl font-semibold text-gray-900">Edit subscription</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit subscription</h1>
   <%= render "form", submit_label: "Save changes" %>
 
   <%# These actions redirect too, so they carry the same origin params as the form. %>

--- a/app/views/topic_subscriptions/email_addresses.html.erb
+++ b/app/views/topic_subscriptions/email_addresses.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:topic_subscriptions) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
     <%= link_to "← Subscriptions", topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
   <div class="mb-6">
-    <h1 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
+    <h1 class="text-primary flex items-center gap-2 font-display text-2xl font-semibold">
       <i class="fa-solid fa-envelope <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
       Email addresses
     </h1>

--- a/app/views/topic_subscriptions/index.html.erb
+++ b/app/views/topic_subscriptions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-primary/10 rounded-2xl shadow-sm p-6">
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
     <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <div class="flex items-center gap-4">
@@ -17,7 +17,7 @@
 
   <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
     <div>
-      <h1 class="flex items-center gap-2 text-2xl font-semibold text-gray-900">
+      <h1 class="font-display flex items-center gap-2 text-2xl font-semibold text-primary">
         <i class="fa-solid fa-envelope-open-text <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
         Subscriptions
       </h1>

--- a/app/views/topic_subscriptions/new.html.erb
+++ b/app/views/topic_subscriptions/new.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="max-w-2xl mx-auto bg-white border border-gray-200 rounded-xl shadow p-6">
+<div class="border-primary/10 mx-auto max-w-2xl rounded-2xl border bg-white p-6 shadow-sm">
   <div class="mb-6">
     <%= render "eyebrow" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-6">New subscription</h1>
+  <h1 class="text-primary mb-6 font-display text-2xl font-semibold">New subscription</h1>
   <%= render "form", submit_label: "Add subscription" %>
 </div>

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :topic_subscriptions_results do %>
-  <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm blur-on-submit">
+  <div class="overflow-hidden rounded-2xl border border-primary/10 bg-white shadow-sm blur-on-submit">
     <%# Outside the empty check: with nothing to list, the toggle is the only way
         back to the other status. It navigates the whole page rather than this
         frame so the filter form — which lives outside the frame and carries the

--- a/app/views/transfer_guide/show.html.erb
+++ b/app/views/transfer_guide/show.html.erb
@@ -19,7 +19,7 @@
       { title: "Payments & allocations (on the registration)",
         desc: "How money shows on the staff registration page.",
         out_text: "The normal payment history and allocations — payments listed, the amount due, and an editable expected payment method.",
-        out_mock: %(<div class="rounded-lg border border-gray-200 p-2.5 text-xs"><div class="text-[0.55rem] uppercase tracking-wide text-gray-400">Payment history</div><div class="mt-1 flex justify-between text-gray-800"><span>Scholarship</span><span class="font-semibold tabular-nums">$50</span></div><div class="mt-1.5 flex items-center justify-between border-t border-gray-100 pt-1.5"><span class="text-[0.55rem] uppercase text-gray-400">Amount due</span><span class="font-bold tabular-nums text-amber-700">$50</span></div></div>),
+        out_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5 text-xs"><div class="text-[0.55rem] uppercase tracking-wide text-gray-400">Payment history</div><div class="mt-1 flex justify-between text-gray-800"><span>Scholarship</span><span class="font-semibold tabular-nums">$50</span></div><div class="mt-1.5 flex items-center justify-between border-t border-gray-100 pt-1.5"><span class="text-[0.55rem] uppercase text-gray-400">Amount due</span><span class="font-bold tabular-nums text-amber-700">$50</span></div></div>),
         in_text: "No own billing cards. Instead a read-only “Financials on the original registration” summary that links back to the source.",
         in_mock: %(<div class="rounded-lg border-2 border-teal-200 bg-teal-50/40 p-2.5 text-xs"><div class="font-semibold text-teal-900"><i class="fa-solid fa-right-to-bracket"></i> Financials on the original registration</div><div class="mt-1 text-[0.65rem] text-teal-700">Payments &amp; scholarship stay on Origin Training &middot; <u>View original registration</u></div></div>) },
       { title: "Attendance (days)",
@@ -31,13 +31,13 @@
       { title: "Continuing education (CE)",
         desc: "How staff manage a person's CE credit and payment.",
         out_text: "Keeps a paid $0-hours “stub” — the money already paid stays counted at this event.",
-        out_mock: %(<div class="rounded-lg border border-gray-200 p-2.5 text-xs"><div class="font-semibold text-gray-900">$40 <span class="font-normal text-gray-400">·</span> 0 hrs</div><div class="mt-0.5 text-[0.65rem] text-gray-500">Paid stub — settled here</div></div>),
+        out_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5 text-xs"><div class="font-semibold text-gray-900">$40 <span class="font-normal text-gray-400">·</span> 0 hrs</div><div class="mt-0.5 text-[0.65rem] text-gray-500">Paid stub — settled here</div></div>),
         in_text: "Carries the hours and the remaining balance, with a link back to the paid original. New payments + the certificate happen here. If the original had no CE, staff can add fresh CE here normally.",
-        in_mock: %(<div class="rounded-lg border border-gray-200 p-2.5 text-xs"><div class="font-semibold text-gray-900">$60 <span class="font-normal text-gray-400">·</span> 6 hrs</div><div class="mt-0.5 text-[0.65rem] text-teal-700"><i class="fa-solid fa-right-to-bracket"></i> <u>From original registration</u></div></div>) },
+        in_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5 text-xs"><div class="font-semibold text-gray-900">$60 <span class="font-normal text-gray-400">·</span> 6 hrs</div><div class="mt-0.5 text-[0.65rem] text-teal-700"><i class="fa-solid fa-right-to-bracket"></i> <u>From original registration</u></div></div>) },
       { title: "Scholarship (staff edit)",
         desc: "How staff manage a person's scholarship award.",
         out_text: "The award lives here — the amount, agreement, and tasks.",
-        out_mock: %(<div class="rounded-lg border border-gray-200 p-2.5 text-xs"><div class="text-[0.55rem] uppercase text-gray-400">Amount awarded</div><div class="font-semibold text-gray-900">$50</div></div>),
+        out_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5 text-xs"><div class="text-[0.55rem] uppercase text-gray-400">Amount awarded</div><div class="font-semibold text-gray-900">$50</div></div>),
         in_text: "No separate award; the scholarship callout and edit link point back to the award on the original registration.",
         in_mock: banner.("border-teal-200 bg-teal-50 text-teal-900", "fa-graduation-cap text-teal-600", "Scholarship recipient — award held on the <u>original registration</u>.") },
       { title: "Manage transfer",
@@ -57,9 +57,9 @@
       { title: "Payment",
         desc: "Where a balance is paid.",
         out_text: "The “Pay” button is hidden — they pay at the new event. The balance still shows for reference.",
-        out_mock: %(<div class="rounded-lg border border-gray-200 p-2.5">#{due_badge}<p class="mt-2 text-center text-[0.65rem] italic text-gray-400">No pay button — paid at the new event</p></div>),
+        out_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5">#{due_badge}<p class="mt-2 text-center text-[0.65rem] italic text-gray-400">No pay button — paid at the new event</p></div>),
         in_text: "Shows the balance and the “Pay” button.",
-        in_mock: %(<div class="rounded-lg border border-gray-200 p-2.5">#{due_badge}<div class="mt-2 text-center"><span class="inline-block rounded bg-red-800 px-3 py-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-white">Pay with credit card</span></div></div>) },
+        in_mock: %(<div class="rounded-2xl border border-primary/10 p-2.5">#{due_badge}<div class="mt-2 text-center"><span class="inline-block rounded bg-red-800 px-3 py-1.5 text-[0.65rem] font-semibold uppercase tracking-wide text-white">Pay with credit card</span></div></div>) },
       { title: "Scholarship",
         desc: "The registrant's scholarship details.",
         out_text: "Shows the award (it lives here).",
@@ -119,7 +119,7 @@
 
 <div class="mx-auto max-w-4xl space-y-6">
   <header>
-    <h1 class="text-2xl font-semibold text-gray-900">Transferring a registration — what changes</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Transferring a registration — what changes</h1>
     <p class="mt-2 text-sm leading-relaxed text-gray-600">
       When you move a registrant from one event to another, the portal keeps
       <strong>two</strong> registrations. This page shows what each screen looks like on both
@@ -145,9 +145,9 @@
 
   <% groups.each do |group_title, rows| %>
     <section class="space-y-3">
-      <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400"><%= group_title %></h2>
+      <h2 class="text-xs font-semibold tracking-wide text-gray-400 uppercase"><%= group_title %></h2>
       <% rows.each do |row| %>
-        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
           <div class="border-b border-gray-100 px-4 py-3">
             <h3 class="text-sm font-semibold text-gray-800"><%= row[:title] %></h3>
             <p class="text-xs text-gray-500"><%= row[:desc] %></p>

--- a/app/views/users/check_duplicates.html.erb
+++ b/app/views/users/check_duplicates.html.erb
@@ -8,7 +8,7 @@
                   d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
           </svg>
         </div>
-        <h1 class="ml-4 text-xl font-semibold text-gray-900">Possible duplicate user</h1>
+        <h1 class="text-primary ml-4 font-display text-xl font-semibold">Possible duplicate user</h1>
       </div>
 
       <p class="mb-2 text-sm text-gray-600">

--- a/app/views/users/confirm_email_change.html.erb
+++ b/app/views/users/confirm_email_change.html.erb
@@ -1,28 +1,28 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="max-w-2xl mx-auto">
-    <div class="flex items-center mb-6">
-      <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-yellow-100">
+<div class="<%= DomainTheme.bg_class_for(:users) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mx-auto max-w-2xl">
+    <div class="mb-6 flex items-center">
+      <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-yellow-100">
         <svg class="h-5 w-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
         </svg>
       </div>
-      <h1 class="ml-3 text-xl font-semibold text-gray-900">Email change saved</h1>
+      <h1 class="text-primary ml-3 font-display text-xl font-semibold">Email change saved</h1>
     </div>
 
-    <div class="bg-white rounded-lg p-4 mb-6">
+    <div class="mb-6 rounded-lg bg-white p-4">
       <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <dt class="text-gray-500">User</dt>
-        <dd class="text-gray-900 font-medium"><%= @user.name %></dd>
+        <dd class="font-medium text-gray-900"><%= @user.name %></dd>
         <dt class="text-gray-500">Current email</dt>
         <dd class="text-gray-900"><%= @user.email %></dd>
         <dt class="text-gray-500">New email (pending)</dt>
-        <dd class="text-gray-900 font-medium"><%= @user.unconfirmed_email %></dd>
+        <dd class="font-medium text-gray-900"><%= @user.unconfirmed_email %></dd>
       </dl>
     </div>
 
-    <p class="text-sm text-gray-600 mb-4">
+    <p class="mb-4 text-sm text-gray-600">
       The new email has been saved but requires confirmation. The user's current email
       will remain <strong><%= @user.email %></strong> until they confirm the new address.
     </p>
@@ -32,7 +32,7 @@
                   data: { turbo: false },
                   class: "space-y-3" do %>
 
-      <label class="flex items-start gap-3 p-3 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
+      <label class="flex cursor-pointer items-start gap-3 rounded-lg border border-gray-200 bg-white p-3 hover:bg-gray-50">
         <%= check_box_tag :send_confirmation, "1", true, class: "mt-0.5" %>
         <div>
           <span class="text-sm font-medium text-gray-900">Send confirmation email</span>
@@ -42,7 +42,7 @@
         </div>
       </label>
 
-      <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
+      <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
         <%= link_to "Skip", user_path(@user), class: "btn btn-secondary-outline" %>
         <button type="submit" class="btn btn-primary">Continue</button>
       </div>

--- a/app/views/users/confirm_email_manual.html.erb
+++ b/app/views/users/confirm_email_manual.html.erb
@@ -1,36 +1,36 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% pending_email_change = @user.unconfirmed_email.present? %>
 <% target_email = pending_email_change ? @user.unconfirmed_email : @user.email %>
-<div class="<%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="max-w-2xl mx-auto">
-    <div class="flex items-center mb-6">
-      <div class="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-blue-100">
+<div class="<%= DomainTheme.bg_class_for(:users) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mx-auto max-w-2xl">
+    <div class="mb-6 flex items-center">
+      <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-100">
         <svg class="h-5 w-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
         </svg>
       </div>
-      <h1 class="ml-3 text-xl font-semibold text-gray-900">Confirm or resend email</h1>
+      <h1 class="text-primary ml-3 font-display text-xl font-semibold">Confirm or resend email</h1>
     </div>
 
-    <div class="bg-white rounded-lg p-4 mb-6">
+    <div class="mb-6 rounded-lg bg-white p-4">
       <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
         <dt class="text-gray-500">User</dt>
-        <dd class="text-gray-900 font-medium"><%= @user.name %></dd>
+        <dd class="font-medium text-gray-900"><%= @user.name %></dd>
         <dt class="text-gray-500">Current email</dt>
         <dd class="text-gray-900"><%= @user.email %></dd>
         <% if pending_email_change %>
           <dt class="text-gray-500">Pending email</dt>
-          <dd class="text-gray-900 font-medium"><%= @user.unconfirmed_email %></dd>
+          <dd class="font-medium text-gray-900"><%= @user.unconfirmed_email %></dd>
         <% end %>
         <dt class="text-gray-500">Status</dt>
         <dd>
           <% if pending_email_change %>
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">
+            <span class="inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
               Email change pending
             </span>
           <% else %>
-            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">
+            <span class="inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
               Unconfirmed
             </span>
           <% end %>
@@ -38,9 +38,9 @@
       </dl>
     </div>
 
-    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+    <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
       <div class="flex items-start gap-2">
-        <i class="fa-solid fa-circle-info text-blue-500 mt-0.5"></i>
+        <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
         <div class="text-sm text-blue-800">
           <p class="font-medium">Recommendation: Resend the confirmation email</p>
           <p class="mt-1">
@@ -52,7 +52,7 @@
       </div>
     </div>
 
-    <div class="bg-white rounded-lg p-4 mb-6 space-y-4">
+    <div class="mb-6 space-y-4 rounded-lg bg-white p-4">
       <%= form_with url: process_email_manual_user_path(@user),
                     method: :post,
                     data: { turbo: false } do %>
@@ -82,7 +82,7 @@
       <% end %>
     </div>
 
-    <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
+    <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
       <%= link_to "Cancel", edit_user_path(@user), class: "btn btn-secondary-outline" %>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden" data-controller="toggle-user-icon">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm" data-controller="toggle-user-icon">
       <!-- User account header banner -->
       <div class="<%= DomainTheme.bg_class_for(:users, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:users, intensity: 300) %> px-8 py-3">
         <div class="flex items-center gap-2">
-          <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
-          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> uppercase tracking-wide">Edit User</span>
+          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> tracking-wide uppercase">Edit User</span>
         </div>
       </div>
-      <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8 space-y-6">
+      <div class="<%= DomainTheme.bg_class_for(:users) %> space-y-6 p-4 sm:p-8">
 
         <% if params[:return_to] == "onboarding" && params[:event_id].present? %>
           <%= link_to onboarding_event_row_path(params[:event_id], params[:highlight]), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
@@ -19,7 +19,7 @@
         <!-- Navigation links -->
         <div class="flex flex-wrap justify-end gap-2">
           <% unless @user.person %>
-            <div class="admin-only bg-blue-100 p-2 rounded">
+            <div class="admin-only rounded bg-blue-100 p-2">
               No person!
               <%= link_to "Create person",
                           new_person_path(user_id: @user.id),
@@ -36,7 +36,7 @@
         </div>
 
         <!-- Identity header -->
-        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
           <div class="flex items-center gap-4">
             <% if @user.person&.avatar&.attached? %>
               <%= image_tag @user.person.avatar,
@@ -45,30 +45,30 @@
               <%= image_tag "missing.png",
                             class: "w-14 h-14 rounded-full object-cover border border-dashed border-gray-300 shrink-0" %>
             <% end %>
-            <div class="flex-1 min-w-0">
-              <h1 class="font-bold text-2xl text-gray-900">
+            <div class="min-w-0 flex-1">
+              <h1 class="text-primary font-display text-2xl font-bold">
                 <%= @user.email %>
-                <i class="fa-solid fa-user-shield text-blue-500 text-lg" data-toggle-user-icon-target="adminIcon"
+                <i class="fa-solid fa-user-shield text-lg text-blue-500" data-toggle-user-icon-target="adminIcon"
                    style="<%= 'display:none' unless @user.super_user? %>"></i>
-                <i class="fa-solid fa-lock text-red-500 text-lg" data-toggle-user-icon-target="lockIcon"
+                <i class="fa-solid fa-lock text-lg text-red-500" data-toggle-user-icon-target="lockIcon"
                    style="<%= 'display:none' unless @user.locked_at.present? %>"></i>
               </h1>
               <% if @user.person %>
-                <p class="text-sm text-gray-500 mt-1">
+                <p class="mt-1 text-sm text-gray-500">
                   <%= link_to @user.person.decorate.title,
                               person_path(@user.person),
                               class: "text-indigo-600 hover:underline" %>
                 </p>
               <% end %>
             </div>
-            <div class="flex flex-col items-end gap-2 shrink-0">
+            <div class="flex shrink-0 flex-col items-end gap-2">
               <% if @user.unconfirmed_email.present? %>
-                <div class="bg-yellow-50 border border-yellow-300 rounded-lg px-3 py-2 text-right">
+                <div class="rounded-lg border border-yellow-300 bg-yellow-50 px-3 py-2 text-right">
                   <div class="flex items-center gap-1.5">
-                    <i class="fa-solid fa-triangle-exclamation text-yellow-500 text-sm"></i>
+                    <i class="fa-solid fa-triangle-exclamation text-sm text-yellow-500"></i>
                     <span class="text-sm font-medium text-yellow-800">Email change pending</span>
                   </div>
-                  <p class="text-xs text-yellow-700 mt-0.5">
+                  <p class="mt-0.5 text-xs text-yellow-700">
                     Change to <strong><%= @user.unconfirmed_email %></strong> awaiting confirmation
                   </p>
                 </div>

--- a/app/views/users/flow_diagram.html.erb
+++ b/app/views/users/flow_diagram.html.erb
@@ -1,180 +1,180 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-semibold text-gray-900">Account management flows</h1>
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex items-center justify-between">
+    <h1 class="text-primary font-display text-2xl font-semibold">Account management flows</h1>
     <div class="flex items-center gap-1">
       <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "Users", users_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
   </div>
-  <p class="text-sm text-gray-500 mb-6">How invitation, password reset, email change, lockout, and unlock work from an admin's perspective</p>
+  <p class="mb-6 text-sm text-gray-500">How invitation, password reset, email change, lockout, and unlock work from an admin's perspective</p>
 
   <%# Triage cheat sheet %>
-  <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6">
+  <div class="border-primary/10 mb-6 rounded-2xl border bg-white p-8 shadow-sm">
     <div data-controller="toggle-details">
-      <div class="flex items-center justify-between mb-4">
+      <div class="mb-4 flex items-center justify-between">
         <h2 class="text-base font-semibold text-gray-900">Admin triage cheat sheet</h2>
         <button type="button"
-                class="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
+                class="cursor-pointer text-xs text-blue-600 hover:text-blue-800"
                 data-action="click->toggle-details#toggleAll"
                 data-toggle-details-target="toggleBtn">Expand all</button>
       </div>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"I never got the invite email"</span>
-            <p class="text-xs text-gray-400 mt-1">Invite may not have been sent, or ended up in spam</p>
+            <p class="mt-1 text-xs text-gray-400">Invite may not have been sent, or ended up in spam</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
-          <p class="text-gray-600 mb-2">Check <strong>Confirmed</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
+          <p class="mb-2 text-gray-600">Check <strong>Confirmed</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
           <div class="space-y-2 text-xs">
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><strong>Invite</strong> button</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>No invite has been sent &mdash; click <strong>Invite</strong> to send</li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-1" class="text-blue-500 hover:underline">flow 1 &darr;</a></div>
             </div>
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><i class="fa-solid fa-clock text-yellow-500"></i> Clock icon</span>
               <span class="text-gray-500">(hover on index for details)</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>Invite was sent &mdash; ask user to check spam</li>
                 <li>Otherwise click <strong>Resend invite email</strong> on user's Edit</li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-2" class="text-blue-500 hover:underline">flow 2 &darr;</a></div>
             </div>
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><i class="fa-solid fa-check-circle text-gray-400"></i> Check icon</span>
               <span class="text-gray-500">(hover on index for details)</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>Already confirmed &mdash; user doesn't need an invite, they need a <strong>password reset</strong></li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-3" class="text-blue-500 hover:underline">flow 3 &darr;</a></div>
             </div>
           </div>
-          <p class="text-xs text-gray-400 mt-2">Note: Confirmation and welcome tokens do not expire</p>
+          <p class="mt-2 text-xs text-gray-400">Note: Confirmation and welcome tokens do not expire</p>
         </div>
       </details>
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"My invite link doesn't work"</span>
-            <p class="text-xs text-gray-400 mt-1">Confirmation link may be invalid or already used</p>
+            <p class="mt-1 text-xs text-gray-400">Confirmation link may be invalid or already used</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
-          <p class="text-gray-600 mb-2">Check <strong>Confirmed</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
+          <p class="mb-2 text-gray-600">Check <strong>Confirmed</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
           <div class="space-y-2 text-xs">
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><i class="fa-solid fa-clock text-yellow-500"></i> Clock icon</span>
               <span class="text-gray-500">(hover on index for details)</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>Invite was sent but not yet confirmed</li>
                 <li>Click <strong>Resend invite email</strong> on user's Edit</li>
               </ul>
-              <p class="text-xs text-gray-400 mt-1 pl-4">Note: This invalidates old links</p>
+              <p class="mt-1 pl-4 text-xs text-gray-400">Note: This invalidates old links</p>
               <div class="mt-1 pl-4"><a href="#flow-2" class="text-blue-500 hover:underline">flow 2 &darr;</a></div>
             </div>
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><i class="fa-solid fa-check-circle text-gray-400"></i> Check icon</span>
               <span class="text-gray-500">(hover on index for details)</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>Already confirmed &mdash; user doesn't need an invite, they need a <strong>password reset</strong></li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-3" class="text-blue-500 hover:underline">flow 3 &darr;</a></div>
             </div>
           </div>
-          <p class="text-xs text-gray-400 mt-2">Note: Confirmation and welcome tokens do not expire</p>
+          <p class="mt-2 text-xs text-gray-400">Note: Confirmation and welcome tokens do not expire</p>
         </div>
       </details>
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"I'm locked out"</span>
-            <p class="text-xs text-gray-400 mt-1">Account likely locked after too many failed attempts</p>
+            <p class="mt-1 text-xs text-gray-400">Account likely locked after too many failed attempts</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
-          <p class="text-gray-600 mb-2">Check <strong>Access</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
+          <p class="mb-2 text-gray-600">Check <strong>Access</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a>:</p>
           <div class="space-y-2 text-xs">
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700">No lock icon</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li><i class="fa-solid fa-clock text-yellow-500"></i> Clock icon in Confirmed &mdash; email unconfirmed, <strong>Resend invite email</strong> on user's Edit</li>
                 <li><i class="fa-solid fa-ban text-red-400"></i> Ban icon &mdash; account is inactive, set to active on user's Edit under Account flags</li>
                 <li>Maybe they mean they forgot their password?</li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-1" class="text-blue-500 hover:underline">flow 1 &darr;</a> &nbsp; <a href="#flow-3" class="text-blue-500 hover:underline">flow 3 &darr;</a></div>
             </div>
-            <div class="bg-white rounded p-2 border border-gray-200">
+            <div class="rounded border border-gray-200 bg-white p-2">
               <span class="font-semibold text-gray-700"><i class="fa-solid fa-lock text-red-400"></i> Lock icon</span>
-              <ul class="list-disc pl-4 mt-1 text-gray-600 space-y-0.5">
+              <ul class="mt-1 list-disc space-y-0.5 pl-4 text-gray-600">
                 <li>Account is locked &mdash; go to user's Edit and click <strong>Unlock account</strong> (sets failed attempts back to 0)</li>
                 <li>User may also need a <strong>password reset</strong></li>
               </ul>
               <div class="mt-1 pl-4"><a href="#flow-5" class="text-blue-500 hover:underline">flow 5 &darr;</a> &nbsp; <a href="#flow-6" class="text-blue-500 hover:underline">flow 6 &darr;</a></div>
             </div>
           </div>
-          <p class="text-xs text-gray-400 mt-2">Note: Accounts don't auto-unlock &mdash; needs an admin.</p>
+          <p class="mt-2 text-xs text-gray-400">Note: Accounts don't auto-unlock &mdash; needs an admin.</p>
         </div>
       </details>
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"I forgot my password" / "My reset expired"</span>
-            <p class="text-xs text-gray-400 mt-1">User needs a password reset</p>
+            <p class="mt-1 text-xs text-gray-400">User needs a password reset</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
           <p class="text-gray-600">User clicks <strong>Forgot your password?</strong> from login <span class="text-gray-400">or</span> admin clicks <strong>Send reset password email</strong> from user's Edit</p>
           <div class="mt-1"><a href="#flow-3" class="text-xs text-blue-500 hover:underline">flow 3 &darr;</a></div>
-          <p class="text-xs text-gray-400 mt-2">Note: Reset links expire after <strong>7 days</strong>.<br>Note: Each new reset invalidates previous email links.<br>Note: User will be automatically signed in after reset.</p>
+          <p class="mt-2 text-xs text-gray-400">Note: Reset links expire after <strong>7 days</strong>.<br>Note: Each new reset invalidates previous email links.<br>Note: User will be automatically signed in after reset.</p>
         </div>
       </details>
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"I confirmed my email but can't sign in"</span>
-            <p class="text-xs text-gray-400 mt-1">Email confirmed but user never set a password</p>
+            <p class="mt-1 text-xs text-gray-400">Email confirmed but user never set a password</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
-          <p class="text-gray-600 mb-2">User confirmed their email but never set a password. They see "Invalid email or password" because they never had one.</p>
-          <ul class="list-disc pl-4 text-gray-600 space-y-1 text-sm">
+          <p class="mb-2 text-gray-600">User confirmed their email but never set a password. They see "Invalid email or password" because they never had one.</p>
+          <ul class="list-disc space-y-1 pl-4 text-sm text-gray-600">
             <li>Check <strong>Confirmed</strong> column on <a href="<%= users_path %>" target="_blank" class="text-blue-600 underline">users index</a> &mdash; should show <i class="fa-solid fa-check-circle text-gray-400"></i> (confirmed)</li>
             <li>Admin clicks <strong>Send reset password email</strong> from user's Edit <span class="text-gray-400">or</span> user clicks <strong>Forgot your password?</strong> from login</li>
             <li>User sets a password via the reset link &mdash; this also auto-signs them in</li>
           </ul>
           <div class="mt-1 pl-4"><a href="#flow-3" class="text-xs text-blue-500 hover:underline">flow 3 &darr;</a></div>
-          <p class="text-xs text-gray-400 mt-2">Note: Accounts are created with a random password the user doesn't know. Ideally they set a real one during the welcome invite flow.<br>Note: Welcome tokens no longer expire, so this mainly applies to legacy accounts created before that change.</p>
+          <p class="mt-2 text-xs text-gray-400">Note: Accounts are created with a random password the user doesn't know. Ideally they set a real one during the welcome invite flow.<br>Note: Welcome tokens no longer expire, so this mainly applies to legacy accounts created before that change.</p>
         </div>
       </details>
-      <details class="bg-gray-50 rounded-lg text-sm leading-relaxed border border-transparent hover:border-blue-200 transition-colors">
-        <summary class="p-4 cursor-pointer select-none list-none flex items-start justify-between [&::-webkit-details-marker]:hidden">
+      <details class="rounded-lg border border-transparent bg-gray-50 text-sm leading-relaxed transition-colors hover:border-blue-200">
+        <summary class="flex cursor-pointer list-none items-start justify-between p-4 select-none [&::-webkit-details-marker]:hidden">
           <div>
             <span class="font-semibold text-gray-700">"I changed my email but can't log in with it"</span>
-            <p class="text-xs text-gray-400 mt-1">New email needs confirmation to become active</p>
+            <p class="mt-1 text-xs text-gray-400">New email needs confirmation to become active</p>
           </div>
-          <i class="fa-solid fa-chevron-down text-gray-400 text-xs mt-1 transition-transform [[open]>&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down mt-1 text-xs text-gray-400 transition-transform [[open]>&]:rotate-180"></i>
         </summary>
         <div class="px-4 pb-4">
-          <p class="text-gray-600 mb-2">After an email change, the old email stays active until the new one is confirmed. User must sign in with the <strong>old email</strong> until then.</p>
-          <ul class="list-disc pl-4 text-gray-600 space-y-1 text-sm">
+          <p class="mb-2 text-gray-600">After an email change, the old email stays active until the new one is confirmed. User must sign in with the <strong>old email</strong> until then.</p>
+          <ul class="list-disc space-y-1 pl-4 text-sm text-gray-600">
             <li>Check if user has a <i class="fa-solid fa-triangle-exclamation text-yellow-500"></i> warning icon on users index or user show &mdash; means confirmation email wasn't sent</li>
             <li>Admin can resend confirmation email from the user show page</li>
             <li>Confirmation link does not expire &mdash; admin can resend if user lost the email</li>
           </ul>
           <div class="mt-1 pl-4"><a href="#flow-4" class="text-xs text-blue-500 hover:underline">flow 4 &darr;</a></div>
-          <p class="text-xs text-gray-400 mt-2">Note: User keeps signing in with old email until new email is confirmed.</p>
+          <p class="mt-2 text-xs text-gray-400">Note: User keeps signing in with old email until new email is confirmed.</p>
         </div>
       </details>
     </div>
@@ -182,9 +182,9 @@
   </div>
 
   <%# Flow index + Legend card %>
-  <div class="bg-slate-700 text-white rounded-xl shadow-sm p-6 mb-6">
-    <h3 class="text-sm font-semibold mb-3">Flows</h3>
-    <ol class="flex flex-wrap gap-x-6 gap-y-1 list-none text-sm mb-5">
+  <div class="mb-6 rounded-xl bg-slate-700 p-6 text-white shadow-sm">
+    <h3 class="mb-3 text-sm font-semibold">Flows</h3>
+    <ol class="mb-5 flex list-none flex-wrap gap-x-6 gap-y-1 text-sm">
       <li><a href="#flow-1" class="text-blue-300 hover:text-blue-100 hover:underline">1. Invite new user</a></li>
       <li><a href="#flow-2" class="text-blue-300 hover:text-blue-100 hover:underline">2. Resend invite email</a></li>
       <li><a href="#flow-3" class="text-blue-300 hover:text-blue-100 hover:underline">3. Reset password</a></li>
@@ -193,30 +193,30 @@
       <li><a href="#flow-6" class="text-blue-300 hover:text-blue-100 hover:underline">6. Manual lock / unlock</a></li>
     </ol>
 
-    <h3 class="text-sm font-semibold mb-3">Key</h3>
+    <h3 class="mb-3 text-sm font-semibold">Key</h3>
     <div class="flex flex-wrap gap-5 text-sm text-slate-300">
       <div class="flex items-center gap-2">
-        <span class="w-4 h-4 rounded bg-blue-100 border border-blue-200"></span> Admin action
+        <span class="h-4 w-4 rounded border border-blue-200 bg-blue-100"></span> Admin action
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-4 h-4 rounded bg-green-100 border border-green-200"></span> System / email
+        <span class="h-4 w-4 rounded border border-green-200 bg-green-100"></span> System / email
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-4 h-4 rounded bg-yellow-100 border border-yellow-200"></span> User action
+        <span class="h-4 w-4 rounded border border-yellow-200 bg-yellow-100"></span> User action
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-4 h-4 rounded bg-red-100 border border-red-200"></span> Error / blocked state
+        <span class="h-4 w-4 rounded border border-red-200 bg-red-100"></span> Error / blocked state
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-4 h-4 rounded bg-purple-100 border border-purple-200"></span> Decision point
+        <span class="h-4 w-4 rounded border border-purple-200 bg-purple-100"></span> Decision point
       </div>
     </div>
   </div>
 
   <%# Flow 1: Invite new user %>
-  <div id="flow-1" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-1" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">1. Invite new user</h2>
-    <p class="text-xs text-gray-500 mb-5">Admin creates a user and sends welcome instructions &bull; Tokens do not expire</p>
+    <p class="mb-5 text-xs text-gray-500">Admin creates a user and sends welcome instructions &bull; Tokens do not expire</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart TD
@@ -254,9 +254,9 @@ flowchart TD
   </div>
 
   <%# Flow 2: Resend invite %>
-  <div id="flow-2" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-2" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">2. Resend invite email</h2>
-    <p class="text-xs text-gray-500 mb-5">Same endpoint as invite &bull; Button shows on users index and user edit page when user has not yet confirmed</p>
+    <p class="mb-5 text-xs text-gray-500">Same endpoint as invite &bull; Button shows on users index and user edit page when user has not yet confirmed</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart TD
@@ -284,9 +284,9 @@ flowchart TD
   </div>
 
   <%# Flow 3: Reset password %>
-  <div id="flow-3" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-3" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">3. Reset password</h2>
-    <p class="text-xs text-gray-500 mb-5">Admin or user can initiate &bull; Token valid 7 days &bull; User auto-signed in after reset</p>
+    <p class="mb-5 text-xs text-gray-500">Admin or user can initiate &bull; Token valid 7 days &bull; User auto-signed in after reset</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart TD
@@ -324,9 +324,9 @@ flowchart TD
   </div>
 
   <%# Flow 4: Email change %>
-  <div id="flow-4" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-4" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">4. Email change (admin-initiated)</h2>
-    <p class="text-xs text-gray-500 mb-5">Devise reconfirmable &bull; Old email stays active until new email is confirmed &bull; Confirmation token does not expire</p>
+    <p class="mb-5 text-xs text-gray-500">Devise reconfirmable &bull; Old email stays active until new email is confirmed &bull; Confirmation token does not expire</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart TD
@@ -362,9 +362,9 @@ flowchart TD
   </div>
 
   <%# Flow 5: Failed passwords & lockout %>
-  <div id="flow-5" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-5" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">5. Failed password attempts &amp; account lockout</h2>
-    <p class="text-xs text-gray-500 mb-5">10 attempts before lockout &bull; Unlock strategy: none (admin must unlock manually) &bull; Last attempt warning shown</p>
+    <p class="mb-5 text-xs text-gray-500">10 attempts before lockout &bull; Unlock strategy: none (admin must unlock manually) &bull; Last attempt warning shown</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart TD
@@ -400,9 +400,9 @@ flowchart TD
   </div>
 
   <%# Flow 6: Admin manual lock/unlock %>
-  <div id="flow-6" class="bg-white border border-gray-200 rounded-xl shadow-sm p-8 mb-6 scroll-mt-20">
+  <div id="flow-6" class="mb-6 scroll-mt-20 rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
     <h2 class="text-base font-semibold text-gray-900">6. Admin manual lock / unlock</h2>
-    <p class="text-xs text-gray-500 mb-5">Admin can lock or unlock any account at any time, independent of failed attempts</p>
+    <p class="mb-5 text-xs text-gray-500">Admin can lock or unlock any account at any time, independent of failed attempts</p>
     <pre class="mermaid flex justify-center">
 %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#dbeafe', 'primaryTextColor': '#1e3a5f', 'primaryBorderColor': '#93c5fd', 'secondaryColor': '#dcfce7', 'tertiaryColor': '#fef9c3', 'lineColor': '#94a3b8', 'fontSize': '14px' }}}%%
 flowchart LR
@@ -425,7 +425,7 @@ flowchart LR
     </pre>
   </div>
 
-  <p class="text-center text-gray-400 text-xs mt-4">
+  <p class="mt-4 text-center text-xs text-gray-400">
     Source: UsersController, WelcomeController, ConfirmationsController, PasswordsController, User model, Devise config
   </p>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,16 +1,16 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:users) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:users) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
 
     <!-- Header -->
     <div class="flex items-center justify-between">
       <div id="users_count">
-        <h1 class="text-2xl font-semibold text-gray-900">
+        <h1 class="text-primary font-display text-2xl font-semibold">
           <%= User.model_name.human.pluralize %>
         </h1>
       </div>
       <div>
-        <div class="flex gap-2 items-center">
+        <div class="flex items-center gap-2">
           <%= link_to flow_diagram_users_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
             <i class="fa-solid fa-diagram-project"></i> Account flow diagram
           <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,14 +6,14 @@
     <% end %>
   </div>
 <% end %>
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
       <!-- User account header banner -->
       <div class="<%= DomainTheme.bg_class_for(:users, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:users, intensity: 300) %> px-8 py-3">
         <div class="flex items-center gap-2">
-          <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
-          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> uppercase tracking-wide">New User</span>
+          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> tracking-wide uppercase">New User</span>
         </div>
       </div>
       <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,18 +1,18 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="border border-gray-200 rounded-xl shadow overflow-hidden">
+<div class="border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
       <!-- User account header banner -->
       <div class="<%= DomainTheme.bg_class_for(:users, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:users, intensity: 300) %> px-8 py-3">
         <div class="flex items-center gap-2">
-          <svg class="w-5 h-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="h-5 w-5 <%= DomainTheme.text_class_for(:users, intensity: 700) %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
-          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> uppercase tracking-wide">User Account</span>
+          <span class="text-sm font-semibold <%= DomainTheme.text_class_for(:users, intensity: 900) %> tracking-wide uppercase">User Account</span>
         </div>
       </div>
-      <div class="<%= DomainTheme.bg_class_for(:users) %> p-4 sm:p-8 space-y-6">
+      <div class="<%= DomainTheme.bg_class_for(:users) %> space-y-6 p-4 sm:p-8">
 
       <!-- Top links -->
-      <div class="flex flex-wrap justify-end items-center gap-2">
+      <div class="flex flex-wrap items-center justify-end gap-2">
         <% unless @user.person %>
           <div class="admin-only bg-blue-100 p-2">
             Not associated with a person
@@ -42,7 +42,7 @@
       </div>
 
       <!-- Identity header -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
+      <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
         <div class="flex items-center gap-4">
           <% if @user.person&.avatar&.attached? %>
             <%= image_tag @user.person.avatar,
@@ -54,18 +54,18 @@
                           class: "w-14 h-14 rounded-full object-cover border border-dashed border-gray-300 shrink-0" %>
           <% end %>
 
-          <div class="flex-1 min-w-0">
-            <h2 class="font-bold text-2xl text-gray-900">
+          <div class="min-w-0 flex-1">
+            <h2 class="text-2xl font-bold text-gray-900">
               <%= @user.email %>
               <% if @user.super_user? %>
-                <i class="fa-solid fa-user-shield text-blue-500 text-lg"></i>
+                <i class="fa-solid fa-user-shield text-lg text-blue-500"></i>
               <% end %>
               <% if @user.locked_at.present? %>
-                <i class="fa-solid fa-lock text-red-500 text-lg"></i>
+                <i class="fa-solid fa-lock text-lg text-red-500"></i>
               <% end %>
             </h2>
             <% if @user.person %>
-              <p class="text-sm text-gray-500 mt-1">
+              <p class="mt-1 text-sm text-gray-500">
                 <%= link_to @user.person.decorate.title,
                             person_path(@user.person),
                             class: "text-indigo-600 hover:underline" %>
@@ -74,12 +74,12 @@
           </div>
 
           <% if @user.unconfirmed_email.present? %>
-            <div class="bg-yellow-50 border border-yellow-300 rounded-lg px-3 py-2 text-right shrink-0">
+            <div class="shrink-0 rounded-lg border border-yellow-300 bg-yellow-50 px-3 py-2 text-right">
               <div class="flex items-center gap-1.5">
-                <i class="fa-solid fa-triangle-exclamation text-yellow-500 text-sm"></i>
+                <i class="fa-solid fa-triangle-exclamation text-sm text-yellow-500"></i>
                 <span class="text-sm font-medium text-yellow-800">Email change pending</span>
               </div>
-              <p class="text-xs text-yellow-700 mt-0.5">
+              <p class="mt-0.5 text-xs text-yellow-700">
                 Change to <strong><%= @user.unconfirmed_email %></strong> awaiting confirmation
               </p>
             </div>
@@ -88,12 +88,12 @@
       </div>
 
       <!-- Devise / Account Details -->
-      <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
+        <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
 
           <!-- Account Status -->
           <div>
-            <h4 class="text-sm font-semibold uppercase text-gray-700 mb-3">
+            <h4 class="mb-3 text-sm font-semibold text-gray-700 uppercase">
               Account status
             </h4>
 
@@ -107,7 +107,7 @@
               <dd class="text-gray-900"><%= @user&.super_user? ? "Yes" : "No" %></dd>
               <% if @last_admin_event %>
                 <dt></dt>
-                <dd class="text-gray-500 text-xs -mt-1">
+                <dd class="-mt-1 text-xs text-gray-500">
                   <%= l(@last_admin_event.time, format: :long) %>
                   <% if @last_admin_event.user %>
                     by <%= @last_admin_event.user.name %>
@@ -126,7 +126,7 @@
                 </dd>
                 <% if @last_lock_event %>
                   <dt></dt>
-                  <dd class="text-gray-500 text-xs -mt-1">
+                  <dd class="-mt-1 text-xs text-gray-500">
                     <%= l(@last_lock_event.time, format: :long) %>
                     <% if @last_lock_event.user %>
                       by <%= @last_lock_event.user.name %>
@@ -139,7 +139,7 @@
 
           <!-- Authentication -->
           <div>
-            <h4 class="text-sm font-semibold uppercase text-gray-700 mb-3">
+            <h4 class="mb-3 text-sm font-semibold text-gray-700 uppercase">
               Authentication
             </h4>
 
@@ -163,7 +163,7 @@
 
           <!-- Audit -->
           <div>
-            <h4 class="text-sm font-semibold uppercase text-gray-700 mb-3">
+            <h4 class="mb-3 text-sm font-semibold text-gray-700 uppercase">
               Audit
             </h4>
 
@@ -189,20 +189,20 @@
       <%= turbo_frame_tag "account_activity_section",
                           src: user_path(@user, section: "account_activity"),
                           loading: :lazy do %>
-        <p class="text-gray-500 italic text-sm p-6">Loading account activity...</p>
+        <p class="p-6 text-sm text-gray-500 italic">Loading account activity...</p>
       <% end %>
 
       <!-- Comments Section -->
       <% if @comments.any? %>
-        <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6">
-          <h4 class="text-sm font-semibold uppercase text-gray-700 mb-3">Comments</h4>
+        <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
+          <h4 class="mb-3 text-sm font-semibold text-gray-700 uppercase">Comments</h4>
           <div class="space-y-3">
             <% @comments.each do |comment| %>
-              <div class="grid grid-cols-[auto_auto_1fr] gap-x-3 items-start">
-                <span class="text-xs font-medium text-gray-500 mt-1">
+              <div class="grid grid-cols-[auto_auto_1fr] items-start gap-x-3">
+                <span class="mt-1 text-xs font-medium text-gray-500">
                   <%= comment.created_by ? "#{comment.created_by.first_name&.first}#{comment.created_by.last_name&.first}".upcase : "—" %>
                 </span>
-                <span class="text-xs text-gray-400 mt-1 whitespace-nowrap">
+                <span class="mt-1 text-xs whitespace-nowrap text-gray-400">
                   <%= comment.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
                 </span>
                 <div class="text-sm text-gray-900">

--- a/app/views/video_recordings/edit.html.erb
+++ b/app/views/video_recordings/edit.html.erb
@@ -1,15 +1,15 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:resources) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-4 flex flex-wrap justify-end gap-2">
           <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "Instructional videos", video_recordings_path(video_type: "instructional"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
           <%= link_to "View", video_recording_path(@video_recording), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         </div>
-        <h1 class="text-2xl font-semibold text-gray-900 mb-3">
+        <h1 class="text-primary mb-3 font-display text-2xl font-semibold">
           Edit <%= @video_recording.class.model_name.human.downcase %>
         </h1>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form" %>
             <%= render "shared/audit_info", resource: @video_recording %>

--- a/app/views/video_recordings/new.html.erb
+++ b/app/views/video_recordings/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:resources) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New <%= @video_recording.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:resources) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New <%= @video_recording.class.model_name.human.downcase %></h1>
         </div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form", video_recording: @video_recording %>
           </div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -1,17 +1,7 @@
-<div class="flex items-center justify-center">
-
-  <div class="w-full max-w-md bg-white rounded-2xl shadow-lg mt-8 p-8">
-
-    <%= render "layouts/mailer/logo" %>
-
-    <div class="text-center">
-      Welcome, <%= @user.first_name_or_email %>!
-
-      <h2 class="text-2xl font-semibold text-center text-gray-800 m-6">
-        Set a password to complete your account setup.
-      </h2>
-    </div>
-
+<%= render layout: "devise/auth_card",
+           locals: { title: "Welcome, #{@user.first_name_or_email}!",
+                     subtitle: "Set a password to complete your account setup.",
+                     links: false } do %>
     <%= simple_form_for(@user, url: user_welcome_update_path(@user.welcome_instructions_token),
                         scope: :user, html: { class: "space-y-4" }) do |f| %>
       <% if @user.errors.any? %>
@@ -19,8 +9,8 @@
       <% end %>
 
       <!-- NEW PASSWORD -->
-      <div data-controller="password-toggle" class="input password required mb-4 mt-6 pt-6">
-        <label class="password required block font-medium mb-1 text-gray-700" for="change-password-new-password">New password <abbr title="required">*</abbr></label>
+      <div data-controller="password-toggle" class="input password required mt-6 mb-4 pt-6">
+        <label class="password required mb-1 block font-medium text-gray-700" for="change-password-new-password">New password <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password,
                                id: "change-password-new-password",
@@ -42,7 +32,7 @@
 
       <!-- CONFIRM PASSWORD -->
       <div data-controller="password-toggle" class="input password required mb-4">
-        <label class="password required block font-medium mb-1 text-gray-700" for="change-password-new-password-confirmation">New password confirmation <abbr title="required">*</abbr></label>
+        <label class="password required mb-1 block font-medium text-gray-700" for="change-password-new-password-confirmation">New password confirmation <abbr title="required">*</abbr></label>
         <div class="relative">
           <%= f.password_field :password_confirmation,
                                id: "change-password-new-password-confirmation",
@@ -65,13 +55,12 @@
       <% if User.devise_modules.include?(:rememberable) %>
         <%= f.input :remember_me, as: :boolean, label: "Remember me" %>
       <% end %>
-      <div class="text-center mt-6">
+      <div class="mt-6 text-center">
         <%= f.button :submit, "Set password", class: "btn btn-primary" %>
       </div>
 
     <% end %>
-    <div class="mt-6 text-center">
-      <%= link_to "Skip and log in later", root_path, class: "action-link-text text-black-300 hover:underline" %>
-    </div>
+  <div class="border-primary/10 mt-6 border-t pt-5 text-center">
+    <%= link_to "Skip and log in later", root_path, class: "action-link-text text-primary text-sm hover:underline" %>
   </div>
-</div>
+<% end %>

--- a/app/views/windows_types/edit.html.erb
+++ b/app/views/windows_types/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Windows Types", windows_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", windows_type_path(@windows_type), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @windows_type.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @windows_type.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/windows_types/index.html.erb
+++ b/app/views/windows_types/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= WindowsType.model_name.human.pluralize %> (<%= @windows_types_count %>)
           </h1>
           <div class="flex gap-2">
@@ -20,7 +20,7 @@
             <tr>
               <th class="px-4 py-2">Short Name</th>
               <th class="px-4 py-2">AgeRange Categories</th>
-              <th class="px-4 py-2 w-32">Actions</th>
+              <th class="w-32 px-4 py-2">Actions</th>
             </tr>
             </thead>
 
@@ -37,13 +37,13 @@
                   <% if wt.categories.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% wt.categories.each do |cat| %>
-                        <span class="px-2 py-0.5 text-xs bg-gray-100 text-gray-700 rounded-full border border-gray-300">
+                        <span class="rounded-full border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700">
                           <%= cat.name %>
                         </span>
                       <% end %>
                     </div>
                   <% else %>
-                    <span class="text-gray-400 italic text-sm">None</span>
+                    <span class="text-sm text-gray-400 italic">None</span>
                   <% end %>
                 </td>
 
@@ -64,13 +64,13 @@
 
         <!-- Empty state -->
         <% unless @windows_types.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No <%= WindowsType.model_name.human.pluralize.downcase %> found.
           </p>
         <% end %>
 
         <!-- Pagination -->
-        <div class="pagination flex justify-center mt-12">
+        <div class="pagination mt-12 flex justify-center">
           <%= tailwind_paginate @windows_types %>
         </div>
   </div>

--- a/app/views/windows_types/new.html.erb
+++ b/app/views/windows_types/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-2xl font-semibold text-gray-900">New <%= @windows_type.class.model_name.human.downcase %></h1>
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">New <%= @windows_type.class.model_name.human.downcase %></h1>
         </div>
 
-        <div class="border-b border-gray-300 mb-6"></div>
+        <div class="mb-6 border-b border-gray-300"></div>
 
-        <div class="bg-white rounded p-6">
+        <div class="rounded bg-white p-6">
           <div class="mt-4">
             <%= render "form", windows_type: @windows_type %>
           </div>

--- a/app/views/windows_types/show.html.erb
+++ b/app/views/windows_types/show.html.erb
@@ -1,19 +1,19 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Windows Types", windows_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% if allowed_to?(:edit?, @windows_type) %>
           <%= link_to "Edit", edit_windows_type_path(@windows_type), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">
         <%= @windows_type.class.model_name.human %> details
       </h1>
 
       <div class="space-y-6">
         <div class="mt-4">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+          <div class="mb-3 grid grid-cols-1 gap-4 md:grid-cols-2">
 
                           <div class="mb-3">
                 <p class="font-bold text-gray-700">Name:</p>

--- a/app/views/workshop_ideas/edit.html.erb
+++ b/app/views/workshop_ideas/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", workshop_idea_path(@workshop_idea), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @workshop_idea.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_ideas/index.html.erb
+++ b/app/views/workshop_ideas/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> rounded-xl border border-gray-200 p-6 shadow">
+<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
         <div class="mb-6 flex items-center justify-between">
-          <h1 class="text-2xl font-semibold text-gray-900">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             <%= WorkshopIdea.model_name.human.pluralize %> (<%= @workshop_ideas_count %>)
           </h1>
           <div class="flex gap-2">

--- a/app/views/workshop_ideas/new.html.erb
+++ b/app/views/workshop_ideas/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">
+<div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-3 flex items-center justify-between">
+        <h1 class="text-primary font-display text-2xl font-semibold">
           New Workshop Idea
         </h1>
         <p>We encourage you to create your own workshop or a
@@ -11,7 +11,7 @@
           <br>Please enter the details of your creation below. Most fields are optional.</p>
       </div>
       <div class="space-y-6">
-        <div class="bg-white rounded mt-4 p-6">
+        <div class="mt-4 rounded bg-white p-6">
           <%= render "form" %>
         </div>
       </div>

--- a/app/views/workshop_ideas/show.html.erb
+++ b/app/views/workshop_ideas/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, WorkshopIdea) %>
       <%= link_to "Workshop Ideas", workshop_ideas_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -10,9 +10,9 @@
     <% end %>
   </div>
 
-  <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
-    <div class="font-semibold text-gray-900 mb-2">
-      <h1 class="text-3xl tracking-tight"><%= @workshop_idea.title %></h1>
+  <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
+    <div class="mb-2 font-semibold text-gray-900">
+      <h1 class="text-primary font-display text-3xl tracking-tight"><%= @workshop_idea.title %></h1>
     </div>
 
     <% if @workshop_idea.workshops.any? %>
@@ -27,8 +27,8 @@
       </div>
     <% end %>
 
-    <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
           <%= credited_author_link(@workshop_idea) %>
@@ -54,7 +54,7 @@
       </div>
 
       <% if @workshop_idea.staff_notes.present? %>
-        <div class="mt-3 pt-3 border-t border-gray-200">
+        <div class="mt-3 border-t border-gray-200 pt-3">
           <span class="font-semibold text-gray-700">Staff notes:</span>
           <%= @workshop_idea.staff_notes %>
         </div>
@@ -89,7 +89,7 @@
     <% sections.each do |label, content| %>
       <% if content.present? %>
         <div class="mb-4">
-          <h3 class="text-sm font-semibold text-gray-700 mb-1"><%= label %></h3>
+          <h3 class="mb-1 text-sm font-semibold text-gray-700"><%= label %></h3>
           <div class="text-gray-900"><%= content %></div>
         </div>
       <% end %>

--- a/app/views/workshop_logs/edit.html.erb
+++ b/app/views/workshop_logs/edit.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "Workshop Logs", workshop_logs_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
         <%= link_to "View", workshop_log_path(@workshop_log), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-6">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
+      <h1 class="text-primary mb-6 font-display text-2xl font-semibold">Edit <%= @workshop_log.class.model_name.human.downcase %></h1>
 
       <div class="space-y-6">
         <div class="mt-4">

--- a/app/views/workshop_logs/index.html.erb
+++ b/app/views/workshop_logs/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="rounded-xl bg-white p-6">
     <%= render "index" %>
   </div>

--- a/app/views/workshop_logs/new.html.erb
+++ b/app/views/workshop_logs/new.html.erb
@@ -1,17 +1,17 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
 
       <!-- Header -->
       <div class="mb-8 space-y-4">
         <!-- Alert -->
         <div id="notification_monthly"
-             class="hidden relative rounded-md border border-green-300 bg-green-50 text-green-800 px-4 py-3 text-sm flex items-start justify-between">
+             class="relative flex hidden items-start justify-between rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-800">
           <span>
             A monthly report has already been submitted for this month.
             To submit an additional workshop log, please contact your program manager.
           </span>
           <button type="button"
-                  class="text-green-700 hover:text-green-900 font-semibold ml-4"
+                  class="ml-4 font-semibold text-green-700 hover:text-green-900"
                   data-dismiss="alert"
                   aria-label="Close">
             &times;
@@ -19,18 +19,18 @@
         </div>
 
         <!-- Title -->
-        <h1 class="text-2xl font-semibold text-gray-900">
+        <h1 class="text-primary font-display text-2xl font-semibold">
           New <%= @workshop_log.class.model_name.human.downcase %>
         </h1>
 
         <!-- Description -->
-        <p class="text-gray-700 leading-relaxed">
+        <p class="leading-relaxed text-gray-700">
           An optional tool to track data from your art workshops. If you don't see the workshop you facilitated listed in the dropdown menu, you can type in a new title in the field below.
         </p>
       </div>
 
       <div class="space-y-6">
-        <div class="bg-white rounded mt-4 p-6">
+        <div class="mt-4 rounded bg-white p-6">
           <%= render "form" %>
         </div>
       </div>

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-member") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end items-center gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:index?, WorkshopLog) %>
       <%= link_to "My Workshop Logs", workshop_logs_path(created_by_id: current_user.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
@@ -14,13 +14,13 @@
     <%= render "bookmarks/editable_bookmark_button", resource: @workshop_log %>
   </div>
 
-  <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
-    <div class="font-semibold text-gray-900 mb-2">
-      <h1 class="text-3xl tracking-tight"><%= @workshop_log.workshop&.title || @workshop_log.external_workshop_title || "Workshop Log" %></h1>
+  <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
+    <div class="mb-2 font-semibold text-gray-900">
+      <h1 class="text-primary font-display text-3xl tracking-tight"><%= @workshop_log.workshop&.title || @workshop_log.external_workshop_title || "Workshop Log" %></h1>
     </div>
 
-    <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <span class="font-semibold text-gray-700">Submitted by:</span>
           <% if @workshop_log.created_by&.person && allowed_to?(:show?, @workshop_log.created_by.person) %>
@@ -87,16 +87,16 @@
 
     <!-- Participant counts -->
     <div>
-      <h2 class="text-lg font-semibold text-gray-800 mb-2">Participant counts</h2>
+      <h2 class="mb-2 text-lg font-semibold text-gray-800">Participant counts</h2>
       <div class="overflow-x-auto">
-        <table class="min-w-full border border-gray-300 rounded-lg overflow-hidden">
+        <table class="min-w-full overflow-hidden rounded-lg border border-gray-300">
           <thead>
           <tr class="bg-gray-100">
             <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Category</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Children</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Teens</th>
-            <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 bg-gray-200">Adults</th>
-            <th class="px-4 py-2 text-center text-sm font-bold text-gray-800 bg-gray-300 uppercase">Total</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Children</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Teens</th>
+            <th class="bg-gray-200 px-4 py-2 text-center text-sm font-semibold text-gray-700">Adults</th>
+            <th class="bg-gray-300 px-4 py-2 text-center text-sm font-bold text-gray-800 uppercase">Total</th>
           </tr>
           </thead>
 
@@ -104,10 +104,10 @@
           <!-- Ongoing -->
           <tr>
             <td class="px-4 py-2 font-medium text-gray-700">Ongoing Participants</td>
-            <td class="text-center bg-blue-100"><%= display_count(@workshop_log.children_ongoing) %></td>
-            <td class="text-center bg-blue-100"><%= display_count(@workshop_log.teens_ongoing) %></td>
-            <td class="text-center bg-blue-100"><%= display_count(@workshop_log.adults_ongoing) %></td>
-            <td class="text-center font-semibold bg-blue-200">
+            <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.children_ongoing) %></td>
+            <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.teens_ongoing) %></td>
+            <td class="bg-blue-100 text-center"><%= display_count(@workshop_log.adults_ongoing) %></td>
+            <td class="bg-blue-200 text-center font-semibold">
               <%= display_count(@workshop_log.children_ongoing.to_i +
                                   @workshop_log.teens_ongoing.to_i +
                                   @workshop_log.adults_ongoing.to_i) %>
@@ -117,10 +117,10 @@
           <!-- First-time -->
           <tr>
             <td class="px-4 py-2 font-medium text-gray-700">First-Time Participants</td>
-            <td class="text-center bg-green-100"><%= display_count(@workshop_log.children_first_time) %></td>
-            <td class="text-center bg-green-100"><%= display_count(@workshop_log.teens_first_time) %></td>
-            <td class="text-center bg-green-100"><%= display_count(@workshop_log.adults_first_time) %></td>
-            <td class="text-center font-semibold bg-green-200">
+            <td class="bg-green-100 text-center"><%= display_count(@workshop_log.children_first_time) %></td>
+            <td class="bg-green-100 text-center"><%= display_count(@workshop_log.teens_first_time) %></td>
+            <td class="bg-green-100 text-center"><%= display_count(@workshop_log.adults_first_time) %></td>
+            <td class="bg-green-200 text-center font-semibold">
               <%= display_count(@workshop_log.children_first_time.to_i +
                                   @workshop_log.teens_first_time.to_i +
                                   @workshop_log.adults_first_time.to_i) %>
@@ -133,10 +133,10 @@
           <% adults_total   = @workshop_log.adults_ongoing.to_i + @workshop_log.adults_first_time.to_i %>
           <tr class="font-semibold">
             <td class="px-4 py-2 text-right text-sm font-bold text-gray-800 uppercase">Subtotal</td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(children_total) %></td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(teens_total) %></td>
-            <td class="text-center font-bold text-md bg-purple-100"><%= display_count(adults_total) %></td>
-            <td class="text-center text-lg font-bold bg-purple-200">
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(children_total) %></td>
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(teens_total) %></td>
+            <td class="bg-purple-100 text-center text-md font-bold"><%= display_count(adults_total) %></td>
+            <td class="bg-purple-200 text-center text-lg font-bold">
               <%= display_count(children_total + teens_total + adults_total) %>
             </td>
           </tr>
@@ -148,7 +148,7 @@
     <!-- Sectors -->
     <% if @workshop_log.sectors.any? %>
       <div>
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Sectors</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Sectors</h2>
         <div class="flex flex-wrap gap-1">
           <% @workshop_log.sectors.each do |sector| %>
             <%= render "sectors/tagging_label", sector: sector %>
@@ -160,7 +160,7 @@
     <!-- Responses -->
     <% if @answers.any? %>
       <div class="space-y-3">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Responses</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Responses</h2>
         <% @answers.each do |answer| %>
           <div class="border-b border-gray-200 pb-2">
             <p class="text-sm font-semibold text-gray-700"><%= answer.form_field.name %></p>
@@ -172,32 +172,32 @@
 
     <!-- Uploads -->
     <div>
-      <h2 class="text-lg font-semibold text-gray-800 mb-2">Uploads</h2>
+      <h2 class="mb-2 text-lg font-semibold text-gray-800">Uploads</h2>
       <%= render "assets/display_assets", resource: @workshop_log, link: true, align: :start %>
     </div>
 
     <!-- Quotes -->
     <% if @workshop_log.quotes.any? %>
       <div class="space-y-3">
-        <h2 class="text-lg font-semibold text-gray-800 mb-2">Quotes</h2>
+        <h2 class="mb-2 text-lg font-semibold text-gray-800">Quotes</h2>
         <div class="space-y-6">
           <% @workshop_log.quotes.decorate.each do |quote| %>
             <div>
-              <div class="relative bg-gray-100 italic leading-relaxed p-6 rounded-2xl">
-                <div class="font-semibold text-gray-700 italic text-lg">
+              <div class="relative rounded-2xl bg-gray-100 p-6 leading-relaxed italic">
+                <div class="text-lg font-semibold text-gray-700 italic">
                   <%= link_to quote.detail, quote_path(quote.object), class: "hover:underline" %>
-                  <span class="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded-full">
+                  <span class="rounded-full bg-gray-200 px-2 py-1 text-xs text-gray-700">
                     <span class="fa fa-eye-slash"></span>
                     Unpublished
                   </span>
                 </div>
-                <div class="text-gray-700 mt-3">
+                <div class="mt-3 text-gray-700">
                   <span class="font-medium not-italic">Speaker:</span> <%= quote.attribution %>
                   <%= "@ " + quote.created_at.strftime("%m-%d-%-Y") %>
                   <%= ("re " + link_to(quote.workshop.title, workshop_path(quote.workshop),
                                        class: "hover:underline") if quote.workshop).to_s.html_safe %>
                 </div>
-                <div class="absolute -bottom-3 left-8 w-0 h-0 border-t-8 border-t-gray-100 border-x-8 border-x-transparent"></div>
+                <div class="absolute -bottom-3 left-8 h-0 w-0 border-x-8 border-t-8 border-x-transparent border-t-gray-100"></div>
               </div>
             </div>
           <% end %>

--- a/app/views/workshop_variation_ideas/edit.html.erb
+++ b/app/views/workshop_variation_ideas/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-4 flex flex-wrap justify-end gap-2">
         <% if @workshop_variation_idea.workshop_variations.any? %>
           <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
             <%= link_to "View Variation", workshop_variation_path(workshop_variation),
@@ -11,7 +11,7 @@
         <%= link_to "View", workshop_variation_idea_path(@workshop_variation_idea),
                     class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       </div>
-      <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop variation idea: <%= @workshop_variation_idea.name %></h1>
+      <h1 class="text-primary mb-4 font-display text-2xl font-semibold">Edit workshop variation idea: <%= @workshop_variation_idea.name %></h1>
       <% if @workshop_variation_idea.workshop.present? %>
         <p class="mb-4">Workshop: <%= link_to("#{@workshop_variation_idea.workshop.title} (#{@workshop_variation_idea.workshop.windows_type&.short_name || 'Combined'})",
                                             workshop_path(@workshop_variation_idea.workshop), class: "btn btn-secondary-outline") %></p>
@@ -19,7 +19,7 @@
 
       <% visible_variations = allowed_to?(:manage?, WorkshopVariation) ? @workshop_variation_idea.workshop_variations : @workshop_variation_idea.workshop_variations.where(published: true) %>
       <% if visible_variations.any? %>
-        <div class="rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 mb-4">
+        <div class="rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> mb-4 p-4">
           <div class="flex items-center gap-2">
             <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
             <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">
@@ -31,7 +31,7 @@
           </div>
         </div>
       <% elsif @workshop_variation_idea.persisted? && allowed_to?(:manage?, WorkshopVariation) %>
-        <div class="admin-only rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> p-4 mb-4">
+        <div class="admin-only rounded-lg border <%= DomainTheme.border_class_for(:workshop_variation_ideas, intensity: 200) %> <%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> mb-4 p-4">
           <div class="flex items-center gap-2">
             <i class="fas fa-arrow-up-from-bracket <%= DomainTheme.text_class_for(:workshop_variation_ideas, intensity: 600) %>"></i>
             <span class="text-sm font-medium <%= DomainTheme.text_class_for(:workshop_variation_ideas) %>">This idea has not been promoted yet.</span>

--- a/app/views/workshop_variation_ideas/index.html.erb
+++ b/app/views/workshop_variation_ideas/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
+<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="space-y-6">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-6">
-          <h1 class="text-2xl font-semibold text-gray-900">
+        <div class="mb-6 flex items-center justify-between">
+          <h1 class="text-primary font-display text-2xl font-semibold">
             Workshop Variation Ideas (<%= @workshop_variation_ideas_count %>)
           </h1>
           <div class="flex gap-2">
@@ -20,21 +20,21 @@
           <table class="w-full border-collapse border border-gray-200">
             <thead class="bg-gray-100">
             <tr>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]"></th>
+              <th class="w-[2%] px-4 py-2 text-center text-sm font-semibold text-gray-700"></th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Name</th>
               <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Description</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Author</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Promoted to</th>
               <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700">Updated</th>
-              <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[2%]">Actions</th>
+              <th class="w-[2%] px-4 py-2 text-center text-sm font-semibold text-gray-700">Actions</th>
             </tr>
             </thead>
 
             <tbody class="divide-y divide-gray-200">
             <% @workshop_variation_ideas.each do |workshop_variation_idea| %>
-              <tr class="hover:bg-gray-50 transition-colors duration-150">
+              <tr class="transition-colors duration-150 hover:bg-gray-50">
                 <td class="px-4 py-2">
-                  <div class="w-12 h-9 rounded bg-gray-200 overflow-hidden">
+                  <div class="h-9 w-12 overflow-hidden rounded bg-gray-200">
                     <%= render "assets/display_image",
                                resource: workshop_variation_idea,
                                width: 12, height: 9,
@@ -45,7 +45,7 @@
                   </div>
                 </td>
                 <td class="px-4 py-2" title="<%= workshop_variation_idea.name %>">
-                  <div class="text-sm text-gray-800 font-semibold">
+                  <div class="text-sm font-semibold text-gray-800">
                     <%= link_to truncate(workshop_variation_idea.name, length: 30),
                                 workshop_variation_idea_path(workshop_variation_idea),
                                 class: "hover:text-blue-600 hover:underline" %>
@@ -66,10 +66,10 @@
                     </span>
                   <% end %>
                 </td>
-                <td class="px-4 py-2 text-sm text-center">
+                <td class="px-4 py-2 text-center text-sm">
                   <%= credited_author_link(workshop_variation_idea, class: "#{eyebrow_link_class}") %>
                 </td>
-                <td class="px-4 py-2 text-sm text-center whitespace-nowrap">
+                <td class="px-4 py-2 text-center text-sm whitespace-nowrap">
                   <% promoted_variation = workshop_variation_idea.workshop_variations.first %>
                   <% if promoted_variation %>
                     <%= link_to "Variation ##{promoted_variation.id}",
@@ -79,7 +79,7 @@
                     <span class="text-gray-300">--</span>
                   <% end %>
                 </td>
-                <td class="px-4 py-2 text-sm text-gray-500 text-center whitespace-nowrap"><%= workshop_variation_idea.updated_at&.strftime("%m/%d/%y") %></td>
+                <td class="px-4 py-2 text-center text-sm whitespace-nowrap text-gray-500"><%= workshop_variation_idea.updated_at&.strftime("%m/%d/%y") %></td>
                 <td class="px-4 py-2 text-center whitespace-nowrap">
                   <%= link_to "View", workshop_variation_idea_path(workshop_variation_idea), class: "btn btn-secondary-outline" %>
                 </td>
@@ -92,7 +92,7 @@
 
         <!-- Empty state -->
         <% unless @workshop_variation_ideas.any? %>
-          <p class="text-gray-500 text-center py-6">
+          <p class="py-6 text-center text-gray-500">
             No workshop variation ideas found.
           </p>
         <% end %>

--- a/app/views/workshop_variation_ideas/new.html.erb
+++ b/app/views/workshop_variation_ideas/new.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border border-gray-200 rounded-xl shadow p-6">
-      <div class="flex items-center justify-between mb-3">
-        <h1 class="text-2xl font-semibold text-gray-900">New workshop variation idea</h1>
+<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+      <div class="mb-3 flex items-center justify-between">
+        <h1 class="text-primary font-display text-2xl font-semibold">New workshop variation idea</h1>
       </div>
 
-      <p class="text-gray-700 leading-relaxed mb-4">
+      <p class="mb-4 leading-relaxed text-gray-700">
         Sharing your unique workshop variations strengthens our curriculum for our entire community.
         We deeply value your innovations and welcome your feedback anytime.
       </p>

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <% if @workshop_variation_idea.workshop_variations.any? %>
       <% @workshop_variation_idea.workshop_variations.each do |workshop_variation| %>
         <%= link_to "View Variation", workshop_variation_path(workshop_variation),
@@ -17,9 +17,9 @@
     <% end %>
   </div>
 
-  <div class="bg-white rounded-lg shadow-md p-6 space-y-6">
-    <div class="font-semibold text-gray-900 mb-2">
-      <h1 class="text-3xl tracking-tight"><%= @workshop_variation_idea.name %></h1>
+  <div class="space-y-6 rounded-lg bg-white p-6 shadow-md">
+    <div class="mb-2 font-semibold text-gray-900">
+      <h1 class="text-primary font-display text-3xl tracking-tight"><%= @workshop_variation_idea.name %></h1>
     </div>
 
     <% visible_variations = allowed_to?(:manage?, WorkshopVariation) ? @workshop_variation_idea.workshop_variations : @workshop_variation_idea.workshop_variations.where(published: true) %>
@@ -47,8 +47,8 @@
       </div>
     <% end %>
 
-    <div class="bg-gray-50 rounded-lg border border-gray-200 p-4 text-sm text-gray-600">
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
           <span class="font-semibold text-gray-700">Submitted by:</span>
           <% if @workshop_variation_idea.created_by&.person && allowed_to?(:show?, @workshop_variation_idea.created_by.person) %>

--- a/app/views/workshop_variations/edit.html.erb
+++ b/app/views/workshop_variations/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-4 flex flex-wrap justify-end gap-2">
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "View", workshop_variation_path(@workshop_variation), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
-  <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop variation: <%= @workshop_variation.name %></h1>
+  <h1 class="text-primary mb-4 font-display text-2xl font-semibold">Edit workshop variation: <%= @workshop_variation.name %></h1>
   <% if @workshop_variation.workshop.present? %>
     <p class="mb-4">Workshop: <%= link_to("#{@workshop_variation.workshop.name} (#{@workshop_variation.workshop.windows_type&.short_name || 'Combined'})",
                                         workshop_path(@workshop_variation.workshop), class: "btn btn-secondary-outline") %></p>

--- a/app/views/workshop_variations/new.html.erb
+++ b/app/views/workshop_variations/new.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border border-gray-200 rounded-xl shadow p-6">
-  <div class="flex items-center justify-between mb-3">
-    <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
+    <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
       New Workshop Variation
     </h1>
   </div>
 
   <div class="space-y-6">
-    <div class="bg-white rounded mt-4 p-6">
+    <div class="mt-4 rounded bg-white p-6">
       <%= render "form" %>
     </div>
   </div>

--- a/app/views/workshops/edit.html.erb
+++ b/app/views/workshops/edit.html.erb
@@ -1,18 +1,18 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
-    <div class="flex flex-wrap justify-end gap-2 mb-4">
+<div class="<%= DomainTheme.bg_class_for(:workshops) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+    <div class="mb-4 flex flex-wrap justify-end gap-2">
       <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "Workshops", workshops_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
       <%= link_to "View", workshop_path(@workshop), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>
-    <h1 class="text-2xl font-semibold text-gray-900 mb-4">Edit workshop: <%= @workshop.remote_search_label[:label] %></h1>
+    <h1 class="text-primary mb-4 font-display text-2xl font-semibold">Edit workshop: <%= @workshop.remote_search_label[:label] %></h1>
 
-    <div class="border-b border-gray-300 mb-6"></div>
+    <div class="mb-6 border-b border-gray-300"></div>
 
     <!-- Form -->
 
     <div class="space-y-6">
-        <div class="mt-4 bg-white rounded p-3">
+        <div class="mt-4 rounded bg-white p-3">
           <%= render "form", workshop: @workshop %>
           <%= render "shared/audit_info", resource: @workshop %>
         </div>

--- a/app/views/workshops/new.html.erb
+++ b/app/views/workshops/new.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshops) %> border border-gray-200 rounded-xl shadow p-6">
-        <div class="flex items-center justify-between mb-3">
-          <h1 class="text-3xl font-semibold text-gray-900 tracking-tight">
+<div class="<%= DomainTheme.bg_class_for(:workshops) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
+        <div class="mb-3 flex items-center justify-between">
+          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
             New <%= @workshop.class.model_name.human.downcase %>
           </h1>
         </div>
         <div class="space-y-6">
-          <div class="bg-white rounded mt-4 p-6">
+          <div class="mt-4 rounded bg-white p-6">
             <%= render "form" %>
           </div>
         </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2538,3 +2538,14 @@
   pro_tips:
     - "Everything that was on the page is still there — description, affiliations, sectors, age groups, workshops, and events attended — just grouped into cards."
     - "The organization's status chip still sits beside the name for admins."
+
+- name: "Admin pages in the AWBW brand"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-29
+  summary: >-
+    The admin and staff-only pages now match the rest of the portal — softer
+    card corners, the brand's navy hairline border, and page titles in the brand
+    serif. Purely visual: no page changed what it shows or does.
+  pro_tips:
+    - "Each page keeps its own domain colour; only the card edges and the page title changed."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2543,6 +2543,7 @@
   area: reporting
   display_status: admin_facing
   released_on: 2026-08-29
+  pr_number: 2404
   summary: >-
     The admin and staff-only pages now match the rest of the portal — softer
     card corners, the brand's navy hairline border, and page titles in the brand


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 style-only but very wide — 205 view files; worth a skim of the transform rules rather than every file

The last unstyled surface. Admin and staff-only pages now match the rest of the portal. **No logic, routes, queries, copy or markup structure changed** — only class strings.

### The two transforms
Applied mechanically, then checked by hand:

**Card wrappers** — a div carrying *both* a `border-gray-200` hairline *and* a card radius:
```
rounded-xl border border-gray-200 … shadow   →   rounded-2xl border border-primary/10 … shadow-sm
```
Requiring both signals means inner chips and icon tiles that merely use `rounded-xl` were left alone. **298 wrappers across 205 files.**

**Page titles** — the `<h1>` only, so each page keeps a single display moment:
```
text-2xl font-semibold text-gray-900   →   font-display text-2xl font-semibold text-primary
```
**170 titles.** Sizes and weights untouched, so nothing reflows.

Every page keeps its own `DomainTheme` colour — that's still what tints each card.

### One page restructured
`welcome/show` was a hand-rolled copy of the devise auth card, so it now renders through `devise/_auth_card` like the other six auth screens. Its copy is byte-identical to before.

### Deliberately excluded
- **The rainbow rule.** It marks public, branded surfaces. Adding it to ~200 admin pages would mean moving each card's padding into an inner div — a structural edit on a style-only pass, and the same clipping that broke CI on #2398.
- **`story_shares` (3 pages)** — its own layout, which loads Lato but **not** Fraunces, so `font-display` would silently fall back.
- **Invoices and receipts (4)** — printable documents; print fidelity is its own problem.
- **`devise/registrations/*` and `*_old`** — unreachable, `:registerable` isn't enabled.
- **Turbo-frame result views (21) and `*_lazy` partials** — they render inside an already-branded shell.
- **`reports/annual`** — legacy Bootstrap markup (`container-fluid`, `row`); needs a rewrite, not a restyle.

### Verified
3641 examples, 0 failures (`spec/requests`, `spec/views`, `spec/helpers`, `spec/lib`, `feature_catalog_spec`) and 171 system examples, 0 failures. `ai/lint` clean, `ai/tw-sort` applied.