### PR TITLE
Retire the purple form slab, and fix two contrast bugs I shipped

### DIFF
--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -47,7 +47,6 @@
         </div>
       </div>
 
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
 
     <!-- Ticket Body -->

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -33,17 +33,17 @@
 
 <div class="mx-auto max-w-2xl px-4 pt-6 pb-12">
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-5 text-white sm:px-8">
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %>
         </div>
         <div class="flex-1">
-          <h1 class="text-primary font-display text-xl leading-tight font-semibold tracking-wide">Form submission</h1>
-          <p class="text-sm text-blue-200"><%= @form_submission.form.name %></p>
+          <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight">Form submission</h1>
+          <p class="text-sm text-white/70"><%= @form_submission.form.name %></p>
         </div>
       </div>
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
     </div>
     <div class="px-6 py-7 sm:px-8">
       <%= render "form_submissions/changes_link", submission: @form_submission, badge: true %>

--- a/app/views/forms/_form_field_fields.html.erb
+++ b/app/views/forms/_form_field_fields.html.erb
@@ -76,7 +76,7 @@
               class: "flex-[2_1_9rem] rounded border-gray-300 shadow-sm px-2 py-1 text-sm",
               data: { answer_options_target: "type", action: "answer-options#typeChanged" } %>
         <label class="flex items-center gap-1 text-sm text-gray-600 shrink-0" data-answer-options-target="requiredLabel">
-          <%= f.check_box :required, class: "rounded border-gray-300 text-purple-600",
+          <%= f.check_box :required, class: "rounded border-gray-300 #{DomainTheme.text_class_for(:forms, intensity: 600)}",
                 data: { answer_options_target: "required" } %>
           Required
         </label>

--- a/app/views/forms/_page_header.html.erb
+++ b/app/views/forms/_page_header.html.erb
@@ -1,0 +1,22 @@
+<%# Shared header for the form builder pages. Replaces the purple gradient slab
+    with the light identity band used across the rest of the portal: brand rule,
+    a domain tint, a circular icon badge, a domain-coloured eyebrow, and the
+    title in the display serif. Optional `meta` holds the right-hand stat chips.
+    locals: icon, eyebrow, title; optional meta. %>
+<%= render "shared/brand_accent_strip", rounded: true %>
+<div class="<%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-6 sm:px-8">
+  <div class="flex flex-wrap items-center justify-between gap-4">
+    <div class="flex items-center gap-4">
+      <span class="<%= DomainTheme.bg_class_for(:forms, intensity: 200) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> flex h-12 w-12 shrink-0 items-center justify-center rounded-full">
+        <i class="<%= icon %> text-xl" aria-hidden="true"></i>
+      </span>
+      <div class="min-w-0">
+        <p class="text-2xs <%= DomainTheme.text_class_for(:forms, intensity: 700) %> font-semibold tracking-widest uppercase"><%= eyebrow %></p>
+        <h1 class="text-primary font-display text-2xl leading-tight tracking-tight"><%= title %></h1>
+      </div>
+    </div>
+    <% if local_assigns[:meta].present? %>
+      <div class="flex flex-wrap items-center gap-2"><%= meta %></div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/forms/_public_header.html.erb
+++ b/app/views/forms/_public_header.html.erb
@@ -1,0 +1,11 @@
+<%# The header on a public form, and on its admin preview, so the two cannot
+    drift — a preview is only useful if it is a true likeness. Navy gradient
+    band under the brand rule, carrying the form's name.
+    locals: form; optional badge (e.g. the preview marker). %>
+<%= render "shared/brand_accent_strip" %>
+<div class="from-brand-navy-900 to-brand-navy-600 bg-gradient-to-r px-6 py-5 text-white sm:px-8">
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= form.display_name %></h1>
+    <%= local_assigns[:badge] %>
+  </div>
+</div>

--- a/app/views/forms/_question_library.html.erb
+++ b/app/views/forms/_question_library.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "question_library" do %>
-  <div class="border border-gray-200 rounded-lg p-4 bg-gray-50">
-    <h3 class="text-lg font-semibold text-gray-800 mb-2">Add questions from library</h3>
-    <p class="text-sm text-gray-500 mb-4">Select questions from other forms to add to this form.</p>
+  <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+    <h3 class="mb-2 text-lg font-semibold text-gray-800">Add questions from library</h3>
+    <p class="mb-4 text-sm text-gray-500">Select questions from other forms to add to this form.</p>
 
     <% if @available_fields.present? %>
       <%= form_with url: add_questions_form_path(@form), method: :post do |f| %>
@@ -13,20 +13,20 @@
                  data-action="input->question-library#filter"
                  class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm">
 
