### PR TITLE
Dedupe workshops

### DIFF
--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -132,6 +132,9 @@ module Dedupable
   #   model_class:        The ActiveRecord model (e.g. Category)
   #   domain:             Symbol for DomainTheme (e.g. :categories) (optional, derived from model)
   #   belongs_to_options: Hash or Proc of { column_name => collection } for select fields (optional)
+  #   remote_select_options: Hash of { belongs_to column_name => search model } rendering an
+  #                       ajax-search TomSelect picker on the keeper instead of a fixed dropdown —
+  #                       for a target set too large to enumerate (e.g. author_id => "person") (optional)
   #   merge_notes:        Lambda(keep, delete) returning an array of informational (non-blocking)
   #                       strings to surface on the preview (e.g. "both people have a login") (optional)
   #   record_extras:      Lambda(record) returning extra detail string for index listing (optional)
@@ -170,6 +173,7 @@ module Dedupable
       editable_columns: config[:editable_columns],
       union_columns: Array(config[:union_columns]).map(&:to_s),
       belongs_to_options: opts.is_a?(Proc) ? opts.call : (opts || {}),
+      remote_select_options: config[:remote_select_options] || {},
       record_extras: config[:record_extras]
     }
   end

--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -137,6 +137,7 @@ module Dedupable
   #                       for a target set too large to enumerate (e.g. author_id => "person") (optional)
   #   field_notes:        Hash of { column_name => hint } rendered under the keeper's field, to guide
   #                       an admin on what to enter (e.g. full_name is a legacy free-text author) (optional)
+  #   deprecated_columns: Array of column names to render muted with a "Deprecated" badge (optional)
   #   merge_notes:        Lambda(keep, delete) returning an array of informational (non-blocking)
   #                       strings to surface on the preview (e.g. "both people have a login") (optional)
   #   record_extras:      Lambda(record) returning extra detail string for index listing (optional)
@@ -177,6 +178,7 @@ module Dedupable
       belongs_to_options: opts.is_a?(Proc) ? opts.call : (opts || {}),
       remote_select_options: config[:remote_select_options] || {},
       field_notes: config[:field_notes] || {},
+      deprecated_columns: Array(config[:deprecated_columns]).map(&:to_s),
       record_extras: config[:record_extras]
     }
   end

--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -135,6 +135,8 @@ module Dedupable
   #   remote_select_options: Hash of { belongs_to column_name => search model } rendering an
   #                       ajax-search TomSelect picker on the keeper instead of a fixed dropdown —
   #                       for a target set too large to enumerate (e.g. author_id => "person") (optional)
+  #   field_notes:        Hash of { column_name => hint } rendered under the keeper's field, to guide
+  #                       an admin on what to enter (e.g. full_name is a legacy free-text author) (optional)
   #   merge_notes:        Lambda(keep, delete) returning an array of informational (non-blocking)
   #                       strings to surface on the preview (e.g. "both people have a login") (optional)
   #   record_extras:      Lambda(record) returning extra detail string for index listing (optional)
@@ -174,6 +176,7 @@ module Dedupable
       union_columns: Array(config[:union_columns]).map(&:to_s),
       belongs_to_options: opts.is_a?(Proc) ? opts.call : (opts || {}),
       remote_select_options: config[:remote_select_options] || {},
+      field_notes: config[:field_notes] || {},
       record_extras: config[:record_extras]
     }
   end

--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -38,10 +38,11 @@ module Dedupable
       return redirect_to url_for(action: :dedupe_index),
         alert: "#{mc.model_name.human} not found (ID: #{missing.join(', ')})."
     end
-    deduper = ModelDeduper.new(model_class: mc)
+    deduper = ModelDeduper.new(model_class: mc, movable_attachments: config[:movable_attachments])
     @reassignment_delete = deduper.reassignment_preview(@record_to_delete)
     @reassignment_keep = deduper.reassignment_preview(@record_to_keep)
     @lost_references = deduper.lost_references(@record_to_delete)
+    @attachment_plan = deduper.attachment_plan(@record_to_keep, @record_to_delete)
     @unhandled_references = deduper.unhandled_references(@record_to_delete)
     @merge_notes = Array(config[:merge_notes]&.call(@record_to_keep, @record_to_delete))
     @dedupe = build_dedupe_vars(config)
@@ -96,7 +97,8 @@ module Dedupable
     # (e.g. an org's FileMaker codes), so the kept record keeps both records' links.
     config[:merge_keeper]&.call(record_to_keep, record_to_delete)
 
