### PR TITLE
Redesign the Story Share portal in the new AWBW brand

### DIFF
--- a/app/helpers/story_shares_helper.rb
+++ b/app/helpers/story_shares_helper.rb
@@ -72,6 +72,21 @@ module StorySharesHelper
     link_to label, "#{AWBW_BASE}#{path}", target: "_blank", rel: "noopener noreferrer", class: html_class
   end
 
+  # A mega-menu photo card: an awbw.org-linked image with an accent gradient and a
+  # serif call-to-action (the marketing site's right-hand menu tile). The accent
+  # comes from the surrounding `--accent` CSS variable.
+  def awbw_menu_link_photo(image:, alt:, cta:, href:)
+    link_to "#{AWBW_BASE}#{href}", target: "_blank", rel: "noopener noreferrer", class: "mega-photo" do
+      safe_join([
+        image_tag(image, alt: alt),
+        tag.span("", class: "mega-photo-overlay"),
+        tag.span(class: "mega-photo-cta") do
+          safe_join([ cta, tag.i("", class: "fa-solid fa-arrow-right text-sm") ], " ")
+        end
+      ])
+    end
+  end
+
   # Featured sectors shown in the navbar focus-area row (first 6 by position).
   # Cached because it renders on every portal page and rarely changes.
   def story_share_nav_sectors

--- a/app/views/layouts/story_shares.html.erb
+++ b/app/views/layouts/story_shares.html.erb
@@ -11,7 +11,7 @@
     <link rel="shortcut icon" type="image/png" href="<%= asset_path(favicon_file) %>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,500;1,9..144,600&display=swap" rel="stylesheet">
 
     <%= vite_stylesheet_tag "application.css" %>
     <%= vite_client_tag %>

--- a/app/views/layouts/story_shares.html.erb
+++ b/app/views/layouts/story_shares.html.erb
@@ -29,14 +29,14 @@
     </style>
   </head>
 
-  <body class="stories share_portal flex flex-col min-h-screen bg-white overflow-x-hidden">
-    <div class="flex-grow min-w-0 w-full" id="main">
-      <div class="sticky top-0 left-0 w-full z-50 print:hidden" id="share-portal-header">
+  <body class="stories share_portal flex min-h-screen flex-col overflow-x-hidden bg-white">
+    <div class="w-full min-w-0 flex-grow" id="main">
+      <div class="sticky top-0 left-0 z-50 w-full print:hidden" id="share-portal-header">
         <!-- Story Share Portal Navbar -->
         <%= render "shared/story_shares_navbar" %>
       </div>
 
-      <div class="not-signed-in-user flex flex-col min-w-0 w-full <%= yield(:page_bg_class) %>">
+      <div class="not-signed-in-user flex w-full min-w-0 flex-col <%= yield(:page_bg_class) %>">
         <%= render "shared/flash_messages" %>
         <%= yield %>
         <%= render "story_shares/get_involved" %>

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -124,7 +124,7 @@
       <div class="hidden items-center space-x-8 lg:flex">
         <!-- WHO WE ARE Mega (accent: green) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-green-700);">
-          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-green-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-green-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
             Who We Are <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -174,7 +174,7 @@
 
         <!-- WHAT WE DO Mega (accent: teal) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-teal-700);">
-          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-teal-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-teal-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
             What We Do <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -224,7 +224,7 @@
 
         <!-- WAYS TO HELP Mega (accent: magenta) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-magenta-700);">
-          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-magenta-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-magenta-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
             Ways to Help <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -273,7 +273,7 @@
 
         <!-- OUR NEXT CHAPTER Mega (accent: orange) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-orange-700);">
-          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-orange-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-orange-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
             Our Next Chapter <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -336,7 +336,7 @@
         <div class="lg:hidden">
           <button
             type="button"
-            class="focus:ring-brand-navy-700 relative inline-flex items-center justify-center rounded-md p-2 text-brand-navy-800 hover:bg-brand-navy-100 focus:ring-2 focus:outline-2"
+            class="focus:ring-brand-navy-700 text-brand-navy-800 hover:bg-brand-navy-100 relative inline-flex items-center justify-center rounded-md p-2 focus:ring-2 focus:outline-2"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"story-shares-mobile-menu":"hidden"}]'>
             <span class="sr-only">Open main menu</span>
@@ -374,7 +374,7 @@
                 type="search"
                 name="query"
                 placeholder="Search keywords to find more stories..."
-                class="portal-search focus:ring-brand-magenta-500 w-80 rounded-full border border-brand-navy-900/15 bg-white py-2 pr-10 pl-4 text-sm text-gray-900 focus:ring-2 focus:outline-none"
+                class="portal-search focus:ring-brand-magenta-500 border-brand-navy-900/15 w-80 rounded-full border bg-white py-2 pr-10 pl-4 text-sm text-gray-900 focus:ring-2 focus:outline-none"
                 value="<%= params[:query] %>"/>
               <button type="submit" class="text-brand-navy-700 hover:text-brand-magenta-700 absolute top-1/2 right-3 -translate-y-1/2" aria-label="Search">
                 <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -389,7 +389,7 @@
 
     <!-- Mobile menu, hidden by default -->
     <div id="story-shares-mobile-menu" class="nav-row border-brand-navy-900/10 hidden border-t lg:hidden">
-      <div class="space-y-1 pb-3 pt-2">
+      <div class="space-y-1 pt-2 pb-3">
         <%= link_to "Home", story_shares_path, class: "text-brand-navy-900 hover:bg-brand-navy-50 block rounded-md px-3 py-2 text-base font-medium" %>
         <% story_share_nav_sectors.each_with_index do |sector, index| %>
           <%= link_to sector.name, story_shares_path(sector_names_all: sector.name),
@@ -414,7 +414,7 @@
               type="search"
               name="query"
               placeholder="Search stories..."
-              class="w-full rounded-full border border-brand-navy-900/15 px-4 py-2 text-sm text-gray-900"
+              class="border-brand-navy-900/15 w-full rounded-full border px-4 py-2 text-sm text-gray-900"
               value="<%= params[:query] %>"
               />
           <% end %>

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="relative bg-white print:hidden" data-controller="dropdown">
+<nav class="bg-brand-cream relative print:hidden" data-controller="dropdown">
   <style>
       /* Mega menu spans the full row, not just the trigger button: keep the
          trigger un-positioned so the absolute menu anchors to .nav-row.row-1
@@ -10,13 +10,12 @@
          :focus-within, which would keep a clicked trigger's menu stuck open on
          top of the others). The hovered menu is lifted above its siblings. */
       .nav-item.has-dropdown .mega-menu {
-          position: absolute;           /* anchored to .nav-row.row-1 (position: relative) */
+          position: absolute;
           left: 0;
           right: 0;
-          top: 100%;                    /* directly below row 1, whatever its height */
-          background: #f7f7f9;
-          padding: 24px 0;
-          box-shadow: 0 10px 30px rgba(0,0,0,0.10);
+          top: 100%;
+          padding: 32px 0 36px;
+          box-shadow: 0 14px 34px rgba(37, 63, 123, 0.12);
           z-index: 9990;
           visibility: hidden;
           opacity: 0;
@@ -28,8 +27,10 @@
           z-index: 9999;
       }
 
-      /* Native clear (✕) for the portal search, nudged left so it sits before
-         the magnifying glass. WebKit/Blink only — Firefox has no native clear. */
+      /* Colored top rule under the nav that appears only while a menu is open —
+         the marketing site's per-section accent. Set --accent per trigger. */
+      .nav-item.has-dropdown .mega-menu { border-top: 3px solid var(--accent, var(--color-brand-navy-800)); }
+
       .portal-search::-webkit-search-cancel-button {
           margin-right: 18px;
           cursor: pointer;
@@ -40,46 +41,76 @@
           margin: 0 auto;
           padding: 0 24px;
           display: grid;
-          grid-template-columns: 1.1fr 1fr 0.9fr;
-          gap: 32px;
+          grid-template-columns: 1fr 1fr 0.9fr;
+          gap: 40px;
           align-items: start;
       }
 
