### PR TITLE
Rename contact form's agency param to organization

### DIFF
--- a/app/views/contact_us/index.html.erb
+++ b/app/views/contact_us/index.html.erb
@@ -177,7 +177,7 @@
                       Agency / Organization *
                     </label>
                     <input type="text"
-                           name="contact_us[agency]"
+                           name="contact_us[organization]"
                            required
                            data-error-message="Agency / Organization is required"
                            class="w-full rounded border border-gray-300 bg-white px-4 py-2.5 text-gray-800 shadow-sm transition focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:outline-none">
@@ -188,7 +188,7 @@
                 <input type="hidden" name="contact_us[first_name]" value="<%= @user.person&.first_name %>">
                 <input type="hidden" name="contact_us[last_name]" value="<%= @user.person&.last_name %>">
                 <input type="hidden" name="contact_us[from]" value="<%= @user.email %>">
-                <input type="hidden" name="contact_us[agency]" value="<%= @user.person&.primary_organization&.name || '' %>">
+                <input type="hidden" name="contact_us[organization]" value="<%= @user.person&.primary_organization&.name || '' %>">
               <% end %>
               <!-- Honeypot -->
               <div class="absolute top-0 left-0 -z-10 h-0 w-0 opacity-0" aria-hidden="true">

--- a/app/views/contact_us_mailer/hello.html.erb
+++ b/app/views/contact_us_mailer/hello.html.erb
@@ -9,9 +9,9 @@
     <% end %>
   </p>
 
-  <% if @contact_us[:agency].present? %>
+  <% if @contact_us[:organization].present? %>
     <p>
-      <strong>Organization:</strong> <%= @contact_us[:agency] %>
+      <strong>Organization:</strong> <%= @contact_us[:organization] %>
     </p>
   <% end %>
 

--- a/spec/mailers/contact_us_mailer_spec.rb
+++ b/spec/mailers/contact_us_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Organization',
         message: 'This is a test message'
       }
 
@@ -27,7 +27,7 @@ RSpec.describe ContactUsMailer do
         q: nil,
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Organization',
         message: 'This is a test message'
       }
 
@@ -43,7 +43,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: 'John',
         last_name: 'Doe',
-        agency: 'Test Agency',
+        organization: 'Test Organization',
         message: 'This is a test message'
       }
 
@@ -51,7 +51,7 @@ RSpec.describe ContactUsMailer do
 
       expect(mail.body.encoded).to include('John Doe')
       expect(mail.body.encoded).to include('This is a test message')
-      expect(mail.body.encoded).to include('Test Agency')
+      expect(mail.body.encoded).to include('Test Organization')
     end
 
     it 'renders the email content correctly for logged in user' do
@@ -62,7 +62,7 @@ RSpec.describe ContactUsMailer do
         q: 'general',
         first_name: user.person.first_name,
         last_name: user.person.last_name,
-        agency: 'Test Agency',
+        organization: 'Test Organization',
         message: 'This is a test message from logged in user'
       }
 

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "ContactUs", type: :request do
         first_name: "Jane",
         last_name: "Smith",
         from: "jane@example.com",
-        agency: "Test Agency",
+        organization: "Test Organization",
         subject: "Test Subject",
         message: "Test message",
         q: "general"
@@ -28,12 +28,12 @@ RSpec.describe "ContactUs", type: :request do
         expect(response.body).not_to include("Hello,")
       end
 
-      it "shows form fields for name, email, and agency" do
+      it "shows form fields for name, email, and organization" do
         get contact_us_path
         expect(response.body).to include('name="contact_us[first_name]"')
         expect(response.body).to include('name="contact_us[last_name]"')
         expect(response.body).to include('name="contact_us[from]"')
-        expect(response.body).to include('name="contact_us[agency]"')
+        expect(response.body).to include('name="contact_us[organization]"')
       end
 
       it "does not show adult or children program options" do
@@ -97,7 +97,7 @@ RSpec.describe "ContactUs", type: :request do
         expect(response.body).to include("reply by email to #{user.email}")
       end
 
-      it "does not show visible form fields for name, email, and agency" do
+      it "does not show visible form fields for name, email, and organization" do
         get contact_us_path
         expect(response.body).to include('type="hidden"')
         expect(response.body).to include('name="contact_us[first_name]"')
@@ -111,7 +111,7 @@ RSpec.describe "ContactUs", type: :request do
             first_name: user.person.first_name,
             last_name: user.person.last_name,
             from: user.email,
-            agency: "",
+            organization: "",
             subject: "Test",
             message: "Test",
             q: "general"
@@ -196,7 +196,7 @@ RSpec.describe "ContactUs", type: :request do
             first_name: user.person.first_name,
             last_name: user.person.last_name,
             from: user.email,
-            agency: "",
+            organization: "",
             subject: "Test Subject from logged in user",
             message: "Test message from logged in user",
             q: "general"

--- a/spec/requests/email_delivery_failure_spec.rb
+++ b/spec/requests/email_delivery_failure_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Email delivery failures", type: :request do
           first_name: "Jane",
           last_name: "Smith",
           from: "jane@example.com",
-          agency: "Test Agency",
+          organization: "Test Organization",
           subject: "Test Subject",
           message: "Test message",
           q: "general"

--- a/test/mailers/previews/contact_us_mailer_preview.rb
+++ b/test/mailers/previews/contact_us_mailer_preview.rb
@@ -6,7 +6,7 @@ class ContactUsMailerPreview < ActionMailer::Preview
       from: "test@example.com",
       first_name: "John",
       last_name: "Doe",
-      agency: "Test Agency",
+      organization: "Test Organization",
       message: "This is a test message"
     }
     ContactUsMailer.hello(contact_us)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small param rename across the contact form, its mailer, and specs — no logic or data change

Renames the last user-facing `agency` key in the contact-us flow to `organization`. The field already displays as "Organization" in the admin email, so this just makes the wire name match — finishing the agency→organization rename for the contact form.

## What changed
- `contact_us[agency]` → `contact_us[organization]` (visible input + the signed-in prefill hidden field).
- Mailer view reads `@contact_us[:organization]`.
- Specs + mailer preview updated (demo value `Test Agency` → `Test Organization`).

## Notes
- No strong-params or controller change — the contact form passes `params[:contact_us]` through as a raw hash.
- The visible **"Agency / Organization"** label and its validation message are left as-is: user-facing copy for people who think of their employer as an "agency".