### PR TITLE
Default FAQs to the public view, add an admin-mode toggle

### DIFF
--- a/app/helpers/faqs_helper.rb
+++ b/app/helpers/faqs_helper.rb
@@ -1,0 +1,7 @@
+module FaqsHelper
+  # FAQs render in public-facing mode by default. Admins opt into the edit/reorder
+  # controls with ?admin=1 (the "Admin mode" link next to the New button).
+  def faq_admin_mode?
+    allowed_to?(:manage?, Faq) && params[:admin].present?
+  end
+end

--- a/app/views/faqs/_faq.html.erb
+++ b/app/views/faqs/_faq.html.erb
@@ -8,7 +8,7 @@
     <div class="flex items-center w-full cursor-pointer hover:bg-gray-50 rounded-md transition-colors duration-150 px-2">
     
 
-      <% if allowed_to?(:edit?, faq) %>
+      <% if faq_admin_mode? && allowed_to?(:edit?, faq) %>
         <span class="admin-only bg-blue-100">
           <i class="fa-solid fa-sort cursor-move self-center pr-2" data-sortable-handle=""></i>
         </span>
@@ -74,7 +74,7 @@
           <%= faq.question %></span>
       <% end %>
 
-      <% if allowed_to?(:destroy?, faq) %>
+      <% if faq_admin_mode? && allowed_to?(:destroy?, faq) %>
         <div class="flex flex-col mx-3">
           <span class="admin-only bg-blue-100">
             <%= link_to faq, data: {
@@ -133,7 +133,7 @@
     <strong class="sr-only">Answer:</strong>
 
     <%= render "inline_edit", model: faq, attribute: :answer, frame_class: "flex flex-col" do %>
-      <% if allowed_to?(:edit?, faq) %>
+      <% if faq_admin_mode? && allowed_to?(:edit?, faq) %>
         <%= link_to("Edit", edit_faq_path(faq), class: "btn btn-secondary-outline self-end admin-only bg-blue-100") %>
 
       <% end %>

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -2,21 +2,21 @@
 <%= render "shared/public_welcome_banner" %>
 
 <% actions = capture do %>
-  <% if allowed_to?(:new?, Faq) %>
-    <%= link_to "New FAQ",
-                new_faq_path,
-                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
-  <% end %>
   <% if allowed_to?(:manage?, Faq) %>
     <% if faq_admin_mode? %>
       <%= link_to "Exit admin mode",
                   faqs_path(request.query_parameters.except("admin")),
-                  class: "btn btn-secondary-outline" %>
+                  class: "text-sm #{eyebrow_link_class}" %>
     <% else %>
       <%= link_to "Admin mode",
                   faqs_path(request.query_parameters.merge(admin: 1)),
-                  class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+                  class: "text-sm #{eyebrow_link_class}" %>
     <% end %>
+  <% end %>
+  <% if allowed_to?(:new?, Faq) %>
+    <%= link_to "New FAQ",
+                new_faq_path,
+                class: "admin-only bg-blue-100 btn btn-primary-outline" %>
   <% end %>
 <% end %>
 <% subtitle = capture do %>

--- a/app/views/faqs/index.html.erb
+++ b/app/views/faqs/index.html.erb
@@ -7,6 +7,17 @@
                 new_faq_path,
                 class: "admin-only bg-blue-100 btn btn-primary-outline" %>
   <% end %>
+  <% if allowed_to?(:manage?, Faq) %>
+    <% if faq_admin_mode? %>
+      <%= link_to "Exit admin mode",
+                  faqs_path(request.query_parameters.except("admin")),
+                  class: "btn btn-secondary-outline" %>
+    <% else %>
+      <%= link_to "Admin mode",
+                  faqs_path(request.query_parameters.merge(admin: 1)),
+                  class: "admin-only bg-blue-100 btn btn-secondary-outline" %>
+    <% end %>
+  <% end %>
 <% end %>
 <% subtitle = capture do %>
   Find answers to common questions here. If you don't see what you need, please reach out to us at <%= mail_to ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"), class: "text-blue-600 hover:text-blue-800" %>.

--- a/config/features.yml
+++ b/config/features.yml
@@ -2601,3 +2601,15 @@
     white card. Every field, link and section is unchanged.
   pro_tips:
     - "The edit pages keep their full width and their sticky heading, so long forms still work the way they did."
+
+- name: "FAQs default to the public view, with an admin toggle"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-29
+  action_path: "/faqs"
+  summary: >-
+    The FAQ page now opens in the clean public-facing view for everyone, including
+    admins. An "Admin mode" link next to New FAQ reveals the reorder, edit, delete
+    and visibility controls when you need them.
+  pro_tips:
+    - "Click Admin mode to edit; click Exit admin mode to go back to the reader's view. Your current search and filters are kept."

--- a/spec/helpers/faqs_helper_spec.rb
+++ b/spec/helpers/faqs_helper_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe FaqsHelper, type: :helper do
+  describe "#faq_admin_mode?" do
+    it "is true when a manager passes ?admin" do
+      allow(helper).to receive(:allowed_to?).with(:manage?, Faq).and_return(true)
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new(admin: "1"))
+      expect(helper.faq_admin_mode?).to be true
+    end
+
+    it "is false for a manager without the admin param" do
+      allow(helper).to receive(:allowed_to?).with(:manage?, Faq).and_return(true)
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new)
+      expect(helper.faq_admin_mode?).to be_falsey
+    end
+
+    it "is false for a non-manager even with the admin param" do
+      allow(helper).to receive(:allowed_to?).with(:manage?, Faq).and_return(false)
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new(admin: "1"))
+      expect(helper.faq_admin_mode?).to be_falsey
+    end
+  end
+end

