### PR TITLE
Make the forms area navigable: name→edit, working kebab, shared page subnav

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -99,7 +99,7 @@ class FormsController < ApplicationController
     authorize! @form
 
     copy = FormCopyService.new(@form).call
-    redirect_to edit_form_path(copy), notice: "Form copied. Now editing \"#{copy.display_name}\"."
+    redirect_to edit_form_path(copy), notice: "Form duplicated. Now editing \"#{copy.display_name}\"."
   end
 
   def edit_sections

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,15 +1,39 @@
 module FormsHelper
-  # The form editor's top-right links. The standalone "Preview form" is always
-  # available. When we also know which event the admin came from, we add a
-  # "View form" link to the real public-facing registration page — the preview
-  # can't fill header tokens or run conditional logic without an event.
-  def form_editor_view_links(form, event)
-    link_class = "text-sm #{eyebrow_link_class} px-2 py-1"
-    preview = link_to "Preview", form_path(form), class: link_class
-    return preview unless event
+  # Sibling-page subnav shared across a form's Results / View / Edit / Copy
+  # pages so each reads like a set of tabs linking to the others. `current`
+  # renders the active page as plain text instead of a link; pass `:none` (e.g.
+  # from the sub-pages like Edit sections) to keep every tab clickable.
+  def form_page_subnav(form, current:, event: nil)
+    tabs = [
+      form_subnav_tab("Results", results_form_path(form), active: current == :results),
+      form_subnav_tab("View", form_path(form), active: current == :view),
+      form_subnav_tab("Edit", edit_form_path(form, event_id: event&.id), active: current == :edit)
+    ]
+    if allowed_to?(:copy?, form)
+      tabs << form_subnav_tab("Copy", copy_form_path(form), active: false,
+        data: { turbo_method: :post, turbo_confirm: %(Make a full copy of "#{form.display_name}"?) })
+    end
+    content_tag :nav, safe_join(tabs), aria: { label: "Form pages" },
+      class: "inline-flex flex-wrap items-center gap-0.5 rounded-lg border #{DomainTheme.border_class_for(:forms, intensity: 200)} #{DomainTheme.bg_class_for(:forms)} p-0.5"
+  end
 
-    view = link_to "View", new_event_public_registration_path(event), class: link_class
-    safe_join([ view, preview ])
+  def form_subnav_tab(label, path, active:, **link_opts)
+    return content_tag(:span, label, aria: { current: "page" },
+      class: "rounded-md bg-white px-2.5 py-1 text-sm font-semibold shadow-sm #{DomainTheme.text_class_for(:forms, intensity: 700)}") if active
+
+    link_to label, path,
+      class: "rounded-md px-2.5 py-1 text-sm #{DomainTheme.text_class_for(:forms, intensity: 700)} #{DomainTheme.bg_class_for(:forms, hover: true)}", **link_opts
+  end
+
+  # The live public registration page for this form, shown on the editor pages.
+  # Only available when we know the event the admin came from — the preview
+  # (the subnav's "View") can't fill header tokens or run conditional logic
+  # without an event.
+  def form_live_view_link(event)
+    return unless event
+
+    link_to "Live form", new_event_public_registration_path(event),
+      class: "text-sm #{eyebrow_link_class} px-2 py-1"
   end
 
   # Human-readable role for a form: "Registration", "Bulk Payment", etc.,

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,8 +1,8 @@
 module FormsHelper
   # Sibling-page subnav shared across a form's Results / Submissions / View /
-  # Edit / Edit sections / Copy pages so each reads like a set of tabs linking
-  # to the others. `current` renders the active page as plain text instead of a
-  # link; pass `:none` to keep every tab clickable.
+  # Edit / Edit sections pages so each reads like a set of tabs linking to the
+  # others. `current` renders the active page as plain text instead of a link;
+  # pass `:none` to keep every tab clickable.
   def form_page_subnav(form, current:, event: nil)
     submissions_return = current == :results ? "form_results" : "forms"
     tabs = [
@@ -12,10 +12,6 @@ module FormsHelper
       form_subnav_tab("Edit", edit_form_path(form, event_id: event&.id), active: current == :edit),
       form_subnav_tab("Edit sections", edit_sections_form_path(form, event_id: event&.id), active: current == :edit_sections)
     ]
