### PR TITLE
Unify bulk payment form fields onto the shared canonical identifiers

### DIFF
--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -77,7 +77,7 @@ module Events
       authorize! @submission, to: :show?, context: { slug: params[:slug] }
 
       payer_email = @submission.person.preferred_email.presence ||
-                    @submission.answers_by_identifier["payer_email"]&.strip
+                    @submission.answers_by_identifier["primary_email"]&.strip
 
       if payer_email.present?
         NotificationServices::CreateNotification.call(

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -71,16 +71,46 @@ class FormField < ApplicationRecord
     "organization_country" => %w[organization_country agency_country]
   }.freeze
 
+  # The bulk payment form once seeded its payer fields under bespoke "payer_"
+  # identifiers; new forms use the same canonical names every other form role
+  # already uses (so one catalog, validator, and set of consumers covers them).
+  # The legacy "payer_" spellings stay valid for forms and submissions already
+  # stored under them. Same shape as ORGANIZATION_FIELD_ALIASES: canonical first,
+  # legacy second.
+  PAYER_FIELD_ALIASES = {
+    "first_name" => %w[first_name payer_first_name],
+    "last_name" => %w[last_name payer_last_name],
+    "primary_email" => %w[primary_email payer_email],
+    "phone" => %w[phone payer_phone]
+  }.freeze
+
+  # Single source of truth mapping each canonical field identifier to every
+  # spelling that should match it. The organization "agency_" rename and the bulk
+  # payment "payer_" rename share one mechanism; "payer_organization" folds into
+  # the existing organization_name entry so the org field resolves the same on a
+  # bulk payment form as anywhere else.
+  FIELD_ALIASES = ORGANIZATION_FIELD_ALIASES
+    .merge("organization_name" => ORGANIZATION_FIELD_ALIASES["organization_name"] + %w[payer_organization])
+    .merge(PAYER_FIELD_ALIASES)
+    .freeze
+
   # Every identifier that should match a field for the given identifier — a
-  # renamed organization field's canonical name plus its legacy "agency_" alias,
-  # or just the identifier itself for everything else. Accepts either spelling as
-  # input, so callers can key on the canonical name and still match legacy data
-  # (or pass a legacy literal and still match a new form). Use it to build the
+  # renamed field's canonical name plus its legacy alias(es), or just the
+  # identifier itself for everything else. Accepts either spelling as input, so
+  # callers can key on the canonical name and still match legacy data (or pass a
+  # legacy literal and still match a new form). Use it to build the
   # `field_identifier IN (…)` set for a lookup, or to compare an identifier.
   def self.aliased_identifiers(identifier)
-    ORGANIZATION_FIELD_ALIASES[identifier] ||
-      ORGANIZATION_FIELD_ALIASES.values.find { |names| names.include?(identifier) } ||
+    FIELD_ALIASES[identifier] ||
+      FIELD_ALIASES.values.find { |names| names.include?(identifier) } ||
       [ identifier ]
+  end
+
+  # The canonical identifier a given spelling folds into (itself when it has no
+  # alias). Lets consumers key submission answers on one canonical name whether
+  # the field was seeded under the new or the legacy spelling.
+  def self.canonical_identifier(identifier)
+    FIELD_ALIASES.find { |_canonical, names| names.include?(identifier) }&.first || identifier
   end
 
   # The payment-method field. Its answer options ("Credit card (now)", etc.) are
@@ -223,11 +253,17 @@ class FormField < ApplicationRecord
   end
 
   # True when this field's identifier matches the given identifier, treating a
-  # renamed organization field's canonical and legacy "agency_" spellings as
-  # equivalent (see ORGANIZATION_FIELD_ALIASES). Lets a caller compare against the
-  # canonical name and still match a field seeded under the legacy one.
+  # renamed field's canonical and legacy spellings as equivalent (see
+  # FIELD_ALIASES). Lets a caller compare against the canonical name and still
+  # match a field seeded under the legacy one.
   def matches_identifier?(identifier)
     field_identifier.in?(FormField.aliased_identifiers(identifier))
+  end
+
+  # This field's canonical identifier, folding a legacy "agency_"/"payer_"
+  # spelling into the shared canonical name.
+  def canonical_identifier
+    FormField.canonical_identifier(field_identifier)
   end
 
   # True for fields whose answer options are tied to backend logic (currently the
