### PR TITLE
Sweep leftover agency naming in spec helper and descriptions

### DIFF
--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "ContactUs", type: :request do
         expect(response.body).not_to include("Hello,")
       end
 
-      it "shows form fields for name, email, and agency" do
+      it "shows form fields for name, email, and organization" do
         get contact_us_path
         expect(response.body).to include('name="contact_us[first_name]"')
         expect(response.body).to include('name="contact_us[last_name]"')
@@ -97,7 +97,7 @@ RSpec.describe "ContactUs", type: :request do
         expect(response.body).to include("reply by email to #{user.email}")
       end
 
-      it "does not show visible form fields for name, email, and agency" do
+      it "does not show visible form fields for name, email, and organization" do
         get contact_us_path
         expect(response.body).to include('type="hidden"')
         expect(response.body).to include('name="contact_us[first_name]"')

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("Healthcare")
     end
 
-    it "renders the agency website as a text input so bare domains pass validation" do
+    it "renders the organization website as a text input so bare domains pass validation" do
       website_field = create(:form_field, form: form, answer_type: :free_form_input_one_line,
              field_identifier: "organization_website", name: "Organization website", required: false)
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1719,7 +1719,7 @@ RSpec.describe "Events", type: :request do
 
       # Stores a submitted "organization_name" answer for the registrant, mirroring
       # what public registration captures, so the Pending/None chip logic has data.
-      def submit_agency_name(name)
+      def submit_organization_name(name)
         registration_form = Form.find_by(name: "Registration") || create(:form, name: "Registration")
         field = registration_form.form_fields.find_by(field_identifier: "organization_name") ||
           create(:form_field, form: registration_form, field_identifier: "organization_name")
@@ -1738,7 +1738,7 @@ RSpec.describe "Events", type: :request do
       end
 
       it "shows a 'Pending' chip when a registrant submitted an org name but has no linked org" do
-        submit_agency_name("Some Unlisted Org")
+        submit_organization_name("Some Unlisted Org")
 
         get registrants_event_path(event)
 
@@ -1755,7 +1755,7 @@ RSpec.describe "Events", type: :request do
 
       it "does not show a 'Pending' chip when an org is linked, even if the submitted name differs" do
         create(:event_registration_organization, event_registration: registration, organization: organization)
-        submit_agency_name("A Different Unlisted Agency")
+        submit_organization_name("A Different Unlisted Agency")
 
         get registrants_event_path(event)
 
@@ -1765,7 +1765,7 @@ RSpec.describe "Events", type: :request do
 
       it "does not show 'Pending' when the submitted name matches a linked org" do
         create(:event_registration_organization, event_registration: registration, organization: organization)
-        submit_agency_name(organization.name)
+        submit_organization_name(organization.name)
 
         get registrants_event_path(event)
 

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(organization.reload.facilitator_status_on(event.start_date.to_date)).to eq(:new)
     end
 
-    it "links the created affiliations to the agency address built from the form" do
+    it "links the created affiliations to the organization address built from the form" do
       params = base_form_params(first_name: "Sam", last_name: "Rowe", email: "sam@example.com").merge(
         field_id(described_class::ORGANIZATION_NAME_IDENTIFIER) => "Helping Hands",
         field_id(described_class::ORGANIZATION_POSITION_IDENTIFIER) => "Counselor",
@@ -103,7 +103,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(linked.map(&:organization_address)).to all(eq(address))
     end
 
-    it "leaves the affiliations' organization address nil when no agency city was typed" do
+    it "leaves the affiliations' organization address nil when no organization city was typed" do
       person = register_with(position: "Counselor")
 
       expect(person.affiliations.where(organization: organization).map(&:organization_address)).to all(be_nil)
@@ -342,7 +342,7 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
         described_class.call(event: event, registration_form: form, form_params: params)
       end
 
-      it "fills website, agency type, and address country" do
+      it "fills website, organization type, and address country" do
         register_with_org(
           field_id("organization_website") => "helpinghands.org",
           field_id("organization_type") => "501c3/nonprofit",


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 test-only renames of a spec helper and example descriptions — no app code, no behavior

Cosmetic, test-only finish to the agency→organization rename. No app code touched.

## What changed
- Renamed the `submit_agency_name` spec helper → `submit_organization_name` (`events_spec`, def + calls).
- Reworded example descriptions in `contact_us_spec`, `public_registrations_spec`, and `public_registration_spec` ("agency address/city/type/website" → "organization …").

## Deliberately left alone
- Demo **data values** (org names like "Test Agency", "Alpha/Beta Agency", "Our agency…") — they're fixture strings, not names to rename, and `"Government agency"` is a real `ORGANIZATION_TYPES` value.
- `form_builder_service_spec.rb`'s `grep(/\Aagency_/).to be_empty` — a regression guard that proves the rename is complete.
- The `agency_type`→"Type" backward-compat map + its spec (kept until the Ahoy JSON backfill runs).

536 affected specs green; rubocop clean.