### PR TITLE
Humanize visitor user agent in the admin visits table

### DIFF
--- a/app/decorators/ahoy/visit_decorator.rb
+++ b/app/decorators/ahoy/visit_decorator.rb
@@ -1,0 +1,54 @@
+module Ahoy
+  class VisitDecorator < ApplicationDecorator
+    # Friendly names for DeviceDetector's device types (dev-speak → plain English).
+    DEVICE_LABELS = {
+      "smartphone" => "Mobile",
+      "phablet" => "Mobile",
+      "tablet" => "Tablet",
+      "desktop" => "Desktop",
+      "console" => "Console",
+      "tv" => "TV",
+      "smart display" => "Smart display",
+      "car browser" => "Car",
+      "camera" => "Camera",
+      "portable media player" => "Media player",
+      "wearable" => "Wearable"
+    }.freeze
+    private_constant :DEVICE_LABELS
+
+    # A short, non-technical summary of the visit for the visits table, device
+    # first, e.g. "Desktop · Windows 10 · Firefox 5.0". The raw user agent is on hover.
+    def user_agent_summary
+      return "Unknown" if object.user_agent.blank?
+
+      [ device_label, os_detail, browser_detail ].compact.join(" · ").presence || "Unknown"
+    end
+
+    # The raw user agent, shown on hover for admins who need the full string.
+    def user_agent_details
+      object.user_agent.to_s
+    end
+
+    private
+
+    def browser_detail
+      return nil if detector.name.blank?
+
+      [ detector.name, detector.full_version ].compact.join(" ")
+    end
+
+    def os_detail
+      return nil if detector.os_name.blank?
+
+      [ detector.os_name, detector.os_full_version ].compact.join(" ")
+    end
+
+    def device_label
+      DEVICE_LABELS[detector.device_type]
+    end
+
+    def detector
+      @detector ||= DeviceDetector.new(object.user_agent.to_s)
+    end
+  end
+end

--- a/app/views/admin/ahoy_activities/visit_results.html.erb
+++ b/app/views/admin/ahoy_activities/visit_results.html.erb
@@ -75,8 +75,9 @@
               <% end %>
             </td>
 
-            <td class="max-w-xs truncate px-4 py-3 text-gray-500" title="<%= visit.user_agent %>">
-              <%= visit.user_agent %>
+            <% decorated_visit = visit.decorate %>
+            <td class="max-w-xs truncate px-4 py-3 text-gray-500" title="<%= decorated_visit.user_agent_details %>">
+              <%= decorated_visit.user_agent_summary %>
             </td>
           </tr>
         <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -2790,3 +2790,14 @@
     User columns.
   pro_tips:
     - "Resource title searches the name captured on each activity, which is more precise than the broader Details search."
+
+- name: "Readable browser and device in the admin visits table"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-08-30
+  action_path: "/admin/activities/visits"
+  summary: >-
+    The visits log now shows a plain-English browser and device summary
+    (e.g. "Desktop · Windows 10 · Firefox 5.0") instead of the raw user agent string.
+  pro_tips:
+    - "Hover the browser column to see the full raw user agent when you need the exact string."

--- a/spec/decorators/ahoy/visit_decorator_spec.rb
+++ b/spec/decorators/ahoy/visit_decorator_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Ahoy::VisitDecorator do
+  def decorate(user_agent)
+    build(:ahoy_visit, user_agent: user_agent).decorate
+  end
+
+  describe "#user_agent_summary" do
+    it "renders device, then OS, then browser" do
+      ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:5.0) Gecko/20100101 Firefox/5.0"
+      expect(decorate(ua).user_agent_summary).to eq("Desktop · Windows 10 · Firefox 5.0")
+    end
+
+    it "labels smartphones as Mobile" do
+      ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 " \
+           "(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+      expect(decorate(ua).user_agent_summary).to eq("Mobile · iOS 17.0 · Mobile Safari 17.0")
+    end
+
+    it "returns Unknown when the user agent is blank" do
+      expect(decorate(nil).user_agent_summary).to eq("Unknown")
+    end
+
+    it "returns Unknown when the user agent can't be parsed" do
+      expect(decorate("not-a-real-user-agent").user_agent_summary).to eq("Unknown")
+    end
+  end
+
+  describe "#user_agent_details" do
+    it "returns the raw user agent string for the hover title" do
+      ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:5.0) Gecko/20100101 Firefox/5.0"
+      expect(decorate(ua).user_agent_details).to eq(ua)
+    end
+
+    it "is blank when the user agent is blank" do
+      expect(decorate(nil).user_agent_details).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one new presenter decorator + a one-cell view swap, contained logic

Admins scanning the visits log see a raw user-agent string in the browser column; this replaces it with a plain-English summary so the column is readable at a glance.

### What is the goal of this PR and why is this important?
The browser column in the admin visits table printed the full raw UA string, which is noise for anyone scanning who visited on what. This shows a short, human summary instead.

### How did you approach the change?
- Added `Ahoy::VisitDecorator`, which parses the UA with `DeviceDetector` (already available via `ahoy_matey`) into a device-first summary like `Desktop · Windows 10 · Firefox 5.0`.
- The visits results table renders that summary, one line (`truncate`, no wrap), with the raw user-agent string on hover via the `title` attribute.
- Blank or unparseable user agents fall back to `Unknown`.
- Added a Features & tips entry for the change.

### Anything else to add?
Rebased onto main, which had refactored the visits view into a lazy `visit_results` turbo frame — the cell change now lives there. Desktop is labeled explicitly (not just mobile); easy to suppress if only non-desktop devices should be called out. Covered by a decorator spec.