@@ -272,11 +308,13 @@ class FormField < ApplicationRecord
   # Field identifiers (system-assigned by FormBuilderService) that collect an
   # email address, so a submitted value should be format-checked. The "*_type"
   # selector fields are deliberately excluded — this is an exact allowlist, not
-  # a name-pattern match, so an unrelated field can't opt in by accident.
-  EMAIL_FIELD_IDENTIFIERS = %w[primary_email confirm_email secondary_email payer_email].freeze
+  # a name-pattern match, so an unrelated field can't opt in by accident. Matched
+  # against the canonical identifier, so a legacy "payer_email" field (now folded
+  # into primary_email) is still validated.
+  EMAIL_FIELD_IDENTIFIERS = %w[primary_email confirm_email secondary_email].freeze
 
   def email_field?
-    field_identifier.in?(EMAIL_FIELD_IDENTIFIERS)
+    canonical_identifier.in?(EMAIL_FIELD_IDENTIFIERS)
   end
 
   # A quote smart field — its answer helps build a Quote on submission.

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -223,12 +223,20 @@ class FormSubmission < ApplicationRecord
 
   # Answers keyed by their field's identifier. Bulk payment (and similar) forms
   # address fields by identifier rather than position. Reuses an already-loaded
-  # association so per-row calls on a preloaded index don't requery.
+  # association so per-row calls on a preloaded index don't requery. Each answer
+  # is also indexed under its canonical identifier, so a consumer keying on the
+  # canonical name (e.g. "organization_name") finds an answer stored under a
+  # legacy spelling (e.g. "payer_organization") without every call site knowing
+  # both.
   def answers_by_identifier
     answers = form_answers.loaded? ? form_answers : form_answers.includes(:form_field)
     answers.each_with_object({}) do |answer, map|
       identifier = answer.form_field&.field_identifier
-      map[identifier] = answer.submitted_answer if identifier.present?
+      next if identifier.blank?
+
+      map[identifier] = answer.submitted_answer
+      canonical = FormField.canonical_identifier(identifier)
+      map[canonical] = answer.submitted_answer unless canonical == identifier
     end
   end
 

--- a/app/presenters/event_invoice.rb
+++ b/app/presenters/event_invoice.rb
@@ -104,7 +104,7 @@ class EventInvoice
     event = submission.resolved_event
     answers = submission.answers_by_identifier
     payer = submission.person
-    payer_name = [ answers["payer_first_name"], answers["payer_last_name"] ]
+    payer_name = [ answers["first_name"], answers["last_name"] ]
       .map(&:presence).compact.join(" ").presence || payer&.full_name
     quantity = [ submission.bulk_payment_attendee_count, 1 ].max
 
@@ -113,9 +113,9 @@ class EventInvoice
       number: "B-#{submission.id}",
       date: submission.created_at.to_date,
       client_id: submission.id,
-      bill_to_name: answers["payer_organization"].presence || payer_name,
+      bill_to_name: answers["organization_name"].presence || payer_name,
       bill_to_address_lines: [],
