### PR TITLE
Give the Create pages a shared, more inviting shell

### DIFF
--- a/app/views/shared/_create_page.html.erb
+++ b/app/views/shared/_create_page.html.erb
@@ -1,0 +1,30 @@
+<%# Shared shell for the Create menu's pages. Carries the same icon the menu item
+    uses, so clicking "New workshop idea" lands on a page wearing the same
+    lightbulb — the menu and the page read as one step. Follows the marketing
+    site's section shape: circular icon badge, domain-coloured eyebrow, serif
+    headline, a width-constrained intro, then the work itself on white.
+    locals: domain, icon, title; optional eyebrow, intro, notice (markup shown
+    above the header, e.g. an alert). %>
+<div class="<%= DomainTheme.bg_class_for(domain, intensity: 50) %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-5xl rounded-2xl border shadow-sm">
+  <%= render "shared/brand_accent_strip", rounded: true %>
+  <div class="p-6 sm:p-8">
+    <%= local_assigns[:notice] %>
+    <div class="flex items-start gap-4">
+      <span class="<%= DomainTheme.bg_class_for(domain, intensity: 100) %> <%= DomainTheme.text_class_for(domain, intensity: 700) %> hidden h-14 w-14 shrink-0 items-center justify-center rounded-full sm:flex">
+        <i class="<%= icon %> text-2xl" aria-hidden="true"></i>
+      </span>
+      <div class="min-w-0">
+        <span class="text-2xs <%= DomainTheme.text_class_for(domain, intensity: 700) %> font-semibold tracking-widest uppercase">
+          <%= local_assigns.fetch(:eyebrow, "Create") %>
+        </span>
+        <h1 class="text-primary font-display text-3xl"><%= title %></h1>
+        <% if local_assigns[:intro].present? %>
+          <div class="mt-3 max-w-2xl leading-relaxed text-gray-700"><%= intro %></div>
+        <% end %>
+      </div>
+    </div>
+    <div class="border-primary/10 mt-8 rounded-2xl border bg-white p-6 shadow-sm">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -1,13 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:stories) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-        <div class="mb-3 flex items-center justify-between">
-          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
-            New <%= @story.class.model_name.human.downcase %>
-          </h1>
-        </div>
-        <div class="space-y-6">
-          <div class="mt-4 rounded bg-white p-6">
-            <%= render "form" %>
-          </div>
-        </div>
-</div>
+<%= render layout: "shared/create_page",
+           locals: { domain: :stories, icon: "fas fa-book",
+                     title: "New #{@story.class.model_name.human.downcase}" } do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/story_ideas/new.html.erb
+++ b/app/views/story_ideas/new.html.erb
@@ -1,10 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:story_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-  <div class="mb-3 flex items-center justify-between">
-    <h1 class="text-primary font-display text-2xl font-semibold">New <%= @story_idea.class.model_name.human.downcase %></h1>
-  </div>
-
-  <div class="mb-6 leading-relaxed text-gray-700">
+<% intro = capture do %>
     At A Window Between Worlds, we value every story you share. Your voice helps paint a picture of the positive impact
     of art on people and communities, inspiring others to use art in similarly powerful and far reaching ways.
     <br><br>
@@ -20,11 +15,9 @@
       Please note: edits may be made, and not all stories
       will be published to the site, but may still be used in other places.
     </span>
-  </div>
-
-  <div class="space-y-6">
-    <div class="mt-4">
-      <%= render "form", story_idea: @story_idea %>
-    </div>
-  </div>
-</div>
+<% end %>
+<%= render layout: "shared/create_page",
+           locals: { domain: :story_ideas, icon: "fas fa-book-open",
+                     title: "New #{@story_idea.class.model_name.human.downcase}", intro: intro } do %>
+  <%= render "form", story_idea: @story_idea %>
+<% end %>

