### PR TITLE
Rename agency → organization across the reports subsystem

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -10,7 +10,7 @@ class ReportsController < ApplicationController
 
     @report.owner_type = "FormBuilder"
     @report.owner_id   = 7
-    @agencies = current_user.organizations
+    @organizations = current_user.organizations
   end
 
   def render_form
@@ -29,7 +29,7 @@ class ReportsController < ApplicationController
     build_month_and_year
     find_form_builder
     @report    = current_user.submitted_monthly_report(@date, @form_builder.windows_type)
-    @agencies  = current_user.organizations.
+    @organizations  = current_user.organizations.
                  where(windows_type_id: @report.windows_type_id)
     @month = @report.date.month
     @year  =  @report.date.year
@@ -43,7 +43,7 @@ class ReportsController < ApplicationController
                              .order(title: :asc)
 
     @report    = Report.find(params[:id])
-    @agencies  = current_user.organizations.
+    @organizations  = current_user.organizations.
                  where(windows_type_id: @report.windows_type_id)
   end
 
@@ -62,7 +62,7 @@ class ReportsController < ApplicationController
         flash[:notice] = "Thanks for reporting on a update report. "
         redirect_to root_path
       else
-        @agencies  = current_user.organizations.
+        @organizations  = current_user.organizations.
                        where(windows_type_id: @report.windows_type_id)
 
         flash[:alert] = "ERROR!!!!!!!!!!!!!!"
@@ -88,7 +88,7 @@ class ReportsController < ApplicationController
         flash[:notice] = "Thanks for reporting on a update report. "
         redirect_to root_path
       else
-        @agencies  = current_user.organizations.
+        @organizations  = current_user.organizations.
                        where(windows_type_id: @report.windows_type_id)
 
         flash[:alert] = "ERROR!!!!!!!!!!!!!!"
@@ -167,7 +167,7 @@ class ReportsController < ApplicationController
     else
       @form_builder = FormBuilder
         .monthly
-        .find_by(windows_type_id: @agency.windows_type_id)
+        .find_by(windows_type_id: @organization.windows_type_id)
         .decorate
     end
   end

--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -179,7 +179,7 @@ class WorkshopLogsController < ApplicationController
         .or(Organization.where(id: @workshop_log.organization_id))
         .distinct
         .order(:name)
-    organization = params[:agency_id].present? ? Organization.where(id: params[:agency_id]).last : @organizations.first
+    organization = params[:organization_id].present? ? Organization.where(id: params[:organization_id]).last : @organizations.first
     @organization_id = organization.id if organization
   end
 

--- a/app/views/monthly_reports/_form.html.erb
+++ b/app/views/monthly_reports/_form.html.erb
@@ -67,13 +67,13 @@
 
       <div class='form-group'>
         <div class="label-plus-comment">
-          <%= f.label 'Agency' %>
-          <div class="custom-smaller">Please contact AWBW if your agency is not listed.</div>
+          <%= f.label 'Organization' %>
+          <div class="custom-smaller">Please contact AWBW if your organization is not listed.</div>
         </div>
-        <% agency = @agencies.find_by(windows_type_id: f.object.windows_type.id) %>
-        <%= f.collection_select :organization_id, @agencies, :id, :name,
-        { selected: agency ? agency.id : nil,class: 'js-agency-select' },
-        class:"selectpicker form-control form-control-custom", onchange: "window.location = $.replaceUrlParam(window.location.toString(),'agency_id',$(this).val() )" %>
+        <% organization = @organizations.find_by(windows_type_id: f.object.windows_type.id) %>
+        <%= f.collection_select :organization_id, @organizations, :id, :name,
+        { selected: organization ? organization.id : nil,class: 'js-organization-select' },
+        class:"selectpicker form-control form-control-custom", onchange: "window.location = $.replaceUrlParam(window.location.toString(),'organization_id',$(this).val() )" %>
       </div>
 
       <%= f.hidden_field :owner_id, value: @form_builder.id %>
