### PR TITLE
Add scheduled site banners (start/end dates)

### DIFF
--- a/app/controllers/banners_controller.rb
+++ b/app/controllers/banners_controller.rb
@@ -65,7 +65,7 @@ class BannersController < ApplicationController
   # Strong parameters
   def banner_params
     params.require(:banner).permit(
-      :content, :published, :created_by_id, :updated_by_id
+      :content, :published, :started_at, :ended_at, :created_by_id, :updated_by_id
     )
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -493,7 +493,7 @@ module ApplicationHelper
 
   def display_banner
     # Cache banners to avoid repeated queries during page render
-    @banners ||= Banner.published.select("id, content").to_a
+    @banners ||= Banner.active.select("id, content").to_a
     return if @banners.empty?
 
     safe_content_array = @banners.map { |banner|

--- a/app/models/banner.rb
+++ b/app/models/banner.rb
@@ -5,11 +5,27 @@ class Banner < ApplicationRecord
   belongs_to :updated_by, class_name: "User"
 
   validates :content, presence: true
+  validate :ended_at_after_started_at
 
   # Scopes
   # See Publishable
 
+  # Published banners whose optional schedule window includes now. A nil
+  # started_at means "already started"; a nil ended_at means "never ends".
+  scope :active, ->(now = Time.current) {
+    published
+      .where("started_at IS NULL OR started_at <= ?", now)
+      .where("ended_at IS NULL OR ended_at >= ?", now)
+  }
+
   def name
     content.truncate(50)
+  end
+
+  private
+
+  def ended_at_after_started_at
+    return if started_at.blank? || ended_at.blank?
+    errors.add(:ended_at, "must be after the start date") if ended_at <= started_at
   end
 end

--- a/app/views/banners/_form.html.erb
+++ b/app/views/banners/_form.html.erb
@@ -8,7 +8,7 @@
     <%= f.hidden_field :updated_by_id, value: current_user&.id %>
 
     <!-- Content + Visibility -->
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-6 items-start">
+    <div class="grid grid-cols-1 items-start gap-6 md:grid-cols-4">
       <div class="md:col-span-3">
         <%= f.input :content,
                     as: :text,
@@ -21,12 +21,26 @@
                     hint: "You can include limited HTML (e.g. <b>, <i>, <a>)." %>
       </div>
 
-      <div class="admin-only bg-blue-100 rounded mt-6 md:mt-0 p-3">
+      <div class="admin-only mt-6 rounded bg-blue-100 p-3 md:mt-0">
         <%= render "shared/visibility_info", flags: %i[published] %>
         <div class="grid grid-cols-1 items-center">
           <%= visibility_flag_input f, :published %>
         </div>
       </div>
+    </div>
+
+    <!-- Optional scheduling window -->
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <%= f.input :started_at,
+                  as: :datetime,
+                  label: "Show from",
+                  input_html: { class: "rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" },
+                  hint: "Leave blank to show as soon as it is published." %>
+      <%= f.input :ended_at,
+                  as: :datetime,
+                  label: "Show until",
+                  input_html: { class: "rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" },
+                  hint: "Leave blank to show until unpublished." %>
     </div>
 
     <div class="action-buttons mt-8 flex justify-center gap-3">

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,18 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Schedule site banners with start and end dates"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-08-30
+  summary: >-
+    Banners can now carry an optional "show from" and "show until" date, so an
+    announcement can be set up ahead of time and disappear on its own instead of
+    having to be published and unpublished by hand.
+  pro_tips:
+    - "Leave both dates blank to behave exactly as before — the banner shows whenever it is published."
+    - "Set only a start date to schedule ahead, or only an end date to auto-expire."
+
 - name: "Scholarship recipients get an agreement confirmation email"
   area: scholarships
   display_status: public_facing

--- a/db/migrate/20260830150308_add_scheduling_to_banners.rb
+++ b/db/migrate/20260830150308_add_scheduling_to_banners.rb
@@ -1,0 +1,11 @@
+class AddSchedulingToBanners < ActiveRecord::Migration[8.1]
+  def up
+    add_column :banners, :started_at, :datetime
+    add_column :banners, :ended_at, :datetime
+  end
+
+  def down
+    remove_column :banners, :started_at, if_exists: true
+    remove_column :banners, :ended_at, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_001119) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -229,8 +229,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_001119) do
     t.text "content", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
