### PR TITLE
Resolve resources' legacy agency name to an organization link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ RuboCop linting on PRs and pushes to main.
 
 ## Rake Tasks
 
-Located in `lib/tasks/` (12 files):
+Located in `lib/tasks/` (13 files):
 - `dev.rake` — Development database seeding from XML/CSV
 - `rhino_migrator.rake` — Rich text editor migration
 - `attachment_report.rake` — Attachment reporting
@@ -544,3 +544,4 @@ Located in `lib/tasks/` (12 files):
 - `migrate_workshop_logs.rake` — Workshop log migration
 - `backfill_user_stamps.rake` — Backfill `created_by_id`/`updated_by_id` on legacy rows from the Ahoy trail (`data:backfill_user_stamps`)
 - `backfill_notification_stamps.rake` — Backfill notifications' `created_by_id`/`updated_by_id` from `sender_id`, nil-only (`data:backfill_notification_stamps`)
+- `resolve_resource_organizations.rake` — Link resources to organizations from the legacy `agency` free-text name (`data:resolve_resource_organizations`, match-or-create, idempotent, DRY_RUN)

--- a/lib/tasks/resolve_resource_organizations.rake
+++ b/lib/tasks/resolve_resource_organizations.rake
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Backfill resources.organization_id from the legacy free-text `agency` column.
+#
+# For each resource that has an `agency` name but no organization linked yet:
+#   - match an Organization by exact, case-insensitive name (agency == org.name)
+#   - exactly one match   -> link it
+#   - no match            -> create the Organization, link it
+#   - more than one match -> ambiguous; skip and report (reconcile by hand)
+#
+# New orgs get status "Unknown" — not because the link cares (it doesn't), but
+# because Organization requires organization_status_id (org status is legacy and
+# no longer consulted, ADR-0003 D4). "Unknown" is the honest value for an org
+# minted from a stale free-text name.
+#
+# Idempotent (only touches rows where organization_id IS NULL) and safe to run
+# while the app still keeps the `agency` column. Drop the column in a follow-up
+# once this has run in prod.
+#
+# Dry-run by default. Set DRY_RUN=false to write changes.
+#   bin/rails data:resolve_resource_organizations             # preview, writes nothing
+#   DRY_RUN=false bin/rails data:resolve_resource_organizations  # link + create
+namespace :data do
+  desc "Link resources to organizations from the legacy `agency` name (match/create). Idempotent. DRY_RUN=false to execute."
+  task resolve_resource_organizations: :environment do
+    dry_run = ENV["DRY_RUN"] != "false"
+    unknown_status = OrganizationStatus.find_by(name: "Unknown")
+    raise "OrganizationStatus \"Unknown\" is required to create organizations" if !dry_run && unknown_status.nil?
+
+    linked = created = ambiguous = 0
+    created_by_name = {}
+
+    ActiveRecord::Base.transaction do
+      Resource.where.not(agency: [ nil, "" ]).where(organization_id: nil).find_each do |resource|
+        name = resource.agency.strip
+        next if name.blank?
+        key = name.downcase
+
+        matches = Organization.where("LOWER(name) = ?", key).to_a
+        if matches.size > 1
+          ambiguous += 1
+          puts "  ! resource ##{resource.id} #{resource.title.inspect}: #{matches.size} orgs named #{name.inspect} (ids: #{matches.map(&:id).join(', ')}) — skipped"
+          next
+        end
+
+        if (organization = matches.first)
+          linked += 1
+          puts "  = resource ##{resource.id}: link existing org ##{organization.id} #{name.inspect}"
+        elsif created_by_name.key?(key)
+          organization = created_by_name[key] # nil during a dry run
+          linked += 1
+          puts "  = resource ##{resource.id}: link org created earlier this run #{name.inspect}"
+        else
+          organization = dry_run ? nil : Organization.create!(name: name, organization_status: unknown_status)
+          created_by_name[key] = organization
+          created += 1
+          puts "  + resource ##{resource.id}: create + link org #{name.inspect}"
+        end
+
+        resource.update_column(:organization_id, organization.id) if organization && !dry_run
+      end
+
+      raise ActiveRecord::Rollback if dry_run
+    end
+
+    puts
+    puts "linked to existing: #{linked}"
+    puts "orgs created:       #{created}"
+    puts "ambiguous, skipped: #{ambiguous}"
+    puts(dry_run ? "\nDRY RUN — rolled back, nothing written. Set DRY_RUN=false to execute." : "\nDone.")
+  end
+end