-      bill_to_email: answers["payer_email"].presence || payer&.preferred_email,
+      bill_to_email: answers["primary_email"].presence || payer&.preferred_email,
       attention: payer_name,
       line_items: [
         LineItem.new(

--- a/app/services/event_registration_services/bulk_payment.rb
+++ b/app/services/event_registration_services/bulk_payment.rb
@@ -20,7 +20,7 @@ module EventRegistrationServices
         # Backfill after the phone-contact guard: create_phone_contact should only
         # fire for a phone the payer actually typed, not one we copied from their
         # own profile (which would needlessly rewrite their contact methods).
-        create_phone_contact(person) if field_value("payer_phone").present?
+        create_phone_contact(person) if field_value("phone").present?
         backfill_payer_fields(person)
         submission = create_form_submission(person)
         send_notifications(submission, person)
@@ -34,7 +34,7 @@ module EventRegistrationServices
 
     # Emails the payer a confirmation and notifies staff with an FYI.
     def send_notifications(submission, person)
-      payer_email = person.preferred_email.presence || field_value("payer_email")&.strip
+      payer_email = person.preferred_email.presence || field_value("primary_email")&.strip
       if payer_email.present?
         NotificationServices::CreateNotification.call(
           noticeable: submission,
@@ -60,15 +60,15 @@ module EventRegistrationServices
     # anything that was actually submitted.
     def backfill_payer_fields(person)
       {
-        "payer_first_name" => person.first_name,
-        "payer_last_name" => person.last_name,
-        "payer_email" => person.preferred_email,
-        "payer_phone" => person.phone_number,
-        "payer_organization" => payer_organization_name(person)
+        "first_name" => person.first_name,
+        "last_name" => person.last_name,
+        "primary_email" => person.preferred_email,
+        "phone" => person.phone_number,
+        "organization_name" => payer_organization_name(person)
       }.each do |key, value|
         next if value.blank?
 
-        field = @form.form_fields.find_by(field_identifier: key)
+        field = @form.form_fields.find_by(field_identifier: FormField.aliased_identifiers(key))
         next unless field
         next if @form_params[field.id.to_s].present?
 
@@ -83,7 +83,7 @@ module EventRegistrationServices
     end
 
     def field_value(key)
-      field = @form.form_fields.find_by(field_identifier: key)
+      field = @form.form_fields.find_by(field_identifier: FormField.aliased_identifiers(key))
       return nil unless field
       @form_params[field.id.to_s]
     end
@@ -91,9 +91,9 @@ module EventRegistrationServices
     def find_or_create_person
       return @person if @person
 
-      first_name = field_value("payer_first_name")&.strip
-      last_name = field_value("payer_last_name")&.strip
-      email = field_value("payer_email")&.strip&.downcase
+      first_name = field_value("first_name")&.strip
+      last_name = field_value("last_name")&.strip
+      email = field_value("primary_email")&.strip&.downcase
 
       person = Person.find_by(
         "LOWER(first_name) = ? AND LOWER(last_name) = ? AND LOWER(email) = ?",
@@ -111,7 +111,7 @@ module EventRegistrationServices
     # Mirrors PublicRegistration#create_phone_contact. The bulk payment form has
     # no phone-type field, so the payer phone is always stored as personal.
     def create_phone_contact(person)
-      phone_value = field_value("payer_phone")&.strip
+      phone_value = field_value("phone")&.strip
       return if phone_value.blank?
 
       existing = person.contact_methods.find_by(kind: :phone, value: phone_value)

--- a/app/services/form_builder_service.rb
+++ b/app/services/form_builder_service.rb
@@ -57,7 +57,7 @@ class FormBuilderService
     payment: %w[payment_method someone_else_will_pay],
     consent: %w[communication_consent],
     post_event_feedback: %w[event_rating most_valuable improvement_suggestions],
-    bulk_payment: %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees payment_method bulk_payment_attendees]
+    bulk_payment: %w[first_name last_name primary_email phone organization_name number_of_attendees payment_method bulk_payment_attendees]
   }.freeze
 
   # Header questions created by each section's builder method
@@ -617,19 +617,19 @@ class FormBuilderService
     position = add_header(form, position, "Payer Information", group: "bulk_payment", visibility: :logged_out_only)
 
     position = add_field(form, position, "Payer first name", :free_form_input_one_line,
-                         key: "payer_first_name", group: "bulk_payment", required: true,
+                         key: "first_name", group: "bulk_payment", required: true,
                          width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Payer last name", :free_form_input_one_line,
-                         key: "payer_last_name", group: "bulk_payment", required: true,
+                         key: "last_name", group: "bulk_payment", required: true,
                          width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Payer email", :free_form_input_one_line,
-                         key: "payer_email", group: "bulk_payment", required: true,
+                         key: "primary_email", group: "bulk_payment", required: true,
                          width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Phone", :free_form_input_one_line,
-                         key: "payer_phone", group: "bulk_payment", required: false,
+                         key: "phone", group: "bulk_payment", required: false,
                          width: :half, visibility: :logged_out_only)
     position = add_field(form, position, "Organization", :free_form_input_one_line,
-                         key: "payer_organization", group: "bulk_payment", required: false,
+                         key: "organization_name", group: "bulk_payment", required: false,
                          visibility: :logged_out_only)
 
     position = add_header(form, position, "Payment Information", group: "bulk_payment")

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -173,8 +173,7 @@ class SmartFormFields
                "drive the invoice, the confirmation email, and the Stripe charge metadata.",
       fields: [
         [ "bulk_payment_attendees", "Attendees", "The list of attendees being paid for. Read by the invoice, the confirmation email, and the payment record." ],
-        [ "number_of_attendees", "Number of attendees", "The attendee count charged for. Falls back to the length of the attendee list when unanswered." ],
-        [ "payer_email", "Payer email", "The payer's email, validated as an email address." ]
+        [ "number_of_attendees", "Number of attendees", "The attendee count charged for. Falls back to the length of the attendee list when unanswered." ]
       ]
     }
   ].freeze