-    deduper = ModelDeduper.new(model_class: mc, logger: Rails.logger, dry_run: false, min_usage: 0)
+    deduper = ModelDeduper.new(model_class: mc, logger: Rails.logger, dry_run: false, min_usage: 0,
+                               movable_attachments: config[:movable_attachments])
 
     if respond_to?(:track_event, true)
       track_event("dedupe.#{mn}", {
@@ -138,6 +140,8 @@ module Dedupable
   #   field_notes:        Hash of { column_name => hint } rendered under the keeper's field, to guide
   #                       an admin on what to enter (e.g. full_name is a legacy free-text author) (optional)
   #   deprecated_columns: Array of column names to render muted with a "Deprecated" badge (optional)
+  #   movable_attachments: Array of has_one_attached names to move to the keeper when it has none
+  #                       (otherwise dropped with the deleted record), e.g. %w[thumbnail header] (optional)
   #   merge_notes:        Lambda(keep, delete) returning an array of informational (non-blocking)
   #                       strings to surface on the preview (e.g. "both people have a login") (optional)
   #   record_extras:      Lambda(record) returning extra detail string for index listing (optional)

--- a/app/controllers/concerns/dedupable.rb
+++ b/app/controllers/concerns/dedupable.rb
@@ -142,6 +142,8 @@ module Dedupable
   #   deprecated_columns: Array of column names to render muted with a "Deprecated" badge (optional)
   #   movable_attachments: Array of has_one_attached names to move to the keeper when it has none
   #                       (otherwise dropped with the deleted record), e.g. %w[thumbnail header] (optional)
+  #   preview_images:     Lambda(record) returning that record's attached images (ActiveStorage
+  #                       attachments) so the preview shows them side by side for comparison (optional)
   #   merge_notes:        Lambda(keep, delete) returning an array of informational (non-blocking)
   #                       strings to surface on the preview (e.g. "both people have a login") (optional)
   #   record_extras:      Lambda(record) returning extra detail string for index listing (optional)
@@ -183,6 +185,7 @@ module Dedupable
       remote_select_options: config[:remote_select_options] || {},
       field_notes: config[:field_notes] || {},
       deprecated_columns: Array(config[:deprecated_columns]).map(&:to_s),
+      preview_images: config[:preview_images],
       record_extras: config[:record_extras]
     }
   end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -184,6 +184,7 @@ class WorkshopsController < ApplicationController
       belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
       remote_select_options: { "author_id" => "person" },
       deprecated_columns: %w[full_name],
+      movable_attachments: %w[thumbnail header],
       field_notes: {
         "full_name" => "Legacy (not referenced). Credit a real person in Author below instead.",
         "author_id" => "Credited author — search any person."

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -181,12 +181,8 @@ class WorkshopsController < ApplicationController
       domain: :workshops,
       candidate_finder: -> { WorkshopServices::DuplicateFinder.new.groups },
       editable_columns: %w[title full_name author_id featured published windows_type_id],
-      belongs_to_options: -> {
-        {
-          "author_id" => Person.joins(:workshops_as_author).distinct.order(:last_name, :first_name),
-          "windows_type_id" => WindowsType.order(:name)
-        }
-      },
+      belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
+      remote_select_options: { "author_id" => "person" },
       record_extras: ->(workshop) {
         [ workshop.windows_type&.name, workshop.author&.name ].compact.join(" · ").presence
       }

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -183,9 +183,10 @@ class WorkshopsController < ApplicationController
       editable_columns: %w[title full_name author_id featured published windows_type_id],
       belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
       remote_select_options: { "author_id" => "person" },
+      deprecated_columns: %w[full_name],
       field_notes: {
         "full_name" => "Legacy free-text author name. Prefer crediting a real person in Author below.",
-        "author_id" => "Credited author — search any person, not just active users."
+        "author_id" => "Credited author — search any person."
       },
       record_extras: ->(workshop) {
         [ workshop.windows_type&.name, workshop.author&.name ].compact.join(" · ").presence

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -183,6 +183,10 @@ class WorkshopsController < ApplicationController
       editable_columns: %w[title full_name author_id featured published windows_type_id],
       belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
       remote_select_options: { "author_id" => "person" },
+      field_notes: {
+        "full_name" => "Legacy free-text author name. Prefer crediting a real person in Author below.",
+        "author_id" => "Credited author — search any person, not just active users."
+      },
       record_extras: ->(workshop) {
         [ workshop.windows_type&.name, workshop.author&.name ].compact.join(" · ").presence
       }

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -185,7 +185,7 @@ class WorkshopsController < ApplicationController
       remote_select_options: { "author_id" => "person" },
       deprecated_columns: %w[full_name],
       field_notes: {
-        "full_name" => "Legacy free-text author name. Prefer crediting a real person in Author below.",
+        "full_name" => "Legacy (not referenced). Credit a real person in Author below instead.",
         "author_id" => "Credited author — search any person."
       },
       record_extras: ->(workshop) {

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -185,6 +185,10 @@ class WorkshopsController < ApplicationController
       remote_select_options: { "author_id" => "person" },
       deprecated_columns: %w[full_name],
       movable_attachments: %w[thumbnail header],
+      preview_images: ->(workshop) {
+        [ workshop.thumbnail, workshop.header, workshop.primary_asset&.file,
+          *workshop.gallery_assets.map(&:file) ].compact.select(&:attached?)
+      },
       field_notes: {
         "full_name" => "Legacy (not referenced). Credit a real person in Author below instead.",
         "author_id" => "Credited author — search any person."

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -1,5 +1,5 @@
 class WorkshopsController < ApplicationController
-  include AhoyTracking, TagAssignable, MentionableScopable
+  include AhoyTracking, TagAssignable, MentionableScopable, Dedupable
 
   skip_before_action :authenticate_user!, only: [ :index, :show ]
 
@@ -173,6 +173,19 @@ class WorkshopsController < ApplicationController
 
   def log_workshop_error(action, error)
     Rails.logger.error "Workshop #{action} failed: #{error.class} - #{error.message}\n#{error.backtrace.join("\n")}"
+  end
+
+  def dedupe_config
+    {
+      model_class: Workshop,
+      domain: :workshops,
+      candidate_finder: -> { WorkshopServices::DuplicateFinder.new.groups },
+      editable_columns: %w[title full_name featured published windows_type_id],
+      belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
+      record_extras: ->(workshop) {
+        [ workshop.windows_type&.name, workshop.author&.full_name ].compact.join(" · ").presence
+      }
+    }
   end
 
   def workshop_params

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -180,10 +180,15 @@ class WorkshopsController < ApplicationController
       model_class: Workshop,
       domain: :workshops,
       candidate_finder: -> { WorkshopServices::DuplicateFinder.new.groups },
-      editable_columns: %w[title full_name featured published windows_type_id],
-      belongs_to_options: -> { { "windows_type_id" => WindowsType.order(:name) } },
+      editable_columns: %w[title full_name author_id featured published windows_type_id],
+      belongs_to_options: -> {
+        {
+          "author_id" => Person.joins(:workshops_as_author).distinct.order(:last_name, :first_name),
+          "windows_type_id" => WindowsType.order(:name)
+        }
+      },
       record_extras: ->(workshop) {
-        [ workshop.windows_type&.name, workshop.author&.full_name ].compact.join(" · ").presence
+        [ workshop.windows_type&.name, workshop.author&.name ].compact.join(" · ").presence
       }
     }
   end

--- a/app/services/model_deduper.rb
+++ b/app/services/model_deduper.rb
@@ -5,11 +5,12 @@ require "set"
 class ModelDeduper
   attr_reader :model_class, :logger, :dry_run, :min_usage
 
-  def initialize(model_class:, logger: Logger.new($stdout), dry_run: true, min_usage: 0)
+  def initialize(model_class:, logger: Logger.new($stdout), dry_run: true, min_usage: 0, movable_attachments: [])
     @model_class = model_class
     @logger = logger
     @dry_run = dry_run
     @min_usage = min_usage
+    @movable_attachments = Array(movable_attachments).map(&:to_s)
   end
 
   def call
@@ -119,7 +120,9 @@ class ModelDeduper
     DEFERRED_REFERENCE_TABLES + IGNORED_REFERENCE_TABLES
   ).freeze
 
-  # Attached files (e.g. the logo) that are deleted with the record, not moved.
+  # Attached files that are deleted with the record, not moved. Any attachment
+  # named in `movable_attachments` is excluded here — it's reported by
+  # #attachment_plan instead, which decides move-vs-drop against the keeper.
   # Each entry is { label:, count: } — drives the preview's "will be lost" note.
   def lost_references(record)
     LOST_POLYMORPHIC_REFERENCES.filter_map do |table, (type_column, id_column)|
@@ -128,10 +131,24 @@ class ModelDeduper
       klass = model_for_table(table)
       next unless klass.column_names.include?(id_column)
 
-      count = klass.where(type_column => model_class.polymorphic_name, id_column => record.id).count
+      scope = klass.where(type_column => model_class.polymorphic_name, id_column => record.id)
+      scope = scope.where.not(name: @movable_attachments) if @movable_attachments.any? && klass.column_names.include?("name")
+      count = scope.count
       next if count.zero?
 
-      { label: "Attached files (e.g. logo)", count: count }
+      { label: "Attached files", count: count }
+    end
+  end
+
+  # For each `movable_attachments` name the deleted record has: whether it will
+  # MOVE to the keeper (keeper has none) or be DROPPED (keeper already has one).
+  # Each entry is { name:, label:, action: :move | :drop }.
+  def attachment_plan(record_to_keep, record_to_delete)
+    @movable_attachments.filter_map do |name|
+      next unless record_to_delete.public_send(name).attached?
+
+      action = record_to_keep.public_send(name).attached? ? :drop : :move
+      { name: name, label: name.humanize, action: action }
     end
   end
 
@@ -321,9 +338,24 @@ class ModelDeduper
       end
 
       reassign_polymorphic_references(primary, dupe)
+      move_attachments(primary, dupe)
 
       dupe.reload.destroy!
       logger.info "  deleted #{model_label} #{dupe.id}"
+    end
+  end
+
+  # Reassign each movable attachment from the dupe to the kept record when the
+  # keeper has none; otherwise leave it on the dupe so it purges on destroy. The
+  # attachment row's record_id moves (record_type is unchanged — same model), so
+  # the file follows the survivor instead of being lost with the deleted record.
+  def move_attachments(primary, dupe)
+    @movable_attachments.each do |name|
+      next unless dupe.public_send(name).attached?
+      next if primary.public_send(name).attached?
+
+      ActiveStorage::Attachment.where(record: dupe, name: name).update_all(record_id: primary.id)
+      logger.info "  moved attachment #{name} to primary"
     end
   end
 

--- a/app/services/workshop_services/duplicate_finder.rb
+++ b/app/services/workshop_services/duplicate_finder.rb
@@ -1,0 +1,89 @@
+require "set"
+
+module WorkshopServices
+  # Surfaces likely-duplicate workshops for the deduper's candidate list.
+  # Clusters workshops by normalized title and by title minus punctuation, then
+  # annotates each cluster with why it was flagged. Deliberately conservative:
+  # workshops that are genuine variations of one another live as separate records
+  # linked through workshop_variations, so only near-identical titles cluster —
+  # not a shared theme word.
+  class DuplicateFinder
+    Group = Struct.new(:key, :label, :records, :reasons, keyword_init: true)
+
+    def initialize(scope = Workshop.all)
+      @workshops = scope.to_a
+    end
+
+    def groups
+      union = UnionFind.new(@workshops.map(&:id))
+      cluster(union) { |workshop| [ normalized_title(workshop).presence ].compact }
+      cluster(union) { |workshop| [ alnum_title(workshop).presence ].compact }
+
+      by_id = @workshops.index_by(&:id)
+      union.components.filter_map do |ids|
+        next if ids.size < 2
+        records = ids.map { |id| by_id[id] }.sort_by(&:id)
+        Group.new(
+          key: records.map(&:id).join("-"),
+          label: records.first.title.to_s,
+          records: records,
+          reasons: reasons_for(records)
+        )
+      end.sort_by { |group| group.label.to_s.downcase }
+    end
+
+    private
+
+    def cluster(union)
+      buckets = Hash.new { |hash, key| hash[key] = [] }
+      @workshops.each do |workshop|
+        yield(workshop).each { |key| buckets[key] << workshop.id }
+      end
+      buckets.each_value { |ids| union.union_all(ids) if ids.size > 1 }
+    end
+
+    def reasons_for(records)
+      reasons = []
+      normalized = records.map { |workshop| normalized_title(workshop) }.uniq
+      reasons << "Same title" if normalized.size == 1
+      reasons << "Same title aside from punctuation" if normalized.size > 1
+      reasons
+    end
+
+    def normalized_title(workshop)
+      workshop.title.to_s.downcase.squish
+    end
+
+    def alnum_title(workshop)
+      workshop.title.to_s.downcase.gsub(/[^a-z0-9 ]/, " ").squish
+    end
+
+    # Minimal disjoint-set: clusters ids connected by any shared signal into
+    # components, so a workshop linked to one dupe by exact title and to another
+    # by punctuation-insensitive title lands in a single group.
+    class UnionFind
+      def initialize(ids)
+        @parent = ids.to_h { |id| [ id, id ] }
+      end
+
+      def union_all(ids)
+        ids.each { |id| union(ids.first, id) }
+      end
+
+      def components
+        @parent.keys.group_by { |id| find(id) }.values
+      end
+
+      private
+
+      def find(id)
+        id = @parent[id] while @parent[id] != id
+        id
+      end
+
+      def union(a, b)
+        @parent[find(a)] = find(b)
+      end
+    end
+  end
+end

--- a/app/services/workshop_services/duplicate_finder.rb
+++ b/app/services/workshop_services/duplicate_finder.rb
@@ -57,33 +57,5 @@ module WorkshopServices
     def alnum_title(workshop)
       workshop.title.to_s.downcase.gsub(/[^a-z0-9 ]/, " ").squish
     end
-
-    # Minimal disjoint-set: clusters ids connected by any shared signal into
-    # components, so a workshop linked to one dupe by exact title and to another
-    # by punctuation-insensitive title lands in a single group.
-    class UnionFind
-      def initialize(ids)
-        @parent = ids.to_h { |id| [ id, id ] }
-      end
-
-      def union_all(ids)
-        ids.each { |id| union(ids.first, id) }
-      end
-
-      def components
-        @parent.keys.group_by { |id| find(id) }.values
-      end
-
-      private
-
-      def find(id)
-        id = @parent[id] while @parent[id] != id
-        id
-      end
-
-      def union(a, b)
-        @parent[find(a)] = find(b)
-      end
-    end
   end
 end

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -159,3 +159,34 @@
     <% end %>
   <% end %>
 </div>
+
+<%# Read-only inventory of every parent (belongs_to) reference not already shown as an
+    editable field above — full visibility into what each record is linked to before merging. %>
+<%
+  shown_fk_names = columns.map(&:name)
+  linked_associations = model_class.reflect_on_all_associations(:belongs_to)
+                                   .reject { |assoc| shown_fk_names.include?(assoc.foreign_key.to_s) }
+  linked_display = ->(record) {
+    record ? (record.try(:name).presence || record.try(:title).presence || "##{record.id}") : "(none)"
+  }
+%>
+<% if linked_associations.any? %>
+  <div class="mt-6">
+    <h3 class="mb-2 text-sm font-semibold text-gray-700">Linked records <span class="font-normal text-gray-400">(read-only — for reference)</span></h3>
+    <div class="grid grid-cols-2 gap-x-6">
+      <% linked_associations.each_with_index do |assoc, index| %>
+        <% first = index.zero? %>
+        <% last = index == linked_associations.size - 1 %>
+        <% assoc_label = assoc.name.to_s.humanize %>
+        <div class="border-x border-b <%= border %> <%= "border-t" if first %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-tl-xl" if first %> <%= "rounded-bl-xl" if last %>">
+          <span class="w-full text-gray-400 sm:w-auto"><%= assoc_label %></span>
+          <span class="text-gray-900"><%= linked_display.call(record_to_delete.public_send(assoc.name)) %></span>
+        </div>
+        <div class="border-x border-b <%= border %> <%= "border-t" if first %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-tr-xl" if first %> <%= "rounded-br-xl" if last %>">
+          <span class="w-full text-gray-400 sm:w-auto"><%= assoc_label %></span>
+          <span class="text-gray-900"><%= linked_display.call(record_to_keep.public_send(assoc.name)) %></span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -69,22 +69,44 @@
     <span class="text-gray-400">ID</span> <span class="ml-2 text-gray-900"><%= record_to_keep.id %></span>
   </div>
 
-  <!-- Photos: attached images on each record, side by side -->
+  <!-- Photos: attached images on each record, side by side, with what happens on merge -->
   <% if preview_images && (delete_images.any? || keep_images.any?) %>
-    <% [ delete_images, keep_images ].each do |images| %>
-      <div class="border-x border-b <%= border %> bg-white px-5 py-3">
-        <p class="text-2xs mb-2 font-semibold tracking-widest text-gray-400 uppercase">Photos</p>
-        <% if images.any? %>
-          <div class="flex flex-wrap gap-2">
-            <% images.first(12).each do |image| %>
-              <%= image_tag url_for(image), loading: "lazy", class: "h-16 w-16 rounded object-cover ring-1 ring-gray-200" %>
-            <% end %>
-          </div>
-        <% else %>
-          <span class="text-sm text-gray-400">No photos</span>
+    <!-- Left: the deleted record's photos move to the keeper -->
+    <div class="border-x border-b <%= border %> bg-white px-5 py-3">
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <p class="text-2xs font-semibold tracking-widest text-gray-400 uppercase">Photos</p>
+        <% if delete_images.any? %>
+          <span class="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-semibold text-emerald-800">Move to the kept <%= model_label.downcase %></span>
         <% end %>
       </div>
-    <% end %>
+      <% if delete_images.any? %>
+        <div class="flex flex-wrap gap-2">
+          <% delete_images.first(12).each do |image| %>
+            <%= image_tag url_for(image), loading: "lazy", class: "h-16 w-16 rounded object-cover ring-1 ring-gray-200" %>
+          <% end %>
+        </div>
+      <% else %>
+        <span class="text-sm text-gray-400">No photos</span>
+      <% end %>
+    </div>
+    <!-- Right: the keeper's own photos stay -->
+    <div class="border-x border-b <%= border %> bg-white px-5 py-3">
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <p class="text-2xs font-semibold tracking-widest text-gray-400 uppercase">Photos</p>
+        <% if keep_images.any? %>
+          <span class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-semibold text-gray-500">Kept</span>
+        <% end %>
+      </div>
+      <% if keep_images.any? %>
+        <div class="flex flex-wrap gap-2">
+          <% keep_images.first(12).each do |image| %>
+            <%= image_tag url_for(image), loading: "lazy", class: "h-16 w-16 rounded object-cover ring-1 ring-gray-200" %>
+          <% end %>
+        </div>
+      <% else %>
+        <span class="text-sm text-gray-400"><%= delete_images.any? ? "None yet — the photos on the left move here" : "No photos" %></span>
+      <% end %>
+    </div>
   <% end %>
 
   <!-- Field rows -->

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -27,6 +27,7 @@
     end
   bt_associations = model_class.reflect_on_all_associations(:belongs_to).index_by { |a| a.foreign_key.to_s }
   belongs_to_options ||= {}
+  remote_select_options ||= {}
 %>
 
 <div class="mb-6 grid grid-cols-2 gap-x-6"
@@ -95,6 +96,14 @@
             <%= keep_f.check_box col.name.to_sym, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-200" %>
             <span class="text-gray-600">Yes</span>
           </label>
+        <% elsif col_assoc && remote_select_options[col.name].present? %>
+          <%
+            current = record_to_keep.public_send(col_assoc.name)
+            current_option = current ? [ [ (current.try(:remote_search_label)&.dig(:label) || current.name), current.id ] ] : []
+          %>
+          <%= keep_f.select col.name.to_sym, current_option, { include_blank: true },
+                            class: "w-full px-2 py-1 border border-gray-300 rounded text-gray-900 focus:border-blue-500 focus:ring-blue-200",
+                            data: { controller: "remote-select", remote_select_model_value: remote_select_options[col.name] } %>
         <% elsif col_assoc && belongs_to_options[col.name].present? %>
           <%= keep_f.collection_select col.name.to_sym, belongs_to_options[col.name], :id, :name, {}, class: "w-full px-2 py-1 border border-gray-300 rounded text-gray-900 focus:border-blue-500 focus:ring-blue-200" %>
         <% elsif col.type == :integer && col_assoc.nil? %>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -141,11 +141,11 @@
     delete_total = reassignment_delete.sum { |entry| entry[:count] }
     keep_total = reassignment_keep.sum { |entry| entry[:count] }
   %>
-  <div class="border-x border-b <%= border %> bg-white px-5 py-3">
-    <h3 class="text-sm font-semibold text-gray-700">Records that will move <span class="font-normal text-gray-400">(<%= delete_total %>)</span></h3>
+  <div class="border-x border-t-2 border-b <%= border %> <%= header_bg %> px-5 py-3">
+    <h3 class="text-2xs font-semibold tracking-widest text-gray-600 uppercase">Records that will move <span class="ml-1 text-gray-400 normal-case">(<%= delete_total %>)</span></h3>
   </div>
-  <div class="border-x border-b <%= border %> bg-white px-5 py-3">
-    <h3 class="text-sm font-semibold text-gray-700">Records already here <span class="font-normal text-gray-400">(<%= keep_total %>)</span></h3>
+  <div class="border-x border-t-2 border-b <%= border %> <%= header_bg %> px-5 py-3">
+    <h3 class="text-2xs font-semibold tracking-widest text-gray-600 uppercase">Records already here <span class="ml-1 text-gray-400 normal-case">(<%= keep_total %>)</span></h3>
   </div>
 
   <% if labels.empty? %>
@@ -172,17 +172,18 @@
 %>
 <% if linked_associations.any? %>
   <div class="mt-6">
-    <h3 class="mb-2 text-sm font-semibold text-gray-700">Linked records <span class="font-normal text-gray-400">(read-only — for reference)</span></h3>
+    <div class="rounded-t-xl border-x border-t border-b <%= border %> <%= header_bg %> px-5 py-3">
+      <h3 class="text-2xs font-semibold tracking-widest text-gray-600 uppercase">Linked records <span class="ml-1 text-gray-400 normal-case">(read-only — for reference)</span></h3>
+    </div>
     <div class="grid grid-cols-2 gap-x-6">
       <% linked_associations.each_with_index do |assoc, index| %>
-        <% first = index.zero? %>
         <% last = index == linked_associations.size - 1 %>
         <% assoc_label = assoc.name.to_s.humanize %>
-        <div class="border-x border-b <%= border %> <%= "border-t" if first %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-tl-xl" if first %> <%= "rounded-bl-xl" if last %>">
+        <div class="border-x border-b <%= border %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-bl-xl" if last %>">
           <span class="w-full text-gray-400 sm:w-auto"><%= assoc_label %></span>
           <span class="text-gray-900"><%= linked_display.call(record_to_delete.public_send(assoc.name)) %></span>
         </div>
-        <div class="border-x border-b <%= border %> <%= "border-t" if first %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-tr-xl" if first %> <%= "rounded-br-xl" if last %>">
+        <div class="border-x border-b <%= border %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "rounded-br-xl" if last %>">
           <span class="w-full text-gray-400 sm:w-auto"><%= assoc_label %></span>
           <span class="text-gray-900"><%= linked_display.call(record_to_keep.public_send(assoc.name)) %></span>
         </div>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -30,6 +30,9 @@
   remote_select_options ||= {}
   field_notes ||= {}
   deprecated_columns ||= []
+  preview_images ||= nil
+  delete_images = preview_images ? Array(preview_images.call(record_to_delete)) : []
+  keep_images = preview_images ? Array(preview_images.call(record_to_keep)) : []
 %>
 
 <div class="mb-6 grid grid-cols-2 gap-x-6"
@@ -65,6 +68,24 @@
   <div class="border-x border-b <%= border %> bg-white px-5 py-3 text-sm">
     <span class="text-gray-400">ID</span> <span class="ml-2 text-gray-900"><%= record_to_keep.id %></span>
   </div>
+
+  <!-- Photos: attached images on each record, side by side -->
+  <% if preview_images && (delete_images.any? || keep_images.any?) %>
+    <% [ delete_images, keep_images ].each do |images| %>
+      <div class="border-x border-b <%= border %> bg-white px-5 py-3">
+        <p class="text-2xs mb-2 font-semibold tracking-widest text-gray-400 uppercase">Photos</p>
+        <% if images.any? %>
+          <div class="flex flex-wrap gap-2">
+            <% images.first(12).each do |image| %>
+              <%= image_tag url_for(image), loading: "lazy", class: "h-16 w-16 rounded object-cover ring-1 ring-gray-200" %>
+            <% end %>
+          </div>
+        <% else %>
+          <span class="text-sm text-gray-400">No photos</span>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 
   <!-- Field rows -->
   <%= form_builder.fields_for keep_param_key, record_to_keep do |keep_f| %>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -29,6 +29,7 @@
   belongs_to_options ||= {}
   remote_select_options ||= {}
   field_notes ||= {}
+  deprecated_columns ||= []
 %>
 
 <div class="mb-6 grid grid-cols-2 gap-x-6"
@@ -76,22 +77,31 @@
         union_column = union_columns.include?(col.name)
         merged_in = union_column && delete_val.to_s.split(",").map(&:strip).reject(&:blank?).difference(keep_val.to_s.split(",").map(&:strip)).any?
         is_different = !union_column && delete_val != keep_val
+        deprecated = deprecated_columns.include?(col.name)
       %>
 
       <!-- Left: read-only -->
-      <div class="border-x border-b <%= border %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm">
+      <div class="border-x border-b <%= border %> flex flex-wrap items-start gap-x-2 bg-white px-5 py-3 text-sm <%= "opacity-60" if deprecated %>">
         <span class="w-full text-gray-400 sm:w-auto"><%= label %></span>
-        <span class="text-gray-900 <%= "font-semibold" if col.name == "name" %>"><%= display_val %></span>
+        <% if deprecated %>
+          <span class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-semibold text-gray-500">Deprecated</span>
+        <% end %>
+        <span class="<%= deprecated ? "text-gray-400 italic" : "text-gray-900" %> <%= "font-semibold" if col.name == "name" %>"><%= display_val %></span>
         <% if merged_in %>
           <span class="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-semibold text-emerald-800">Kept on merge</span>
-        <% elsif is_different %>
+        <% elsif is_different && !deprecated %>
           <span class="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-800">Will be dropped</span>
         <% end %>
       </div>
 
       <!-- Right: editable -->
-      <div class="border-x border-b <%= border %> bg-white px-5 py-3 text-sm">
-        <label class="mb-1 block text-gray-400"><%= label %></label>
+      <div class="border-x border-b <%= border %> bg-white px-5 py-3 text-sm <%= "opacity-60" if deprecated %>">
+        <label class="mb-1 flex items-center gap-2 text-gray-400">
+          <%= label %>
+          <% if deprecated %>
+            <span class="rounded bg-gray-100 px-1.5 py-0.5 text-xs font-semibold text-gray-500">Deprecated</span>
+          <% end %>
+        </label>
         <% if col.type == :boolean %>
           <label class="inline-flex items-center gap-2">
             <%= keep_f.check_box col.name.to_sym, class: "rounded border-gray-300 text-blue-600 focus:ring-blue-200" %>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -28,6 +28,7 @@
   bt_associations = model_class.reflect_on_all_associations(:belongs_to).index_by { |a| a.foreign_key.to_s }
   belongs_to_options ||= {}
   remote_select_options ||= {}
+  field_notes ||= {}
 %>
 
 <div class="mb-6 grid grid-cols-2 gap-x-6"
@@ -114,6 +115,9 @@
           <%= keep_f.text_field col.name.to_sym, class: "w-full px-2 py-1 border border-gray-300 rounded text-gray-900 #{"font-semibold" if col.name == "name"} focus:border-blue-500 focus:ring-blue-200" %>
         <% else %>
           <span class="text-gray-500"><%= record_to_keep.public_send(col_assoc.name)&.try(:name) || "(none)" %></span>
+        <% end %>
+        <% if field_notes[col.name].present? %>
+          <p class="mt-1 text-xs text-gray-500"><%= field_notes[col.name] %></p>
         <% end %>
       </div>
     <% end %>

--- a/app/views/dedupes/_preview.html.erb
+++ b/app/views/dedupes/_preview.html.erb
@@ -41,11 +41,21 @@
   <!-- Column headers -->
   <div class="border <%= border %> rounded-t-xl <%= header_bg %> flex items-center gap-2 px-5 py-3">
     <i class="fa-solid fa-trash-can text-red-400"></i>
-    <span class="font-semibold text-gray-900"><%= model_label %> to delete: <strong><%= record_to_delete.name %></strong></span>
+    <span class="font-semibold text-gray-900"><%= model_label %> to delete:</span>
+    <%= link_to edit_polymorphic_path(record_to_delete), target: "_blank", rel: "noopener",
+                class: "group inline-flex items-center gap-1.5 font-semibold text-gray-900 hover:underline" do %>
+      <strong><%= record_to_delete.name %></strong>
+      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400 group-hover:text-gray-600"></i>
+    <% end %>
   </div>
   <div class="border <%= border %> rounded-t-xl <%= header_bg %> flex items-center gap-2 px-5 py-3">
     <i class="fa-solid fa-circle-check text-emerald-500"></i>
-    <span class="font-semibold text-gray-900"><%= model_label %> to keep: <strong><%= record_to_keep.name %></strong></span>
+    <span class="font-semibold text-gray-900"><%= model_label %> to keep:</span>
+    <%= link_to edit_polymorphic_path(record_to_keep), target: "_blank", rel: "noopener",
+                class: "group inline-flex items-center gap-1.5 font-semibold text-gray-900 hover:underline" do %>
+      <strong><%= record_to_keep.name %></strong>
+      <i class="fa-solid fa-arrow-up-right-from-square text-xs text-gray-400 group-hover:text-gray-600"></i>
+    <% end %>
   </div>
 
   <!-- ID row -->

--- a/app/views/dedupes/_reassignment_entry.html.erb
+++ b/app/views/dedupes/_reassignment_entry.html.erb
@@ -14,9 +14,9 @@
     <% extra = entry[:count] - entry[:names].size %>
     <details class="group">
       <summary class="flex cursor-pointer list-none items-center gap-1 text-gray-600 [&::-webkit-details-marker]:hidden">
-        <i class="fa-solid fa-chevron-right text-xs text-gray-400 transition-transform group-open:rotate-90"></i>
         <span class="font-medium text-gray-800"><%= entry[:label] %></span>
         <span class="text-gray-400">(<%= entry[:count] %>)</span>
+        <i class="fa-solid fa-chevron-right ml-auto text-xs text-gray-400 transition-transform group-open:rotate-90"></i>
       </summary>
       <ul class="mt-1 ml-5 list-disc space-y-0.5 text-gray-500">
         <% entry[:names].each do |name| %>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -78,7 +78,8 @@
                  union_columns: @dedupe[:union_columns],
                  form_builder: f,
                  belongs_to_options: @dedupe[:belongs_to_options],
-                 remote_select_options: @dedupe[:remote_select_options] %>
+                 remote_select_options: @dedupe[:remote_select_options],
+                 field_notes: @dedupe[:field_notes] %>
 
       <!-- Lost with the deleted record -->
       <% if @lost_references.any? %>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -79,7 +79,8 @@
                  form_builder: f,
                  belongs_to_options: @dedupe[:belongs_to_options],
                  remote_select_options: @dedupe[:remote_select_options],
-                 field_notes: @dedupe[:field_notes] %>
+                 field_notes: @dedupe[:field_notes],
+                 deprecated_columns: @dedupe[:deprecated_columns] %>
 
       <!-- Lost with the deleted record -->
       <% if @lost_references.any? %>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -77,7 +77,8 @@
                  editable_columns: @dedupe[:editable_columns],
                  union_columns: @dedupe[:union_columns],
                  form_builder: f,
-                 belongs_to_options: @dedupe[:belongs_to_options] %>
+                 belongs_to_options: @dedupe[:belongs_to_options],
+                 remote_select_options: @dedupe[:remote_select_options] %>
 
       <!-- Lost with the deleted record -->
       <% if @lost_references.any? %>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -80,7 +80,8 @@
                  belongs_to_options: @dedupe[:belongs_to_options],
                  remote_select_options: @dedupe[:remote_select_options],
                  field_notes: @dedupe[:field_notes],
-                 deprecated_columns: @dedupe[:deprecated_columns] %>
+                 deprecated_columns: @dedupe[:deprecated_columns],
+                 preview_images: @dedupe[:preview_images] %>
 
       <!-- Attached images: moved to the keeper only when it has none, else dropped -->
       <% if @attachment_plan.present? %>

--- a/app/views/dedupes/preview.html.erb
+++ b/app/views/dedupes/preview.html.erb
@@ -82,6 +82,27 @@
                  field_notes: @dedupe[:field_notes],
                  deprecated_columns: @dedupe[:deprecated_columns] %>
 
+      <!-- Attached images: moved to the keeper only when it has none, else dropped -->
+      <% if @attachment_plan.present? %>
+        <div class="mt-6 rounded-xl border border-gray-200 bg-white p-4">
+          <p class="text-sm font-semibold text-gray-800">Attached images</p>
+          <ul class="mt-2 space-y-1 text-sm">
+            <% @attachment_plan.each do |entry| %>
+              <li class="flex items-center gap-2">
+                <span class="font-medium text-gray-700"><%= entry[:label] %></span>
+                <% if entry[:action] == :move %>
+                  <span class="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-semibold text-emerald-800">Moves to keeper</span>
+                  <span class="text-gray-500">— the kept <%= @dedupe[:model_label].downcase %> has none</span>
+                <% else %>
+                  <span class="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-800">Dropped</span>
+                  <span class="text-gray-500">— the kept <%= @dedupe[:model_label].downcase %> already has one</span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
       <!-- Lost with the deleted record -->
       <% if @lost_references.any? %>
         <div class="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-4">

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -2,6 +2,10 @@
 
 <% content_for(:page_bg_class, "public") %>
 <% actions = capture do %>
+  <% if allowed_to?(:manage?, Workshop) %>
+    <%= link_to "Dedupe", dedupe_index_workshops_path,
+                class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% end %>
   <% if allowed_to?(:new?, Workshop) %>
     <%= link_to "New workshop",
                 new_workshop_path,

--- a/config/features.yml
+++ b/config/features.yml
@@ -2525,6 +2525,28 @@
     - "Use Swap if you picked the wrong record to keep."
     - "If both people have a login, the preview says so: after the merge both logins sign in to the kept person, and no login is lost."
 
+- name: "Merge duplicate workshops"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-30
+  pr_number: 2434
+  action_path: "/workshops/dedupe_index"
+  summary: >-
+    Admins can now merge two duplicate workshops into one, the same way
+    organizations, categories, and sectors are deduped. It suggests likely
+    duplicates by title, then previews exactly what will move before merging.
+  description: >-
+    Reach it from the Dedupe link on the Workshops page. It clusters workshops
+    with the same title (ignoring case and punctuation) and flags why each was
+    grouped. The preview shows a side-by-side of both workshops with the kept
+    one's key fields editable, plus a summary of every associated record
+    (workshop logs, resources, series links, tags, bookmarks, and more) that
+    moves to the kept workshop. The merge reassigns all of them and deletes the
+    duplicate. It can't be undone. Admin-only.
+  pro_tips:
+    - "Edit the kept workshop's fields right in the preview before you merge."
+    - "Use Swap if you picked the wrong workshop to keep."
+
 - name: "People and Organizations lists in the AWBW brand"
   area: people
   display_status: user_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,6 +380,12 @@ Rails.application.routes.draw do
   resources :workshop_variation_ideas
   resources :workshop_variations
   resources :workshops do
+    collection do
+      get :dedupe_index
+      get :dedupe_preview
+      post :dedupe_perform
+      patch :dedupe_update_keep
+    end
     resources :comments, only: [ :create, :update ]
   end
 

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -596,6 +596,21 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Created by")
       end
 
+      it "shows a thumbnail on the deleted workshop as moving to the keeper" do
+        blob = ActiveStorage::Blob.create_before_direct_upload!(
+          filename: "thumb.png", byte_size: 1, checksum: "x", content_type: "image/png"
+        )
+        ActiveStorage::Attachment.create!(name: "thumbnail", record: delete_rec, blob: blob)
+
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Attached images")
+        expect(response.body).to include("Moves to keeper")
+      end
+
       it "still renders the author picker when neither workshop has a person author" do
         keep.update!(author: nil)
         delete_rec.update!(author: nil)

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -535,8 +535,10 @@ RSpec.describe "Dedupable concern", type: :request do
     end
 
     describe "GET dedupe_preview" do
-      let!(:keep) { create(:workshop, title: "Keep Workshop") }
-      let!(:delete_rec) { create(:workshop, title: "Delete Workshop") }
+      let!(:keep_author) { create(:person, first_name: "Ada", last_name: "Keeper") }
+      let!(:delete_author) { create(:person, first_name: "Ben", last_name: "Duplicate") }
+      let!(:keep) { create(:workshop, title: "Keep Workshop", author: keep_author) }
+      let!(:delete_rec) { create(:workshop, title: "Delete Workshop", author: delete_author) }
       before do
         sign_in admin
         create(:workshop_log, workshop: delete_rec)
@@ -550,6 +552,17 @@ RSpec.describe "Dedupable concern", type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Keep Workshop", "Delete Workshop")
+      end
+
+      it "surfaces each workshop's author so it can be edited on the kept record" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Author")
+        expect(response.body).to include("Ada Keeper", "Ben Duplicate")
+        expect(response.body).to include("[workshop_to_keep][author_id]")
       end
     end
 

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -577,6 +577,15 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Credited author")
       end
 
+      it "marks the legacy Full name field as deprecated" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Deprecated")
+      end
+
       it "still renders the author picker when neither workshop has a person author" do
         keep.update!(author: nil)
         delete_rec.update!(author: nil)

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -573,7 +573,7 @@ RSpec.describe "Dedupable concern", type: :request do
           workshop_to_delete_id: delete_rec.id
         )
 
-        expect(response.body).to include("Legacy free-text author name")
+        expect(response.body).to include("Legacy (not referenced)")
         expect(response.body).to include("Credited author")
       end
 

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -586,6 +586,16 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Deprecated")
       end
 
+      it "lists belongs_to references not shown as fields in a read-only Linked records section" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Linked records")
+        expect(response.body).to include("Created by")
+      end
+
       it "still renders the author picker when neither workshop has a person author" do
         keep.update!(author: nil)
         delete_rec.update!(author: nil)

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -567,6 +567,16 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include('data-remote-select-model-value="person"')
       end
 
+      it "notes that Full name is the legacy author and Author should be a person" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Legacy free-text author name")
+        expect(response.body).to include("Credited author")
+      end
+
       it "still renders the author picker when neither workshop has a person author" do
         keep.update!(author: nil)
         delete_rec.update!(author: nil)

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -621,11 +621,11 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Moves to keeper")
       end
 
-      it "renders the attached photos of each workshop side by side" do
+      it "renders each workshop's photos and shows the deleted record's moving to the keeper" do
         blob = ActiveStorage::Blob.create_and_upload!(
-          io: StringIO.new("img"), filename: "keep.png", content_type: "image/png"
+          io: StringIO.new("img"), filename: "del.png", content_type: "image/png"
         )
-        ActiveStorage::Attachment.create!(name: "thumbnail", record: keep, blob: blob)
+        ActiveStorage::Attachment.create!(name: "thumbnail", record: delete_rec, blob: blob)
 
         get dedupe_preview_workshops_path(
           workshop_to_keep_id: keep.id,
@@ -634,6 +634,7 @@ RSpec.describe "Dedupable concern", type: :request do
 
         expect(response.body).to include("Photos")
         expect(response.body).to include("active_storage/blobs")
+        expect(response.body).to include("Move to the kept workshop")
       end
 
       it "still renders the author picker when neither workshop has a person author" do

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -554,6 +554,16 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Keep Workshop", "Delete Workshop")
       end
 
+      it "links each record's title to its edit page" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("href=\"#{edit_workshop_path(keep)}\"")
+        expect(response.body).to include("href=\"#{edit_workshop_path(delete_rec)}\"")
+      end
+
       it "surfaces each workshop's author with a searchable picker on the kept record" do
         get dedupe_preview_workshops_path(
           workshop_to_keep_id: keep.id,

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -508,4 +508,93 @@ RSpec.describe "Dedupable concern", type: :request do
       end
     end
   end
+
+  # ============================================================
+  # WORKSHOPS — dedupe wired through WorkshopsController on the
+  # config-driven Dedupable pattern, matched by title.
+  # ============================================================
+
+  describe "Workshops" do
+    describe "GET dedupe_index" do
+      it "surfaces title-matched candidate groups for an admin" do
+        sign_in admin
+        create(:workshop, title: "Paper Bag Puppets")
+        create(:workshop, title: "paper bag puppets")
+
+        get dedupe_index_workshops_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Same title")
+      end
+
+      it "denies access to a regular user" do
+        sign_in regular_user
+        get dedupe_index_workshops_path
+        expect(response).not_to have_http_status(:ok)
+      end
+    end
+
+    describe "GET dedupe_preview" do
+      let!(:keep) { create(:workshop, title: "Keep Workshop") }
+      let!(:delete_rec) { create(:workshop, title: "Delete Workshop") }
+      before do
+        sign_in admin
+        create(:workshop_log, workshop: delete_rec)
+      end
+
+      it "renders the preview with a reassignment summary" do
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Keep Workshop", "Delete Workshop")
+      end
+    end
+
+    describe "POST dedupe_perform" do
+      let!(:keep) { create(:workshop, title: "Keeper Workshop") }
+      let!(:delete_rec) { create(:workshop, title: "Duplicate Workshop") }
+      let!(:log) { create(:workshop_log, workshop: delete_rec) }
+
+      it "merges, reassigns FK associations, and deletes the duplicate" do
+        sign_in admin
+
+        expect {
+          post dedupe_perform_workshops_path, params: {
+            workshop_to_delete_id: delete_rec.id,
+            workshop_to_keep_id: keep.id
+          }
+        }.to change(Workshop, :count).by(-1)
+
+        expect(response).to redirect_to(workshops_path)
+        expect(Workshop.exists?(delete_rec.id)).to be false
+        expect(log.reload.workshop_id).to eq(keep.id)
+      end
+
+      it "applies keep-field edits before merging" do
+        sign_in admin
+
+        post dedupe_perform_workshops_path, params: {
+          workshop_to_delete_id: delete_rec.id,
+          workshop_to_keep_id: keep.id,
+          workshop_to_keep: { title: "Canonical Workshop" }
+        }
+
+        expect(keep.reload.title).to eq("Canonical Workshop")
+      end
+
+      it "denies access to a regular user and does not merge" do
+        sign_in regular_user
+
+        expect {
+          post dedupe_perform_workshops_path, params: {
+            workshop_to_delete_id: delete_rec.id,
+            workshop_to_keep_id: keep.id
+          }
+        }.not_to change(Workshop, :count)
+      end
+    end
+  end
 end

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -621,6 +621,21 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Moves to keeper")
       end
 
+      it "renders the attached photos of each workshop side by side" do
+        blob = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new("img"), filename: "keep.png", content_type: "image/png"
+        )
+        ActiveStorage::Attachment.create!(name: "thumbnail", record: keep, blob: blob)
+
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("Photos")
+        expect(response.body).to include("active_storage/blobs")
+      end
+
       it "still renders the author picker when neither workshop has a person author" do
         keep.update!(author: nil)
         delete_rec.update!(author: nil)

--- a/spec/requests/dedupable_spec.rb
+++ b/spec/requests/dedupable_spec.rb
@@ -554,7 +554,7 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Keep Workshop", "Delete Workshop")
       end
 
-      it "surfaces each workshop's author so it can be edited on the kept record" do
+      it "surfaces each workshop's author with a searchable picker on the kept record" do
         get dedupe_preview_workshops_path(
           workshop_to_keep_id: keep.id,
           workshop_to_delete_id: delete_rec.id
@@ -563,6 +563,21 @@ RSpec.describe "Dedupable concern", type: :request do
         expect(response.body).to include("Author")
         expect(response.body).to include("Ada Keeper", "Ben Duplicate")
         expect(response.body).to include("[workshop_to_keep][author_id]")
+        expect(response.body).to include('data-controller="remote-select"')
+        expect(response.body).to include('data-remote-select-model-value="person"')
+      end
+
+      it "still renders the author picker when neither workshop has a person author" do
+        keep.update!(author: nil)
+        delete_rec.update!(author: nil)
+
+        get dedupe_preview_workshops_path(
+          workshop_to_keep_id: keep.id,
+          workshop_to_delete_id: delete_rec.id
+        )
+
+        expect(response.body).to include("[workshop_to_keep][author_id]")
+        expect(response.body).to include('data-controller="remote-select"')
       end
     end
 

--- a/spec/services/model_deduper_spec.rb
+++ b/spec/services/model_deduper_spec.rb
@@ -252,4 +252,61 @@ RSpec.describe ModelDeduper do
       expect(service.lost_references(create(:organization))).to eq([])
     end
   end
+
+  describe "movable attachments (Workshop thumbnail/header)" do
+    subject(:service) do
+      described_class.new(model_class: Workshop, dry_run: false, logger: logger, movable_attachments: %w[thumbnail header])
+    end
+
+    def attach_thumbnail(workshop)
+      blob = ActiveStorage::Blob.create_before_direct_upload!(
+        filename: "thumb.png", byte_size: 1, checksum: "x", content_type: "image/png"
+      )
+      ActiveStorage::Attachment.create!(name: "thumbnail", record: workshop, blob: blob)
+    end
+
+    it "moves the attachment to the keeper when the keeper has none" do
+      keep = create(:workshop, title: "Keeper")
+      delete_rec = create(:workshop, title: "Duplicate")
+      attachment = attach_thumbnail(delete_rec)
+
+      service.merge(keep, delete_rec)
+
+      expect(Workshop.exists?(delete_rec.id)).to be false
+      expect(attachment.reload.record_id).to eq(keep.id)
+      expect(keep.reload.thumbnail).to be_attached
+    end
+
+    it "drops the deleted record's attachment when the keeper already has one" do
+      keep = create(:workshop, title: "Keeper")
+      delete_rec = create(:workshop, title: "Duplicate")
+      attach_thumbnail(keep)
+      dupe_attachment = attach_thumbnail(delete_rec)
+
+      service.merge(keep, delete_rec)
+
+      expect(keep.reload.thumbnail).to be_attached
+      expect(ActiveStorage::Attachment.exists?(dupe_attachment.id)).to be false
+    end
+
+    it "reports move vs drop in #attachment_plan" do
+      keep = create(:workshop, title: "Keeper")
+      delete_rec = create(:workshop, title: "Duplicate")
+      attach_thumbnail(delete_rec)
+
+      plan = service.attachment_plan(keep, delete_rec)
+      expect(plan).to include(a_hash_including(name: "thumbnail", action: :move))
+
+      attach_thumbnail(keep)
+      plan = service.attachment_plan(keep.reload, delete_rec)
+      expect(plan).to include(a_hash_including(name: "thumbnail", action: :drop))
+    end
+
+    it "excludes movable attachments from #lost_references" do
+      workshop = create(:workshop)
+      attach_thumbnail(workshop)
+
+      expect(service.lost_references(workshop)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained wiring of an existing generic deduper onto a new model

Lets admins merge duplicate workshops from the workshops index, the same way they already dedupe organizations, categories, and sectors.

- Reimplements the stale #1007 on main’s current **config-driven `Dedupable`** — that PR patched the pre-refactor concern and no longer rebases.
- Follows the **organization deduper pattern**: a `WorkshopServices::DuplicateFinder` (clusters by normalized/punctuation-insensitive title) + a controller `dedupe_config`.
- Reuses the generic dedupe views, `ModelDeduper` reassignment, and its unhandled-reference safeguard — no changes to shared dedupe code.
- Admin-only via the default `manage?` policy rule; "Dedupe" link added to the workshops index.

Closes #507