--- a/app/views/workshop_ideas/new.html.erb
+++ b/app/views/workshop_ideas/new.html.erb
@@ -1,18 +1,13 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-      <div class="mb-3 flex items-center justify-between">
-        <h1 class="text-primary font-display text-2xl font-semibold">
-          New Workshop Idea
-        </h1>
-        <p>We encourage you to create your own workshop or a
-          <%= link_to "variation of an existing workshop",
-                      new_workshop_variation_idea_path,
-                      class: "text-blue-500 hover:underline" %>.
-          <br>Please enter the details of your creation below. Most fields are optional.</p>
-      </div>
-      <div class="space-y-6">
-        <div class="mt-4 rounded bg-white p-6">
-          <%= render "form" %>
-        </div>
-      </div>
-</div>
+<% intro = capture do %>
+  We encourage you to create your own workshop or a
+  <%= link_to "variation of an existing workshop",
+              new_workshop_variation_idea_path,
+              class: "text-blue-500 hover:underline" %>.
+  <br>Please enter the details of your creation below. Most fields are optional.
+<% end %>
+<%= render layout: "shared/create_page",
+           locals: { domain: :workshop_ideas, icon: "fas fa-lightbulb",
+                     title: "New workshop idea", intro: intro } do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/workshop_logs/new.html.erb
+++ b/app/views/workshop_logs/new.html.erb
@@ -1,38 +1,25 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_logs) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-
-      <!-- Header -->
-      <div class="mb-8 space-y-4">
-        <!-- Alert -->
-        <div id="notification_monthly"
-             class="relative flex hidden items-start justify-between rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-800">
-          <span>
-            A monthly report has already been submitted for this month.
-            To submit an additional workshop log, please contact your program manager.
-          </span>
-          <button type="button"
-                  class="ml-4 font-semibold text-green-700 hover:text-green-900"
-                  data-dismiss="alert"
-                  aria-label="Close">
-            &times;
-          </button>
-        </div>
-
-        <!-- Title -->
-        <h1 class="text-primary font-display text-2xl font-semibold">
-          New <%= @workshop_log.class.model_name.human.downcase %>
-        </h1>
-
-        <!-- Description -->
-        <p class="leading-relaxed text-gray-700">
-          An optional tool to track data from your art workshops. If you don't see the workshop you facilitated listed in the dropdown menu, you can type in a new title in the field below.
-        </p>
-      </div>
-
-      <div class="space-y-6">
-        <div class="mt-4 rounded bg-white p-6">
-          <%= render "form" %>
-        </div>
-      </div>
-
-</div>
+<% notice = capture do %>
+  <div id="notification_monthly"
+       class="relative mb-6 flex hidden items-start justify-between rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-800">
+    <span>
+      A monthly report has already been submitted for this month.
+      To submit an additional workshop log, please contact your program manager.
+    </span>
+    <button type="button"
+            class="ml-4 font-semibold text-green-700 hover:text-green-900"
+            data-dismiss="alert"
+            aria-label="Close">
+      &times;
+    </button>
+  </div>
+<% end %>
+<% intro = capture do %>
+  An optional tool to track data from your art workshops. If you don't see the workshop you facilitated listed in the dropdown menu, you can type in a new title in the field below.
+<% end %>
+<%= render layout: "shared/create_page",
+           locals: { domain: :workshop_logs, icon: "fas fa-clipboard-list",
+                     title: "New #{@workshop_log.class.model_name.human.downcase}",
+                     intro: intro, notice: notice } do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/workshop_variation_ideas/new.html.erb
+++ b/app/views/workshop_variation_ideas/new.html.erb
@@ -1,17 +1,10 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variation_ideas, intensity: 200) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-      <div class="mb-3 flex items-center justify-between">
-        <h1 class="text-primary font-display text-2xl font-semibold">New workshop variation idea</h1>
-      </div>
-
-      <p class="mb-4 leading-relaxed text-gray-700">
-        Sharing your unique workshop variations strengthens our curriculum for our entire community.
-        We deeply value your innovations and welcome your feedback anytime.
-      </p>
-
-      <div class="space-y-6">
-        <div class="mt-4">
-          <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
-        </div>
-      </div>
-</div>
+<% intro = capture do %>
+  Sharing your unique workshop variations strengthens our curriculum for our entire community.
+  We deeply value your innovations and welcome your feedback anytime.
+<% end %>
+<%= render layout: "shared/create_page",
+           locals: { domain: :workshop_variation_ideas, icon: "fas fa-layer-group",
+                     title: "New workshop variation idea", intro: intro } do %>
+  <%= render "form", workshop_variation_idea: @workshop_variation_idea %>
+<% end %>

