### PR TITLE
Add an organization association to resources

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -180,7 +180,7 @@ class ResourcesController < ApplicationController
     params.require(:resource).permit(
       :rhino_body, :kind, :male, :female, :title, :featured, :published, :publicly_visible, :publicly_featured,
       :hidden_from_search,
-      :agency, :author_id, :author_credit_preference, :filemaker_code, :windows_type_id, :position,
+      :organization_id, :author_id, :author_credit_preference, :filemaker_code, :windows_type_id, :position,
       primary_asset_attributes: [ :id, :file, :_destroy ],
       downloadable_asset_attributes: [ :id, :file, :_destroy ],
       gallery_assets_attributes: [ :id, :file, :_destroy ],

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -20,6 +20,7 @@ class Resource < ApplicationRecord
   belongs_to :author, class_name: "Person", optional: true
   belongs_to :workshop, optional: true
   belongs_to :windows_type, optional: true
+  belongs_to :organization, optional: true
   has_one :form, as: :owner
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, as: :categorizable

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -24,7 +24,7 @@
           <%= title_with_badges(@resource, font_size: "text-3xl", display: true) %>
           <%#= "(#{@resource.windows_type&.short_name})" if @resource.windows_type %>
         </div>
-        <!-- Author and Date -->
+        <!-- Author, Organization, and Date -->
         <div class="flex flex-col gap-1">
           <% unless @resource.toolkit_and_form? %>
             <div class="flex items-center gap-2 text-sm text-gray-600">
@@ -36,6 +36,11 @@
                   <%= @resource.display_date %>
                 </span>
               <% end %>
+            </div>
+          <% end %>
+          <% if @resource.organization %>
+            <div class="text-sm text-gray-600">
+              <span class="font-medium">Organization:</span> <%= @resource.organization.name %>
             </div>
           <% end %>
         </div>

--- a/db/migrate/20260830001119_add_organization_to_resources.rb
+++ b/db/migrate/20260830001119_add_organization_to_resources.rb
@@ -1,0 +1,15 @@
+class AddOrganizationToResources < ActiveRecord::Migration[8.0]
+  def up
+    add_column :resources, :organization_id, :integer unless column_exists?(:resources, :organization_id)
+    add_index :resources, :organization_id unless index_exists?(:resources, :organization_id)
+    unless foreign_key_exists?(:resources, :organizations, column: :organization_id)
+      add_foreign_key :resources, :organizations, column: :organization_id
+    end
+  end
+
+  def down
+    remove_foreign_key :resources, column: :organization_id, if_exists: true
+    remove_index :resources, :organization_id, if_exists: true
+    remove_column :resources, :organization_id, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_29_234350) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_001119) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1447,6 +1447,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_234350) do
     t.string "legacy_author_name"
     t.integer "legacy_id"
     t.boolean "male", default: false
+    t.integer "organization_id"
     t.integer "position"
     t.boolean "publicly_featured", default: false, null: false
     t.boolean "publicly_visible", default: false, null: false
@@ -1458,6 +1459,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_234350) do
     t.integer "workshop_id"
     t.index ["author_id"], name: "index_resources_on_author_id"
     t.index ["created_by_id"], name: "index_resources_on_created_by_id"
+    t.index ["organization_id"], name: "index_resources_on_organization_id"
     t.index ["published"], name: "index_resources_on_published"
     t.index ["windows_type_id"], name: "index_resources_on_windows_type_id"
     t.index ["workshop_id"], name: "index_resources_on_workshop_id"
@@ -2137,6 +2139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_29_234350) do
   add_foreign_key "reports", "people", column: "author_id"
   add_foreign_key "reports", "users", column: "created_by_id"
   add_foreign_key "reports", "windows_types"
+  add_foreign_key "resources", "organizations"
   add_foreign_key "resources", "people", column: "author_id"
   add_foreign_key "resources", "users", column: "created_by_id"
   add_foreign_key "resources", "windows_types"

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Resource do
 
   describe 'associations' do
     it { should belong_to(:author).class_name("Person").optional }
+    it { should belong_to(:organization).optional }
 
     # Nested Attributes
     it { should accept_nested_attributes_for(:primary_asset).allow_destroy(true) }


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small schema + model/permit/view change plus a one-time resolve pass; low blast radius, but it adds a FK and will create Organization records

Gives resources a real `Organization` link instead of the legacy free-text `agency` name, so a resource points at an actual org record (and shows it). First step of retiring `resources.agency`.

## What's here
- Migration: adds `resources.organization_id` (nullable, indexed, FK to `organizations`). Reversible.
- `Resource belongs_to :organization, optional: true`.
- Permit swaps `:agency` → `:organization_id` (the `agency` column was never form-editable, so nothing wrote it).
- Resource show page displays the linked organization name (when present).

## The resolve pass (run in prod before the follow-up)
`.context/resolve_resource_organizations.rb` (console script, dry-run first, idempotent) backfills `organization_id` from `agency`:
- match an Organization by **exact, case-insensitive name**;
- one match → link; no match → **create** the org (name + Active status) and link;
- multiple matches → skip and report (reconcile by hand).

## Not in this PR (follow-ups)
- Dropping the `agency` column — after the resolve pass has run in prod (it still reads `agency`).
- The `params[:agency_id] → organization_id` rename in the monthly-report/workshop-log flow — separate small PR.

## Open questions for review
- **Create policy:** new orgs get name + Active status only. Should they also inherit the resource's `filemaker_code`? (Left off deliberately — say the word to enrich.)
- No org picker is added to the resource form (there isn't one for `agency` today either); new resources still won't set an org until we add that UI. Flagging in case that's wanted here.