-          <div class="max-h-96 overflow-y-auto space-y-4" data-question-library-target="list">
+          <div class="max-h-96 space-y-4 overflow-y-auto" data-question-library-target="list">
             <% @available_fields.each do |group, fields| %>
               <div data-question-library-target="group">
-                <h4 class="text-sm font-semibold text-gray-700 mb-2 capitalize sticky top-0 bg-gray-50 py-1"><%= group.presence || "Ungrouped" %></h4>
+                <h4 class="sticky top-0 mb-2 bg-gray-50 py-1 text-sm font-semibold text-gray-700 capitalize"><%= group.presence || "Ungrouped" %></h4>
                 <div class="space-y-1">
                   <% fields.uniq(&:field_key).each do |field| %>
-                    <label class="flex items-center gap-3 p-2 bg-white rounded border border-gray-100 hover:bg-gray-50 cursor-pointer"
+                    <label class="flex cursor-pointer items-center gap-3 rounded border border-gray-100 bg-white p-2 hover:bg-gray-50"
                            data-question-library-target="item"
                            data-question-text="<%= field.question.downcase %>">
                       <input type="checkbox" name="source_field_ids[]" value="<%= field.id %>"
-                             class="h-4 w-4 text-purple-600 rounded border-gray-300">
+                             class="h-4 w-4 <%= DomainTheme.text_class_for(:forms, intensity: 600) %> rounded border-gray-300">
                       <div class="flex-1">
                         <span class="text-sm text-gray-800"><%= field.question %></span>
-                        <span class="text-xs text-gray-400 ml-2 font-mono"><%= field.field_key %></span>
+                        <span class="ml-2 font-mono text-xs text-gray-400"><%= field.field_key %></span>
                       </div>
                       <span class="text-xs text-gray-500"><%= field.answer_type_label %></span>
                     </label>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -19,41 +19,27 @@
   <% end %>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="overflow-hidden rounded-2xl bg-purple-900 shadow-lg ring-1 ring-black/5">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-6 text-white sm:px-8">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <div class="flex items-center gap-4">
-          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
-            <i class="fa-solid fa-list-check text-xl"></i>
-          </div>
-          <div>
-            <p class="text-xs font-medium tracking-[0.2em] text-purple-200 uppercase">Edit</p>
-            <h1 class="text-primary font-display text-2xl leading-tight font-bold tracking-tight"><%= @form.display_name %></h1>
-          </div>
-        </div>
-
-        <%# Quick stats pulled up into the header so the page reads at a glance %>
-        <div class="flex flex-wrap items-center gap-2">
-          <% events_count = @form.events.size %>
-          <% if events_count.positive? %>
-            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
-              <i class="fa-solid fa-calendar-day text-purple-600"></i>
-              <%= pluralize(events_count, "event") %> connected
-            <% end %>
-          <% else %>
-            <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600 shadow-sm">
-              <i class="fa-solid fa-calendar-day text-gray-400"></i>
-              No events connected
-            </span>
-          <% end %>
-          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
-            <i class="fa-solid fa-inbox text-purple-600"></i>
-            <%= pluralize(@form.form_submissions.size, "submission") %>
-          </span>
-        </div>
-      </div>
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
-    </div>
+  <% meta = capture do %>
+    <% events_count = @form.events.size %>
+    <% if events_count.positive? %>
+      <%= link_to events_path(form_id: @form.id), class: "#{DomainTheme.text_class_for(:forms, intensity: 700)} inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm font-medium shadow-sm hover:bg-white/70" do %>
+        <i class="fa-solid fa-calendar-day <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"></i>
+        <%= pluralize(events_count, "event") %> connected
+      <% end %>
+    <% else %>
+      <span class="inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm text-gray-600 shadow-sm">
+        <i class="fa-solid fa-calendar-day text-gray-400"></i>
+        No events connected
+      </span>
+    <% end %>
+    <span class="<%= DomainTheme.text_class_for(:forms, intensity: 700) %> inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm font-medium shadow-sm">
+      <i class="fa-solid fa-inbox <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"></i>
+      <%= pluralize(@form.form_submissions.size, "submission") %>
+    </span>
+  <% end %>
+  <div class="<%= DomainTheme.bg_class_for(:forms, intensity: 50) %> border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
+    <%= render "forms/page_header", icon: "fa-solid fa-list-check",
+                                    eyebrow: "Edit", title: @form.display_name, meta: meta %>
 
     <div class="px-4 py-6 sm:px-6">
   <%= form_with model: @form, url: form_path(@form, event_id: @dashboard_event&.id), class: "space-y-6" do |f| %>
@@ -72,10 +58,10 @@
 
     <details class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
       <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