@@ -188,7 +187,6 @@ class SmartFormFields
     scholarship_eligibility scholarship_contribution impact_description
     implementation_plan additional_comments
     event_rating most_valuable improvement_suggestions
-    payer_first_name payer_last_name payer_phone payer_organization
   ].freeze
 
   def self.groups

--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -40,10 +40,10 @@
   <% end %>
 
   <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
-    <% if @answers["payer_organization"].present? %>
+    <% if @answers["organization_name"].present? %>
       <tr>
         <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Organization</td>
-        <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_organization"] %></td>
+        <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["organization_name"] %></td>
       </tr>
     <% end %>
     <% if @answers["number_of_attendees"].present? %>

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -10,7 +10,7 @@ We've received your payment submission<%= " for the following event" if @event %
 <% if @event.location.present? %>Location: <%= @event.location.name %>
 <% end %><% if @event.labelled_cost.present? %><%= @event.labelled_cost %>
 <% end %><% end %>
-<% if @answers["payer_organization"].present? %>Organization: <%= @answers["payer_organization"] %>
+<% if @answers["organization_name"].present? %>Organization: <%= @answers["organization_name"] %>
 <% end %><% if @answers["number_of_attendees"].present? %>Number of attendees: <%= @answers["number_of_attendees"] %>
 <% end %><% if @answers["payment_method"].present? %>Payment method: <%= @answers["payment_method"] %>
 <% end %><% if @total_cents.to_i > 0 %>Total: <%= dollars_from_cents(@total_cents) %>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -71,7 +71,7 @@
 
         <%
           fields_by_identifier = @form_fields.select(&:field_identifier).index_by(&:field_identifier)
-          payer_fields = %w[payer_first_name payer_last_name payer_email payer_phone payer_organization number_of_attendees]
+          payer_fields = %w[first_name last_name primary_email phone organization_name number_of_attendees]
         %>
 
         <div class="grid grid-cols-1 gap-x-4 md:grid-cols-12">
@@ -84,7 +84,7 @@
                   <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
                 </h3>
               </div>
-            <% elsif payer_fields.include?(field.field_identifier) %>
+            <% elsif payer_fields.include?(field.canonical_identifier) %>
               <%
                 submitted_value = @form_params&.dig(field.id.to_s)
                 error = @field_errors&.dig(field.id)
@@ -103,9 +103,9 @@
                     <p class="rich-label mb-1.5 text-xs text-gray-500"><%= form_label_html(field.subtitle) %></p>
                   <% end %>
                   <%
-                    html_type = case field.field_identifier
-                                when "payer_email" then "email"
-                                when "payer_phone" then "tel"
+                    html_type = case field.canonical_identifier
+                                when "primary_email" then "email"
+                                when "phone" then "tel"
                                 else field.number_integer? ? "number" : "text"
                                 end
                     extra_attrs = []

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -3,8 +3,8 @@
   attendees = @submission.bulk_payment_attendees
   total_cents = @payment&.amount_cents || @submission.bulk_payment_amount_cents(@event)
   answers = @submission.answers_by_identifier
-  payer_name = [ answers["payer_first_name"], answers["payer_last_name"] ].compact_blank.join(" ").presence || @submission.person.name
-  payer_organization = answers["payer_organization"]
+  payer_name = [ answers["first_name"], answers["last_name"] ].compact_blank.join(" ").presence || @submission.person.name
+  payer_organization = answers["organization_name"]
   attendee_count = @submission.bulk_payment_attendee_count
 %>
 

--- a/app/views/notification_mailer/bulk_payment_confirmation_fyi.html.erb
+++ b/app/views/notification_mailer/bulk_payment_confirmation_fyi.html.erb
@@ -41,16 +41,16 @@
 <% end %>
 
 <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
-  <% if @answers["payer_organization"].present? %>
+  <% if @answers["organization_name"].present? %>
     <tr>
       <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Organization</td>
-      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_organization"] %></td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["organization_name"] %></td>
     </tr>
   <% end %>
-  <% if @answers["payer_phone"].present? %>
+  <% if @answers["phone"].present? %>
     <tr>
       <td style="padding: 6px 0; color: #6b7280; font-size: 14px;">Phone</td>
-      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["payer_phone"] %></td>
+      <td style="padding: 6px 0; text-align: right; font-weight: 600;"><%= @answers["phone"] %></td>
     </tr>
   <% end %>
   <% if @answers["number_of_attendees"].present? %>