--- a/spec/tasks/resolve_resource_organizations_spec.rb
+++ b/spec/tasks/resolve_resource_organizations_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "data:resolve_resource_organizations" do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("data:resolve_resource_organizations")
+  end
+
+  before do
+    Rake::Task["data:resolve_resource_organizations"].reenable
+  end
+
+  let!(:unknown_status) { create(:organization_status, name: "Unknown") }
+
+  def run_task(dry_run: false)
+    ENV["DRY_RUN"] = dry_run ? "true" : "false"
+    suppress_output { Rake::Task["data:resolve_resource_organizations"].invoke }
+  ensure
+    ENV.delete("DRY_RUN")
+  end
+
+  def suppress_output
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original_stdout
+  end
+
+  it "links a resource to an existing organization matched by name (case-insensitive)" do
+    org = create(:organization, name: "Harbor House")
+    resource = create(:resource, agency: "harbor house")
+
+    run_task
+
+    expect(resource.reload.organization).to eq(org)
+  end
+
+  it "creates an Unknown-status organization and links it when no match exists" do
+    resource = create(:resource, agency: "Brand New Org")
+
+    expect { run_task }.to change(Organization, :count).by(1)
+
+    org = resource.reload.organization
+    expect(org.name).to eq("Brand New Org")
+    expect(org.organization_status).to eq(unknown_status)
+  end
+
+  it "reuses a single created org for two resources sharing the same agency name" do
+    r1 = create(:resource, agency: "Shared Name")
+    r2 = create(:resource, agency: "shared name")
+
+    expect { run_task }.to change(Organization, :count).by(1)
+
+    expect(r1.reload.organization).to eq(r2.reload.organization)
+  end
+
+  it "skips a resource whose agency name is ambiguous across multiple orgs" do
+    create(:organization, name: "Twins")
+    create(:organization, name: "Twins")
+    resource = create(:resource, agency: "Twins")
+
+    run_task
+
+    expect(resource.reload.organization_id).to be_nil
+  end
+
+  it "leaves an already-linked resource untouched" do
+    existing = create(:organization, name: "Existing Link")
+    other = create(:organization, name: "Someplace Else")
+    resource = create(:resource, agency: "Someplace Else", organization: existing)
+
+    run_task
+
+    expect(resource.reload.organization).to eq(existing)
+    expect(resource.organization).not_to eq(other)
+  end
+
+  it "writes nothing on a dry run" do
+    resource = create(:resource, agency: "Dry Run Org")
+
+    expect { run_task(dry_run: true) }.not_to change(Organization, :count)
+    expect(resource.reload.organization_id).to be_nil
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one committed data task + spec; no schema/app-behavior change, run by hand

Converts the free-text `resources.agency` into a real `organization_id` link, so the legacy column can be dropped in a follow-up. The `organization_id` column + optional `belongs_to :organization` already shipped (#2421); this fills it in.

## What it does
`bin/rails data:resolve_resource_organizations` (dry-run by default; `DRY_RUN=false` to write). For each resource with an `agency` name but no org linked:
- **exact, case-insensitive name match** → link the existing org
- **no match** → create the org (status "Unknown", since org status is required but legacy) and link it
- **more than one match** → ambiguous, skip and report for hand reconciliation

Idempotent — only touches rows where `organization_id IS NULL`, so it's safe to re-run and safe to run while the `agency` column still exists.

## Notes
- **Not a data migration** — matches this repo's other one-off conversions (`data:migrate_sectors`, `data:convert_age_ranges`): a committed, reviewable, hand-run task with a dry run. Promotes the ad-hoc `.context` script into version control.
- **Follow-up:** once this has run in prod, a separate PR drops the `agency` column and removes the two dev-seed `agency:` writes.
- Spec covers link / create / dedupe-within-run / ambiguous-skip / already-linked / dry-run.