-        <div class="flex items-center gap-2.5 border-b border-transparent bg-purple-100 px-6 py-3 hover:bg-purple-200 [[open]_&]:border-purple-300">
-          <i class="fa-solid fa-gear text-purple-700"></i>
-          <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Form settings</h2>
-          <i class="fa-solid fa-chevron-down ml-auto text-xs text-purple-500 transition-transform [[open]_&]:rotate-180"></i>
+        <div class="flex items-center gap-2.5 border-b border-transparent <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 100, hover: true) %> [[open]_&]:<%= DomainTheme.border_class_for(:forms) %>">
+          <i class="fa-solid fa-gear <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+          <h2 class="text-sm font-semibold tracking-wide <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase">Form settings</h2>
+          <i class="fa-solid fa-chevron-down ml-auto text-xs <%= DomainTheme.text_class_for(:forms, intensity: 500) %> transition-transform [[open]_&]:rotate-180"></i>
         </div>
         <p class="px-6 py-3 text-sm text-gray-400 [[open]_&]:hidden">Toggle to edit</p>
       </summary>
@@ -98,11 +84,11 @@
 
         <div class="flex flex-wrap gap-x-6 gap-y-2">
           <label class="flex cursor-pointer items-center gap-2">
-            <%= f.check_box :hide_answered_person_questions, class: "rounded border-gray-300 text-purple-600" %>
+            <%= f.check_box :hide_answered_person_questions, class: "rounded border-gray-300 #{DomainTheme.text_class_for(:forms, intensity: 600)}" %>
             <span class="text-sm text-gray-800">Hide any answered person & organization questions</span>
           </label>
           <label class="flex cursor-pointer items-center gap-2">
-            <%= f.check_box :hide_answered_form_questions, class: "rounded border-gray-300 text-purple-600" %>
+            <%= f.check_box :hide_answered_form_questions, class: "rounded border-gray-300 #{DomainTheme.text_class_for(:forms, intensity: 600)}" %>
             <span class="text-sm text-gray-800">Hide any questions the user already answered</span>
           </label>
         </div>
@@ -114,25 +100,25 @@
           an event-connected form stays tied to its event. %>
       <% if @form.event_connected? %>
         <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
-          <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
-            <i class="fa-solid fa-link text-purple-700"></i>
-            <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Share with a public link</h2>
+          <div class="flex items-center gap-2.5 border-b <%= DomainTheme.border_class_for(:forms) %> <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-3">
+            <i class="fa-solid fa-link <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+            <h2 class="text-sm font-semibold tracking-wide <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase">Share with a public link</h2>
           </div>
           <p class="p-6 text-sm text-gray-600">This form is connected to an event, so it can't be published at a public link — event-connected forms are filled out through their event.</p>
         </div>
       <% else %>
       <details class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <summary class="cursor-pointer list-none select-none [&::-webkit-details-marker]:hidden">
-          <div class="flex items-center gap-2.5 border-b border-transparent bg-purple-100 px-6 py-3 hover:bg-purple-200 [[open]_&]:border-purple-300">
-            <i class="fa-solid fa-link text-purple-700"></i>
-            <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Share with a public link</h2>
-            <i class="fa-solid fa-chevron-down ml-auto text-xs text-purple-500 transition-transform [[open]_&]:rotate-180"></i>
+          <div class="flex items-center gap-2.5 border-b border-transparent <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 100, hover: true) %> [[open]_&]:<%= DomainTheme.border_class_for(:forms) %>">
+            <i class="fa-solid fa-link <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+            <h2 class="text-sm font-semibold tracking-wide <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase">Share with a public link</h2>
+            <i class="fa-solid fa-chevron-down ml-auto text-xs <%= DomainTheme.text_class_for(:forms, intensity: 500) %> transition-transform [[open]_&]:rotate-180"></i>
           </div>
           <p class="px-6 py-3 text-sm text-gray-400 [[open]_&]:hidden">Toggle to edit</p>
         </summary>
         <div class="space-y-4 p-6">
           <label class="flex cursor-pointer items-center gap-2">
-            <%= f.check_box :published, class: "rounded border-gray-300 text-purple-600" %>
+            <%= f.check_box :published, class: "rounded border-gray-300 #{DomainTheme.text_class_for(:forms, intensity: 600)}" %>
             <span class="text-sm text-gray-800">Publish this form at a public link (anyone can fill it out, no account needed)</span>
           </label>
           <p class="text-xs text-gray-500">Publishes the form at the public link below. A form connected to an event can't be published — event forms are filled out through their event.</p>
@@ -165,10 +151,10 @@
         Collapsed by default so the header setup stays out of the way once configured. %>
     <details class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
       <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden">
