### PR TITLE
Story Share mega menu tweaks

### DIFF
--- a/app/helpers/story_shares_helper.rb
+++ b/app/helpers/story_shares_helper.rb
@@ -68,8 +68,11 @@ module StorySharesHelper
   # so visitors don't lose the story they were reading.
   AWBW_BASE = "https://awbw.org".freeze
 
-  def awbw_menu_link(label, path, html_class: "hover:text-purple-700")
-    link_to label, "#{AWBW_BASE}#{path}", target: "_blank", rel: "noopener noreferrer", class: html_class
+  # `arrow: true` puts the trailing arrow inside the link, so it is part of the
+  # click target and picks up the link's hover — outside it, it was neither.
+  def awbw_menu_link(label, path, html_class: "hover:text-purple-700", arrow: false)
+    body = arrow ? safe_join([ label, tag.i("", class: "fa-solid fa-arrow-right text-xs") ], " ") : label
+    link_to body, "#{AWBW_BASE}#{path}", target: "_blank", rel: "noopener noreferrer", class: html_class
   end
 
   # A mega-menu photo card: an awbw.org-linked image with an accent gradient and a

--- a/app/views/shared/_story_shares_navbar.html.erb
+++ b/app/views/shared/_story_shares_navbar.html.erb
@@ -52,7 +52,7 @@
           margin: 0 auto;
           padding: 0 24px;
           display: grid;
-          grid-template-columns: 1fr 1fr 0.9fr;
+          grid-template-columns: 1fr 1.35fr 0.85fr;
           gap: 40px;
           align-items: start;
       }
@@ -86,6 +86,7 @@
       .mega-visit:hover { text-decoration: underline; }
 
       .links-wrapper { display: flex; gap: 40px; }
+      .links-group { flex: 1 1 0; min-width: 0; }
       .links-group { margin-bottom: 18px; }
       .links-group h4 {
           font-size: 0.72rem;
@@ -152,8 +153,7 @@
                   service organizations across the country to bring creative expression into their
                   work with trauma survivors.
                 </p>
-                <%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-green-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -202,8 +202,7 @@
                   trauma-informed art workshops, then supporting them as they bring the Windows model
                   to the people they serve.
                 </p>
-                <%= awbw_menu_link "Visit the Program page", "/programs/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-teal-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the Program page", "/programs/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -251,8 +250,7 @@
                   Give, fund a scholarship, or leave a legacy — every path fuels accessible healing
                   for the individuals and communities our facilitators serve.
                 </p>
-                <%= awbw_menu_link "Visit the Get Involved page", "/ways-to-give/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-magenta-700 text-xs"></i>
+                <%= awbw_menu_link "Visit the Get Involved page", "/ways-to-give/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->
@@ -301,8 +299,7 @@
                   staff, board member, and survivor — has created AWBW. Join us in carrying that work
                   into a sustainable future.
                 </p>
-                <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "mega-visit" %>
-                <i class="fa-solid fa-arrow-right text-brand-orange-700 text-xs"></i>
+                <%= awbw_menu_link "Learn more", "/key-initiatives/", html_class: "mega-visit", arrow: true %>
               </div>
 
               <!-- MIDDLE: links -->


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/helper changes, but this is a working branch for iterating on the menu

A branch to tweak the Story Share mega menu's look and contents. Two fixes to start; more to come as we decide what the menu should say.

### The visit link was broken in half
All four menus rendered the trailing arrow **outside** the "Visit the X page" link:

```erb
<%= awbw_menu_link "Visit the About page", "/about-us/", html_class: "mega-visit" %>
<i class="fa-solid fa-arrow-right …"></i>
```

So the arrow wasn't part of the click target and didn't pick up the link's hover underline — it just sat beside it. `awbw_menu_link` takes an `arrow: true` option now and renders it inside.

### The link column was too narrow
The middle column holds **two** link groups side by side but had only `1fr` of `1fr 1fr 0.9fr`, so headings and longer labels wrapped — visible in the "Our Next Chapter" menu, where "Centering Social Justice" and "Fueling the Future Campaign" both break across lines. Now `1fr 1.35fr 0.85fr`, with the two groups sharing the column evenly (`flex: 1 1 0; min-width: 0`).

### Stacked on #2418
That PR makes the bar and menu full-bleed and fixes the menu closing before you can reach it. This branch builds on it because both touch the same partial and the column widths only make sense at full width. Retarget to `main` once #2418 merges.

### Verified
3684 examples, 0 failures. Lint clean.

**Still open — tell me what you want:** which links belong in each menu, whether the photo cards earn their space, and whether four top-level menus is the right number.