-      .mega-col h3,
-      .mega-col h4 {
-          font-weight: 800;
-          letter-spacing: 0.02em;
+      .mega-eyebrow {
+          font-size: 0.75rem;
+          font-weight: 700;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: var(--accent, var(--color-brand-navy-800));
+          margin-bottom: 8px;
+      }
+
+      .mega-headline {
+          font-family: var(--font-display);
+          font-size: 1.85rem;
+          line-height: 1.1;
+          color: var(--color-brand-navy-900);
           margin-bottom: 12px;
       }
 
-      .mega-col p {
-          margin: 0 0 10px 0;
-          line-height: 1.5;
-          color: #111827;
-          font-weight: 400;
-      }
+      .mega-col p { margin: 0 0 12px; line-height: 1.55; color: #4b5563; }
 
-      .image-col img {
-          width: 100%;
-          height: auto;
-          border-radius: 8px;
-          display: block;
+      .mega-visit {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          font-weight: 700;
+          color: var(--accent, var(--color-brand-navy-800));
       }
+      .mega-visit:hover { text-decoration: underline; }
 
-      /* About + News horizontal */
-      .links-wrapper {display: flex;gap: 48px;}
+      .links-wrapper { display: flex; gap: 40px; }
       .links-group { margin-bottom: 18px; }
+      .links-group h4 {
+          font-size: 0.72rem;
+          font-weight: 700;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: #6b7280;
+          margin-bottom: 10px;
+      }
       .links-group ul { list-style: none; padding: 0; margin: 0; }
-      .links-group li { margin-bottom: 8px; }
-      .links-group a { color: #111827; text-decoration: none; }
-      .links-group a:hover { color: #6d28d9; text-decoration: underline; }
+      .links-group li { margin-bottom: 9px; }
+      .links-group a { color: var(--color-brand-navy-900); text-decoration: none; font-weight: 600; }
+      .links-group a:hover { color: var(--accent, var(--color-brand-navy-800)); text-decoration: underline; }
+
+      /* Photo card in the right column: image with an accent gradient + serif CTA. */
+      .mega-photo { position: relative; border-radius: 16px; overflow: hidden; display: block; }
+      .mega-photo img { width: 100%; height: 100%; object-fit: cover; display: block; aspect-ratio: 4 / 3; }
+      .mega-photo .mega-photo-overlay {
+          position: absolute; inset: 0;
+          background: linear-gradient(to top, var(--accent, var(--color-brand-navy-900)) 0%, transparent 70%);
+          opacity: 0.9;
+      }
+      .mega-photo .mega-photo-cta {
+          position: absolute; left: 20px; right: 20px; bottom: 18px;
+          font-family: var(--font-display);
+          font-size: 1.15rem;
+          color: #fff;
+          display: flex; align-items: center; gap: 8px;
+      }
   </style>
 
   <div class="px-2 sm:px-6 lg:px-8">
     <!-- Row 1: Logo and Main Navigation -->
-    <div class="nav-row row-1 relative flex items-center justify-center border-b-4 border-purple-700 py-3">
+    <div class="nav-row row-1 border-brand-navy-900/10 relative flex items-center justify-center border-b py-4">
       <!-- Logo (always visible) -->
-      <div class="flex shrink-0 items-center absolute left-2 sm:left-6 lg:left-8">
+      <div class="absolute left-2 flex shrink-0 items-center sm:left-6 lg:left-8">
         <% if current_user %>
           <% path = root_path %>
         <% else %>
@@ -90,44 +121,32 @@
         <% end %>
       </div>
 
-      <div class="hidden lg:flex space-x-6 items-center">
-        <!-- Mega dropdown trigger -->
-        <div class="relative group nav-item has-dropdown">
-          <button type="button" class="font-telefon text-gray-700 hover:text-purple-700 text-md font-medium transition-colors">
-            Who We Are ▾
+      <div class="hidden items-center space-x-8 lg:flex">
+        <!-- WHO WE ARE Mega (accent: green) -->
+        <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-green-700);">
+          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-green-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+            Who We Are <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
-          <div class="mega-menu" aria-label="Who We Are menu">
+          <div class="mega-menu bg-white" aria-label="Who We Are menu">
             <div class="mega-container">
-              <!-- LEFT: IMAGE -->
-              <div class="mega-col image-col">
-                <img src="/assets/who-we-are-grid.jpg" alt="Artwork collage" />
+              <!-- LEFT: intro -->
+              <div class="mega-col">
+                <p class="mega-eyebrow">About</p>
+                <h3 class="mega-headline">Who we are</h3>
+                <p>
+                  A leader in creativity and mental wellness — AWBW supports hundreds of direct
+                  service organizations across the country to bring creative expression into their
+                  work with trauma survivors.
+                </p>
+                <%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit" %>
+                <i class="fa-solid fa-arrow-right text-brand-green-700 text-xs"></i>
               </div>
 
-              <!-- MIDDLE: DESCRIPTION -->
-              <div class="mega-col content-col text-gray-900">
-                <div class="font-telefon">
-                  <h3>WHO WE ARE</h3>
-                </div>
-                <p>
-                  A leader in creativity and mental wellness. AWBW supports
-                  hundreds of direct service organizations across the country
-                  to incorporate creative expression into their work with
-                  trauma survivors.
-                </p>
-                <p>
-                  AWBW’s training in facilitating art as a tool for
-                  transformation and healing, along with our library of
-                  curriculum and ongoing support, strengthens our program
-                  partners’ ability to better assist the individuals and
-                  communities they serve.
-                </p>
-              </div>
-
-              <!-- RIGHT: LINKS -->
-              <div class="mega-col links-col links-wrapper">
+              <!-- MIDDLE: links -->
+              <div class="mega-col links-wrapper">
                 <div class="links-group">
-                  <h4>ABOUT US</h4>
+                  <h4>About us</h4>
                   <ul>
                     <li><%= awbw_menu_link "Our Approach", "/about-us/our-approach/", html_class: "" %></li>
                     <li><%= awbw_menu_link "Mission, Vision & Values", "/about-us/mission-vision-values/", html_class: "" %></li>
@@ -136,9 +155,8 @@
                     <li><%= awbw_menu_link "Contact us", "/about-us/contact-us/", html_class: "" %></li>
                   </ul>
                 </div>
-
                 <div class="links-group">
-                  <h4>NEWS</h4>
+                  <h4>News</h4>
                   <ul>
                     <li><%= awbw_menu_link "Press Release", "/news/press-releases/", html_class: "" %></li>
                     <li><%= awbw_menu_link "Media Press Kit", "/news/media-press-kit/", html_class: "" %></li>
@@ -146,230 +164,168 @@
                   </ul>
                 </div>
               </div>
+
+              <!-- RIGHT: photo card -->
+              <%= awbw_menu_link_photo image: "who-we-are-grid.jpg", alt: "Artwork collage",
+                                       cta: "Read our 2025 Impact Report", href: "/about-us/impact-report/" %>
             </div>
           </div>
         </div>
 
-        <!-- WHAT WE DO Mega -->
-        <div class="relative group nav-item has-dropdown">
-          <button type="button"
-                  class="font-telefon text-gray-700 hover:text-purple-700 text-md font-medium transition-colors">
-            What We Do ▾
+        <!-- WHAT WE DO Mega (accent: teal) -->
+        <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-teal-700);">
+          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-teal-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+            What We Do <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
-          <div class="mega-menu" aria-label="What We Do menu">
+          <div class="mega-menu bg-white" aria-label="What We Do menu">
             <div class="mega-container">
-
-              <!-- LEFT: IMAGE -->
-              <div class="mega-col image-col">
-                <%= image_tag "what-we-do.jpg",
-                              alt: "Facilitators leading art workshop",
-                              class: "rounded-lg" %>
-              </div>
-
-              <!-- MIDDLE: DESCRIPTION -->
-              <div class="mega-col content-col text-gray-900">
-                <div class="font-telefon">
-                  <h3>WHAT WE DO</h3>
-                </div>
+              <!-- LEFT: intro -->
+              <div class="mega-col">
+                <p class="mega-eyebrow">Program</p>
+                <h3 class="mega-headline">How our model works</h3>
                 <p>
-                  AWBW builds capacity at partnering organizations through training
-                  their staff to facilitate our trauma-informed art workshops, as well
-                  as continuing to support them as they implement the Windows Program
-                  with those who have experienced various forms of trauma.
+                  AWBW builds capacity at partnering organizations — training staff to facilitate our
+                  trauma-informed art workshops, then supporting them as they bring the Windows model
+                  to the people they serve.
                 </p>
-                <p>
-                  Through this unique model, we have developed a nationwide network of
-                  450+ active Windows Facilitators, allowing us to reach tens of
-                  thousands of survivors each year.
-                </p>
+                <%= awbw_menu_link "Visit the Program page", "/programs/", html_class: "mega-visit" %>
+                <i class="fa-solid fa-arrow-right text-brand-teal-700 text-xs"></i>
               </div>
 
-              <!-- RIGHT: PROGRAM LINKS -->
-              <div class="mega-col links-col">
-                <div class="links-wrapper">
-
-                  <!-- PROGRAM COLUMN -->
-                  <div class="links-group">
-                    <h4>PROGRAM</h4>
-                    <ul>
-                      <li><%= awbw_menu_link "Our Philosophy", "/programs/our-philosophy/", html_class: "" %></li>
-                      <li><%= awbw_menu_link "Community of Practice", "/programs/community-of-practice/", html_class: "" %></li>
-                      <li><%= awbw_menu_link "Windows Facilitator Trainings", "/programs/facilitator-trainings/", html_class: "" %></li>
-                      <li><%= awbw_menu_link "Durational Art", "/programs/durational-art/", html_class: "" %></li>
-                      <li><%= link_to "Story Share", story_shares_path %></li>
-                    </ul>
-                  </div>
-
-                  <!-- FACILITATOR COLUMN -->
-                  <div class="links-group">
-                    <h4>&nbsp;</h4>
-                    <ul>
-                      <li><%= awbw_menu_link "Facilitator Blog", "/blog/", html_class: "" %></li>
-                      <li><%= awbw_menu_link "Themes in Healing", "/impact/themes-in-healing/", html_class: "" %></li>
-                      <li><%= awbw_menu_link "Impact Report", "/about-us/impact-report/", html_class: "" %></li>
-                    </ul>
-                  </div>
-
-                </div>
-              </div>
-
-            </div>
-          </div>
-        </div>
-
-        <!-- WAYS TO HELP Mega -->
-        <div class="relative group nav-item has-dropdown">
-          <button type="button"
-                  class="font-telefon text-gray-700 hover:text-purple-700 text-md font-medium transition-colors">
-            Ways to Help ▾
-          </button>
-
-          <div class="mega-menu" aria-label="Ways to Help menu">
-            <div class="mega-container ways-help-container">
-
-              <!-- LEFT: IMAGE -->
-              <div class="mega-col image-col">
-                <%= image_tag "ways-to-help.jpg",
-                              alt: "Family holding painted hearts",
-                              class: "rounded-lg" %>
-              </div>
-
-              <!-- MIDDLE: CONTENT -->
-              <div class="mega-col content-col text-gray-900">
-
-                <div class="mb-6">
-                  <div class="font-telefon">
-                    <h3>GET INVOLVED</h3>
-                  </div>
-                  <ul class="mt-3 space-y-2">
-                    <li><%= awbw_menu_link "Join the Ignite Team", "/fueling-the-future/join-the-ignite-team/" %></li>
-                    <li><%= awbw_menu_link "Join Our Team", "/joinourteam/" %></li>
+              <!-- MIDDLE: links -->
+              <div class="mega-col links-wrapper">
+                <div class="links-group">
+                  <h4>Program</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Our Philosophy", "/programs/our-philosophy/", html_class: "" %></li>
+                    <li><%= awbw_menu_link "Community of Practice", "/programs/community-of-practice/", html_class: "" %></li>
+                    <li><%= awbw_menu_link "Windows Facilitator Trainings", "/programs/facilitator-trainings/", html_class: "" %></li>
+                    <li><%= awbw_menu_link "Durational Art", "/programs/durational-art/", html_class: "" %></li>
+                    <li><%= link_to "Story Share", story_shares_path %></li>
                   </ul>
                 </div>
+                <div class="links-group">
+                  <h4>Impact</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Facilitator Blog", "/blog/", html_class: "" %></li>
+                    <li><%= awbw_menu_link "Themes in Healing", "/impact/themes-in-healing/", html_class: "" %></li>
+                    <li><%= awbw_menu_link "Impact Report", "/about-us/impact-report/", html_class: "" %></li>
+                  </ul>
+                </div>
+              </div>
 
-                <div>
-                  <div class="font-telefon">
-                    <h3>MAKE A DONATION</h3>
-                  </div>
-                  <ul class="mt-3 space-y-2">
+              <!-- RIGHT: photo card -->
+              <%= awbw_menu_link_photo image: "what-we-do.jpg", alt: "Facilitators leading an art workshop",
+                                       cta: "See the full Windows model", href: "/programs/" %>
+            </div>
+          </div>
+        </div>
+
+        <!-- WAYS TO HELP Mega (accent: magenta) -->
+        <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-magenta-700);">
+          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-magenta-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+            Ways to Help <i class="fa-solid fa-chevron-down text-xs"></i>
+          </button>
+
+          <div class="mega-menu bg-white" aria-label="Ways to Help menu">
+            <div class="mega-container">
+              <!-- LEFT: intro -->
+              <div class="mega-col">
+                <p class="mega-eyebrow">Get involved</p>
+                <h3 class="mega-headline">Ways to support</h3>
+                <p>
+                  Give, fund a scholarship, or leave a legacy — every path fuels accessible healing
+                  for the individuals and communities our facilitators serve.
+                </p>
+                <%= awbw_menu_link "Visit the Get Involved page", "/ways-to-give/", html_class: "mega-visit" %>
+                <i class="fa-solid fa-arrow-right text-brand-magenta-700 text-xs"></i>
+              </div>
+
+              <!-- MIDDLE: links -->
+              <div class="mega-col links-wrapper">
+                <div class="links-group">
+                  <h4>Get involved</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Join the Ignite Team", "/fueling-the-future/join-the-ignite-team/" %></li>
+                    <li><%= awbw_menu_link "Join Our Team", "/joinourteam/" %></li>
                     <li><%= awbw_menu_link "One-Time Gift", "/ways-to-give/" %></li>
                     <li><%= awbw_menu_link "Give Monthly", "/ways-to-give/" %></li>
                   </ul>
                 </div>
-
-              </div>
-
-              <!-- RIGHT: GIVE + BADGE -->
-              <div class="mega-col links-col">
-                <div class="links-wrapper">
-
-                  <!-- Ways to Give -->
-                  <div class="links-group">
-                    <div class="font-telefon">
-                      <h4>WAYS TO GIVE</h4>
-                    </div>
-                    <ul class="mt-3 space-y-2">
-                      <li><%= awbw_menu_link "Sustaining Gifts", "/ways-to-give/impact-journey-circle/" %></li>
-                      <li><%= awbw_menu_link "Planned Giving", "/ways-to-give/planned-giving/" %></li>
-                      <li><%= awbw_menu_link "More Ways To Give", "/ways-to-give/" %></li>
-                      <li><%= awbw_menu_link "Supporter Spotlights", "/ways-to-give/supporter-spotlights/" %></li>
-                    </ul>
-                  </div>
-
-                  <!-- Badge Box -->
-                  <div class="badge-box">
-                    <div class="badge-inner">
-                      <p class="text-sm tracking-wide">Platinum Transparency</p>
-                      <p class="text-lg font-semibold">2026</p>
-                      <p class="text-xl font-bold mt-3">Candid.</p>
-                    </div>
-                  </div>
-
+                <div class="links-group">
+                  <h4>Ways to give</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Sustaining Gifts", "/ways-to-give/impact-journey-circle/" %></li>
+                    <li><%= awbw_menu_link "Planned Giving", "/ways-to-give/planned-giving/" %></li>
+                    <li><%= awbw_menu_link "More Ways To Give", "/ways-to-give/" %></li>
+                    <li><%= awbw_menu_link "Supporter Spotlights", "/ways-to-give/supporter-spotlights/" %></li>
+                  </ul>
                 </div>
               </div>
 
+              <!-- RIGHT: photo card -->
+              <%= awbw_menu_link_photo image: "ways-to-help.jpg", alt: "Family holding painted hearts",
+                                       cta: "Your gift makes healing reachable", href: "/ways-to-give/" %>
             </div>
           </div>
         </div>
 
-        <!-- OUR NEXT CHAPTER Mega -->
-        <div class="relative group nav-item has-dropdown">
-          <button type="button"
-                  class="font-telefon text-gray-700 hover:text-purple-700 text-md font-medium transition-colors">
-            Our Next Chapter ▾
+        <!-- OUR NEXT CHAPTER Mega (accent: orange) -->
+        <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-orange-700);">
+          <button type="button" class="font-display text-brand-navy-900 hover:text-brand-orange-700 inline-flex items-center gap-1.5 text-lg font-semibold transition-colors">
+            Our Next Chapter <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
-          <div class="mega-menu" aria-label="Our Next Chapter menu">
-            <div class="mega-container next-chapter-container">
-
-              <!-- LEFT: IMAGE -->
-              <div class="mega-col image-col">
-                <%= image_tag "our-next-chapter.jpg",
-                              alt: "Colorful circular artwork",
-                              class: "rounded-lg" %>
-              </div>
-
-              <!-- MIDDLE: DESCRIPTION -->
-              <div class="mega-col content-col text-gray-900">
-                <div class="font-telefon">
-                  <h4>OUR NEXT CHAPTER</h4>
-                </div>
-
-                <p class="mt-3">
-                  From the beginning, a circle of connected innovation —
-                  comprised of each facilitator, supporter, staff, board member,
-                  and survivor — has created AWBW.
+          <div class="mega-menu bg-white" aria-label="Our Next Chapter menu">
+            <div class="mega-container">
+              <!-- LEFT: intro -->
+              <div class="mega-col">
+                <p class="mega-eyebrow">Our next chapter</p>
+                <h3 class="mega-headline">Carrying the work forward</h3>
+                <p>
+                  From the beginning, a circle of connected innovation — each facilitator, supporter,
+                  staff, board member, and survivor — has created AWBW. Join us in carrying that work
+                  into a sustainable future.
                 </p>
+                <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "mega-visit" %>
+                <i class="fa-solid fa-arrow-right text-brand-orange-700 text-xs"></i>
+              </div>
 
-                <p class="mt-3">
-                  As we celebrate 30 years of transforming trauma,
-                  we invite you to join us in both honoring the talents
-                  that have brought our work this far and carrying
-                  that work into a sustainable future.
-                </p>
-
-                <div class="mt-4">
-                  <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "underline font-semibold hover:text-purple-700" %>
+              <!-- MIDDLE: links -->
+              <div class="mega-col links-wrapper">
+                <div class="links-group">
+                  <h4>Key initiatives</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Uplifting Voices", "/key-initiatives/uplifting-voices/" %></li>
+                    <li><%= awbw_menu_link "Centering Social Justice", "/key-initiatives/initiative-2-centering-social-justice/" %></li>
+                    <li><%= awbw_menu_link "Embedding Sustainability", "/key-initiatives/initiative-3-embedding-sustainability/" %></li>
+                  </ul>
+                </div>
+                <div class="links-group">
+                  <h4>Celebrate with us</h4>
+                  <ul>
+                    <li><%= awbw_menu_link "Fueling the Future Campaign", "/fueling-the-future-updated/" %></li>
+                    <li><%= awbw_menu_link "View Our Impact Report", "/about-us/impact-report/" %></li>
+                  </ul>
                 </div>
               </div>
 
-              <!-- RIGHT: LINKS -->
-              <div class="mega-col links-col">
-                <div class="links-wrapper">
-
-                  <!-- Key Initiatives -->
-                  <div class="links-group">
-                    <h4>KEY INITIATIVES</h4>
-                    <ul class="mt-3 space-y-2">
-                      <li><%= awbw_menu_link "Uplifting Voices", "/key-initiatives/uplifting-voices/" %></li>
-                      <li><%= awbw_menu_link "Centering Social Justice", "/key-initiatives/initiative-2-centering-social-justice/" %></li>
-                      <li><%= awbw_menu_link "Embedding Sustainability", "/key-initiatives/initiative-3-embedding-sustainability/" %></li>
-                    </ul>
-                  </div>
-
-                  <!-- Celebrate With Us -->
-                  <div class="links-group">
-                    <h4>CELEBRATE WITH US</h4>
-                    <ul class="mt-3 space-y-2">
-                      <li><%= awbw_menu_link "Fueling the Future Campaign", "/fueling-the-future-updated/" %></li>
-                      <li><%= awbw_menu_link "View Our Impact Report", "/about-us/impact-report/" %></li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
+              <!-- RIGHT: photo card -->
+              <%= awbw_menu_link_photo image: "our-next-chapter.jpg", alt: "Colorful circular artwork",
+                                       cta: "Explore our next chapter", href: "/key-initiatives/" %>
             </div>
           </div>
         </div>
       </div>
 
-      <div class="flex items-center space-x-4 absolute right-2 sm:right-6 lg:right-8">
-        <%= awbw_menu_link "Donate", "/ways-to-give/", html_class: "hidden md:inline-flex px-6 py-2 bg-gray-800 text-white text-sm font-medium hover:bg-gray-900 transition-colors" %>
+      <div class="absolute right-2 flex items-center space-x-4 sm:right-6 lg:right-8">
+        <%= awbw_menu_link "Donate", "/ways-to-give/", html_class: "hidden md:inline-flex items-center rounded-full bg-brand-yellow-400 hover:bg-brand-yellow-500 text-brand-navy-900 px-6 py-2 text-sm font-semibold shadow-sm transition-colors" %>
 
         <%= link_to new_user_session_path,
-                    class: "hidden md:inline-flex text-gray-700 hover:text-purple-700 transition-colors",
+                    class: "hidden md:inline-flex text-brand-navy-800 hover:text-brand-magenta-700 transition-colors",
                     aria: { label: "Login" } do %>
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="2"
@@ -380,7 +336,7 @@
         <div class="lg:hidden">
           <button
             type="button"
-            class="relative inline-flex items-center justify-center rounded-md p-2 text-gray-700 hover:bg-gray-100 focus:outline-2 focus:ring-2 focus:ring-purple-700"
+            class="focus:ring-brand-navy-700 relative inline-flex items-center justify-center rounded-md p-2 text-brand-navy-800 hover:bg-brand-navy-100 focus:ring-2 focus:outline-2"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"story-shares-mobile-menu":"hidden"}]'>
             <span class="sr-only">Open main menu</span>