-        <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-transparent [[open]_&]:border-purple-300 hover:bg-purple-200">
-          <i class="fa-solid fa-heading text-purple-700"></i>
-          <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Form header</h2>
-          <i class="fa-solid fa-chevron-down text-purple-500 text-xs ml-auto transition-transform [[open]_&]:rotate-180"></i>
+        <div class="flex items-center gap-2.5 px-6 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> border-b border-transparent [[open]_&]:<%= DomainTheme.border_class_for(:forms) %> <%= DomainTheme.bg_class_for(:forms, intensity: 100, hover: true) %>">
+          <i class="fa-solid fa-heading <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+          <h2 class="text-sm font-semibold <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase tracking-wide">Form header</h2>
+          <i class="fa-solid fa-chevron-down <%= DomainTheme.text_class_for(:forms, intensity: 500) %> text-xs ml-auto transition-transform [[open]_&]:rotate-180"></i>
         </div>
         <p class="px-6 py-3 text-sm text-gray-400 [[open]_&]:hidden">Toggle to edit</p>
       </summary>
@@ -188,7 +174,7 @@
           <dl class="space-y-3">
             <% ApplicationHelper::FORM_HEADER_TOKENS.each do |token, (label, example)| %>
               <div>
-                <dt><code class="rounded bg-purple-100 text-purple-900 px-1.5 py-0.5 font-mono"><%= token %></code></dt>
+                <dt><code class="rounded <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> <%= DomainTheme.text_class_for(:forms, intensity: 900) %> px-1.5 py-0.5 font-mono"><%= token %></code></dt>
                 <dd class="mt-1 text-gray-600"><%= label %> — e.g. <span class="text-gray-800"><%= example %></span></dd>
               </div>
             <% end %>
@@ -200,13 +186,13 @@
     <details open class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden"
          data-controller="expand-all"
          data-expand-all-field-options-outlet="[data-controller~='field-options']">
-      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-6 py-3 bg-purple-50 border-b border-purple-200 hover:bg-purple-100 flex items-center justify-between">
-        <h2 class="flex items-center gap-2.5 text-sm font-semibold text-purple-900 uppercase tracking-wide">
-          <i class="fa-solid fa-list-ul text-purple-500"></i>Questions
+      <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-6 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 50) %> border-b <%= DomainTheme.border_class_for(:forms, intensity: 200) %> hover:<%= DomainTheme.bg_class_for(:forms, intensity: 100) %> flex items-center justify-between">
+        <h2 class="flex items-center gap-2.5 text-sm font-semibold <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase tracking-wide">
+          <i class="fa-solid fa-list-ul <%= DomainTheme.text_class_for(:forms, intensity: 500) %>"></i>Questions
         </h2>
         <div class="flex items-center gap-3">
           <span class="text-sm text-gray-500"><%= pluralize(@form_fields.size, "question") %></span>
-          <i class="fa-solid fa-chevron-down text-purple-500 text-xs transition-transform [[open]_&]:rotate-180"></i>
+          <i class="fa-solid fa-chevron-down <%= DomainTheme.text_class_for(:forms, intensity: 500) %> text-xs transition-transform [[open]_&]:rotate-180"></i>
         </div>
       </summary>
 

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -12,48 +12,33 @@
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <div class="flex items-center gap-4">
-          <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
-            <i class="fa-solid fa-layer-group text-xl"></i>
-          </div>
-          <div>
-            <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Edit sections</p>
-            <h1 class="font-display text-2xl font-bold tracking-tight leading-tight text-primary"><%= @form.display_name %></h1>
-          </div>
-        </div>
-
-        <%# Quick stats pulled up into the header so the page reads at a glance %>
-        <div class="flex flex-wrap items-center gap-2">
-          <% events_count = @form.events.size %>
-          <% if events_count.positive? %>
-            <%= link_to events_path(form_id: @form.id), class: "inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm hover:bg-purple-50" do %>
-              <i class="fa-solid fa-calendar-day text-purple-600"></i>
-              <%= pluralize(events_count, "event") %> connected
-            <% end %>
-          <% else %>
-            <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600 shadow-sm">
-              <i class="fa-solid fa-calendar-day text-gray-400"></i>
-              No events connected
-            </span>
-          <% end %>
-          <span class="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-sm font-medium text-purple-900 shadow-sm">
-            <i class="fa-solid fa-inbox text-purple-600"></i>
-            <%= pluralize(@form.form_submissions.size, "submission") %>
-          </span>
-        </div>
-      </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
-    </div>
-
+  <% meta = capture do %>
+    <% events_count = @form.events.size %>
+    <% if events_count.positive? %>
+      <%= link_to events_path(form_id: @form.id), class: "#{DomainTheme.text_class_for(:forms, intensity: 700)} inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm font-medium shadow-sm hover:bg-white/70" do %>
+        <i class="fa-solid fa-calendar-day <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"></i>
+        <%= pluralize(events_count, "event") %> connected
+      <% end %>
+    <% else %>
+      <span class="inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm text-gray-600 shadow-sm">
+        <i class="fa-solid fa-calendar-day text-gray-400"></i>
+        No events connected
+      </span>
+    <% end %>
+    <span class="<%= DomainTheme.text_class_for(:forms, intensity: 700) %> inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-sm font-medium shadow-sm">
+      <i class="fa-solid fa-inbox <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"></i>
+      <%= pluralize(@form.form_submissions.size, "submission") %>
+    </span>
+  <% end %>
+  <div class="<%= DomainTheme.bg_class_for(:forms, intensity: 50) %> border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
+    <%= render "forms/page_header", icon: "fa-solid fa-layer-group",
+                                    eyebrow: "Edit sections", title: @form.display_name, meta: meta %>
     <div class="px-4 sm:px-6 py-6">
   <%= form_with url: update_sections_form_path(@form, event_id: @dashboard_event&.id), method: :patch, class: "space-y-6" do |f| %>
     <div class="bg-white border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