-    if allowed_to?(:copy?, form)
-      tabs << form_subnav_tab("Copy", copy_form_path(form), active: false,
-        data: { turbo_method: :post, turbo_confirm: %(Make a full copy of "#{form.display_name}"?) })
-    end
     content_tag :nav, safe_join(tabs), aria: { label: "Form pages" },
       class: "inline-flex flex-wrap items-center gap-0.5 rounded-lg border #{DomainTheme.border_class_for(:forms, intensity: 200)} #{DomainTheme.bg_class_for(:forms)} p-0.5"
   end
@@ -26,6 +22,19 @@ module FormsHelper
 
     link_to label, path,
       class: "rounded-md px-2.5 py-1 text-sm #{DomainTheme.text_class_for(:forms, intensity: 700)} #{DomainTheme.bg_class_for(:forms, hover: true)}", **link_opts
+  end
+
+  # "Duplicate form" action button, shown beneath the subnav on the View and
+  # Edit pages. Makes a full copy of the form (route stays `copy`); nil when the
+  # admin can't copy this form.
+  def form_duplicate_button(form)
+    return unless allowed_to?(:copy?, form)
+
+    link_to copy_form_path(form),
+      class: "btn btn-sm btn-secondary-outline inline-flex items-center gap-1.5 whitespace-nowrap",
+      data: { turbo_method: :post, turbo_confirm: %(Make a full duplicate of "#{form.display_name}"?) } do
+      safe_join([ content_tag(:i, "", class: "fa-solid fa-clone"), "Duplicate form" ])
+    end
   end
 
   # The live public registration page for this form, shown on the editor pages.

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -1,13 +1,16 @@
 module FormsHelper
-  # Sibling-page subnav shared across a form's Results / View / Edit / Copy
-  # pages so each reads like a set of tabs linking to the others. `current`
-  # renders the active page as plain text instead of a link; pass `:none` (e.g.
-  # from the sub-pages like Edit sections) to keep every tab clickable.
+  # Sibling-page subnav shared across a form's Results / Submissions / View /
+  # Edit / Edit sections / Copy pages so each reads like a set of tabs linking
+  # to the others. `current` renders the active page as plain text instead of a
+  # link; pass `:none` to keep every tab clickable.
   def form_page_subnav(form, current:, event: nil)