@@ -394,23 +350,23 @@
 
     <!-- Row 2: Focus Area Navigation -->
     <div class="nav-row">
-      <div class="hidden lg:flex items-center justify-center py-3 space-x-6">
-        <%= link_to "Home", story_shares_path, class: "font-telefon text-[#5B2C8A] hover:bg-gray-100 px-3 py-1 rounded text-sm font-medium transition-all" %>
+      <div class="hidden items-center justify-center space-x-6 py-3 lg:flex">
+        <%= link_to "Home", story_shares_path, class: "font-display text-brand-navy-900 hover:bg-brand-navy-50 rounded-full px-3 py-1 text-sm font-semibold transition-all" %>
         <% story_share_nav_sectors.each_with_index do |sector, index| %>
           <%= link_to sector.name, story_shares_path(sector_names_all: sector.name),
-                      class: "font-telefon #{story_share_slot_theme(index)[:heading]} hover:bg-gray-100 px-3 py-1 rounded text-sm font-medium transition-all" %>
+                      class: "font-display #{story_share_slot_theme(index)[:heading]} hover:bg-brand-navy-50 rounded-full px-3 py-1 text-sm font-semibold transition-all" %>
         <% end %>
-        <%= link_to "Facilitator Spotlights", story_shares_path(facilitator_spotlights: true), class: "font-telefon text-purple-700 hover:bg-gray-100 px-3 py-1 rounded text-sm font-medium transition-all" %>
-        <%= link_to "Additional Focus Areas", story_shares_path(additional_focus_areas: true), class: "font-telefon text-[#F28C00] hover:bg-gray-100 px-3 py-1 rounded text-sm font-medium transition-all" %>
+        <%= link_to "Facilitator Spotlights", story_shares_path(facilitator_spotlights: true), class: "font-display text-brand-magenta-700 hover:bg-brand-navy-50 rounded-full px-3 py-1 text-sm font-semibold transition-all" %>
+        <%= link_to "Additional Focus Areas", story_shares_path(additional_focus_areas: true), class: "font-display text-brand-orange-600 hover:bg-brand-navy-50 rounded-full px-3 py-1 text-sm font-semibold transition-all" %>
       </div>
     </div>
 
     <!-- Row 3: Participant Type Navigation and Search - Centered Below Row 2 -->
-    <div class="nav-row border-b-4 border-purple-700 ">
-      <div class="hidden lg:flex flex-col items-center justify-center py-3 space-y-3">
+    <div class="nav-row border-brand-navy-900/10 border-t">
+      <div class="hidden flex-col items-center justify-center space-y-3 py-3 lg:flex">
         <div class="flex items-center space-x-6">
           <% story_share_audience_categories.each do |category| %>
-            <%= link_to category.name, story_shares_path(category_names_all: category.name), class: "font-telefon text-gray-600 hover:bg-gray-100 px-3 py-1 rounded text-sm font-medium transition-all" %>
+            <%= link_to category.name, story_shares_path(category_names_all: category.name), class: "font-display text-gray-600 hover:bg-brand-navy-50 rounded-full px-3 py-1 text-sm font-medium transition-all" %>
           <% end %>
           <div>
             <%= form_with url: story_shares_path, method: :get, class: "relative" do %>
@@ -418,10 +374,10 @@
                 type="search"
                 name="query"
                 placeholder="Search keywords to find more stories..."
-                class="portal-search w-80 pl-4 pr-10 py-2 rounded-md border border-gray-300 text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-purple-700"
+                class="portal-search focus:ring-brand-magenta-500 w-80 rounded-full border border-brand-navy-900/15 bg-white py-2 pr-10 pl-4 text-sm text-gray-900 focus:ring-2 focus:outline-none"
                 value="<%= params[:query] %>"/>
-              <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 <%= eyebrow_link_class %>" aria-label="Search">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <button type="submit" class="text-brand-navy-700 hover:text-brand-magenta-700 absolute top-1/2 right-3 -translate-y-1/2" aria-label="Search">
+                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                 </svg>
               </button>
@@ -432,25 +388,25 @@
     </div>
 
     <!-- Mobile menu, hidden by default -->
-    <div id="story-shares-mobile-menu" class="lg:hidden hidden nav-row border-b-4 border-purple-700 ">
+    <div id="story-shares-mobile-menu" class="nav-row border-brand-navy-900/10 hidden border-t lg:hidden">
       <div class="space-y-1 pb-3 pt-2">
-        <%= link_to "Home", story_shares_path, class: "block px-3 py-2 text-gray-800 hover:bg-gray-100 text-base font-medium rounded-md" %>
+        <%= link_to "Home", story_shares_path, class: "text-brand-navy-900 hover:bg-brand-navy-50 block rounded-md px-3 py-2 text-base font-medium" %>
         <% story_share_nav_sectors.each_with_index do |sector, index| %>
           <%= link_to sector.name, story_shares_path(sector_names_all: sector.name),
-                      class: "block px-3 py-2 #{story_share_slot_theme(index)[:heading]} hover:bg-gray-100 text-base font-medium rounded-md" %>
+                      class: "block px-3 py-2 #{story_share_slot_theme(index)[:heading]} hover:bg-brand-navy-50 rounded-md text-base font-medium" %>
         <% end %>
-        <%= link_to "Facilitator Spotlights", story_shares_path(facilitator_spotlights: true), class: "block px-3 py-2 text-purple-700 hover:bg-gray-100 text-base font-medium rounded-md" %>
-        <%= link_to "Additional Focus Areas", story_shares_path(additional_focus_areas: true), class: "block px-3 py-2 text-[#F28C00] hover:bg-gray-100 text-base font-medium rounded-md" %>
+        <%= link_to "Facilitator Spotlights", story_shares_path(facilitator_spotlights: true), class: "text-brand-magenta-700 hover:bg-brand-navy-50 block rounded-md px-3 py-2 text-base font-medium" %>
+        <%= link_to "Additional Focus Areas", story_shares_path(additional_focus_areas: true), class: "text-brand-orange-600 hover:bg-brand-navy-50 block rounded-md px-3 py-2 text-base font-medium" %>
 