+    t.datetime "ended_at"
     t.boolean "published", default: false, null: false
     t.boolean "show"
+    t.datetime "started_at"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "updated_by_id"
     t.index ["created_by_id"], name: "index_banners_on_created_by_id"

--- a/spec/models/banner_spec.rb
+++ b/spec/models/banner_spec.rb
@@ -1,19 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Banner, type: :model do
-  let(:banner) { build(:banner) } # Keep if needed for other tests
-
-  describe 'associations' do
-    # Add association tests if any
-  end
-
   describe 'validations' do
     subject { build(:banner) }
     it { should validate_presence_of(:content) }
+
+    it 'is invalid when ended_at is not after started_at' do
+      banner = build(:banner, started_at: 1.day.from_now, ended_at: 1.day.ago)
+      expect(banner).not_to be_valid
+      expect(banner.errors[:ended_at]).to be_present
+    end
+
+    it 'is valid when only one bound of the window is set' do
+      expect(build(:banner, started_at: 1.day.ago, ended_at: nil)).to be_valid
+      expect(build(:banner, started_at: nil, ended_at: 1.day.from_now)).to be_valid
+    end
   end
 
-  # Basic validity test included via shoulda
-  # it 'is valid with valid attributes' do
-  #   expect(build(:banner)).to be_valid
-  # end
+  describe '.active' do
+    it 'includes published banners with no schedule window' do
+      banner = create(:banner, published: true, started_at: nil, ended_at: nil)
+      expect(Banner.active).to include(banner)
+    end
+
+    it 'excludes unpublished banners even when in window' do
+      banner = create(:banner, published: false, started_at: 1.day.ago, ended_at: 1.day.from_now)
+      expect(Banner.active).not_to include(banner)
+    end
+
+    it 'includes a published banner currently within its window' do
+      banner = create(:banner, published: true, started_at: 1.day.ago, ended_at: 1.day.from_now)
+      expect(Banner.active).to include(banner)
+    end
+
+    it 'excludes a published banner whose window has not started' do
+      banner = create(:banner, published: true, started_at: 1.day.from_now, ended_at: 2.days.from_now)
+      expect(Banner.active).not_to include(banner)
+    end
+
+    it 'excludes a published banner whose window has ended' do
+      banner = create(:banner, published: true, started_at: 2.days.ago, ended_at: 1.day.ago)
+      expect(Banner.active).not_to include(banner)
+    end
+  end
 end

--- a/spec/requests/banners_spec.rb
+++ b/spec/requests/banners_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe "/banners", type: :request do
         post banners_url, params: { banner: valid_attributes }
         expect(response).to redirect_to(banner_url(Banner.last))
       end
+
+      it "persists the scheduling window" do
+        starts = 1.day.from_now.change(usec: 0)
+        ends = 3.days.from_now.change(usec: 0)
+        post banners_url, params: { banner: valid_attributes.merge(started_at: starts, ended_at: ends) }
+        banner = Banner.last
+        expect(banner.started_at).to be_within(1.second).of(starts)
+        expect(banner.ended_at).to be_within(1.second).of(ends)
+      end
     end
 
     context "with invalid parameters" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small model/helper/form change plus a migration adding two nullable columns

Reworks the stalled #1342 fresh off main: site banners can now carry an optional start/end date, so an admin can queue an announcement ahead of time and have it disappear on its own instead of publishing and unpublishing by hand.

Closes #216 (supersedes #1342 by @diti0-dot, which couldn't merge and had a couple of gaps).

## What changed
- **Migration** — adds nullable `started_at` / `ended_at` to `banners`.
- **`Banner.active` scope** — published banners whose optional window includes now (nil start = already showing, nil end = never expires).
- **`display_banner`** now uses `Banner.active`.
- **Form + strong params** — admins can actually set the two dates (the previous attempt permitted neither).
- **Validation** — `ended_at` must be after `started_at`.

## Why it differs from #1342
- Gates on **`published`**, not the legacy `show` column. Banners are published via the `published` flag (that's what the form and strong params set); the old scope filtered `show: true`, so it would have hidden the banners admins actually publish.
- Adds the **form fields + strong params** so the dates are settable end-to-end — #1342 had no UI for them (the author flagged this themselves).
- Real second-level migration timestamp instead of a round zero-trailing one.