-      <div class="flex items-center gap-2.5 px-6 py-3 bg-purple-100 border-b border-purple-300">
-        <i class="fa-solid fa-list-check text-purple-700"></i>
-        <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide">Sections to include</h2>
+      <div class="flex items-center gap-2.5 px-6 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:forms) %>">
+        <i class="fa-solid fa-list-check <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+        <h2 class="text-sm font-semibold <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase tracking-wide">Sections to include</h2>
       </div>
       <div class="p-6">
         <p class="text-xs text-gray-500 mb-3">Numbered in the order these sections appear on this form. Custom sections you added are marked and edited on the <%= link_to "edit questions", edit_form_path(@form, event_id: @dashboard_event&.id), class: "underline hover:text-gray-700" %> page. Unless you change these selections, saving here does not change your form.</p>
@@ -68,10 +53,10 @@
                     <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
                     <%= hidden_field_tag "custom_sections[]", section[:header].id %>
                     <%= check_box_tag "kept_custom_sections[]", section[:header].id, true,
-                          class: "rounded border-gray-300 text-purple-600",
+                          class: "rounded border-gray-300 #{DomainTheme.text_class_for(:forms, intensity: 600)}",
                           data: { form_section_toggle_target: "checkbox", action: "form-section-toggle#update" } %>
                     <span class="text-sm font-semibold text-gray-800"><%= section[:label] %></span>
-                    <span class="text-xs px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-800 border border-purple-200">Custom</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded-full <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> <%= DomainTheme.text_class_for(:forms, intensity: 800) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %>">Custom</span>
                   </label>
                   <% if names.any? %>
                     <%= render "forms/field_list_toggle", count: names.size %>
@@ -91,7 +76,7 @@
                   <label class="flex flex-1 items-center gap-2 cursor-pointer">
                     <span class="w-5 text-sm text-gray-400 tabular-nums text-right"><%= index + 1 %>.</span>
                     <input type="checkbox" name="sections[]" value="<%= section[:key] %>"
-                           class="rounded border-gray-300 text-purple-600"
+                           class="rounded border-gray-300 <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"
                            data-form-section-toggle-target="checkbox"
                            data-action="form-section-toggle#update"
                            <%= "checked" if section[:included] %>>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -5,26 +5,16 @@
   </div>
 
   <%# Colored hero banner so the page reads at a glance instead of all-white %>
-  <div class="overflow-hidden rounded-2xl bg-purple-900 shadow-lg ring-1 ring-black/5">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 px-6 py-6 text-white sm:px-8">
-      <div class="flex items-center gap-4">
-        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
-          <i class="fa-solid fa-file-circle-plus text-xl"></i>
-        </div>
-        <div>
-          <p class="text-xs font-medium tracking-[0.2em] text-purple-200 uppercase">New form</p>
-          <h1 class="text-primary font-display text-2xl leading-tight font-bold tracking-tight">Create a form</h1>
-        </div>
-      </div>
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
-    </div>
+  <div class="<%= DomainTheme.bg_class_for(:forms, intensity: 50) %> border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
+    <%= render "forms/page_header", icon: "fa-solid fa-file-circle-plus",
+                                    eyebrow: "New form", title: "Create a form" %>
 
     <div class="px-4 py-6 sm:px-6">
       <%= form_with url: forms_path, method: :post, class: "space-y-6", data: { controller: "section-filter" } do |f| %>
         <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