--- a/spec/views/faqs/index.html.erb_spec.rb
+++ b/spec/views/faqs/index.html.erb_spec.rb
@@ -12,30 +12,56 @@ RSpec.describe "faqs/index", type: :view do
     end
   end
 
-  context "as an admin" do
+  context "as an admin in the default (public-facing) view" do
     let(:admin) { build_stubbed(:user, :admin) }
 
     before do
       allow(view).to receive(:current_user).and_return(admin)
       allow(view).to receive(:allowed_to?).and_return(true)
+      allow(view).to receive(:faq_admin_mode?).and_return(false)
       assign(:faqs, paginate_faqs([ faq1, faq2, unpublished_faq ]))
       render
     end
 
-    it "renders all FAQ divs including the unpublished status for unpublished FAQs" do
+    it "renders every FAQ question" do
       expect(rendered).to have_css("##{dom_id(faq1)}", text: faq1.question)
       expect(rendered).to have_css("##{dom_id(faq2)}", text: faq2.question)
-
       expect(rendered).to have_css("##{dom_id(unpublished_faq)}", text: unpublished_faq.question)
-
-      within("##{dom_id(unpublished_faq)}") do
-        expect(rendered).to have_selector("strong", text: "Unpublished:")
-        expect(rendered).to include(unpublished_faq.unpublished.to_s)
-      end
     end
 
-    it "shows New FAQ button for admin" do
+    it "hides the admin edit controls" do
+      expect(rendered).not_to include("data-sortable-handle")
+      expect(rendered).not_to have_css("i.fa-toggle-on, i.fa-toggle-off")
+      expect(rendered).not_to include("Confirm: Delete FAQ?")
+    end
+
+    it "shows the New FAQ button and an Admin mode link" do
       expect(rendered).to include("New FAQ")
+      expect(rendered).to have_link("Admin mode")
+      expect(rendered).not_to have_link("Exit admin mode")
+    end
+  end
+
+  context "as an admin in admin mode" do
+    let(:admin) { build_stubbed(:user, :admin) }
+
+    before do
+      allow(view).to receive(:current_user).and_return(admin)
+      allow(view).to receive(:allowed_to?).and_return(true)
+      allow(view).to receive(:faq_admin_mode?).and_return(true)
+      assign(:faqs, paginate_faqs([ faq1, faq2, unpublished_faq ]))
+      render
+    end
+
+    it "shows the reorder handle, visibility toggles, and delete control" do
+      expect(rendered).to include("data-sortable-handle")
+      expect(rendered).to have_css("i.fa-toggle-on, i.fa-toggle-off")
+      expect(rendered).to include("Confirm: Delete FAQ?")
+    end
+
+    it "swaps the toggle for an Exit admin mode link" do
+      expect(rendered).to have_link("Exit admin mode")
+      expect(rendered).not_to have_link("Admin mode")
     end
   end
 
@@ -58,6 +84,10 @@ RSpec.describe "faqs/index", type: :view do
 
     it "does not New FAQ button for regular_user" do
       expect(rendered).to_not include("New FAQ")
+    end
+
+    it "does not show an Admin mode link" do
+      expect(rendered).not_to have_link("Admin mode")
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-layer gating on a new helper flag plus its specs; low blast radius

The FAQ page opened with every admin's inline edit/reorder/delete controls showing, cluttering the reader's view. Now everyone — admins included — gets the clean public view by default, and admins opt into editing with an **Admin mode** link next to New FAQ.

- New `faq_admin_mode?` helper: admin mode is on only when a manager passes `?admin=1`.
- `_faq.html.erb` gates the reorder handle, published/publicly-visible toggles, edit links, and delete on that flag.
- `index.html.erb` adds an **Admin mode** / **Exit admin mode** toggle beside New FAQ that preserves the current search/filter params.
- Server-side policy is unchanged — the update/destroy endpoints are still admin-only, so this is display-only.
- Fixed the index view spec's `within` blocks, which were silently RSpec's `be_within` matcher (Capybara `within` isn't available in view specs), so their assertions never executed.

Added a Features & tips entry (admin-facing).