--- a/app/views/notification_mailer/bulk_payment_confirmation_fyi.text.erb
+++ b/app/views/notification_mailer/bulk_payment_confirmation_fyi.text.erb
@@ -21,8 +21,8 @@ Event date
 Cost
 <%= @event.labelled_cost %>
 <% end %><% end %>
-<% if @answers["payer_organization"].present? %>Organization: <%= @answers["payer_organization"] %>
-<% end %><% if @answers["payer_phone"].present? %>Phone: <%= @answers["payer_phone"] %>
+<% if @answers["organization_name"].present? %>Organization: <%= @answers["organization_name"] %>
+<% end %><% if @answers["phone"].present? %>Phone: <%= @answers["phone"] %>
 <% end %><% if @answers["number_of_attendees"].present? %>Number of attendees: <%= @answers["number_of_attendees"] %>
 <% end %><% if @answers["payment_method"].present? %>Payment method: <%= @answers["payment_method"] %>
 <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2613,3 +2613,14 @@
     and visibility controls when you need them.
   pro_tips:
     - "Click Admin mode to edit; click Exit admin mode to go back to the reader's view. Your current search and filters are kept."
+
+- name: "Organization name shows on bulk payment forms"
+  area: payments
+  display_status: user_facing
+  released_on: 2026-08-29
+  summary: >-
+    The bulk payment form now shows its Organization field to the person paying,
+    so the organization is captured and appears on the invoice and confirmation
+    email. Bulk payment now uses the same field names as every other form.
+  pro_tips:
+    - "Older bulk payment forms keep working — the payer, phone and organization fields are recognised whichever naming they were built with."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2618,6 +2618,7 @@
   area: payments
   display_status: user_facing
   released_on: 2026-08-29
+  pr_number: 2415
   summary: >-
     The bulk payment form now shows its Organization field to the person paying,
     so the organization is captured and appears on the invoice and confirmation

--- a/db/seeds/dev/bulk_payments.rb
+++ b/db/seeds/dev/bulk_payments.rb
@@ -99,9 +99,9 @@ build_submission = ->(payer:, method:, attendees:) do
   # event_id (see EventsController#bulk_payments), so an event-less submission
   # would never show up there.
   submission = FormSubmission.create!(person: payer, form: bulk_form, event: event, role: "bulk_payment")
-  set_answer.(submission, "payer_first_name", payer.first_name)
-  set_answer.(submission, "payer_last_name", payer.last_name)
-  set_answer.(submission, "payer_email", payer.email)
+  set_answer.(submission, "first_name", payer.first_name)
+  set_answer.(submission, "last_name", payer.last_name)
+  set_answer.(submission, "primary_email", payer.email)
   set_answer.(submission, "number_of_attendees", attendees.size)
   set_answer.(submission, "payment_method", method)
   attendee_json = attendees.map do |first, last, email|

--- a/spec/models/form_field_spec.rb
+++ b/spec/models/form_field_spec.rb
@@ -657,15 +657,40 @@ RSpec.describe FormField do
 
   describe ".aliased_identifiers" do
     it "expands a canonical organization identifier to its canonical and legacy names" do
-      expect(described_class.aliased_identifiers("organization_name")).to eq(%w[organization_name agency_name])
+      expect(described_class.aliased_identifiers("organization_name")).to eq(%w[organization_name agency_name payer_organization])
     end
 
     it "expands a legacy agency identifier to the same canonical and legacy names" do
       expect(described_class.aliased_identifiers("agency_type")).to eq(%w[organization_type agency_type])
     end
 
-    it "returns the identifier alone when it isn't a renamed organization field" do
-      expect(described_class.aliased_identifiers("first_name")).to eq(%w[first_name])
+    it "expands a canonical payer identifier to its canonical and legacy bulk-payment names" do
+      expect(described_class.aliased_identifiers("first_name")).to eq(%w[first_name payer_first_name])
+      expect(described_class.aliased_identifiers("primary_email")).to eq(%w[primary_email payer_email])
+    end
+
+    it "expands a legacy payer identifier to the same canonical and legacy names" do
+      expect(described_class.aliased_identifiers("payer_phone")).to eq(%w[phone payer_phone])
+    end
+
+    it "returns the identifier alone when it isn't a renamed field" do
+      expect(described_class.aliased_identifiers("payment_method")).to eq(%w[payment_method])
+    end
+  end
+
+  describe ".canonical_identifier" do
+    it "folds a legacy payer spelling into its canonical name" do
+      expect(described_class.canonical_identifier("payer_first_name")).to eq("first_name")
+      expect(described_class.canonical_identifier("payer_email")).to eq("primary_email")
+      expect(described_class.canonical_identifier("payer_organization")).to eq("organization_name")
+    end
+
+    it "folds a legacy agency spelling into its canonical name" do
+      expect(described_class.canonical_identifier("agency_city")).to eq("organization_city")
+    end
+
+    it "returns the identifier unchanged when it has no alias" do
+      expect(described_class.canonical_identifier("payment_method")).to eq("payment_method")
     end
   end
 