--- a/app/views/workshop_variations/new.html.erb
+++ b/app/views/workshop_variations/new.html.erb
@@ -1,14 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshop_variations) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-  <div class="mb-3 flex items-center justify-between">
-    <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
-      New Workshop Variation
-    </h1>
-  </div>
-
-  <div class="space-y-6">
-    <div class="mt-4 rounded bg-white p-6">
-      <%= render "form" %>
-    </div>
-  </div>
-</div>
+<%= render layout: "shared/create_page",
+           locals: { domain: :workshop_variations, icon: "fas fa-swatchbook",
+                     title: "New workshop variation" } do %>
+  <%= render "form" %>
+<% end %>

--- a/app/views/workshops/new.html.erb
+++ b/app/views/workshops/new.html.erb
@@ -1,13 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:workshops) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-        <div class="mb-3 flex items-center justify-between">
-          <h1 class="text-primary font-display text-3xl font-semibold tracking-tight">
-            New <%= @workshop.class.model_name.human.downcase %>
-          </h1>
-        </div>
-        <div class="space-y-6">
-          <div class="mt-4 rounded bg-white p-6">
-            <%= render "form" %>
-          </div>
-        </div>
-</div>
+<%= render layout: "shared/create_page",
+           locals: { domain: :workshops, icon: "fas fa-chalkboard-teacher",
+                     title: "New #{@workshop.class.model_name.human.downcase}" } do %>
+  <%= render "form" %>
+<% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2550,3 +2550,15 @@
     serif. Purely visual: no page changed what it shows or does.
   pro_tips:
     - "Each page keeps its own domain colour; only the card edges and the page title changed."
+
+- name: "Create pages redesigned"
+  area: content
+  display_status: user_facing
+  released_on: 2026-08-29
+  summary: >-
+    Every page behind the Create menu — workshops, variations, ideas, stories
+    and workshop logs — now opens with the same icon you clicked, a serif
+    heading and its intro, with the form on its own white card below.
+  pro_tips:
+    - "The icon on the page matches the one in the Create menu, so you can see at a glance which form you landed on."
+    - "The intro explaining why a submission matters now sits above the form instead of beside the heading."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2555,6 +2555,7 @@
   area: content
   display_status: user_facing
   released_on: 2026-08-29
+  pr_number: 2405
   summary: >-
     Every page behind the Create menu — workshops, variations, ideas, stories
     and workshop logs — now opens with the same icon you clicked, a serif


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only, but it restructures seven pages onto a new shell and corrects two page titles to sentence case

The seven pages behind the **Create** menu each hand-rolled the same header, with drifting results. They now share one shell built on the marketing site's own section shape.

### What the reference designs actually do
Looking at `docs/design/awbw-home-03-approach.jpg` and `awbw-home-06-find-your-path.jpg`, every section follows the same order: a **circular icon badge**, a small **uppercase eyebrow** in a warm accent, a big **Fraunces headline**, then **width-constrained body copy**. The Create/Carry/Connect cards use exactly that icon-badge treatment.

`shared/_create_page` applies it: rainbow rule → icon badge in the domain colour → `CREATE` eyebrow → serif headline → intro capped at `max-w-2xl` → the form on its own white card.

### The idea worth calling out
**The page wears the same icon as the menu item you clicked.** Click "New workshop idea" (a lightbulb) and the page greets you with that lightbulb in a domain-coloured badge. Menu and page become one step instead of two unrelated screens. All seven icons are lifted straight from `shared/_navbar`.

### Other things this fixes
- **The form now looks like the task.** Three of the seven had the form floating directly on the tinted card with no separation from the prose; it's now always a white card, so "read this" and "do this" are visually distinct.
- **`workshop_ideas` had its intro beside the heading** in a `justify-between` flex, which read as a caption. It's an intro now.
- **`story_ideas`' wall of prose** is width-constrained instead of running the full card.
- **Two titles corrected to sentence case** — "New Workshop Idea" and "New Workshop Variation". CLAUDE.md mandates sentence case, and this also makes them match their Create-menu labels exactly. This is the only copy change; every other word is verbatim.

### Verified
680 examples 0 failures (workshops, stories, workshop_logs, story_ideas, workshop_ideas, workshop_variation_ideas requests + `spec/views`), plus 17 system examples covering the workshop and workshop-log create flows. Lint clean, tw-sort applied.