### PR TITLE
Centralize created_by stamping in UserStampable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ This codebase (Rails 8.1)
 | `StaffTaggable` | Adds the polymorphic `staff_taggings`/`staff_tags` associations for internal admin StaffTags (Person today) |
 | `TagFilterable` | Scope-based filtering by tag names |
 | `Trendable` | Trending metrics tracking |
-| `UserStampable` | Stamps `updated_by_id` from `Current.user` on every write (no-op without the column) |
+| `UserStampable` | Stamps `created_by_id` (at create, if unset) and `updated_by_id` (every write) from `Current.user` (no-op without the column) |
 | `WindowsTypeFilterable` | Filter by WindowsType association |
 
 ## Controllers

--- a/app/models/concerns/user_stampable.rb
+++ b/app/models/concerns/user_stampable.rb
@@ -1,25 +1,39 @@
 module UserStampable
   extend ActiveSupport::Concern
 
-  # Stamps updated_by_id from Current.user on every write, so the last editor is
-  # recorded on the record itself. (created_by_id is set at create time by the
-  # controllers; only updated_by_id was going unset on updates.) Included on
-  # ApplicationRecord; the guard makes it a no-op for tables without the column. Runs
-  # on before_validation so it satisfies a required belongs_to :updated_by before the
-  # presence check.
+  # Stamps the audit columns from Current.user so a record records who created and who
+  # last edited it, without every controller assigning them by hand. Included on
+  # ApplicationRecord; each stamp is a no-op for tables that lack the column, and the
+  # whole thing is a no-op when Current.user is nil (seeds, jobs, unauthenticated
+  # flows). Runs on before_validation so it satisfies a required belongs_to before the
+  # presence check. Both stamps respect a value the caller assigned explicitly.
   included do
-    before_validation :stamp_updated_by
+    before_validation :stamp_user_columns
   end
 
   private
 
-  def stamp_updated_by
+  def stamp_user_columns
     user = Current.user
     return unless user
-    return unless has_attribute?(:updated_by_id)
 
-    # Skip when the caller set updated_by_id explicitly (respect it), and when nothing
-    # else changed (don't turn a no-op save into a write / spurious update event).
+    stamp_created_by(user)
+    stamp_updated_by(user)
+  end
+
+  # created_by is set once, at create time, and never overwritten afterward.
+  def stamp_created_by(user)
+    return unless new_record?
+    return unless has_attribute?(:created_by_id)
+    return if created_by_id.present?
+
+    self.created_by_id = user.id
+  end
+
+  # updated_by tracks the last editor on every write. Skip when the caller set it
+  # explicitly, and when nothing else changed (so a no-op save stays a no-op).
+  def stamp_updated_by(user)
+    return unless has_attribute?(:updated_by_id)
     return if updated_by_id_changed?
     return unless new_record? || changed?
 

--- a/app/models/staff_tagging.rb
+++ b/app/models/staff_tagging.rb
@@ -18,9 +18,6 @@ class StaffTagging < ApplicationRecord
     staff_taggable.try(:preferred_email)
   end
 
-  before_create :stamp_created_by
-  before_save :stamp_updated_by
-
   scope :for_staff_tag, ->(ids) {
     tag_ids = Array(ids).reject(&:blank?)
     return all if tag_ids.empty?
@@ -59,15 +56,5 @@ class StaffTagging < ApplicationRecord
     results = results.matching_text(params[:query]) if params[:query].present?
     results = results.matching_content(params[:content]) if params[:content].present?
     results
-  end
-
-  private
-
-  def stamp_created_by
-    self.created_by ||= Current.user
-  end
-
-  def stamp_updated_by
-    self.updated_by = Current.user if Current.user
   end
 end

--- a/spec/models/concerns/user_stampable_spec.rb
+++ b/spec/models/concerns/user_stampable_spec.rb
@@ -11,17 +11,23 @@ RSpec.describe UserStampable, type: :model do
 
   describe "on create" do
     it "stamps updated_by from Current.user" do
-      banner = with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) }
+      banner = with_current(creator) { Banner.create!(content: "Hi", show: true) }
 
       expect(banner.updated_by).to eq(creator)
     end
 
-    it "satisfies a required belongs_to :updated_by without an explicit assignment" do
-      expect { with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: creator) } }
+    it "stamps created_by from Current.user when the caller leaves it unset" do
+      banner = with_current(creator) { Banner.create!(content: "Hi", show: true) }
+
+      expect(banner.created_by).to eq(creator)
+    end
+
+    it "satisfies required created_by/updated_by belongs_to without an explicit assignment" do
+      expect { with_current(creator) { Banner.create!(content: "Hi", show: true) } }
         .not_to raise_error
     end
 
-    it "leaves created_by to the caller" do
+    it "respects an explicitly assigned created_by" do
       banner = with_current(creator) { Banner.create!(content: "Hi", show: true, created_by: editor) }
 
       expect(banner.created_by).to eq(editor)
@@ -49,6 +55,16 @@ RSpec.describe UserStampable, type: :model do
       with_current(editor) { banner.save! }
 
       expect(banner.reload.updated_by).to eq(creator)
+    end
+
+    it "never backfills created_by on update — only stamps it at create" do
+      tag = StaffTag.create!(name: "Legacy tag")
+      expect(tag.created_by).to be_nil
+
+      with_current(editor) { tag.update!(name: "Edited tag") }
+
+      expect(tag.reload.created_by).to be_nil
+      expect(tag.updated_by).to eq(editor)
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small concern change, but it runs on every model at create time — worth reading the created_by guard and the authorize!-timing note

Follow-up to #2024: every model now records **both** `created_by` and `updated_by` from `Current.user` without a per-model callback. #2024 centralized `updated_by`; `created_by` was still stamped by hand in each controller. This makes the audit trail consistent and future-proof — a new model or create path gets `created_by` for free.

## What changed
- **`UserStampable`** now also stamps `created_by_id` at create time, from `Current.user`, **only when it is blank**. `updated_by` behavior is unchanged.
- **`StaffTagging`** loses its own `before_create :stamp_created_by` / `before_save :stamp_updated_by` — the concern now covers it (its `create?` policy is admin-only, so nothing read `created_by` at authorize time).

## Why controllers still assign created_by
Owner-based `create?` policies check `record.created_by_id == user.id` (`ApplicationPolicy#owner?`) **before the record is saved** — i.e. before the concern runs at `before_validation`. So controllers keep setting `created_by` ahead of `authorize!` (e.g. non-admin story-idea submission relies on it). The concern no-ops there and covers every other create path. It stays a no-op when `Current.user` is nil (public self-service, accountless submissions, seeds, jobs), so deliberately-unattributed records stay unattributed.

## Tests
- `spec/models/concerns/user_stampable_spec.rb` — created_by stamped when unset, respected when set, never backfilled on update.
- Re-ran the create-flow request/service specs that assert `created_by` (stories, grants, staff tags, quotes capture, CE attendance, etc.) — all green.