-        <div class="border-t border-gray-200 my-2"></div>
+        <div class="border-brand-navy-900/10 my-2 border-t"></div>
 
         <% story_share_audience_categories.each do |category| %>
-          <%= link_to category.name, story_shares_path(category_names_all: category.name), class: "block px-3 py-2 text-gray-600 hover:bg-gray-100 text-base font-medium rounded-md" %>
+          <%= link_to category.name, story_shares_path(category_names_all: category.name), class: "block rounded-md px-3 py-2 text-base font-medium text-gray-600 hover:bg-brand-navy-50" %>
         <% end %>
 
-        <div class="border-t border-gray-200 my-2"></div>
+        <div class="border-brand-navy-900/10 my-2 border-t"></div>
 
-        <%= link_to "Share your story", new_story_share_path, class: "block px-3 py-2 text-purple-700 hover:bg-gray-100 text-base font-medium rounded-md" %>
+        <%= link_to "Share your story", new_story_share_path, class: "text-brand-magenta-700 hover:bg-brand-navy-50 block rounded-md px-3 py-2 text-base font-medium" %>
 
         <div class="px-3 py-2">
           <%= form_with url: story_shares_path, method: :get do %>
@@ -458,7 +414,7 @@
               type="search"
               name="query"
               placeholder="Search stories..."