--- a/spec/models/form_submission_spec.rb
+++ b/spec/models/form_submission_spec.rb
@@ -93,11 +93,22 @@ RSpec.describe FormSubmission do
   describe "#answers_by_identifier" do
     it "maps submitted answers by their field identifier" do
       form = create(:form)
+      field = create(:form_field, form: form, field_identifier: "primary_email", name: "Email")
+      submission = create(:form_submission, form: form)
+      submission.form_answers.create!(form_field: field, submitted_answer: "pat@example.com")
+
+      expect(submission.answers_by_identifier["primary_email"]).to eq("pat@example.com")
+    end
+
+    it "also indexes a legacy-spelled answer under its canonical identifier" do
+      form = create(:form)
       field = create(:form_field, form: form, field_identifier: "payer_email", name: "Payer email")
       submission = create(:form_submission, form: form)
       submission.form_answers.create!(form_field: field, submitted_answer: "pat@example.com")
 
-      expect(submission.answers_by_identifier["payer_email"]).to eq("pat@example.com")
+      answers = submission.answers_by_identifier
+      expect(answers["payer_email"]).to eq("pat@example.com")
+      expect(answers["primary_email"]).to eq("pat@example.com")
     end
   end
 

--- a/spec/presenters/event_invoice_spec.rb
+++ b/spec/presenters/event_invoice_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe EventInvoice do
     end
 
     before do
-      add_answer("payer_first_name", "Helena")
-      add_answer("payer_last_name", "Lopez")
-      add_answer("payer_organization", "A Greater Hope")
+      add_answer("first_name", "Helena")
+      add_answer("last_name", "Lopez")
+      add_answer("organization_name", "A Greater Hope")
       add_answer("number_of_attendees", "8")
     end
 

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
   let(:admin) { create(:user, :admin) }
   let(:event) { create(:event, cost_cents: 0) }
   let(:form) { create(:form) }
-  # The bulk payment view only renders a known set of "payer" fields, so the
-  # min-word rule is exercised through payer_organization (a free-form text field).
+  # The bulk payment view only renders a known set of payer fields, so the
+  # min-word rule is exercised through the organization field (free-form text).
   let!(:org_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_organization", name: "Organization",
+           field_identifier: "organization_name", name: "Organization",
            required: true, min_words: 5)
   end
   let!(:payment_method_field) do
@@ -22,17 +22,17 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
   end
   let!(:payer_first_name_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_first_name", name: "Payer first name",
+           field_identifier: "first_name", name: "Payer first name",
            required: false)
   end
   let!(:payer_last_name_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_last_name", name: "Payer last name",
+           field_identifier: "last_name", name: "Payer last name",
            required: false)
   end
   let!(:payer_email_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_email", name: "Payer email",
+           field_identifier: "primary_email", name: "Payer email",
            required: false)
   end
 

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Events::BulkPayments", type: :request do
   let(:form) { create(:form) }
   let!(:org_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_organization", name: "Organization",
+           field_identifier: "organization_name", name: "Organization",
            required: true, min_words: 5)
   end
   let!(:payment_method_field) do
@@ -20,17 +20,17 @@ RSpec.describe "Events::BulkPayments", type: :request do
   end
   let!(:payer_first_name_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_first_name", name: "Payer first name",
+           field_identifier: "first_name", name: "Payer first name",
            required: false)
   end
   let!(:payer_last_name_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_last_name", name: "Payer last name",
+           field_identifier: "last_name", name: "Payer last name",
            required: false)
   end
   let!(:payer_email_field) do
     create(:form_field, form: form, answer_type: :free_form_input_one_line,
-           field_identifier: "payer_email", name: "Payer email",
+           field_identifier: "primary_email", name: "Payer email",
            required: false)
   end
 

