### PR TITLE
Run the Story Share nav and mega menu full bleed, and make the menu reachable

### DIFF
--- a/app/helpers/story_shares_helper.rb
+++ b/app/helpers/story_shares_helper.rb
@@ -68,8 +68,11 @@ module StorySharesHelper
   # so visitors don't lose the story they were reading.
   AWBW_BASE = "https://awbw.org".freeze
 
-  def awbw_menu_link(label, path, html_class: "hover:text-purple-700")
-    link_to label, "#{AWBW_BASE}#{path}", target: "_blank", rel: "noopener noreferrer", class: html_class
+  # `arrow: true` puts the trailing arrow inside the link, so it is part of the
+  # click target and picks up the link's hover — outside it, it was neither.
+  def awbw_menu_link(label, path, html_class: "hover:text-purple-700", arrow: false)
+    body = arrow ? safe_join([ label, tag.i("", class: "fa-solid fa-arrow-right text-xs") ], " ") : label
+    link_to body, "#{AWBW_BASE}#{path}", target: "_blank", rel: "noopener noreferrer", class: html_class
   end
 
   # A mega-menu photo card: an awbw.org-linked image with an accent gradient and a

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -52,7 +52,7 @@
           margin: 0 auto;
           padding: 0 24px;
           display: grid;
-          grid-template-columns: 1fr 1fr 0.9fr;
+          grid-template-columns: 1fr 1.35fr 0.85fr;
           gap: 40px;
           align-items: start;
       }
@@ -86,6 +86,7 @@
       .mega-visit:hover { text-decoration: underline; }
 
       .links-wrapper { display: flex; gap: 40px; }
+      .links-group { flex: 1 1 0; min-width: 0; }
       .links-group { margin-bottom: 18px; }
       .links-group h4 {
           font-size: 0.72rem;
@@ -152,8 +153,7 @@
                   service organizations across the country to bring creative expression into their
                   work with trauma survivors.
                 </p>
-                <%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-green-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -202,8 +202,7 @@
                   trauma-informed art workshops, then supporting them as they bring the Windows model
                   to the people they serve.
                 </p>
-                <%= awbw_menu_link "Visit the Program page", "/programs/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-teal-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the Program page", "/programs/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -251,8 +250,7 @@
                   Give, fund a scholarship, or leave a legacy — every path fuels accessible healing
                   for the individuals and communities our facilitators serve.
                 </p>
-                <%= awbw_menu_link "Visit the Get Involved page", "/ways-to-give/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-magenta-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the Get Involved page", "/ways-to-give/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -301,8 +299,7 @@
                   staff, board member, and survivor — has created AWBW. Join us in carrying that work
                   into a sustainable future.
                 </p>
-                <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-orange-700 text-xs"></i>
+                <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -21,6 +21,17 @@
           opacity: 0;
       }
 
+      /* The menu opens below row 1's padding and bottom border, so the pointer
+         used to leave .nav-item crossing that gap and the menu closed before it
+         could be reached. Extend the trigger's hover area down across the gap;
+         the negative margin keeps the layout and the centring unchanged. A
+         bridge on .mega-menu itself would span the whole row and hold this menu
+         open while a *different* trigger was hovered. */
+      .nav-item.has-dropdown > button {
+          padding-bottom: 18px;
+          margin-bottom: -18px;
+      }
+
       .nav-item.has-dropdown:hover .mega-menu {
           visibility: visible;
           opacity: 1;
@@ -106,7 +117,9 @@
       }
   </style>
 
-  <div class="px-2 sm:px-6 lg:px-8">
+  <%# No gutters here: the rows and the mega menu anchored to them run full
+      bleed. The logo and right-hand controls set their own left-/right- insets. %>
+  <div>
     <!-- Row 1: Logo and Main Navigation -->
     <div class="nav-row row-1 border-brand-navy-800 relative flex items-center justify-center border-b-2 py-4">
       <!-- Logo (always visible) -->


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two CSS/markup changes in one partial, but the hover fix has a subtle failure mode worth understanding

Two bugs in the Story Share navbar.

### The bar and menu weren't full width
The rows sat inside `<div class="px-2 sm:px-6 lg:px-8">`, so the bar was inset by 32px — and the mega menu with it, since it anchors `left: 0; right: 0` to `.nav-row.row-1`.

The wrapper's gutters turned out to be unnecessary: the logo and the right-hand controls set **their own** absolute insets (`left-2 sm:left-6 lg:left-8` / `right-…`), rows 2 and 3 centre their content, the mobile menu pads its own links, and `.mega-container` already caps the menu's contents at 1280px. Dropping the wrapper padding makes the bar, its bottom border and the menu run edge to edge with nothing else moving.

### The menu closed before you could reach it
The menu opens at `top: 100%` of row 1 — below that row's `py-3` **and** its `border-b-4`, so there's a 16px dead zone between the trigger and the menu. Crossing it, the pointer left `.nav-item`, `:hover` went false, and the menu vanished mid-transit.

The trigger's hover area now extends down across the gap:

```css
.nav-item.has-dropdown > button { padding-bottom: 18px; margin-bottom: -18px; }
```

The negative margin cancels the padding for layout, so nothing shifts and vertical centring is unchanged.

**Why not a bridge on the menu.** My first attempt put a `::before` spacer on `.mega-menu`. That works, but the menu is now full-width, so the bridge would span the entire row — hovering it while over a *different* trigger would hold both menus open, fighting over the shared box. Extending the trigger keeps the hover region scoped to the trigger's own width.

### Verified
553 examples, 0 failures (`story_share_spec`, `spec/views`). Lint clean.

**Not verified in a browser** — there are no Story Share system specs, so the hover behaviour is reasoned from the geometry rather than driven. Worth a quick hover across all four menus before merging.