### PR TITLE
Theme people & organizations index panels with their DomainTheme color

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+<div class="border-primary/10 <%= DomainTheme.bg_class_for(:organizations) %> mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
   <%= render "shared/brand_accent_strip" %>
   <div class="p-6">
     <!-- Header -->

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
-<div class="border-primary/10 bg-brand-cream mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
+<div class="border-primary/10 <%= DomainTheme.bg_class_for(:people) %> mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
   <%= render "shared/brand_accent_strip" %>
   <div class="w-full p-6">
     <% back_label, back_path =


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only class swap on two index panels

Themes the people and organizations index panels with their own DomainTheme color instead of the generic brand-cream, so the panel tint matches every other index and reinforces which domain you're looking at.

### What is the goal of this PR and why is this important?
The people and organizations index panels were still on the generic `bg-brand-cream`, unlike every other index, which tints its panel with its own domain color. This makes them consistent so the color signals the domain.

### How did you approach the change?
Replaced the literal `bg-brand-cream` on each index's outer panel with `DomainTheme.bg_class_for(:people)` (cyan) and `DomainTheme.bg_class_for(:organizations)` (emerald) — both keys already exist in `DomainTheme::COLORS` and are safelisted.

### UI Testing Checklist
- [ ] People index panel renders with the cyan domain tint
- [ ] Organizations index panel renders with the emerald domain tint

### Anything else to add?
View-only; no logic or data changes.