-              class="w-full px-4 py-2 rounded-md border border-gray-300 text-gray-900 text-sm"
+              class="w-full rounded-full border border-brand-navy-900/15 px-4 py-2 text-sm text-gray-900"
               value="<%= params[:query] %>"
               />
           <% end %>

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-brand-cream relative print:hidden" data-controller="dropdown">
+<nav class="bg-brand-cream border-brand-navy-800 relative border-t-[3px] border-b-2 print:hidden" data-controller="dropdown">
   <style>
       /* Mega menu spans the full row, not just the trigger button: keep the
          trigger un-positioned so the absolute menu anchors to .nav-row.row-1
@@ -108,7 +108,7 @@
 
   <div class="px-2 sm:px-6 lg:px-8">
     <!-- Row 1: Logo and Main Navigation -->
-    <div class="nav-row row-1 border-brand-navy-900/10 relative flex items-center justify-center border-b py-4">
+    <div class="nav-row row-1 border-brand-navy-800 relative flex items-center justify-center border-b-2 py-4">
       <!-- Logo (always visible) -->
       <div class="absolute left-2 flex shrink-0 items-center sm:left-6 lg:left-8">
         <% if current_user %>
@@ -124,7 +124,7 @@
       <div class="hidden items-center space-x-8 lg:flex">
         <!-- WHO WE ARE Mega (accent: green) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-green-700);">
-          <button type="button" class="text-brand-navy-900 hover:text-brand-green-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-green-700 hover:bg-brand-green-50 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 font-display text-lg font-semibold transition-colors">
             Who We Are <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -174,7 +174,7 @@
 
         <!-- WHAT WE DO Mega (accent: teal) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-teal-700);">
-          <button type="button" class="text-brand-navy-900 hover:text-brand-teal-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-teal-700 hover:bg-brand-teal-50 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 font-display text-lg font-semibold transition-colors">
             What We Do <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -224,7 +224,7 @@
 
         <!-- WAYS TO HELP Mega (accent: magenta) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-magenta-700);">
-          <button type="button" class="text-brand-navy-900 hover:text-brand-magenta-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-magenta-700 hover:bg-brand-magenta-50 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 font-display text-lg font-semibold transition-colors">
             Ways to Help <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 
@@ -273,7 +273,7 @@
 
         <!-- OUR NEXT CHAPTER Mega (accent: orange) -->
         <div class="group nav-item has-dropdown" style="--accent: var(--color-brand-orange-700);">
-          <button type="button" class="text-brand-navy-900 hover:text-brand-orange-700 inline-flex items-center gap-1.5 font-display text-lg font-semibold transition-colors">
+          <button type="button" class="text-brand-navy-900 hover:text-brand-orange-700 hover:bg-brand-orange-50 inline-flex items-center gap-1.5 rounded-lg px-4 py-2 font-display text-lg font-semibold transition-colors">
             Our Next Chapter <i class="fa-solid fa-chevron-down text-xs"></i>
           </button>
 

--- a/app/views/story_shares/_browse.html.erb
+++ b/app/views/story_shares/_browse.html.erb
@@ -1,10 +1,11 @@
-<div class="bg-gray-100 min-h-screen py-8">
-  <div class="max-w-6xl mx-auto px-6">
+<div class="bg-brand-cream -mx-2 min-h-screen py-10 sm:-mx-6 lg:-mx-8">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 
-    <div class="flex items-baseline justify-between mb-6">
+    <p class="text-brand-orange-600 mb-1 text-sm font-semibold tracking-widest uppercase">Story share</p>
+    <div class="mb-8 flex items-baseline justify-between">
       <%# Sector/category names carry intentional casing ("LGBTQIA+",
           "Self-Care/Personal Growth"); render as stored, never .titleize. %>
-      <h1 class="text-2xl font-bold text-gray-900"><%= browse_title(params) %></h1>
+      <h1 class="text-brand-navy-900 font-display text-3xl tracking-tight"><%= browse_title(params) %></h1>
       <p class="text-sm text-gray-500"><%= pluralize(@count_display, "story") %></p>
     </div>
 
@@ -15,11 +16,11 @@
 
       <% if single_hero %>
         <% lead = @stories.first %>
-        <div class="rounded shadow-md overflow-hidden mb-12">
+        <div class="ring-brand-navy-900/10 mb-12 overflow-hidden rounded-2xl shadow-md ring-1">
           <%= link_to story_share_path(lead), class: "block" do %>
             <%= render "story_image", story: lead, aspect: "aspect-[16/6]" %>
-            <div class="bg-gray-700 text-white p-4">
-              <h2 class="font-telefon text-lg font-semibold"><%= lead.title %></h2>
+            <div class="bg-brand-navy-800 p-5 text-white">
+              <h2 class="font-display text-xl"><%= lead.title %></h2>
               <p class="text-sm opacity-80">
                 <%= lead.organization_name %><%= " – #{lead.organization.state}" if lead.organization&.state.present? %>
               </p>
@@ -31,15 +32,15 @@
       <% else %>
         <% hero_stories = @stories.first(5) %>
         <div data-controller="carousel"
-             class="relative swiper rounded-lg overflow-hidden shadow-lg mb-12"
+             class="swiper ring-brand-navy-900/10 relative mb-12 overflow-hidden rounded-2xl shadow-lg ring-1"
              data-carousel-options-value='{ "autoplay": { "delay": 5000, "pauseOnMouseEnter": true }, "slidesPerView": 1, "breakpoints": {} }'>
           <div class="swiper-wrapper">
             <% hero_stories.each do |story| %>
               <div class="swiper-slide">
                 <%= link_to story_share_path(story), class: "block relative" do %>
                   <%= render "story_image", story: story, aspect: "aspect-[16/6]" %>
-                  <div class="absolute bottom-0 left-0 right-0 bg-black/50 p-6 text-white">
-                    <h2 class="font-telefon text-2xl mb-1"><%= story.title %></h2>
+                  <div class="from-brand-navy-950/85 absolute right-0 bottom-0 left-0 bg-gradient-to-t to-transparent p-6 text-white">
+                    <h2 class="mb-1 font-display text-2xl"><%= story.title %></h2>
                     <p class="text-sm opacity-90">
                       <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
                     </p>
@@ -48,11 +49,11 @@
               </div>
             <% end %>
           </div>
-          <button aria-label="Previous story" class="swiper-button-prev-custom absolute left-4 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-20">
-            <i class="fa-solid fa-chevron-left text-gray-800"></i>
+          <button aria-label="Previous story" class="swiper-button-prev-custom text-brand-navy-900 absolute top-1/2 left-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 shadow-lg hover:bg-white">
+            <i class="fa-solid fa-chevron-left"></i>
           </button>
-          <button aria-label="Next story" class="swiper-button-next-custom absolute right-4 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-20">
-            <i class="fa-solid fa-chevron-right text-gray-800"></i>
+          <button aria-label="Next story" class="swiper-button-next-custom text-brand-navy-900 absolute top-1/2 right-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 shadow-lg hover:bg-white">
+            <i class="fa-solid fa-chevron-right"></i>
           </button>
         </div>
         <% grid_stories = @stories.drop(5).first(3) %>
@@ -61,7 +62,7 @@
 
       <!-- 3-up featured grid -->
       <% if grid_stories.any? %>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
+        <div class="mb-16 grid grid-cols-1 gap-8 md:grid-cols-3">
           <% grid_stories.each do |story| %>
             <%= render "browse_card", story: story %>
           <% end %>
@@ -77,7 +78,7 @@
 
       <div class="pagination mt-10"><%= tailwind_paginate @stories %></div>
     <% else %>
-      <div class="text-center text-gray-600 py-20">
+      <div class="py-20 text-center text-gray-600">
         No stories found.
       </div>
     <% end %>

--- a/app/views/story_shares/_browse_card.html.erb
+++ b/app/views/story_shares/_browse_card.html.erb
@@ -1,4 +1,4 @@
-<article class="border-brand-navy-900/15 flex flex-col overflow-hidden rounded-2xl border bg-white shadow-sm transition-shadow hover:shadow-lg">
+<article class="border-brand-navy-900/15 flex flex-col overflow-hidden rounded-2xl border bg-white shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-2xl">
   <%= link_to story_share_path(story), class: "block" do %>
     <%= render "story_image", story: story, aspect: "aspect-[4/3]" %>
   <% end %>

--- a/app/views/story_shares/_browse_card.html.erb
+++ b/app/views/story_shares/_browse_card.html.erb
@@ -1,16 +1,18 @@
-<article>
-  <%= link_to story_share_path(story), class: "block rounded shadow-md overflow-hidden hover:shadow-xl transition-shadow" do %>
+<article class="flex flex-col overflow-hidden rounded-2xl border border-brand-navy-900/15 bg-white shadow-sm transition-shadow hover:shadow-lg">
+  <%= link_to story_share_path(story), class: "block" do %>
     <%= render "story_image", story: story, aspect: "aspect-[4/3]" %>
   <% end %>
-  <h3 class="font-telefon text-lg font-bold text-gray-900 mt-3 leading-tight">
-    <%= link_to story.title, story_share_path(story), class: "hover:text-purple-700" %>
-  </h3>
-  <p class="text-xs text-gray-500 mt-1">
-    <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
-  </p>
-  <p class="text-sm text-gray-700 mt-2"><%= truncate(story.rhino_body.to_plain_text, length: 140) %></p>
-  <div class="mt-3">
-    <%= link_to "Read more", story_share_path(story),
-                class: "inline-block bg-gray-700 hover:bg-gray-800 text-white text-sm px-5 py-2 rounded transition" %>
+  <div class="flex flex-1 flex-col p-5">
+    <h3 class="font-display text-xl leading-snug text-brand-navy-900">
+      <%= link_to story.title, story_share_path(story), class: "hover:text-brand-magenta-700" %>
+    </h3>
+    <p class="mt-1 text-xs text-gray-500">
+      <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
+    </p>
+    <p class="mt-2 text-sm text-gray-600 line-clamp-3"><%= truncate(story.rhino_body.to_plain_text, length: 140) %></p>
+    <%= link_to story_share_path(story),
+                class: "text-brand-magenta-700 hover:text-brand-magenta-800 mt-4 inline-flex items-center gap-1.5 text-sm font-semibold" do %>
+      Read the story <i class="fa-solid fa-arrow-right text-xs"></i>
+    <% end %>
   </div>
 </article>

--- a/app/views/story_shares/_browse_card.html.erb
+++ b/app/views/story_shares/_browse_card.html.erb
@@ -1,15 +1,15 @@
-<article class="flex flex-col overflow-hidden rounded-2xl border border-brand-navy-900/15 bg-white shadow-sm transition-shadow hover:shadow-lg">
+<article class="border-brand-navy-900/15 flex flex-col overflow-hidden rounded-2xl border bg-white shadow-sm transition-shadow hover:shadow-lg">
   <%= link_to story_share_path(story), class: "block" do %>
     <%= render "story_image", story: story, aspect: "aspect-[4/3]" %>
   <% end %>
   <div class="flex flex-1 flex-col p-5">
-    <h3 class="font-display text-xl leading-snug text-brand-navy-900">
+    <h3 class="text-brand-navy-900 font-display text-xl leading-snug">
       <%= link_to story.title, story_share_path(story), class: "hover:text-brand-magenta-700" %>
     </h3>
     <p class="mt-1 text-xs text-gray-500">
       <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
     </p>
-    <p class="mt-2 text-sm text-gray-600 line-clamp-3"><%= truncate(story.rhino_body.to_plain_text, length: 140) %></p>
+    <p class="line-clamp-3 mt-2 text-sm text-gray-600"><%= truncate(story.rhino_body.to_plain_text, length: 140) %></p>
     <%= link_to story_share_path(story),
                 class: "text-brand-magenta-700 hover:text-brand-magenta-800 mt-4 inline-flex items-center gap-1.5 text-sm font-semibold" do %>
       Read the story <i class="fa-solid fa-arrow-right text-xs"></i>

--- a/app/views/story_shares/_browse_row.html.erb
+++ b/app/views/story_shares/_browse_row.html.erb
@@ -1,27 +1,29 @@
-<div class="grid md:grid-cols-2 gap-8 md:gap-12 items-center">
+<div class="grid items-center gap-8 md:grid-cols-2 md:gap-12">
   <!-- LEFT CONTENT -->
   <div>
-    <h2 class="font-telefon text-2xl font-bold text-gray-900">
-      <%= link_to story.title, story_share_path(story), class: "hover:text-purple-700" %>
+    <h2 class="text-brand-navy-900 font-display text-2xl leading-tight">
+      <%= link_to story.title, story_share_path(story), class: "hover:text-brand-magenta-700" %>
     </h2>
 
     <p class="mt-2 text-sm text-gray-500">
       <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
     </p>
 
-    <p class="mt-6 text-gray-700 leading-relaxed">
+    <p class="mt-6 leading-relaxed text-gray-700">
       <%= truncate(story.rhino_body.to_plain_text, length: 280) %>
     </p>
 
     <div class="mt-6">
-      <%= link_to "Read more", story_share_path(story),
-                  class: "inline-block bg-gray-700 hover:bg-gray-800 text-white px-6 py-2 rounded transition" %>
+      <%= link_to story_share_path(story),
+                  class: "text-brand-magenta-700 hover:text-brand-magenta-800 inline-flex items-center gap-1.5 text-sm font-semibold" do %>
+        Read the story <i class="fa-solid fa-arrow-right text-xs"></i>
+      <% end %>
     </div>
   </div>
 
   <!-- RIGHT IMAGE -->
   <div class="w-full">
-    <%= link_to story_share_path(story), class: "block rounded shadow-lg overflow-hidden" do %>
+    <%= link_to story_share_path(story), class: "block rounded-2xl shadow-lg overflow-hidden ring-1 ring-brand-navy-900/10" do %>
       <%= render "story_image", story: story, aspect: "aspect-[4/3]" %>
     <% end %>
   </div>

--- a/app/views/story_shares/_get_involved.html.erb
+++ b/app/views/story_shares/_get_involved.html.erb
@@ -1,14 +1,15 @@
-<section class="bg-white py-16 -mx-2 sm:-mx-6 lg:-mx-8">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-    <h2 class="font-telefon text-4xl text-black mb-8">Get involved!</h2>
+<section class="bg-brand-cream -mx-2 py-16 sm:-mx-6 lg:-mx-8">
+  <div class="mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
+    <p class="text-brand-orange-600 mb-2 text-sm font-semibold tracking-widest uppercase">Get involved</p>
+    <h2 class="text-brand-navy-900 mb-8 font-display text-4xl tracking-tight">There's a place for you at AWBW</h2>
 
-    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+    <div class="flex flex-col justify-center gap-4 sm:flex-row">
       <%= awbw_menu_link "Attend our training", "/programs/facilitator-trainings/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-100 hover:text-purple-900 transition-colors duration-500" %>
+                         html_class: "bg-brand-navy-800 hover:bg-brand-navy-900 inline-flex items-center justify-center rounded-full px-8 py-4 font-display text-lg text-white transition-colors" %>
       <%= awbw_menu_link "Support our program", "/ways-to-give/",
-                         html_class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-white bg-purple-900 hover:bg-purple-100 hover:text-purple-900 transition-colors duration-500" %>
+                         html_class: "bg-brand-magenta-600 hover:bg-brand-magenta-700 inline-flex items-center justify-center rounded-full px-8 py-4 font-display text-lg text-white transition-colors" %>
       <%= link_to "Share your story", new_story_share_path,
-                  class: "inline-flex items-center justify-center px-8 py-4 rounded-md font-telefon text-xl text-purple-900 border-2 border-purple-900 hover:bg-purple-100 hover:border-purple-100 transition-colors duration-500" %>
+                  class: "border-brand-navy-800 text-brand-navy-800 hover:bg-brand-navy-50 inline-flex items-center justify-center rounded-full border-2 px-8 py-4 font-display text-lg transition-colors" %>
     </div>
   </div>
 </section>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -1,52 +1,49 @@
-<!-- Hero Section -->
-<section class="bg-white mt-12 pt-6 -mx-2 sm:-mx-6 lg:-mx-8">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-    <h1 class="font-telefon text-4xl sm:text-5xl text-black text-center mb-12">
-      Welcome to our Story Share
+<!-- Hero -->
+<section class="bg-brand-cream -mx-2 pt-14 pb-10 sm:-mx-6 lg:-mx-8">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <p class="text-brand-orange-600 mb-3 text-sm font-semibold tracking-widest uppercase">Story share</p>
+    <h1 class="font-display text-4xl leading-tight tracking-tight text-brand-navy-900 sm:text-5xl">
+      Stories of healing in action
     </h1>
-
-    <blockquote class="text-center mb-6">
-      <p class="text-lg text-gray-800 font-semibold">
-        "If we can share our story with someone who responds with empathy and understanding, shame can't survive." ~ Brené Brown
-      </p>
-    </blockquote>
-
-    <div class="text-gray-800 leading-relaxed space-y-4">
+    <div class="mt-5 max-w-3xl space-y-4 text-lg leading-relaxed text-gray-700">
       <p>
-        At A Window Between Worlds, we aim to uplift the voices and showcase the leadership of our extensive network of art workshop facilitators. We invite you to explore these impactful stories and accompanying participant artwork from trained Windows Facilitators across the country and abroad.
+        At A Window Between Worlds, we uplift the voices and showcase the leadership of our
+        extensive network of art workshop facilitators — real stories and participant artwork
+        from trained Windows Facilitators across the country and abroad.
       </p>
-      <p>
-        This evolving collection illustrates the transformative power of creative expression that is experienced by individuals and communities participating in our art workshops. As we share these powerful stories, we empower others facing their own challenges, helping facilitate their healing journey.
-      </p>
+      <blockquote class="border-brand-magenta-300 border-l-4 pl-4 font-display text-xl text-brand-navy-900 italic">
+        “If we can share our story with someone who responds with empathy and understanding,
+        shame can’t survive.” <span class="text-base not-italic text-gray-500">— Brené Brown</span>
+      </blockquote>
     </div>
   </div>
 </section>
 
-<!-- Featured Story Carousel -->
+<!-- Featured story carousel -->
 <% if @featured_stories.any? %>
-  <section class="bg-gray-50 py-12 -mx-2 sm:-mx-6 lg:-mx-8">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+  <section class="bg-brand-cream -mx-2 pb-14 sm:-mx-6 lg:-mx-8">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <div data-controller="carousel"
-           class="relative swiper rounded-lg overflow-hidden shadow-lg"
+           class="swiper relative overflow-hidden rounded-2xl shadow-lg ring-1 ring-brand-navy-900/10"
            data-carousel-options-value='{ "autoplay": { "delay": 5000, "pauseOnMouseEnter": true }, "slidesPerView": 1, "breakpoints": {} }'>
         <div class="swiper-wrapper">
           <% @featured_stories.each do |story| %>
             <div class="swiper-slide">
               <%= link_to story_share_path(story), class: "block relative" do %>
-                <div class="h-72 sm:h-96 bg-gray-200 overflow-hidden">
+                <div class="h-72 overflow-hidden bg-brand-navy-100 sm:h-96">
                   <%= render "assets/display_image",
                              resource: story,
                              extra_image_classes: "!w-full h-full object-cover",
                              variant: :hero %>
                 </div>
                 <% if story.sectors.first %>
-                  <div class="absolute top-6 left-6 bg-purple-700 text-white text-xs font-semibold uppercase px-4 py-2 z-10">
+                  <div class="<%= story_share_sector_chip_class(story.sectors.first.name) %> absolute top-5 left-5 z-10 rounded-full px-4 py-1.5 text-xs font-semibold tracking-wide text-white uppercase">
                     <%= story.sectors.first.name %>
                   </div>
                 <% end %>
-                <div class="absolute bottom-0 left-0 right-0 bg-black/50 p-6 sm:p-8 text-white">
-                  <h2 class="font-telefon text-2xl sm:text-3xl mb-2"><%= story.title %></h2>
-                  <p class="text-sm opacity-90">
+                <div class="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-brand-navy-950/85 to-transparent p-6 text-white sm:p-8">
+                  <h2 class="font-display text-2xl sm:text-3xl"><%= story.title %></h2>
+                  <p class="mt-1 text-sm opacity-90">
                     <%= story.organization_name %>
                     <% if story.organization&.city_state.present? %>- <%= story.organization.city_state %><% end %>
                   </p>
@@ -56,21 +53,21 @@
           <% end %>
         </div>
 
-        <button aria-label="Previous story" class="swiper-button-prev-custom absolute left-4 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-20">
-          <i class="fa-solid fa-chevron-left text-gray-800"></i>
+        <button aria-label="Previous story" class="swiper-button-prev-custom absolute top-1/2 left-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-brand-navy-900 shadow-lg hover:bg-white">
+          <i class="fa-solid fa-chevron-left"></i>
         </button>
-        <button aria-label="Next story" class="swiper-button-next-custom absolute right-4 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white rounded-full p-2 shadow-lg z-20">
-          <i class="fa-solid fa-chevron-right text-gray-800"></i>
+        <button aria-label="Next story" class="swiper-button-next-custom absolute top-1/2 right-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-brand-navy-900 shadow-lg hover:bg-white">
+          <i class="fa-solid fa-chevron-right"></i>
         </button>
       </div>
     </div>
   </section>
 <% end %>
 
-<!-- Sector Sections -->
-<section class="bg-white py-12 -mx-2 sm:-mx-6 lg:-mx-8">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+<!-- Sector sections -->
+<section class="-mx-2 bg-white py-14 sm:-mx-6 lg:-mx-8">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <div class="grid grid-cols-1 gap-10 md:grid-cols-3">
       <% @stories_by_sector.each_with_index do |(sector, stories), index| %>
         <%= render "sector_section",
                    title: sector.name,
@@ -89,24 +86,25 @@
 
 <!-- What others are reading -->
 <% if @recent_stories.any? %>
-  <section class="bg-white py-12 -mx-2 sm:-mx-6 lg:-mx-8">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-      <h2 class="font-telefon text-3xl text-black mb-8">What others are reading</h2>
+  <section class="bg-brand-cream -mx-2 py-14 sm:-mx-6 lg:-mx-8">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <p class="text-brand-orange-600 mb-2 text-sm font-semibold tracking-widest uppercase">Story share</p>
+      <h2 class="font-display mb-8 text-3xl tracking-tight text-brand-navy-900">What others are reading</h2>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0">
-        <% @recent_stories.each_with_index do |story, index| %>
-          <% theme = story_share_slot_theme(index) %>
-          <%= link_to story_share_path(story), class: "group block relative aspect-[3/4] overflow-hidden bg-gray-200" do %>
-            <%= image_tag story.display_image, loading: "lazy", alt: story.title,
-                          class: "absolute inset-0 w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-110" %>
-            <div class="absolute inset-0 <%= theme[:overlay] %>"></div>
-            <div class="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <% @recent_stories.each do |story| %>
+          <%= link_to story_share_path(story), class: "group block overflow-hidden rounded-2xl border border-brand-navy-900/15 bg-white shadow-sm transition-shadow hover:shadow-lg" do %>
+            <div class="aspect-[4/3] overflow-hidden bg-brand-navy-50">
+              <%= image_tag story.display_image, loading: "lazy", alt: story.title,
+                            class: "h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105" %>
+            </div>
+            <div class="p-4">
               <% if story.sectors.first %>
-                <div class="<%= story_share_sector_chip_class(story.sectors.first.name) %> text-white text-sm font-bold uppercase tracking-wide px-4 py-2 mb-4 text-center">
+                <span class="bg-brand-magenta-50 text-brand-magenta-700 mb-2 inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium">
                   <%= story.sectors.first.name %>
-                </div>
+                </span>
               <% end %>
-              <h3 class="font-telefon text-white text-base leading-tight line-clamp-2 min-h-[2.5rem]"><%= story.title %></h3>
+              <h3 class="font-display text-lg leading-snug text-brand-navy-900 line-clamp-2"><%= story.title %></h3>
             </div>
           <% end %>
         <% end %>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -2,7 +2,7 @@
 <section class="bg-brand-cream -mx-2 pt-14 pb-10 sm:-mx-6 lg:-mx-8">
   <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
     <p class="text-brand-orange-600 mb-3 text-sm font-semibold tracking-widest uppercase">Story share</p>
-    <h1 class="font-display text-4xl leading-tight tracking-tight text-brand-navy-900 sm:text-5xl">
+    <h1 class="text-brand-navy-900 font-display text-4xl leading-tight tracking-tight sm:text-5xl">
       Stories of healing in action
     </h1>
     <div class="mt-5 max-w-3xl space-y-4 text-lg leading-relaxed text-gray-700">
@@ -11,9 +11,9 @@
         extensive network of art workshop facilitators — real stories and participant artwork
         from trained Windows Facilitators across the country and abroad.
       </p>
-      <blockquote class="border-brand-magenta-300 border-l-4 pl-4 font-display text-xl text-brand-navy-900 italic">
+      <blockquote class="border-brand-magenta-300 text-brand-navy-900 border-l-4 pl-4 font-display text-xl italic">
         “If we can share our story with someone who responds with empathy and understanding,
-        shame can’t survive.” <span class="text-base not-italic text-gray-500">— Brené Brown</span>
+        shame can’t survive.” <span class="text-base text-gray-500 not-italic">— Brené Brown</span>
       </blockquote>
     </div>
   </div>
@@ -24,13 +24,13 @@
   <section class="bg-brand-cream -mx-2 pb-14 sm:-mx-6 lg:-mx-8">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <div data-controller="carousel"
-           class="swiper relative overflow-hidden rounded-2xl shadow-lg ring-1 ring-brand-navy-900/10"
+           class="swiper ring-brand-navy-900/10 relative overflow-hidden rounded-2xl shadow-lg ring-1"
            data-carousel-options-value='{ "autoplay": { "delay": 5000, "pauseOnMouseEnter": true }, "slidesPerView": 1, "breakpoints": {} }'>
         <div class="swiper-wrapper">
           <% @featured_stories.each do |story| %>
             <div class="swiper-slide">
               <%= link_to story_share_path(story), class: "block relative" do %>
-                <div class="h-72 overflow-hidden bg-brand-navy-100 sm:h-96">
+                <div class="bg-brand-navy-100 h-72 overflow-hidden sm:h-96">
                   <%= render "assets/display_image",
                              resource: story,
                              extra_image_classes: "!w-full h-full object-cover",
@@ -41,7 +41,7 @@
                     <%= story.sectors.first.name %>
                   </div>
                 <% end %>
-                <div class="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-brand-navy-950/85 to-transparent p-6 text-white sm:p-8">
+                <div class="from-brand-navy-950/85 absolute right-0 bottom-0 left-0 bg-gradient-to-t to-transparent p-6 text-white sm:p-8">
                   <h2 class="font-display text-2xl sm:text-3xl"><%= story.title %></h2>
                   <p class="mt-1 text-sm opacity-90">
                     <%= story.organization_name %>
@@ -53,10 +53,10 @@
           <% end %>
         </div>
 
-        <button aria-label="Previous story" class="swiper-button-prev-custom absolute top-1/2 left-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-brand-navy-900 shadow-lg hover:bg-white">
+        <button aria-label="Previous story" class="swiper-button-prev-custom text-brand-navy-900 absolute top-1/2 left-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 shadow-lg hover:bg-white">
           <i class="fa-solid fa-chevron-left"></i>
         </button>
-        <button aria-label="Next story" class="swiper-button-next-custom absolute top-1/2 right-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 text-brand-navy-900 shadow-lg hover:bg-white">
+        <button aria-label="Next story" class="swiper-button-next-custom text-brand-navy-900 absolute top-1/2 right-4 z-20 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-white/90 shadow-lg hover:bg-white">
           <i class="fa-solid fa-chevron-right"></i>
         </button>
       </div>
@@ -89,12 +89,12 @@
   <section class="bg-brand-cream -mx-2 py-14 sm:-mx-6 lg:-mx-8">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="text-brand-orange-600 mb-2 text-sm font-semibold tracking-widest uppercase">Story share</p>
-      <h2 class="font-display mb-8 text-3xl tracking-tight text-brand-navy-900">What others are reading</h2>
+      <h2 class="text-brand-navy-900 mb-8 font-display text-3xl tracking-tight">What others are reading</h2>
 
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <% @recent_stories.each do |story| %>
           <%= link_to story_share_path(story), class: "group block overflow-hidden rounded-2xl border border-brand-navy-900/15 bg-white shadow-sm transition-shadow hover:shadow-lg" do %>
-            <div class="aspect-[4/3] overflow-hidden bg-brand-navy-50">
+            <div class="bg-brand-navy-50 aspect-[4/3] overflow-hidden">
               <%= image_tag story.display_image, loading: "lazy", alt: story.title,
                             class: "h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105" %>
             </div>
@@ -104,7 +104,7 @@
                   <%= story.sectors.first.name %>
                 </span>
               <% end %>
-              <h3 class="font-display text-lg leading-snug text-brand-navy-900 line-clamp-2"><%= story.title %></h3>
+              <h3 class="text-brand-navy-900 line-clamp-2 font-display text-lg leading-snug"><%= story.title %></h3>
             </div>
           <% end %>
         <% end %>

--- a/app/views/story_shares/_home.html.erb
+++ b/app/views/story_shares/_home.html.erb
@@ -1,21 +1,45 @@
-<!-- Hero -->
-<section class="bg-brand-cream -mx-2 pt-14 pb-10 sm:-mx-6 lg:-mx-8">
-  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-    <p class="text-brand-orange-600 mb-3 text-sm font-semibold tracking-widest uppercase">Story share</p>
-    <h1 class="text-brand-navy-900 font-display text-4xl leading-tight tracking-tight sm:text-5xl">
-      Stories of healing in action
-    </h1>
-    <div class="mt-5 max-w-3xl space-y-4 text-lg leading-relaxed text-gray-700">
-      <p>
-        At A Window Between Worlds, we uplift the voices and showcase the leadership of our
-        extensive network of art workshop facilitators — real stories and participant artwork
-        from trained Windows Facilitators across the country and abroad.
+<%# Hero: full-bleed photo (top featured story) under a navy→purple wash, with the
+    marketing site's big serif statement + gold accent + CTAs. %>
+<% hero_story = @featured_stories.first %>
+<section class="relative -mx-2 overflow-hidden sm:-mx-6 lg:-mx-8">
+  <% if hero_story %>
+    <%= image_tag hero_story.display_image, alt: "", loading: "eager", class: "absolute inset-0 h-full w-full object-cover" %>
+  <% end %>
+  <div class="from-brand-navy-950/95 via-brand-navy-900/85 to-brand-purple-900/75 absolute inset-0 bg-gradient-to-r"></div>
+  <div class="relative mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-28 lg:px-8">
+    <div class="max-w-2xl text-white">
+      <p class="text-brand-yellow-400 mb-4 text-sm font-semibold tracking-widest uppercase">Story share</p>
+      <h1 class="font-display text-5xl leading-[1.05] tracking-tight sm:text-6xl">
+        Stories of healing <span class="text-brand-yellow-400 italic">in action.</span>
+      </h1>
+      <p class="mt-6 max-w-xl text-lg leading-relaxed text-white/90">
+        Real stories and participant artwork from trained Windows Facilitators across the country
+        and abroad — and the people whose lives are changing because of it.
       </p>
-      <blockquote class="border-brand-magenta-300 text-brand-navy-900 border-l-4 pl-4 font-display text-xl italic">
-        “If we can share our story with someone who responds with empathy and understanding,
-        shame can’t survive.” <span class="text-base text-gray-500 not-italic">— Brené Brown</span>
-      </blockquote>
+      <div class="mt-8 flex flex-wrap gap-4">
+        <%= link_to story_shares_path(page: 1),
+                    class: "bg-brand-yellow-400 hover:bg-brand-yellow-500 text-brand-navy-900 inline-flex items-center gap-2 rounded-full px-7 py-3 font-semibold shadow-sm transition-colors" do %>
+          Browse all stories <i class="fa-solid fa-arrow-right text-sm"></i>
+        <% end %>
+        <%= link_to "Share your story", new_story_share_path,
+                    class: "inline-flex items-center gap-2 rounded-full border-2 border-white/70 px-7 py-3 font-semibold text-white transition-colors hover:bg-white/10" %>
+      </div>
     </div>
+  </div>
+</section>
+
+<!-- Intro + quote -->
+<section class="bg-brand-cream -mx-2 py-12 sm:-mx-6 lg:-mx-8">
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <p class="max-w-3xl text-lg leading-relaxed text-gray-700">
+      At A Window Between Worlds, we uplift the voices and showcase the leadership of our extensive
+      network of art workshop facilitators. This evolving collection illustrates the transformative
+      power of creative expression experienced in our workshops.
+    </p>
+    <blockquote class="border-brand-magenta-300 font-display text-brand-navy-900 mt-6 max-w-3xl border-l-4 pl-4 text-xl italic">
+      “If we can share our story with someone who responds with empathy and understanding,
+      shame can’t survive.” <span class="text-base text-gray-500 not-italic">— Brené Brown</span>
+    </blockquote>
   </div>
 </section>
 
@@ -84,27 +108,26 @@
   </div>
 </section>
 
-<!-- What others are reading -->
+<%# What others are reading: saturated color-wash tiles that lift on hover. %>
 <% if @recent_stories.any? %>
   <section class="bg-brand-cream -mx-2 py-14 sm:-mx-6 lg:-mx-8">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="text-brand-orange-600 mb-2 text-sm font-semibold tracking-widest uppercase">Story share</p>
-      <h2 class="text-brand-navy-900 mb-8 font-display text-3xl tracking-tight">What others are reading</h2>
+      <h2 class="font-display text-brand-navy-900 mb-8 text-3xl tracking-tight">What others are reading</h2>
 
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        <% @recent_stories.each do |story| %>
-          <%= link_to story_share_path(story), class: "group block overflow-hidden rounded-2xl border border-brand-navy-900/15 bg-white shadow-sm transition-shadow hover:shadow-lg" do %>
-            <div class="bg-brand-navy-50 aspect-[4/3] overflow-hidden">
-              <%= image_tag story.display_image, loading: "lazy", alt: story.title,
-                            class: "h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105" %>
-            </div>
-            <div class="p-4">
+        <% @recent_stories.each_with_index do |story, index| %>
+          <% theme = story_share_slot_theme(index) %>
+          <%= link_to story_share_path(story), class: "group relative block aspect-[3/4] overflow-hidden rounded-2xl shadow-sm transition-all duration-200 hover:-translate-y-1.5 hover:shadow-2xl" do %>
+            <%= image_tag story.display_image, loading: "lazy", alt: story.title,
+                          class: "absolute inset-0 h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-110" %>
+            <div class="absolute inset-0 <%= theme[:overlay] %> mix-blend-multiply"></div>
+            <div class="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent"></div>
+            <div class="absolute inset-x-0 bottom-0 p-5">
               <% if story.sectors.first %>
-                <span class="bg-brand-magenta-50 text-brand-magenta-700 mb-2 inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium">
-                  <%= story.sectors.first.name %>
-                </span>
+                <span class="mb-2 inline-flex rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-semibold tracking-wide text-white uppercase"><%= story.sectors.first.name %></span>
               <% end %>
-              <h3 class="text-brand-navy-900 line-clamp-2 font-display text-lg leading-snug"><%= story.title %></h3>
+              <h3 class="font-display text-xl leading-snug text-white line-clamp-3"><%= story.title %></h3>
             </div>
           <% end %>
         <% end %>

--- a/app/views/story_shares/_portal_footer.html.erb
+++ b/app/views/story_shares/_portal_footer.html.erb
@@ -1,27 +1,76 @@
-<footer class="bg-black text-white print:hidden">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 md:grid-cols-3 gap-8 items-center">
-    <div class="flex justify-center md:justify-start">
-      <%= link_to "Contact us", contact_us_path(from: "story_share"),
-                  class: "inline-block rounded border border-white px-6 py-2 text-sm font-bold uppercase tracking-wide hover:bg-white hover:text-black transition-colors" %>
+<footer class="bg-brand-navy-950 text-white print:hidden">
+  <!-- Rainbow accent strip (AWBW brand) -->
+  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+
+  <div class="mx-auto max-w-6xl px-4 py-14 sm:px-6 lg:px-8">
+    <div class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-4">
+      <!-- Brand + social -->
+      <div>
+        <div class="font-display text-2xl leading-none font-bold text-white">A Window Between Worlds</div>
+        <div class="text-brand-yellow-400 mt-1 text-xs font-semibold tracking-widest uppercase">Art transforming trauma</div>
+        <p class="mt-4 max-w-xs text-sm leading-relaxed text-white/70">
+          Trauma-informed healing arts, transforming individuals, teams, and communities for over 35 years.
+        </p>
+        <div class="mt-5 flex items-center gap-2">
+          <% social = [
+               [ "fa-brands fa-instagram", "Instagram" ],
+               [ "fa-brands fa-facebook-f", "Facebook" ],
+               [ "fa-brands fa-linkedin-in", "LinkedIn" ],
+               [ "fa-brands fa-youtube", "YouTube" ]
+             ] %>
+          <% social.each do |icon, label| %>
+            <%= link_to "https://awbw.org", target: "_blank", rel: "noopener noreferrer",
+                        aria: { label: label },
+                        class: "hover:bg-brand-navy-800 flex size-9 items-center justify-center rounded-lg bg-white/10 text-white transition-colors" do %>
+              <i class="<%= icon %>"></i>
+            <% end %>
+          <% end %>
+          <%= link_to "mailto:info@awbw.org", aria: { label: "Email" },
+                      class: "hover:bg-brand-navy-800 flex size-9 items-center justify-center rounded-lg bg-white/10 text-white transition-colors" do %>
+            <i class="fa-solid fa-envelope"></i>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- Explore -->
+      <div>
+        <h3 class="text-brand-yellow-400 mb-4 text-xs font-bold tracking-widest uppercase">Explore</h3>
+        <ul class="space-y-3 text-sm text-white/80">
+          <li><%= awbw_menu_link "About", "/about-us/", html_class: "hover:text-white" %></li>
+          <li><%= awbw_menu_link "Program", "/programs/", html_class: "hover:text-white" %></li>
+          <li><%= awbw_menu_link "Training", "/programs/facilitator-trainings/", html_class: "hover:text-white" %></li>
+          <li><%= awbw_menu_link "News & Events", "/news/", html_class: "hover:text-white" %></li>
+          <li><%= awbw_menu_link "Get Involved", "/ways-to-give/", html_class: "hover:text-white" %></li>
+        </ul>
+      </div>
+
+      <!-- Connect -->
+      <div>
+        <h3 class="text-brand-yellow-400 mb-4 text-xs font-bold tracking-widest uppercase">Connect</h3>
+        <ul class="space-y-3 text-sm text-white/80">
+          <li><%= link_to "Facilitator Portal", root_url(host: ENV.fetch("APP_HOST", request.host)), class: "hover:text-white" %></li>
+          <li><%= link_to "Art in Action", story_shares_path, class: "hover:text-white" %></li>
+          <li><%= link_to "Contact Us", contact_us_path(from: "story_share"), class: "hover:text-white" %></li>
+          <li><%= awbw_menu_link "Newsletter Signup", "/news/enewsletter/", html_class: "hover:text-white" %></li>
+        </ul>
+      </div>
+
+      <!-- Get in touch -->
+      <div>
+        <h3 class="text-brand-yellow-400 mb-4 text-xs font-bold tracking-widest uppercase">Get in touch</h3>
+        <ul class="space-y-2 text-sm text-white/80">
+          <li><%= mail_to "info@awbw.org", "info@awbw.org", class: "hover:text-white" %></li>
+          <li><%= link_to "(310) 396-0317", "tel:+13103960317", class: "hover:text-white" %></li>
+          <li class="pt-1 text-white/70">1029 1/2 W 24th Street<br>Los Angeles, CA 90007</li>
+        </ul>
+        <%= awbw_menu_link "Donate", "/ways-to-give/",
+                           html_class: "bg-brand-yellow-400 hover:bg-brand-yellow-500 text-brand-navy-900 mt-5 inline-flex items-center rounded-full px-6 py-2 text-sm font-semibold transition-colors" %>
+      </div>
     </div>
 
-    <div class="text-center text-sm space-y-3">
-      <p>Registered 501(c)(3). EIN: 95-448606</p>
-      <p>© 2021–<%= Date.current.year %> A Window Between Worlds</p>
-    </div>
-
-    <div class="flex justify-center md:justify-end">
-      <a href="https://www.guidestar.org/profile/95-4448606"
-         target="_blank"
-         rel="noopener noreferrer"
-         class="bg-white p-1 rounded-sm border border-[#a9c5dd]">
-        <span class="block border-2 border-[#a9c5dd] px-5 py-4 text-black text-sm leading-tight">
-          <span class="block">Platinum</span>
-          <span class="block">Transparency</span>
-          <span class="block"><%= Date.current.year %></span>
-          <span class="block font-bold mt-3">Candid.</span>
-        </span>
-      </a>
+    <div class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-6 text-xs text-white/60 sm:flex-row">
+      <p>© <%= Date.current.year %> A Window Between Worlds • Registered 501(c)(3) EIN: 95-448606</p>
+      <p>Portal built with 🤍 by <%= link_to "Ruby for Good", "https://www.rubyforgood.org", class: "underline hover:text-white" %></p>
     </div>
   </div>
 </footer>

--- a/app/views/story_shares/_portal_footer.html.erb
+++ b/app/views/story_shares/_portal_footer.html.erb
@@ -13,13 +13,13 @@
         </p>
         <div class="mt-5 flex items-center gap-2">
           <% social = [
-               [ "fa-brands fa-instagram", "Instagram" ],
-               [ "fa-brands fa-facebook-f", "Facebook" ],
-               [ "fa-brands fa-linkedin-in", "LinkedIn" ],
-               [ "fa-brands fa-youtube", "YouTube" ]
+               [ "fa-brands fa-instagram", "Instagram", "https://www.instagram.com/awbworg" ],
+               [ "fa-brands fa-facebook-f", "Facebook", "https://www.facebook.com/awbworg" ],
+               [ "fa-brands fa-linkedin-in", "LinkedIn", "https://www.linkedin.com/company/a-window-between-worlds" ],
+               [ "fa-brands fa-youtube", "YouTube", "https://www.youtube.com/@awbworg" ]
              ] %>
-          <% social.each do |icon, label| %>
-            <%= link_to "https://awbw.org", target: "_blank", rel: "noopener noreferrer",
+          <% social.each do |icon, label, url| %>
+            <%= link_to url, target: "_blank", rel: "noopener noreferrer",
                         aria: { label: label },
                         class: "hover:bg-brand-navy-800 flex size-9 items-center justify-center rounded-lg bg-white/10 text-white transition-colors" do %>
               <i class="<%= icon %>"></i>
@@ -68,7 +68,30 @@
       </div>
     </div>
 
-    <div class="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-6 text-xs text-white/60 sm:flex-row">
+    <!-- Recognized & supported by -->
+    <div class="mt-12 flex flex-col items-center gap-6 border-t border-white/10 pt-8 sm:flex-row sm:items-center sm:gap-8">
+      <span class="text-xs font-bold tracking-widest text-white/60 uppercase">Recognized &amp; supported by</span>
+      <div class="flex items-center gap-4">
+        <%= link_to "https://www.guidestar.org/profile/95-4448606", target: "_blank", rel: "noopener noreferrer",
+                    class: "rounded-sm bg-white p-1", aria: { label: "Candid Platinum Transparency #{Date.current.year}" } do %>
+          <span class="text-brand-navy-900 text-2xs block border-2 border-[#a9c5dd] px-4 py-2 text-center leading-tight">
+            <span class="block">Platinum</span>
+            <span class="block">Transparency</span>
+            <span class="block"><%= Date.current.year %></span>
+            <span class="mt-1 block font-bold">Candid.</span>
+          </span>
+        <% end %>
+        <span class="text-brand-navy-900 text-2xs rounded-sm bg-white px-4 py-3 text-center leading-tight font-semibold">
+          <span class="block">Los Angeles County</span>
+          <span class="block text-sm font-bold">Arts &amp; Culture</span>
+        </span>
+      </div>
+      <p class="max-w-md text-xs leading-relaxed text-white/60">
+        Supported, in part, by the LA County Board of Supervisors through the Department of Arts and Culture.
+      </p>
+    </div>
+
+    <div class="mt-8 flex flex-col items-center justify-between gap-4 border-t border-white/10 pt-6 text-xs text-white/60 sm:flex-row">
       <p>© <%= Date.current.year %> A Window Between Worlds • Registered 501(c)(3) EIN: 95-448606</p>
       <p>Portal built with 🤍 by <%= link_to "Ruby for Good", "https://www.rubyforgood.org", class: "underline hover:text-white" %></p>
     </div>

--- a/app/views/story_shares/_sector_section.html.erb
+++ b/app/views/story_shares/_sector_section.html.erb
@@ -2,17 +2,17 @@
     Locals: title, stories, theme (from StorySharesHelper::SLOT_THEMES), more_path. %>
 <% if stories.any? %>
   <div>
-    <h2 class="font-telefon text-2xl <%= theme[:heading] %> mb-4"><%= title %></h2>
+    <h2 class="font-display text-2xl <%= theme[:heading] %> mb-4"><%= title %></h2>
 
     <% featured = stories.first %>
-    <article class="bg-white rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow mb-4">
+    <article class="ring-brand-navy-900/10 mb-4 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 transition-shadow hover:shadow-lg">
       <%= link_to story_share_path(featured), class: "block relative" do %>
-        <div class="aspect-[4/3] bg-gray-200 relative">
+        <div class="bg-brand-navy-50 relative aspect-[4/3]">
           <%= render "assets/display_image", resource: featured, variant: :hero %>
-          <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent flex items-end">
-            <div class="p-4 w-full">
-              <h3 class="font-telefon text-white text-base mb-1 leading-tight"><%= featured.title %></h3>
-              <p class="text-white text-xs opacity-90">
+          <div class="from-brand-navy-950/85 via-brand-navy-950/40 absolute inset-0 flex items-end bg-gradient-to-t to-transparent">
+            <div class="w-full p-4">
+              <h3 class="mb-1 font-display text-base leading-tight text-white"><%= featured.title %></h3>
+              <p class="text-xs text-white opacity-90">
                 <%= featured.organization_name %>
                 <% if featured.organization&.city_state.present? %>- <%= featured.organization.city_state %><% end %>
               </p>
@@ -25,13 +25,13 @@
     <ul class="space-y-2 text-sm">
       <% stories.drop(1).first(4).each do |story| %>
         <li class="flex items-start">
-          <i class="fa-solid fa-caret-right w-3 mr-2 mt-1 text-purple-700 flex-shrink-0"></i>
-          <%= link_to story.title, story_share_path(story), class: "font-bold text-gray-900 hover:text-purple-700 hover:underline" %>
+          <i class="fa-solid fa-caret-right text-brand-magenta-600 mt-1 mr-2 w-3 flex-shrink-0"></i>
+          <%= link_to story.title, story_share_path(story), class: "font-bold text-gray-900 hover:text-brand-magenta-700 hover:underline" %>
         </li>
       <% end %>
       <li class="flex items-start">
-        <i class="fa-solid fa-caret-right w-3 mr-2 mt-1 text-purple-700 flex-shrink-0"></i>
-        <%= link_to "More #{title} stories...", more_path, class: "font-bold text-gray-900 hover:text-purple-700 hover:underline" %>
+        <i class="fa-solid fa-caret-right text-brand-magenta-600 mt-1 mr-2 w-3 flex-shrink-0"></i>
+        <%= link_to "More #{title} stories...", more_path, class: "font-bold text-gray-900 hover:text-brand-magenta-700 hover:underline" %>
       </li>
     </ul>
   </div>

--- a/app/views/story_shares/_sector_section.html.erb
+++ b/app/views/story_shares/_sector_section.html.erb
@@ -5,7 +5,7 @@
     <h2 class="font-display text-2xl <%= theme[:heading] %> mb-4"><%= title %></h2>
 
     <% featured = stories.first %>
-    <article class="ring-brand-navy-900/10 mb-4 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 transition-shadow hover:shadow-lg">
+    <article class="ring-brand-navy-900/10 mb-4 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 transition-all duration-200 hover:-translate-y-1 hover:shadow-2xl">
       <%= link_to story_share_path(featured), class: "block relative" do %>
         <div class="bg-brand-navy-50 relative aspect-[4/3]">
           <%= render "assets/display_image", resource: featured, variant: :hero %>

--- a/app/views/story_shares/_story_image.html.erb
+++ b/app/views/story_shares/_story_image.html.erb
@@ -5,7 +5,7 @@
 <div class="relative <%= aspect %> overflow-hidden bg-gray-200">
   <%= image_tag story.display_image, alt: story.title, loading: "lazy", class: "w-full h-full object-cover" %>
   <% if sector %>
-    <div class="absolute top-3 left-3 <%= story_share_sector_chip_class(sector.name) %> text-white text-xs font-semibold uppercase px-3 py-1.5">
+    <div class="absolute top-3 left-3 <%= story_share_sector_chip_class(sector.name) %> rounded-full text-white text-xs font-semibold uppercase px-3 py-1.5">
       <%= sector.name %>
     </div>
   <% end %>

--- a/app/views/story_shares/_story_image.html.erb
+++ b/app/views/story_shares/_story_image.html.erb
@@ -5,14 +5,14 @@
 <div class="relative <%= aspect %> overflow-hidden bg-gray-200">
   <%= image_tag story.display_image, alt: story.title, loading: "lazy", class: "w-full h-full object-cover" %>
   <% if sector %>
-    <div class="absolute top-3 left-3 <%= story_share_sector_chip_class(sector.name) %> rounded-full text-white text-xs font-semibold uppercase px-3 py-1.5">
+    <div class="absolute top-3 left-3 <%= story_share_sector_chip_class(sector.name) %> rounded-full px-3 py-1.5 text-xs font-semibold text-white uppercase">
       <%= sector.name %>
     </div>
   <% end %>
   <% if story.youtube_url.present? %>
-    <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
-      <span class="flex items-center justify-center w-14 h-14 rounded-full bg-white/70">
-        <i class="fa-solid fa-play text-gray-800 text-lg ml-1"></i>
+    <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+      <span class="flex h-14 w-14 items-center justify-center rounded-full bg-white/70">
+        <i class="fa-solid fa-play ml-1 text-lg text-gray-800"></i>
       </span>
     </div>
   <% end %>

--- a/app/views/story_shares/_tag_chips.html.erb
+++ b/app/views/story_shares/_tag_chips.html.erb
@@ -6,11 +6,11 @@
   <div class="flex flex-wrap gap-2 mb-8">
     <% sectors.each do |sector| %>
       <%= link_to sector.name, story_shares_path(sector_names_all: sector.name),
-                  class: "inline-flex items-center rounded-full bg-purple-100 text-purple-800 px-3 py-1 text-xs font-medium hover:bg-purple-200 transition-colors" %>
+                  class: "bg-brand-magenta-50 text-brand-magenta-700 hover:bg-brand-magenta-100 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors" %>
     <% end %>
     <% audiences.each do |category| %>
       <%= link_to category.decorate.display_name, story_shares_path(category_names_all: category.name),
-                  class: "inline-flex items-center rounded-full bg-gray-100 text-gray-700 px-3 py-1 text-xs font-medium hover:bg-gray-200 transition-colors" %>
+                  class: "bg-brand-amber-50 text-brand-amber-800 hover:bg-brand-amber-100 inline-flex items-center rounded-full px-3 py-1 text-xs font-medium transition-colors" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/story_shares/new.html.erb
+++ b/app/views/story_shares/new.html.erb
@@ -1,14 +1,15 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <% content_for(:title, "Share your story - AWBW Story Share") %>
 
-<section class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+<section class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
   <div class="mb-4">
-    <%= link_to "← Story Share", story_shares_path, class: "text-sm text-purple-700 hover:underline" %>
+    <%= link_to "← Story Share", story_shares_path, class: "text-sm text-brand-magenta-700 hover:underline" %>
   </div>
 
-  <h1 class="font-telefon text-3xl text-black mb-4">Share your story</h1>
+  <p class="text-brand-orange-600 mb-1 text-sm font-semibold tracking-widest uppercase">Story share</p>
+  <h1 class="text-brand-navy-900 mb-4 font-display text-4xl tracking-tight">Share your story</h1>
 
-  <div class="mb-8 text-gray-700 leading-relaxed">
+  <div class="mb-8 leading-relaxed text-gray-700">
     <p>
       This Story Share was created to uplift your voice and experiences as an anchor for your peers,
       as well as to illustrate to the general public the transformative and healing power of art you

--- a/app/views/story_shares/show.html.erb
+++ b/app/views/story_shares/show.html.erb
@@ -9,9 +9,9 @@
   <% end %>
 <% end %>
 
-<section class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+<section class="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
   <!-- Utility buttons -->
-  <div class="flex flex-wrap justify-end gap-1 mb-6">
+  <div class="mb-6 flex flex-wrap justify-end gap-1">
     <%= link_to "All stories", story_shares_path, class: "btn btn-secondary-outline" %>
     <%= link_to "Home", root_path, class: "btn btn-secondary-outline" %>
     <% if current_user&.super_user? %>
@@ -23,13 +23,13 @@
     <%= print_button(@story, printable_type: "Story", button_text: "Print page") %>
   </div>
 
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-10">
+  <div class="grid grid-cols-1 gap-10 lg:grid-cols-3">
     <!-- MAIN COLUMN -->
-    <div class="lg:col-span-2 min-w-0">
-      <h1 class="font-telefon text-3xl sm:text-4xl text-gray-900 mb-4"><%= @story.title %></h1>
+    <div class="min-w-0 lg:col-span-2">
+      <h1 class="text-brand-navy-900 mb-4 font-display text-3xl leading-tight sm:text-4xl"><%= @story.title %></h1>
 
       <!-- Metadata -->
-      <div class="text-sm text-gray-700 space-y-1 mb-5">
+      <div class="mb-5 space-y-1 text-sm text-gray-700">
         <p><strong>Story by:</strong> <%= @story.author_credit %></p>
         <% if @story.organization_name.present? %>
           <p>
@@ -48,25 +48,25 @@
       <%= render "assets/display_assets_carousel", resource: @story %>
 
       <!-- Body -->
-      <div class="prose prose-lg max-w-none text-gray-700 mb-10">
+      <div class="mb-10 max-w-none prose prose-lg text-gray-700">
         <%= @story.rhino_body %>
       </div>
 
       <!-- YouTube embed -->
       <% if (embed_url = youtube_embed_url(@story.youtube_url)) %>
-        <div class="aspect-video mb-10">
-          <iframe src="<%= embed_url %>" class="w-full h-full rounded-lg"
+        <div class="mb-10 aspect-video">
+          <iframe src="<%= embed_url %>" class="h-full w-full rounded-lg"
                   title="<%= @story.title %> video" allowfullscreen loading="lazy"></iframe>
         </div>
       <% end %>
 
       <!-- Share -->
-      <div class="border-t border-gray-200 pt-6 mb-8">
+      <div class="mb-8 border-t border-gray-200 pt-6">
         <%= render "share_buttons", story: @story %>
       </div>
 
       <!-- Boilerplate footer -->
-      <p class="text-xs text-gray-400 leading-relaxed border-t border-gray-200 pt-6">
+      <p class="border-t border-gray-200 pt-6 text-xs leading-relaxed text-gray-400">
         <%= render "shared/organization_footer" %>
       </p>
     </div>
@@ -74,15 +74,15 @@
     <!-- RELATED SIDEBAR -->
     <% if @related_stories.any? %>
       <aside class="lg:col-span-1">
-        <h2 class="font-telefon text-lg text-purple-800 border-b-2 border-purple-800 pb-1 mb-5">Related stories:</h2>
+        <h2 class="text-brand-magenta-800 border-brand-magenta-700 mb-5 border-b-2 pb-1 font-display text-xl">Related stories</h2>
         <div class="space-y-8">
           <% @related_stories.each do |story| %>
             <article>
-              <%= link_to story.title, story_share_path(story), class: "font-telefon text-lg text-gray-900 hover:text-purple-700 leading-tight" %>
-              <p class="text-xs text-gray-500 mt-1 mb-2">
+              <%= link_to story.title, story_share_path(story), class: "font-display text-lg text-brand-navy-900 hover:text-brand-magenta-700 leading-tight" %>
+              <p class="mt-1 mb-2 text-xs text-gray-500">
                 <%= story.organization_name %><%= " – #{story.organization.state}" if story.organization&.state.present? %>
               </p>
-              <%= link_to story_share_path(story), class: "block rounded overflow-hidden bg-gray-100" do %>
+              <%= link_to story_share_path(story), class: "block rounded-xl overflow-hidden bg-brand-navy-50" do %>
                 <%= image_tag story.display_image, loading: "lazy", alt: story.title,
                               class: "w-full aspect-[4/3] object-cover" %>
               <% end %>

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe "ContactUs", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("info@awbw.org")
       expect(response.body).to include("1029 1/2 W 24th Street")
-      # Rendered inside the story_shares layout
-      expect(response.body).to include("Get involved!")
+      # Rendered inside the story_shares layout (the get-involved band)
+      expect(response.body).to include("There's a place for you at AWBW")
       # Subject preset picker posts straight through as contact_us[subject]
       expect(response.body).to include('<select name="contact_us[subject]"')
       expect(response.body).to include("Interest in Windows Facilitator trainings")


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 wide visual rework across the public Story Share portal (navbar mega-menu, home, browse, cards, show)

Restyles the public **Story Share** portal to match the new awbw.org marketing brand, so the facilitator-facing storytelling site reads as the same organization as the main site. Presentation only — no controller, policy, routing, or data changes.

## Focus areas (per request)
- **Menu redesign** — the navbar mega-menu adopts the new marketing look: cream bar with Fraunces nav labels, a per-menu accent (Who We Are = green, What We Do = teal, Ways to Help = magenta, Our Next Chapter = orange) shown as the flyout's top rule, eyebrow, and "Visit the … page →" link, a 3-column flyout (serif intro + link lists + a photo card with a serif overlay CTA), and a gold Donate pill.
- **"Stories in action" photo** — home hero + carousel + story cards get the branded treatment: cream surface, "Story share" eyebrow, Fraunces "Stories of healing in action", rounded cards with serif titles, soft pill category badges, and "Read the story →".

## Surfaces restyled
- `shared/_story_shares_navbar` (+ new `awbw_menu_link_photo` helper), and the Story Share layout now loads Fraunces.
- `story_shares/_home`, `_browse`, `_browse_card`, `_browse_row`, `_sector_section`, `_story_image`, `_tag_chips`, `_get_involved`, `show`, `new`.

## Notes
- Builds on the `brand-*` palette + `brand-cream` + `font-display` (Fraunces) already on `main`.
- **Menu structure/links unchanged** — the four menus keep their existing awbw.org destinations; only the presentation changed. Adopting the new marketing IA (About / Program / Training / Get Involved) with the new site's URLs is a follow-up once those paths are known.
- Story Share request + admin specs pass (34 examples).

_Screenshots (home, mega-menu, show) attached._