+    submissions_return = current == :results ? "form_results" : "forms"
     tabs = [
       form_subnav_tab("Results", results_form_path(form), active: current == :results),
+      form_subnav_tab("Submissions", form_submissions_path(form_id: form.id, return_to: submissions_return), active: current == :submissions),
       form_subnav_tab("View", form_path(form), active: current == :view),
-      form_subnav_tab("Edit", edit_form_path(form, event_id: event&.id), active: current == :edit)
+      form_subnav_tab("Edit", edit_form_path(form, event_id: event&.id), active: current == :edit),
+      form_subnav_tab("Edit sections", edit_sections_form_path(form, event_id: event&.id), active: current == :edit_sections)
     ]
     if allowed_to?(:copy?, form)
       tabs << form_subnav_tab("Copy", copy_form_path(form), active: false,

--- a/app/services/form_copy_service.rb
+++ b/app/services/form_copy_service.rb
@@ -1,5 +1,5 @@
 class FormCopyService
-  COPY_NAME_PREFIX = "Duplicate of ".freeze
+  COPY_NAME_PREFIX = "DUPLICATE of ".freeze
 
   def initialize(form)
     @form = form

--- a/app/services/form_copy_service.rb
+++ b/app/services/form_copy_service.rb
@@ -1,5 +1,5 @@
 class FormCopyService
-  COPY_NAME_PREFIX = "COPY of ".freeze
+  COPY_NAME_PREFIX = "Duplicate of ".freeze
 
   def initialize(form)
     @form = form

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -2,22 +2,25 @@
 
 <div class="form-submissions-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-2xl border border-primary/10 p-6 shadow-sm">
   <div class="w-full">
-    <% if params[:return_to] == "form_results" && @form %>
-      <div class="mb-4">
-        <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
-        <% end %>
-      </div>
-    <% elsif params[:return_to] == "forms" && @form %>
-      <div class="mb-4">
-        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> Forms
-        <% end %>
-      </div>
-    <% elsif @person %>
-      <div class="mb-4">
-        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
+    <% if @form || @person %>
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <% if params[:return_to] == "form_results" && @form %>
+            <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+              <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
+            <% end %>
+          <% elsif params[:return_to] == "forms" && @form %>
+            <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+              <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+            <% end %>
+          <% elsif @person %>
+            <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+              <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
+            <% end %>
+          <% end %>
+        </div>
+        <% if @form %>
+          <%= form_page_subnav(@form, current: :submissions) %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,17 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="px-4 py-8">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_page_subnav(@form, current: :edit, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <% end %>
-    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <% if @dashboard_event %>
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
-                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_live_view_link(@dashboard_event) %>
   </div>
 

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="px-4 py-8">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
+    <%= form_page_subnav(@form, current: :edit, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
@@ -11,7 +12,7 @@
     <%= link_to "Edit sections", edit_sections_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= form_editor_view_links(@form, @dashboard_event) %>
+    <%= form_live_view_link(@dashboard_event) %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="px-4 py-8">
+<div class="px-4 py-6">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -12,6 +12,12 @@
     <%= form_live_view_link(@dashboard_event) %>
   </div>
 
+  <% if allowed_to?(:copy?, @form) %>
+    <div class="mb-4 flex justify-end">
+      <%= form_duplicate_button(@form) %>
+    </div>
+  <% end %>
+
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
   <div class="overflow-hidden rounded-2xl bg-purple-900 shadow-lg ring-1 ring-black/5">
     <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-6 text-white sm:px-8">

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,14 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <%= form_page_subnav(@form, current: :none, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= link_to "Edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
                 class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= form_editor_view_links(@form, @dashboard_event) %>
+    <%= form_live_view_link(@dashboard_event) %>
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
-    <%= form_page_subnav(@form, current: :none, event: @dashboard_event) %>
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
+                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= form_page_subnav(@form, current: :edit_sections, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Dashboard", dashboard_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= link_to "Smart field settings", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),
-                class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_live_view_link(@dashboard_event) %>
   </div>
 

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="py-8 px-4">
+<div class="py-6 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),

--- a/app/views/forms/forms_results.html.erb
+++ b/app/views/forms/forms_results.html.erb
@@ -72,8 +72,8 @@
                   <%= link_to "View", form_path(form), class: item_class, data: { turbo_frame: "_top" } %>
                   <%= link_to "Edit", edit_form_path(form), class: item_class, data: { turbo_frame: "_top" } %>
                   <% if allowed_to?(:copy?, form) %>
-                    <%= link_to "Copy", copy_form_path(form), class: item_class,
-                                data: { turbo_frame: "_top", turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
+                    <%= link_to "Duplicate form", copy_form_path(form), class: item_class,
+                                data: { turbo_frame: "_top", turbo_method: :post, turbo_confirm: "Make a full duplicate of \"#{form.display_name}\"?" } %>
                   <% end %>
                 </div>
               </div>

--- a/app/views/forms/forms_results.html.erb
+++ b/app/views/forms/forms_results.html.erb
@@ -15,8 +15,10 @@
       <tbody class="divide-y divide-gray-200">
         <% @forms.each do |form| %>
           <tr id="form_<%= form.id %>" class="scroll-mt-24 hover:bg-gray-50">
-            <td class="px-4 py-2 text-sm font-medium text-gray-900">
-              <%= form.display_name %>
+            <td class="px-4 py-2 text-sm">
+              <%= link_to form.display_name, edit_form_path(form),
+                          class: "font-medium text-gray-900 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline",
+                          data: { turbo_frame: "_top" } %>
             </td>
             <td class="px-4 py-2 text-sm text-gray-600"><%= form_role_label(form) %></td>
             <%# A public link and an event form are mutually exclusive — an
@@ -34,7 +36,7 @@
                   <span class="inline-flex items-center gap-1.5 rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
                     <i class="fa-solid fa-calendar-day"></i>Event form
                   </span>
-                  <%= link_to pluralize(form.events.size, "event"), events_path(form_id: form.id), class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
+                  <%= link_to pluralize(form.events.size, "event"), events_path(form_id: form.id), data: { turbo_frame: "_top" }, class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
                 <% end %>
                 <% unless form.publicly_fillable? || form.events.size.positive? %>
                   <span class="inline-flex items-center rounded-md border border-gray-200 px-2 py-0.5 text-xs text-gray-500">Not published</span>
@@ -46,6 +48,7 @@
               <% submissions_count = form.form_submissions.size %>
               <% if submissions_count.positive? %>
                 <%= link_to submissions_count, form_submissions_path(form_id: form.id, return_to: "forms"),
+                            data: { turbo_frame: "_top" },
                             class: "inline-flex items-center rounded-md #{DomainTheme.bg_class_for(:forms)} px-2 py-0.5 #{DomainTheme.text_class_for(:forms, intensity: 700)} font-medium #{DomainTheme.bg_class_for(:forms, hover: true)}" %>
               <% else %>
                 0
@@ -65,12 +68,12 @@
                 <div id="<%= dropdown_id %>"
                      data-dropdown-target="content"
                      class="absolute right-0 z-10 mt-1 hidden min-w-[160px] rounded-md border border-gray-200 bg-white py-1 shadow-lg">
-                  <%= link_to "Results", results_form_path(form), class: item_class %>
-                  <%= link_to "View", form_path(form), class: item_class %>
-                  <%= link_to "Edit", edit_form_path(form), class: item_class %>
+                  <%= link_to "Results", results_form_path(form), class: item_class, data: { turbo_frame: "_top" } %>
+                  <%= link_to "View", form_path(form), class: item_class, data: { turbo_frame: "_top" } %>
+                  <%= link_to "Edit", edit_form_path(form), class: item_class, data: { turbo_frame: "_top" } %>
                   <% if allowed_to?(:copy?, form) %>
                     <%= link_to "Copy", copy_form_path(form), class: item_class,
-                                data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
+                                data: { turbo_frame: "_top", turbo_method: :post, turbo_confirm: "Make a full copy of \"#{form.display_name}\"?" } %>
                   <% end %>
                 </div>
               </div>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -22,7 +22,7 @@
       </div>
     </div>
     <%= link_to form_submissions_path(form_id: @form.id, return_to: "form_results"),
-                class: "whitespace-nowrap btn btn-secondary-outline" do %>
+                class: "inline-flex items-center whitespace-nowrap text-sm font-medium #{DomainTheme.text_class_for(:forms, intensity: 700)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} hover:underline" do %>
       <i class="fa-solid fa-table-list mr-1.5"></i>View submissions
     <% end %>
   </div>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -12,20 +12,14 @@
     <%= form_page_subnav(@form, current: :results) %>
   </div>
 
-  <div class="mb-6 flex flex-wrap items-start justify-between gap-4">
-    <div class="flex items-start gap-4">
-      <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
-        <i class="fa-solid fa-chart-pie text-xl" aria-hidden="true"></i>
-      </span>
-      <div>
-        <h1 class="text-primary font-display text-2xl font-semibold"><%= @form.display_name %> — results</h1>
-        <p class="mt-1 text-gray-600">Every submission to this form, rolled up question by question.</p>
-      </div>
+  <div class="mb-6 flex items-start gap-4">
+    <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
+      <i class="fa-solid fa-chart-pie text-xl" aria-hidden="true"></i>
+    </span>
+    <div>
+      <h1 class="text-primary font-display text-2xl font-semibold"><%= @form.display_name %> — results</h1>
+      <p class="mt-1 text-gray-600">Every submission to this form, rolled up question by question.</p>
     </div>
-    <%= link_to form_submissions_path(form_id: @form.id, return_to: "form_results"),
-                class: "inline-flex items-center whitespace-nowrap text-sm font-medium #{DomainTheme.text_class_for(:forms, intensity: 700)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} hover:underline" do %>
-      <i class="fa-solid fa-table-list mr-1.5"></i>View submissions
-    <% end %>
   </div>
 
   <% unless @aggregator.any_submissions? %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -5,10 +5,11 @@
 <% palette = %w[#3b82f6 #ef4444 #f59e0b #10b981 #6366f1 #ec4899 #14b8a6 #f97316 #8b5cf6 #84cc16 #06b6d4 #eab308 #a855f7 #22c55e #fb7185] %>
 
 <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-  <div class="mb-4">
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
     <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> Forms
     <% end %>
+    <%= form_page_subnav(@form, current: :results) %>
   </div>
 
   <div class="mb-6 flex flex-wrap items-start justify-between gap-4">

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -23,7 +23,7 @@
     </div>
     <%= link_to form_submissions_path(form_id: @form.id, return_to: "form_results"),
                 class: "whitespace-nowrap btn btn-secondary-outline" do %>
-      <i class="fa-solid fa-table-list mr-1.5"></i>View responses
+      <i class="fa-solid fa-table-list mr-1.5"></i>View submissions
     <% end %>
   </div>
 

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_page_subnav(@form, current: :view, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
-    <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>
       <%= link_to "Delete", form_path(@form), class: "text-sm text-red-600 hover:text-red-800 px-2 py-1",
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto py-6 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -13,6 +13,12 @@
     <% end %>
   </div>
 
+  <% if allowed_to?(:copy?, @form) %>
+    <div class="mb-4 flex justify-end">
+      <%= form_duplicate_button(@form) %>
+    </div>
+  <% end %>
+
   <div class="bg-white rounded-2xl shadow-lg overflow-hidden border border-primary/10">
     <%# Admin chrome wrapping the form preview below. The amber "Preview" badge
         signals this is not the live page (echoing the amber token note inside). %>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,16 +1,12 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="max-w-2xl mx-auto py-8 px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+    <%= form_page_subnav(@form, current: :view, event: @dashboard_event) %>
     <% if @dashboard_event %>
       <%= link_to "Edit event", edit_event_path(@dashboard_event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <% end %>
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <%= link_to "Edit", edit_form_path(@form), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <% if allowed_to?(:copy?, @form) %>
-      <%= link_to "Copy", copy_form_path(@form), class: "text-sm #{eyebrow_link_class} px-2 py-1",
-                  data: { turbo_method: :post, turbo_confirm: "Make a full copy of \"#{@form.display_name}\"?" } %>
-    <% end %>
     <% if allowed_to?(:destroy?, @form) && @form.event_forms.none? %>
       <%= link_to "Delete", form_path(@form), class: "text-sm text-red-600 hover:text-red-800 px-2 py-1",
                   data: { turbo_method: :delete, turbo_confirm: "Delete \"#{@form.display_name}\"?" } %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -35,10 +35,10 @@
   pr_number: 2410
   summary: >-
     On the forms list, a form's name now opens its editor and the "⋮" menu actions work again
-    (they were breaking the page). A form's Results, View, Edit, and Copy pages now share a subnav,
-    so you can move between them like tabs.
+    (they were breaking the page). A form's Results, Submissions, View, Edit, and Edit sections
+    pages now share a subnav, so you can move between them like tabs.
   pro_tips:
-    - "Copy makes a full duplicate of the form and drops you into editing the copy."
+    - "Duplicate form makes a full copy of the form and drops you into editing the duplicate."
 
 - name: "Person profile in the new AWBW brand"
   area: people
@@ -2183,9 +2183,9 @@
   action_path: "/forms"
   pr_number: 2258
   summary: >-
-    Duplicate any form with one click. The copy ("COPY of ...") carries over
-    every field and answer option so you can tweak a near-identical form instead
-    of rebuilding it from scratch.
+    Duplicate any form with one click (the "Duplicate form" action). The copy
+    ("Duplicate of ...") carries over every field and answer option so you can
+    tweak a near-identical form instead of rebuilding it from scratch.
   pro_tips:
     - The copy starts unpublished with no public link — set those on the new form
       when you're ready.

--- a/config/features.yml
+++ b/config/features.yml
@@ -2184,7 +2184,7 @@
   pr_number: 2258
   summary: >-
     Duplicate any form with one click (the "Duplicate form" action). The copy
-    ("Duplicate of ...") carries over every field and answer option so you can
+    ("DUPLICATE of ...") carries over every field and answer option so you can
     tweak a near-identical form instead of rebuilding it from scratch.
   pro_tips:
     - The copy starts unpublished with no public link — set those on the new form

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,19 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Navigate a form's pages, and fix the forms list actions"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-29
+  action_path: /forms
+  pr_number: 2410
+  summary: >-
+    On the forms list, a form's name now opens its editor and the "⋮" menu actions work again
+    (they were breaking the page). A form's Results, View, Edit, and Copy pages now share a subnav,
+    so you can move between them like tabs.
+  pro_tips:
+    - "Copy makes a full duplicate of the form and drops you into editing the copy."
+
 - name: "Person profile in the new AWBW brand"
   area: people
   display_status: user_facing

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -138,6 +138,24 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).to include(CGI.escapeHTML(forms_path(anchor: "form_#{form.id}")))
       end
 
+      it "shows the form page subnav with Submissions active when filtered to a single form" do
+        form = create(:form, name: "Volunteer interest")
+        get form_submissions_path(form_id: form.id)
+
+        nav = Nokogiri::HTML(response.body).at_css("nav[aria-label='Form pages']")
+        expect(nav).to be_present
+        expect(nav.css("a").map { |a| a["href"] }).to include(results_form_path(form), edit_form_path(form))
+        expect(nav.at_css("[aria-current='page']")&.text&.strip).to eq("Submissions")
+      end
+
+      it "omits the form page subnav when several forms are selected" do
+        one = create(:form, name: "One")
+        two = create(:form, name: "Two")
+        get form_submissions_path(form_id: [ one.id, two.id ])
+
+        expect(response.body).not_to include("aria-label=\"Form pages\"")
+      end
+
       it "keeps the forms origin on the filter form so changing the filter doesn't lose it" do
         form = create(:form, name: "Volunteer interest")
         get form_submissions_path(form_id: form.id, return_to: "forms")

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -770,14 +770,14 @@ RSpec.describe "Forms", type: :request do
     context "as admin" do
       before { sign_in admin }
 
-      it "creates a full copy named \"Duplicate of [name]\" and redirects to its editor" do
+      it "creates a full copy named \"DUPLICATE of [name]\" and redirects to its editor" do
         form = create(:form, :standalone, name: "Volunteer")
         create(:form_field, form: form, name: "First name")
 
         expect { post copy_form_path(form) }.to change(Form, :count).by(1)
 
-        copy = Form.find_by(name: "Duplicate of Volunteer")
-        expect(copy.name).to eq("Duplicate of Volunteer")
+        copy = Form.find_by(name: "DUPLICATE of Volunteer")
+        expect(copy.name).to eq("DUPLICATE of Volunteer")
         expect(copy.form_fields.map(&:name)).to eq([ "First name" ])
         expect(response).to redirect_to(edit_form_path(copy))
       end

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -250,18 +250,17 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).not_to include("Dashboard")
     end
 
-    it "offers only the standalone Preview link when no event is known" do
+    it "offers the preview (View) subnav tab but no live-form link when no event is known" do
       get edit_form_path(form)
-      expect(response.body).to include(">Preview<")
-      expect(response.body).not_to include(">View<")
+      expect(response.body).to include(">View<")
+      expect(response.body).not_to include(">Live form<")
     end
 
-    it "adds a View link to the live registration form when the event is known" do
+    it "adds a Live form link to the registration page when the event is known" do
       create(:event_form, form: form, event: event)
       get edit_form_path(form, event_id: event.id)
-      expect(response.body).to include(">View<")
+      expect(response.body).to include(">Live form<")
       expect(response.body).to include(new_event_public_registration_path(event))
-      expect(response.body).to include(">Preview<")
     end
   end
 
@@ -846,6 +845,19 @@ RSpec.describe "Forms", type: :request do
         form = create(:form, :standalone, name: "Untouched")
         get results_form_path(form)
         expect(response.body).to include("No submissions to this form yet")
+      end
+
+      it "shows the shared page subnav linking to the form's sibling pages" do
+        form = create(:form, :standalone, name: "Survey")
+        get results_form_path(form)
+        doc = Nokogiri::HTML(response.body)
+        nav = doc.at_css("nav[aria-label='Form pages']")
+        expect(nav).to be_present
+        expect(nav.css("a").map { |a| a["href"] }).to include(
+          form_path(form), edit_form_path(form), copy_form_path(form)
+        )
+        active = nav.at_css("[aria-current='page']")
+        expect(active&.text&.strip).to eq("Results")
       end
     end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -76,6 +76,24 @@ RSpec.describe "Forms", type: :request do
         get forms_path, headers: frame_headers
         expect(response.body).not_to include(">Delete<")
       end
+
+      it "links the form name to its editor, breaking out of the lazy frame" do
+        form = create(:form, :standalone, name: "My Form")
+        get forms_path, headers: frame_headers
+        link = Nokogiri::HTML(response.body).css("a").find { |a| a.text.strip == "My Form" }
+        expect(link&.[]("href")).to eq(edit_form_path(form))
+        expect(link["data-turbo-frame"]).to eq("_top")
+      end
+
+      it "targets the top frame from the row action links so they navigate the whole page" do
+        create(:form, :standalone, name: "My Form")
+        get forms_path, headers: frame_headers
+        doc = Nokogiri::HTML(response.body)
+        %w[Results View Edit].each do |label|
+          link = doc.css("a").find { |a| a.text.strip == label }
+          expect(link&.[]("data-turbo-frame")).to eq("_top"), "expected #{label} link to target _top"
+        end
+      end
     end
 
     context "as regular user" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -274,6 +274,15 @@ RSpec.describe "Forms", type: :request do
       expect(response.body).to include("First Name")
     end
 
+    it "shows the Duplicate form button posting to the copy action" do
+      form = create(:form, :standalone, name: "Test")
+      get edit_form_path(form)
+      doc = Nokogiri::HTML(response.body)
+      button = doc.css("a").find { |a| a.text.strip == "Duplicate form" }
+      expect(button&.[]("href")).to eq(copy_form_path(form))
+      expect(button["data-turbo-method"]).to eq("post")
+    end
+
     it "renders the collapsible per-field options controls" do
       form = FormBuilderService.new(name: "Test", sections: %i[person_identifier]).call
       get edit_form_path(form)
@@ -761,14 +770,14 @@ RSpec.describe "Forms", type: :request do
     context "as admin" do
       before { sign_in admin }
 
-      it "creates a full copy named \"COPY of [name]\" and redirects to its editor" do
+      it "creates a full copy named \"Duplicate of [name]\" and redirects to its editor" do
         form = create(:form, :standalone, name: "Volunteer")
         create(:form_field, form: form, name: "First name")
 
         expect { post copy_form_path(form) }.to change(Form, :count).by(1)
 
-        copy = Form.find_by(name: "COPY of Volunteer")
-        expect(copy.name).to eq("COPY of Volunteer")
+        copy = Form.find_by(name: "Duplicate of Volunteer")
+        expect(copy.name).to eq("Duplicate of Volunteer")
         expect(copy.form_fields.map(&:name)).to eq([ "First name" ])
         expect(response).to redirect_to(edit_form_path(copy))
       end
@@ -855,11 +864,18 @@ RSpec.describe "Forms", type: :request do
         expect(nav).to be_present
         hrefs = nav.css("a").map { |a| a["href"] }
         expect(hrefs).to include(
-          form_path(form), edit_form_path(form), edit_sections_form_path(form), copy_form_path(form)
+          form_path(form), edit_form_path(form), edit_sections_form_path(form)
         )
         expect(hrefs.any? { |h| h.start_with?(form_submissions_path) }).to be(true)
+        expect(hrefs).not_to include(copy_form_path(form))
         active = nav.at_css("[aria-current='page']")
         expect(active&.text&.strip).to eq("Results")
+      end
+
+      it "does not show the Duplicate form button on the results page" do
+        form = create(:form, :standalone, name: "Survey")
+        get results_form_path(form)
+        expect(response.body).not_to include("Duplicate form")
       end
     end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -853,9 +853,11 @@ RSpec.describe "Forms", type: :request do
         doc = Nokogiri::HTML(response.body)
         nav = doc.at_css("nav[aria-label='Form pages']")
         expect(nav).to be_present
-        expect(nav.css("a").map { |a| a["href"] }).to include(
-          form_path(form), edit_form_path(form), copy_form_path(form)
+        hrefs = nav.css("a").map { |a| a["href"] }
+        expect(hrefs).to include(
+          form_path(form), edit_form_path(form), edit_sections_form_path(form), copy_form_path(form)
         )
+        expect(hrefs.any? { |h| h.start_with?(form_submissions_path) }).to be(true)
         active = nav.at_css("[aria-current='page']")
         expect(active&.text&.strip).to eq("Results")
       end

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe FormCopyService do
   describe "#call" do
-    it "names the copy \"COPY of [name]\"" do
+    it "names the copy \"Duplicate of [name]\"" do
       form = create(:form, name: "Volunteer Intake")
 
       copy = described_class.new(form).call
 
-      expect(copy.name).to eq("COPY of Volunteer Intake")
+      expect(copy.name).to eq("Duplicate of Volunteer Intake")
     end
 
     it "returns a persisted, distinct record" do

--- a/spec/services/form_copy_service_spec.rb
+++ b/spec/services/form_copy_service_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe FormCopyService do
   describe "#call" do
-    it "names the copy \"Duplicate of [name]\"" do
+    it "names the copy \"DUPLICATE of [name]\"" do
       form = create(:form, name: "Volunteer Intake")
 
       copy = described_class.new(form).call
 
-      expect(copy.name).to eq("Duplicate of Volunteer Intake")
+      expect(copy.name).to eq("DUPLICATE of Volunteer Intake")
     end
 
     it "returns a persisted, distinct record" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view changes + one small shared helper across the forms pages

Makes the forms area navigable and fixes the "Oopsie!" error facilitators hit on `/forms`.

## Forms index (`/forms`)
- Clicking a form **name** now opens its editor (was plain text).
- Kebab actions and the event/submission chips now work — they set `data-turbo-frame="_top"` so they navigate the full page instead of loading into the lazy `forms_results` frame (which lacked the frame → `turbo:frame-missing` → the error overlay). Matches `people_results`.

## Shared page subnav
- A form's Results, View, and editor pages had inconsistent ad-hoc link clusters and none linked to Results.
- Added one segmented subnav — **Results · Submissions · View · Edit · Edit sections · Copy** — that marks the current page and renders on all of them, so they read like tabs.
- Contextual links (Forms/Events, Forms/Smart fields) sit to the **left** of the subnav; "Smart field settings" shortened to **Smart fields**.
- Editor "Preview" folded into the subnav's **View**; the live-registration link renamed **Live form**.
- Dropped the redundant standalone "View responses/submissions" button on the results page — it's a subnav tab now.

## Features & tips
- Seeded a `config/features.yml` entry (admin-facing) describing the fix + subnav.

## Tests
- Name links to editor + breaks out of the frame; kebab links target `_top`.
- Subnav renders with sibling-page links (incl. submissions) and marks the active page.
- Updated editor-link specs for the new View / Live form wording.