-          <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
-            <i class="fa-solid fa-gear text-purple-700"></i>
-            <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Form details</h2>
+          <div class="flex items-center gap-2.5 border-b <%= DomainTheme.border_class_for(:forms) %> <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-3">
+            <i class="fa-solid fa-gear <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+            <h2 class="text-sm font-semibold tracking-wide <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase">Form details</h2>
           </div>
           <div class="space-y-4 p-6">
             <div class="flex flex-col gap-4 sm:flex-row">
@@ -53,9 +43,9 @@
         </div>
 
         <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm">
-          <div class="flex items-center gap-2.5 border-b border-purple-300 bg-purple-100 px-6 py-3">
-            <i class="fa-solid fa-list-check text-purple-700"></i>
-            <h2 class="text-sm font-semibold tracking-wide text-purple-900 uppercase">Sections to include</h2>
+          <div class="flex items-center gap-2.5 border-b <%= DomainTheme.border_class_for(:forms) %> <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-3">
+            <i class="fa-solid fa-list-check <%= DomainTheme.text_class_for(:forms, intensity: 700) %>"></i>
+            <h2 class="text-sm font-semibold tracking-wide <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase">Sections to include</h2>
           </div>
           <div class="p-6">
             <div class="space-y-1.5">
@@ -72,7 +62,7 @@
                   <div class="flex items-center gap-2">
                     <label class="flex flex-1 cursor-pointer items-center gap-2">
                       <input type="checkbox" name="sections[]" value="<%= key %>"
-                             class="rounded border-gray-300 text-purple-600"
+                             class="rounded border-gray-300 <%= DomainTheme.text_class_for(:forms, intensity: 600) %>"
                              <%= "checked" if params.dig(:sections)&.include?(key.to_s) %>>
                       <span class="text-sm font-medium text-gray-800"><%= section[:label] %></span>
                     </label>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="max-w-2xl mx-auto py-6 px-4">
-  <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
+<div class="mx-auto max-w-2xl px-4 py-6">
+  <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= form_page_subnav(@form, current: :view, event: @dashboard_event) %>
@@ -19,20 +19,23 @@
     </div>
   <% end %>
 
-  <div class="bg-white rounded-2xl shadow-lg overflow-hidden border border-primary/10">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-lg">
     <%# Admin chrome wrapping the form preview below. The amber "Preview" badge
         signals this is not the live page (echoing the amber token note inside). %>
-    <div class="bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 py-5">
+    <%# The chrome mirrors the live public form's header, since that is what this
+        page previews — only the amber badge marks it as not-live. %>
+    <%= render "shared/brand_accent_strip" %>
+    <div class="bg-primary px-6 py-5 text-white">
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="flex items-center gap-4">
           <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto shrink-0") %>
           <div class="h-8 w-px bg-white/20"></div>
           <div>
-            <h2 class="text-xl font-semibold tracking-wide leading-tight"><%= @form.display_name %></h2>
-            <p class="mt-0.5 text-xs text-purple-200"><%= form_role_label(@form) %> form</p>
+            <h2 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= @form.display_name %></h2>
+            <p class="mt-0.5 text-xs text-white/70"><%= form_role_label(@form) %> form</p>
           </div>
         </div>
-        <span class="inline-flex items-center gap-1.5 rounded-full bg-amber-400 px-3 py-1 text-xs font-bold uppercase tracking-[0.15em] text-purple-950 shadow-sm">
+        <span class="text-primary inline-flex items-center gap-1.5 rounded-full bg-amber-400 px-3 py-1 text-xs font-bold tracking-[0.15em] uppercase shadow-sm">
           <i class="fa-solid fa-eye"></i>Preview
         </span>
       </div>
@@ -72,7 +75,7 @@
         has_conditional = @form_fields.any?(&:conditional_visibility?)
       %>
 
-      <div class="mb-6 rounded-2xl bg-gray-50 border border-primary/10 p-3">
+      <div class="border-primary/10 mb-6 rounded-2xl border bg-gray-50 p-3">
         <% if has_conditional %>
           <p class="text-xs text-gray-600">This preview shows every field. Highlighted fields are only asked under certain conditions — the conditional logic runs on the live registration form.</p>
         <% else %>
@@ -81,11 +84,11 @@
       </div>
 
       <fieldset disabled>
-        <div class="grid grid-cols-1 md:grid-cols-12 gap-x-4">
+        <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
           <% @form_fields.each do |field| %>
             <% conditional = field.conditional_visibility? %>
             <% if field.group_header? %>