@@ -257,8 +257,8 @@
    });
 
 
-  if ($.urlParam('agency_id') != null){
-    $("#report_organization_id").val("<%=params[:agency_id] %>");
+  if ($.urlParam('organization_id') != null){
+    $("#report_organization_id").val("<%=params[:organization_id] %>");
   }
 
   function validateOptions(event, div_id, input_type) {

--- a/app/views/monthly_reports/_sectorable_items.html.erb
+++ b/app/views/monthly_reports/_sectorable_items.html.erb
@@ -2,7 +2,7 @@
 <% @sectors = Sector.published.map{ |si| [ si.id, si.name ] } %>
 
 <div class="form-group">
-  <label for="agency">Select all populations served this month *:</label>
+  <label>Select all populations served this month *:</label>
   <% i= 0 %>
   <div class="four-btn-row four-btn-row-custom clearfix" id="population_fields">
     <% @sectors.each do |sf| %>

--- a/app/views/monthly_reports/_workshop_log_summary.html.erb
+++ b/app/views/monthly_reports/_workshop_log_summary.html.erb
@@ -2,9 +2,9 @@
 <div>
   <h4 class='normal light js-workshop-logs' <%= tag_options({'data-workshop-logs' => workshop_logs}, false) %>>
     Workshop Log Summary
-    <table class='table table-striped'>
-      <div class='right small js-workshop-logs-button-wrapper'>
-        <%= link_to 'Add Workshop Log', new_workshop_log_path(windows_type_id: @form_builder.windows_type, agency_id: @agency_id, month: @month, year: @year), class: "btn btn--small" %>
+    <table class='table-striped table'>
+      <div class='small js-workshop-logs-button-wrapper right'>
+        <%= link_to 'Add Workshop Log', new_workshop_log_path(windows_type_id: @form_builder.windows_type, organization_id: @organization&.id, month: @month, year: @year), class: "btn btn--small" %>
       </div>
       <th class='bold small'>Date</th>
       <th class='bold small'>Person/Workshop</th>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -48,12 +48,12 @@
 
       <div class='form-group'>
         <div class="label-plus-comment">
-          <%= f.label 'Agency' %>
-          <div class="custom-smaller">Please contact AWBW if your agency is not listed.</div>
+          <%= f.label 'Organization' %>
+          <div class="custom-smaller">Please contact AWBW if your organization is not listed.</div>
         </div>
-        <% agency = agencies.find_by(windows_type_id: f.object.windows_type.id) %>
+        <% organization = organizations.find_by(windows_type_id: f.object.windows_type.id) %>
         <%= f.collection_select :organization_id, agencies, :id, :name,
-        { selected: agency ? agency.id : nil,class: 'js-agency-select' },
+        { selected: organization ? organization.id : nil,class: 'js-organization-select' },
         class:"selectpicker form-control form-control-custom", onchange: 'redirectToNewOrganization()' %>
       </div>
 

--- a/app/views/reports/_sectorable_items.html.erb
+++ b/app/views/reports/_sectorable_items.html.erb
@@ -2,7 +2,7 @@
 <% @sectors = Sector.published.map{ |si| [ si.id, si.name ] } %>
 
 <div class="form-group">
-  <label for="agency">Select all populations served this month:</label>
+  <label>Select all populations served this month:</label>
   <% i= 0 %>
   <div class="four-btn-row clearfix">
     <% @sectors.each do |sf| %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -44,12 +44,12 @@
 
       <div class='form-group'>
         <div class="label-plus-comment">
-          <%= f.label 'Agency' %>
-          <div class="custom-smaller">Please contact AWBW if your agency is not listed.</div>
+          <%= f.label 'Organization' %>
+          <div class="custom-smaller">Please contact AWBW if your organization is not listed.</div>
         </div>
-        <% agency = @agencies.find_by(windows_type_id: f.object.windows_type.id) %>
-        <%= f.collection_select :organization_id, @agencies, :id, :name,
-        { selected: agency ? agency.id : nil,class: 'js-agency-select' },
+        <% organization = @organizations.find_by(windows_type_id: f.object.windows_type.id) %>
+        <%= f.collection_select :organization_id, @organizations, :id, :name,
+        { selected: organization ? organization.id : nil,class: 'js-organization-select' },
         class:"selectpicker form-control form-control-custom", onchange: 'redirectToNewOrganization()' %>
       </div>
 

--- a/app/views/reports/edit_story.html.erb
+++ b/app/views/reports/edit_story.html.erb
@@ -20,14 +20,14 @@
 
       <div class='form-group'>
         <div class="label-plus-comment">
-          <%= f.label 'Agency' %>
+          <%= f.label 'Organization' %>
           <div class="custom-smaller">
-            Please contact AWBW if your agency is not listed.
+            Please contact AWBW if your organization is not listed.
           </div>
         </div>
-        <% agency = @organizations.find_by(windows_type_id: f.object.windows_type.id) %>
+        <% organization = @organizations.find_by(windows_type_id: f.object.windows_type.id) %>
         <%= f.collection_select :organization_id, @organizations, :id, :name,
-{ selected: agency ? agency.id : nil,class: 'js-agency-select' },
+{ selected: organization ? organization.id : nil,class: 'js-organization-select' },
   class:"selectpicker form-control form-control-custom", onchange: 'redirectToNewOrganization()' %>
       </div>
 

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <br>
 <h2 class='normal'><%= "#{@form_builder.name}" %></h2>
-<%= render "form", form_fields: @form_builder.form_fields, agencies: current_user.person&.organizations || [] %>
+<%= render "form", form_fields: @form_builder.form_fields, organizations: current_user.person&.organizations || [] %>
 <script>
   //<![CDATA[
     $(function() {

--- a/app/views/reports/share_story.html.erb
+++ b/app/views/reports/share_story.html.erb
@@ -26,14 +26,14 @@
            <!-- ##### AGENCIES  #### -->
            <div class='form-group'>
              <div class="label-plus-comment">
-               <%= f.label 'Agency' %>
+               <%= f.label 'Organization' %>
                <div class="custom-smaller">
-                 Please contact AWBW if your agency is not listed.
+                 Please contact AWBW if your organization is not listed.
                </div>
              </div>
-             <% agency = @agencies.find_by(windows_type_id: f.object.windows_type.id) %>
-             <%= f.collection_select :organization_id, @agencies, :id, :name,
-{ selected: agency ? agency.id : nil,class: 'js-agency-select' },
+             <% organization = @organizations.find_by(windows_type_id: f.object.windows_type.id) %>
+             <%= f.collection_select :organization_id, @organizations, :id, :name,
+{ selected: organization ? organization.id : nil,class: 'js-organization-select' },
 class:"selectpicker form-control form-control-custom" %>
            </div>
 

--- a/app/views/story_ideas/_form.html.erb
+++ b/app/views/story_ideas/_form.html.erb
@@ -107,7 +107,7 @@
                       label: "Organization",
                       required: true,
                       disabled: promoted_to_story,
-                      hint: "Please contact AWBW if your agency is not listed.",
+                      hint: "Please contact AWBW if your organization is not listed.",
                       prompt: "Select organization",
                       selected: (params[:organization_id].presence || f.object.organization_id || default_org&.id),
                       input_html: {

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -5,12 +5,12 @@
 
     <!-- Error messages -->
     <% if f.object.errors.any? %>
-      <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm"><%= f.object.errors.full_messages.to_sentence %></div>
+      <div class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700"><%= f.object.errors.full_messages.to_sentence %></div>
     <% end %>
 
     <!-- Workshop Selection -->
-    <div class="flex flex-col md:flex-row md:space-x-4 mb-6">
-      <div class="flex-1 mb-4 md:mb-0">
+    <div class="mb-6 flex flex-col md:flex-row md:space-x-4">
+      <div class="mb-4 flex-1 md:mb-0">
         <%= f.input :workshop_id,
           collection: f.object.workshop.present? ? [[ f.object.workshop.remote_search_label[:label], f.object.workshop.id]] : [],
           include_blank: true,
@@ -35,7 +35,7 @@
                   label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
       </div>
 
-      <div class="flex-1 mb-4 md:mb-0">
+      <div class="mb-4 flex-1 md:mb-0">
         <% if allowed_to?(:index?, Organization) || current_user.person&.affiliations&.count != 1 %>
           <%= f.input :organization_id,
                     as: :select,
@@ -44,7 +44,7 @@
                     value_method: :id,
                     label: "Organization",
                     required: true,
-                    hint: "Please contact AWBW if your agency is not listed.",
+                    hint: "Please contact AWBW if your organization is not listed.",
                     prompt: (@organizations.count > 1 ? "Please select the relevant organization" : nil),
                     selected: (params[:organization_id].presence || (f.object.organization_id || (@organizations.count == 1 ? @organizations.first.id : nil))),
                     input_html: { value: params[:organization_id].presence || f.object.organization_id || @organization_id,
@@ -56,7 +56,7 @@
         <% end %>
       </div>
 
-      <div class="flex-1 mb-4 md:mb-0">
+      <div class="mb-4 flex-1 md:mb-0">
         <%= f.input :workshop_held_on,
                   label: "Workshop date",
                   as: :string,
@@ -70,13 +70,13 @@
     <!-- Participants Section -->
     <hr class="my-6 border-gray-200">
 
-    <h2 class="text-lg font-semibold text-gray-800 mb-2">Participants</h2>
+    <h2 class="mb-2 text-lg font-semibold text-gray-800">Participants</h2>
 
     <!-- Ongoing Participants -->
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-700 mb-2">Ongoing participants <span class="text-xs text-gray-500">(have attended an AWBW workshop before)</span></label>
+      <label class="mb-2 block text-sm font-medium text-gray-700">Ongoing participants <span class="text-xs text-gray-500">(have attended an AWBW workshop before)</span></label>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+      <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-3">
         <%= f.input :children_ongoing, as: :integer, label: "Children (0–12)",
                   input_html: {
                     min: 0,
@@ -96,9 +96,9 @@
 
     <!-- First-Time Participants -->
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-700 mb-2">First-time participants <span class="text-xs text-gray-500">(have never attended an AWBW workshop)</span></label>
+      <label class="mb-2 block text-sm font-medium text-gray-700">First-time participants <span class="text-xs text-gray-500">(have never attended an AWBW workshop)</span></label>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+      <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-3">
         <%= f.input :children_first_time, as: :integer, label: "Children (0–12)", input_html: { min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" } %>
         <%= f.input :teens_first_time, as: :integer, label: "Teens (13–17)", input_html: { min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" } %>
         <%= f.input :adults_first_time, as: :integer, label: "Adults (18+)", input_html: { min: 0, class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" } %>
@@ -108,9 +108,9 @@
     <!-- Quotes Section -->
     <hr class="my-6 border-gray-200">
 
-    <h2 class="text-lg font-semibold text-gray-800 mb-2">Quotes from participants</h2>
+    <h2 class="mb-2 text-lg font-semibold text-gray-800">Quotes from participants</h2>
 
-    <p class="text-sm text-gray-600 mb-3">
+    <p class="mb-3 text-sm text-gray-600">
       What did your participants share about their experience? Please write quotes in first person.
     </p>
 

--- a/app/views/workshop_variation_ideas/_form.html.erb
+++ b/app/views/workshop_variation_ideas/_form.html.erb
@@ -12,7 +12,7 @@
       <%= f.hidden_field :rhino_body, value: f.object.rhino_body %>
       <%= f.hidden_field :youtube_url, value: f.object.youtube_url %>
       <%= f.hidden_field :permission_given, value: f.object.permission_given %>
-      <div class="admin-only bg-yellow-100 m-3 p-3">
+      <div class="admin-only m-3 bg-yellow-100 p-3">
         This workshop variation idea has been promoted to a
         <% f.object.workshop_variations.each do |workshop_variation| %>
           <%= link_to "Workshop Variation ##{workshop_variation.id}",
@@ -23,7 +23,7 @@
     <% end %>
     <%= render 'shared/errors', resource: workshop_variation_idea if workshop_variation_idea.errors.any? %>
     <!-- Workshop + Organization -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+    <div class="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
       <div>
         <% if !promoted_to_variation && (params[:admin] == "true" || f.object.new_record?) %>
           <%= f.input :workshop_id,
@@ -53,8 +53,8 @@
                       label: "Organization",
                       required: true,
                       disabled: promoted_to_variation,
-                      hint: "Please contact AWBW if your agency is not listed.",
-                      prompt: (@organizations.count > 1 ? "Please select the relevant agency" : nil),
+                      hint: "Please contact AWBW if your organization is not listed.",
+                      prompt: (@organizations.count > 1 ? "Please select the relevant organization" : nil),
                       selected: (params[:organization_id].presence || (f.object.organization_id || (@organizations.count == 1 ? @organizations.first.id : nil))),
                       input_html: { value: params[:organization_id].presence || f.object.organization_id || @organization_id,
                                     class: "#{ "readonly" if promoted_to_variation } block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" },
@@ -67,7 +67,7 @@
     </div>
 
     <!-- Name + Windows type -->
-    <div class="flex flex-col md:flex-row md:space-x-4 mb-6">
+    <div class="mb-6 flex flex-col md:flex-row md:space-x-4">
       <div class="flex-1">
         <%= f.input :name,
                     label: "Variation name",
@@ -102,7 +102,7 @@
       </div>
     <% end %>
 
-    <div class="flex my-6 gap-4">
+    <div class="my-6 flex gap-4">
       <%= render "shared/author_credit_status", f: f %>
       <%= f.input :youtube_url,
                   as: :text,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 wide but mechanical rename across the report/monthly-report/workshop-log forms; no logic or data change, main risk is a missed reference in the shared partials

Retires the last "agency" wording in the app: the monthly-report / report / workshop-log forms called Organization records "agency". This renames it end to end so these pages match the rest of the portal.

## What changed (all rename, no behavior change)
- **URL param `agency_id` → `organization_id`** — the monthly-report org dropdown's onchange reload + the workshop-log "Add" preselect (`workshop_logs_controller#set_form`). The param always carried an Organization id.
- **`@agencies` / `@agency` ivars and the `agencies` / `agency` view locals → `@organizations` / `organization`.** They were always `current_user.organizations`. Renaming every assignment + read together keeps behavior identical, and incidentally repairs `edit_story` (its view already read `@organizations`, which the controller never set).
- **`js-agency-select` → `js-organization-select`** — a hook class nothing in JS actually targets.
- **User-facing copy** — "Agency" field labels and "…if your agency is not listed" hints → "Organization" / "organization" (sentence case); the "Please select the relevant agency" prompt; and dropped the dangling `for="agency"` on the populations label (it pointed at no element).

## Notes for the reviewer
- `ReportsController#find_form_builder` still references a **never-assigned single-org ivar** (`@organization`, formerly `@agency`) in an else-branch — a **pre-existing latent bug**, left as-is rather than fixed blind in a rename PR.
- `monthly_reports/_form.html.erb` appears to have no live renderer I could find (possibly partly-dead legacy); renamed for consistency regardless.

## Tests
- 103 subsystem request/system specs green (reports, monthly_reports, workshop_logs, story_ideas, workshop_variation_ideas). Rubocop + tw-sort clean.
- No spec referenced the old names.