--- a/spec/requests/events/invoices_spec.rb
+++ b/spec/requests/events/invoices_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe "Events::Invoices", type: :request do
         end
 
         before do
-          add_answer("payer_first_name", "Helena")
-          add_answer("payer_last_name", "Lopez")
-          add_answer("payer_organization", "A Greater Hope")
+          add_answer("first_name", "Helena")
+          add_answer("last_name", "Lopez")
+          add_answer("organization_name", "A Greater Hope")
           add_answer("number_of_attendees", "8")
         end
 

--- a/spec/services/event_registration_services/bulk_payment_spec.rb
+++ b/spec/services/event_registration_services/bulk_payment_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe EventRegistrationServices::BulkPayment do
 
   def base_form_params(overrides = {})
     {
-      field_id("payer_first_name") => "Pat",
-      field_id("payer_last_name") => "Payer",
-      field_id("payer_email") => "pat@example.com",
+      field_id("first_name") => "Pat",
+      field_id("last_name") => "Payer",
+      field_id("primary_email") => "pat@example.com",
       field_id("payment_method") => "Check",
       field_id("number_of_attendees") => "3"
     }.merge(overrides)
@@ -27,7 +27,7 @@ RSpec.describe EventRegistrationServices::BulkPayment do
       result = described_class.call(
         event: event,
         form: form,
-        form_params: base_form_params(field_id("payer_phone") => "555-123-4567")
+        form_params: base_form_params(field_id("phone") => "555-123-4567")
       )
 
       expect(result.success?).to be true
@@ -81,11 +81,11 @@ RSpec.describe EventRegistrationServices::BulkPayment do
 
       expect(result.success?).to be true
       submission = result.form_submission
-      expect(answer(submission, "payer_email")).to eq("logged.in@example.com")
-      expect(answer(submission, "payer_first_name")).to eq("Logged")
-      expect(answer(submission, "payer_last_name")).to eq("In")
-      expect(answer(submission, "payer_phone")).to eq("555-987-6543")
-      expect(answer(submission, "payer_organization")).to eq("Acme Co")
+      expect(answer(submission, "primary_email")).to eq("logged.in@example.com")
+      expect(answer(submission, "first_name")).to eq("Logged")
+      expect(answer(submission, "last_name")).to eq("In")
+      expect(answer(submission, "phone")).to eq("555-987-6543")
+      expect(answer(submission, "organization_name")).to eq("Acme Co")
     end
 
     it "falls back to the most recent active org when the payer has no facilitator affiliation" do
@@ -104,7 +104,7 @@ RSpec.describe EventRegistrationServices::BulkPayment do
         person: person
       )
 
-      expect(answer(result.form_submission, "payer_organization")).to eq("Newer Org")
+      expect(answer(result.form_submission, "organization_name")).to eq("Newer Org")
     end
 
     it "does not rewrite the payer's existing phone contact when backfilling" do
@@ -131,14 +131,14 @@ RSpec.describe EventRegistrationServices::BulkPayment do
         event: event,
         form: form,
         form_params: {
-          field_id("payer_email") => "typed@example.com",
+          field_id("primary_email") => "typed@example.com",
           field_id("payment_method") => "Check",
           field_id("number_of_attendees") => "3"
         },
         person: person
       )
 
-      expect(answer(result.form_submission, "payer_email")).to eq("typed@example.com")
+      expect(answer(result.form_submission, "primary_email")).to eq("typed@example.com")
     end
   end
 

--- a/spec/services/form_builder_service_spec.rb
+++ b/spec/services/form_builder_service_spec.rb
@@ -136,23 +136,23 @@ RSpec.describe FormBuilderService do
     context "bulk_payment section" do
       let(:form) { described_class.new(name: "Test", sections: %i[bulk_payment], role: "bulk_payment").call }
 
-      it "creates payer fields including an optional phone field" do
+      it "creates payer fields using the shared canonical identifiers" do
         keys = form.form_fields.pluck(:field_identifier).compact
         expect(keys).to include(
-          "payer_first_name", "payer_last_name", "payer_email", "payer_phone", "payer_organization"
+          "first_name", "last_name", "primary_email", "phone", "organization_name"
         )
       end
 
       it "makes the phone and organization fields optional" do
