### PR TITLE
Rename contact-us form param agency → organization

### DIFF
--- a/app/views/contact_us/index.html.erb
+++ b/app/views/contact_us/index.html.erb
@@ -177,7 +177,7 @@
                       Agency / Organization *
                     </label>
                     <input type="text"
-                           name="contact_us[agency]"
+                           name="contact_us[organization]"
                            required
                            data-error-message="Agency / Organization is required"
                            class="w-full rounded border border-gray-300 bg-white px-4 py-2.5 text-gray-800 shadow-sm transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:outline-none">
@@ -188,7 +188,7 @@
                 <input type="hidden" name="contact_us[first_name]" value="<%= @user.person&.first_name %>">
                 <input type="hidden" name="contact_us[last_name]" value="<%= @user.person&.last_name %>">
                 <input type="hidden" name="contact_us[from]" value="<%= @user.email %>">
-                <input type="hidden" name="contact_us[agency]" value="<%= @user.person&.primary_organization&.name || '' %>">
+                <input type="hidden" name="contact_us[organization]" value="<%= @user.person&.primary_organization&.name || '' %>">
               <% end %>
               <!-- Honeypot -->
               <div class="absolute top-0 left-0 -z-10 h-0 w-0 opacity-0" aria-hidden="true">

--- a/app/views/contact_us_mailer/hello.html.erb
+++ b/app/views/contact_us_mailer/hello.html.erb
@@ -9,9 +9,9 @@
     <% end %>
   </p>
 
-  <% if @contact_us[:agency].present? %>
+  <% if @contact_us[:organization].present? %>
     <p>
-      <strong>Organization:</strong> <%= @contact_us[:agency] %>
+      <strong>Organization:</strong> <%= @contact_us[:organization] %>
     </p>
   <% end %>
 

--- a/spec/mailers/contact_us_mailer_spec.rb
+++ b/spec/mailers/contact_us_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Agency',
         message: 'This is a test message'
       }
 
@@ -27,7 +27,7 @@ RSpec.describe ContactUsMailer do
         q: nil,
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Agency',
         message: 'This is a test message'
       }
 
@@ -43,7 +43,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Agency',
         message: 'This is a test message'
       }
 
@@ -62,7 +62,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: user.person.first_name,
         last_name: user.person.last_name,
-        agency: 'Test Agency',
+        organization: 'Test Agency',
         message: 'This is a test message from logged in user'
       }
 

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "ContactUs", type: :request do
         first_name: "Jane",
         last_name: "Smith",
         from: "jane@example.com",
-        agency: "Test Agency",
+        organization: "Test Agency",
         subject: "Test Subject",
         message: "Test message",
         q: "general"
@@ -33,7 +33,7 @@ RSpec.describe "ContactUs", type: :request do
         expect(response.body).to include('name="contact_us[first_name]"')
         expect(response.body).to include('name="contact_us[last_name]"')
         expect(response.body).to include('name="contact_us[from]"')
-        expect(response.body).to include('name="contact_us[agency]"')
+        expect(response.body).to include('name="contact_us[organization]"')
       end
 
       it "does not show adult or children program options" do
@@ -111,7 +111,7 @@ RSpec.describe "ContactUs", type: :request do
             first_name: user.person.first_name,
             last_name: user.person.last_name,
             from: user.email,
-            agency: "",
+            organization: "",
             subject: "Test",
             message: "Test",
             q: "general"
@@ -196,7 +196,7 @@ RSpec.describe "ContactUs", type: :request do
             first_name: user.person.first_name,
             last_name: user.person.last_name,
             from: user.email,
-            agency: "",
+            organization: "",
             subject: "Test Subject from logged in user",
             message: "Test message from logged in user",
             q: "general"

--- a/spec/requests/email_delivery_failure_spec.rb
+++ b/spec/requests/email_delivery_failure_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Email delivery failures", type: :request do
           first_name: "Jane",
           last_name: "Smith",
           from: "jane@example.com",
-          agency: "Test Agency",
+          organization: "Test Agency",
           subject: "Test Subject",
           message: "Test message",
           q: "general"

--- a/test/mailers/previews/contact_us_mailer_preview.rb
+++ b/test/mailers/previews/contact_us_mailer_preview.rb
@@ -6,7 +6,7 @@ class ContactUsMailerPreview < ActionMailer::Preview
       from: "test@example.com",
       first_name: "John",
       last_name: "Doe",
-      agency: "Test Agency",
+      organization: "Test Agency",
       message: "This is a test message"
     }
     ContactUsMailer.hello(contact_us)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small param rename across the contact form, mailer, and specs

Renames the contact-us form field's param key from `agency` to `organization` — the last live user-facing form field still keyed on the old `agency` term.

- The label already read "Agency / Organization"; only the param key lagged.
- Touches the form input (visible + hidden), the admin mailer template, and the contact-us specs/preview.
- No data or behavior change — the value flows straight into the same email.