-              <div class="md:col-span-12 pt-6 pb-2 border-b border-gray-200 mb-4">
+              <div class="mb-4 border-b border-gray-200 pt-6 pb-2 md:col-span-12">
                 <div class="flex flex-wrap items-center gap-2">
                   <span class="<%= form_section_bar_class %>"></span>
                   <h3 class="rich-label text-lg font-semibold text-gray-800"><%= form_label_html(field.name) %></h3>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -13,33 +13,24 @@
     <% end %>
   </div>
 
-  <% if allowed_to?(:copy?, @form) %>
-    <div class="mb-4 flex justify-end">
+  <div class="mb-4 flex flex-wrap items-center justify-end gap-3">
+    <span class="<%= DomainTheme.bg_class_for(:forms, intensity: 100) %> <%= DomainTheme.text_class_for(:forms, intensity: 800) %> <%= DomainTheme.border_class_for(:forms, intensity: 200) %> inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium">
+      <i class="fa-solid fa-file-lines"></i><%= form_role_label(@form) %> form
+    </span>
+    <% if allowed_to?(:copy?, @form) %>
       <%= form_duplicate_button(@form) %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 
   <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-lg">
-    <%# Admin chrome wrapping the form preview below. The amber "Preview" badge
-        signals this is not the live page (echoing the amber token note inside). %>
-    <%# The chrome mirrors the live public form's header, since that is what this
-        page previews — only the amber badge marks it as not-live. %>
-    <%= render "shared/brand_accent_strip" %>
-    <div class="bg-primary px-6 py-5 text-white">
-      <div class="flex flex-wrap items-center justify-between gap-4">
-        <div class="flex items-center gap-4">
-          <%= image_tag("logo.png", alt: "Organization logo", class: "h-8 w-auto shrink-0") %>
-          <div class="h-8 w-px bg-white/20"></div>
-          <div>
-            <h2 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= @form.display_name %></h2>
-            <p class="mt-0.5 text-xs text-white/70"><%= form_role_label(@form) %> form</p>
-          </div>
-        </div>
-        <span class="text-primary inline-flex items-center gap-1.5 rounded-full bg-amber-400 px-3 py-1 text-xs font-bold tracking-[0.15em] uppercase shadow-sm">
-          <i class="fa-solid fa-eye"></i>Preview
-        </span>
-      </div>
-    </div>
+    <%# Renders the live form's own header so the preview is a true likeness —
+        only the amber badge marks it as not-live. %>
+    <% preview_badge = capture do %>
+      <span class="text-primary inline-flex items-center gap-1.5 rounded-full bg-amber-400 px-3 py-1 text-xs font-bold tracking-[0.15em] uppercase shadow-sm">
+        <i class="fa-solid fa-eye"></i>Preview
+      </span>
+    <% end %>
+    <%= render "forms/public_header", form: @form, badge: preview_badge %>
 
     <div class="px-6 py-6">
       <% if form_header_uses_tokens?(@form) %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -14,19 +14,9 @@
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <div class="rounded-2xl overflow-hidden shadow-lg ring-1 ring-black/5 bg-purple-900">
-    <div class="relative bg-gradient-to-r from-purple-950 to-purple-700 text-white px-6 sm:px-8 py-6">
-      <div class="flex items-center gap-4">
-        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15">
-          <i class="fa-solid fa-wand-magic-sparkles text-xl"></i>
-        </div>
-        <div>
-          <p class="text-xs font-medium uppercase tracking-[0.2em] text-purple-200">Reference</p>
-          <h1 class="font-display text-2xl font-bold tracking-tight leading-tight text-primary">Smart field settings</h1>
-        </div>
-      </div>
-      <div class="absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r from-accent via-amber-400 to-accent"></div>
-    </div>
+  <div class="<%= DomainTheme.bg_class_for(:forms, intensity: 50) %> border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
+    <%= render "forms/page_header", icon: "fa-solid fa-wand-magic-sparkles",
+                                    eyebrow: "Reference", title: "Smart field settings" %>
 
     <div class="bg-white px-4 sm:px-6 py-6 space-y-6">
       <div class="rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
@@ -50,14 +40,14 @@
       <nav class="flex flex-wrap gap-2" aria-label="Sections">
         <% @groups.each do |group| %>
           <%= link_to group.title, "##{group.key}",
-                      class: "inline-flex items-center rounded-full border border-purple-200 bg-purple-50 px-3 py-1 text-xs font-medium text-purple-900 hover:bg-purple-100" %>
+                      class: "inline-flex items-center rounded-full border #{DomainTheme.border_class_for(:forms, intensity: 200)} #{DomainTheme.bg_class_for(:forms, intensity: 50)} px-3 py-1 text-xs font-medium #{DomainTheme.text_class_for(:forms, intensity: 900)} #{DomainTheme.bg_class_for(:forms, intensity: 50, hover: true)}" %>
         <% end %>
       </nav>
 
       <% @groups.each do |group| %>
         <section id="<%= group.key %>" class="scroll-mt-8 rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-          <div class="px-5 py-3 bg-purple-100 border-b border-purple-300">