-        phone = form.form_fields.find_by(field_identifier: "payer_phone")
-        organization = form.form_fields.find_by(field_identifier: "payer_organization")
+        phone = form.form_fields.find_by(field_identifier: "phone")
+        organization = form.form_fields.find_by(field_identifier: "organization_name")
         expect(phone.required).to be(false)
         expect(organization.required).to be(false)
       end
 
       it "lays payer name, email, and phone fields out as halves" do
         widths = form.form_fields.where(
-          field_identifier: %w[payer_first_name payer_last_name payer_email payer_phone]
+          field_identifier: %w[first_name last_name primary_email phone]
         ).pluck(:width)
         expect(widths).to all(eq("half"))
       end

--- a/spec/system/public_registration_form_submission_spec.rb
+++ b/spec/system/public_registration_form_submission_spec.rb
@@ -240,11 +240,11 @@ RSpec.describe "Public form submissions", type: :system do
     it "incognito: creates the payer and saves the bulk payment submission" do
       visit new_event_bulk_payment_path(event)
 
-      fill_bp_text bp_field("payer_first_name"), with: "Pat"
-      fill_bp_text bp_field("payer_last_name"), with: "Morgan"
-      fill_bp_text bp_field("payer_email"), with: "pat.morgan@example.com"
-      fill_bp_text bp_field("payer_phone"), with: "555-987-6543"
-      fill_bp_text bp_field("payer_organization"), with: "Group Health"
+      fill_bp_text bp_field("first_name"), with: "Pat"
+      fill_bp_text bp_field("last_name"), with: "Morgan"
+      fill_bp_text bp_field("primary_email"), with: "pat.morgan@example.com"
+      fill_bp_text bp_field("phone"), with: "555-987-6543"
+      fill_bp_text bp_field("organization_name"), with: "Group Health"
       fill_bp_text bp_field("number_of_attendees"), with: "3"
       choose_bp_radio bp_field("payment_method"), "Check"
 
@@ -256,11 +256,11 @@ RSpec.describe "Public form submissions", type: :system do
 
       submission = FormSubmission.bulk_payment.find_by!(person: person, event: event)
       expect(answers_by_identifier(submission)).to include(
-        "payer_first_name" => "Pat",
-        "payer_last_name" => "Morgan",
-        "payer_email" => "pat.morgan@example.com",
-        "payer_phone" => "555-987-6543",
-        "payer_organization" => "Group Health",
+        "first_name" => "Pat",
+        "last_name" => "Morgan",
+        "primary_email" => "pat.morgan@example.com",
+        "phone" => "555-987-6543",
+        "organization_name" => "Group Health",
         "number_of_attendees" => "3",
         "payment_method" => "Check"
       )
@@ -273,7 +273,7 @@ RSpec.describe "Public form submissions", type: :system do
 
       visit new_event_bulk_payment_path(event)
 
-      expect(page).not_to have_selector("#bulk_payment_form_fields_#{bp_field('payer_first_name').id}")
+      expect(page).not_to have_selector("#bulk_payment_form_fields_#{bp_field('first_name').id}")
 
       fill_bp_text bp_field("number_of_attendees"), with: "2"
       choose_bp_radio bp_field("payment_method"), "Check"


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 substantive logic across the bulk-payment form builder, submission service, invoice/ticket/mailers, plus a backward-compat alias seam and 9 spec files

Fixes bulk payment forms silently dropping the Organization field: it used the canonical `organization_name` identifier, but the view only rendered a hardcoded `payer_*` allowlist, so the field never showed to the paying public.

## What changed
- Bulk payment now seeds its payer fields under the **same identifiers every other form role already uses** — `first_name`, `last_name`, `primary_email`, `phone`, `organization_name` — instead of bespoke `payer_*` names. One catalog, one validator, one set of consumers now cover it.
- The view renders and the submission service reads fields by **canonical identifier**, so the org (and every payer) field shows correctly.

## Backward compatibility (no data migration)
- Legacy `payer_*` (and `agency_*`) spellings stay valid through the existing `FIELD_ALIASES` seam. Forms and submissions already stored under the old names keep resolving.
- `answers_by_identifier` now indexes each answer under **both** its stored spelling and its canonical name, so consumers key on one canonical name whether the field is old or new.
- Covered by explicit legacy-alias tests (`FormSubmission#answers_by_identifier`, `FormField.canonical_identifier`, the email validator).

## Notes for the reviewer
- `email_field?` now matches on the canonical identifier, so a legacy `payer_email` field still gets format validation.
- Display labels ("Payer first name", etc.) are unchanged — only the identifiers unified.