-            <h2 class="text-sm font-semibold text-purple-900 uppercase tracking-wide"><%= group.title %></h2>
+          <div class="px-5 py-3 <%= DomainTheme.bg_class_for(:forms, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:forms) %>">
+            <h2 class="text-sm font-semibold <%= DomainTheme.text_class_for(:forms, intensity: 900) %> uppercase tracking-wide"><%= group.title %></h2>
           </div>
           <div class="px-5 py-4">
             <p class="text-sm text-gray-600 mb-4"><%= group.summary %></p>

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -14,8 +14,7 @@
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
     <%= render "shared/brand_accent_strip" %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
-      <h1 class="text-xl leading-tight font-semibold tracking-wide"><%= @form.display_name %></h1>
-      <div class="from-accent to-accent absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r via-amber-400"></div>
+      <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= @form.display_name %></h1>
     </div>
 
     <div class="px-6 py-7 sm:px-8">

--- a/app/views/public_forms/show.html.erb
+++ b/app/views/public_forms/show.html.erb
@@ -12,10 +12,7 @@
   </div>
 
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
-    <div class="bg-primary px-6 py-5 text-white sm:px-8">
-      <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= @form.display_name %></h1>
-    </div>
+    <%= render "forms/public_header", form: @form %>
 
     <div class="px-6 py-7 sm:px-8">
       <%= render "forms/header", form: @form %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2669,6 +2669,7 @@
   area: registration
   display_status: user_facing
   released_on: 2026-08-29
+  pr_number: 2413
   summary: >-
     The form builder pages lose the heavy purple banner for the same light
     identity band the rest of the portal uses, and the public form and its

--- a/config/features.yml
+++ b/config/features.yml
@@ -2664,3 +2664,14 @@
     - "Counts edits to records that already existed, plus an org created through linking; a submitter's own brand-new records and tags aren't counted."
     - "Each row links to that record's edit page at the changed field."
     - "The admin submission view now links straight to the registrant's own public version of the form (opens in a new tab)."
+
+- name: "Form builder and public form redesigned"
+  area: registration
+  display_status: user_facing
+  released_on: 2026-08-29
+  summary: >-
+    The form builder pages lose the heavy purple banner for the same light
+    identity band the rest of the portal uses, and the public form and its
+    preview now share one header so what you preview is what registrants see.
+  pro_tips:
+    - "The preview page and the live public form use the same header now, so the preview is a true likeness."


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only, but it fixes a real contrast bug and routes 30 hard-coded colours through DomainTheme

The form builder was the last surface still wearing the purple gradient. It now uses the same light identity band as everything else — and doing it surfaced two bugs I'd introduced in earlier PRs.

### Internal: the builder pages
`forms/_page_header` replaces the gradient slab on **new · edit · edit sections · smart field settings**: brand rule → domain tint → circular icon badge → domain-coloured eyebrow → serif title, with the stat chips ("3 events connected", "12 submissions") as white pills on the tint.

### Public-facing: preview and live form now match
`forms/show` is a **preview of the live public form**, so its chrome had no business being purple when the real page is navy. Both now render the same navy header with the brand rule; only the amber "Preview" badge marks the difference. `form_submissions/show` — the record a registrant can open — gets the same navy treatment.

### Two bugs, both mine
- **#2404's blanket `h1` restyle put `text-primary` on titles sitting on the purple gradient.** Navy on `purple-700` measures **1.22:1** — effectively invisible. It affected `forms/new`, `forms/edit`, `forms/edit_sections`, `smart_form_settings` and `form_submissions/show`.
- **#2398 removed `relative` from several headers but left their absolutely-positioned accent bars behind.** `ai/tw-sort` had reordered the classes (`from-accent to-accent absolute …`), so my removal pattern missed them. Five orphaned bars, now gone — including one on the bulk-payment ticket.

### 30 hard-coded purples
The section chrome wrote the forms colour literally, which CLAUDE.md forbids. It resolves through `DomainTheme` now, so re-colouring forms stays a one-line change. The **visibility-status palette stays literal** — `scholarship_only` / `logged_out_only` / `answers_on_file` are status colours, not the domain's identity.

### Verified
3648 examples, 0 failures (`spec/requests`, `spec/views`, `spec/helpers`, `spec/lib`) plus 8 system examples covering public form submission and the CE form toggle. Lint clean, tw-sort applied.