### PR TITLE
Fix affiliation status badges (never both; hidden on active rows)

### DIFF
--- a/app/frontend/javascript/controllers/inactive_toggle_controller.js
+++ b/app/frontend/javascript/controllers/inactive_toggle_controller.js
@@ -4,8 +4,8 @@ import { isFacilitatorTitle } from "../lib/affiliation";
 // Live styling for the affiliation editor row as you edit, before saving. Four
 // states by colour: role is the hue (facilitator = purple, else blue) and status
 // is the saturation (active = full, inactive = super-light). Inactive rows also
-// strike their fields (.aff-ended). A not-yet-started row (future start date, not
-// ended) additionally shows an "Upcoming" badge.
+// strike their fields (.aff-ended). A row shows at most one status badge:
+// "Inactive" when ended/flagged, "Upcoming" when its start date is still future.
 export default class extends Controller {
   static targets = ["endDate", "title", "row", "accentBar", "valueField", "startDate", "upcomingBadge", "inactiveBadge", "inactiveField", "suppliedField", "inactiveCheckbox"]
   static values = { expired: Boolean, today: String }
@@ -70,12 +70,11 @@ export default class extends Controller {
     this.rowTarget.classList.toggle("aff-ended", this.isPast());
   }
 
-  // "Inactive" whenever the affiliation isn't currently active (ended, flagged,
-  // or not-yet-started); "Upcoming" additionally for a future start — so an
-  // upcoming row shows both and an ended one shows only Inactive.
+  // At most one badge: "Inactive" for an ended/flagged row, "Upcoming" for a
+  // not-yet-started one, nothing for a currently-active row. isPast and isUpcoming
+  // are mutually exclusive (isUpcoming is false once isPast is true).
   updateBadges() {
-    const notActive = this.isPast() || this.isUpcoming();
-    if (this.hasInactiveBadgeTarget) this.inactiveBadgeTarget.classList.toggle("hidden", !notActive);
+    if (this.hasInactiveBadgeTarget) this.inactiveBadgeTarget.classList.toggle("hidden", !this.isPast());
     if (this.hasUpcomingBadgeTarget) this.upcomingBadgeTarget.classList.toggle("hidden", !this.isUpcoming());
   }
 

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -8,11 +8,9 @@
   <% expired = f.object.inactive? || (f.object.end_date.present? && f.object.end_date < Date.current) %>
   <%# Not yet started: a future start date, and not already ended. %>
   <% upcoming = !expired && f.object.start_date.present? && f.object.start_date > Date.current %>
-  <%# Status badges (kept live by inactive-toggle as the dates are edited):
-      "Inactive" whenever the affiliation isn't currently active (ended, flagged,
-      or not-yet-started), plus "Upcoming" for a future start — so an upcoming row
-      shows both, while an ended one shows only Inactive. %>
-  <% not_active = expired || upcoming %>
+  <%# Status badges (kept live by inactive-toggle as the dates are edited), at most
+      one: "Inactive" for an ended/flagged row, "Upcoming" for a not-yet-started
+      one, and nothing at all for a currently-active row. %>
   <%# A blank title displays (and saves) as the "Facilitator" default, so treat it
       as a facilitator for the row styling too — otherwise the JS (which reads the
       shown title) tints the row purple while the server-rendered pill stays neutral. %>
@@ -87,13 +85,16 @@
             label: label,
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
+        <%# `[&:not(.hidden)]:inline-flex` so the badge lays out only when shown:
+            a plain `inline-flex` here is emitted after `.hidden` in the compiled
+            CSS and would override it, leaving the badge permanently visible. %>
         <div class="mt-1 flex flex-wrap gap-1">
           <span data-inactive-toggle-target="inactiveBadge"
-                class="<%= "hidden" unless not_active %> inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+                class="<%= "hidden" unless expired %> [&:not(.hidden)]:inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
             <i class="fa-solid fa-circle-minus"></i>Inactive
           </span>
           <span data-inactive-toggle-target="upcomingBadge"
-                class="<%= "hidden" unless upcoming %> inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+                class="<%= "hidden" unless upcoming %> [&:not(.hidden)]:inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
             <i class="fa-solid fa-clock"></i>Upcoming
           </span>
         </div>

--- a/app/views/affiliations/_fields.html.erb
+++ b/app/views/affiliations/_fields.html.erb
@@ -85,19 +85,6 @@
             label: label,
             label_html: { class: "block text-sm font-medium text-gray-700 mb-1 xl:hidden" } %>
         <% end %>
-        <%# `[&:not(.hidden)]:inline-flex` so the badge lays out only when shown:
-            a plain `inline-flex` here is emitted after `.hidden` in the compiled
-            CSS and would override it, leaving the badge permanently visible. %>
-        <div class="mt-1 flex flex-wrap gap-1">
-          <span data-inactive-toggle-target="inactiveBadge"
-                class="<%= "hidden" unless expired %> [&:not(.hidden)]:inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
-            <i class="fa-solid fa-circle-minus"></i>Inactive
-          </span>
-          <span data-inactive-toggle-target="upcomingBadge"
-                class="<%= "hidden" unless upcoming %> [&:not(.hidden)]:inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
-            <i class="fa-solid fa-clock"></i>Upcoming
-          </span>
-        </div>
       </div>
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
@@ -130,6 +117,13 @@
                       style: "height: 42px;",
                       data: { inactive_toggle_target: "valueField startDate", action: "change->affiliation-dates#recalculate change->inactive-toggle#paintFields change->inactive-toggle#updateBadges" }
                     } %>
+        <%# `[&:not(.hidden)]:inline-flex` so the chip lays out only when shown — a
+            plain `inline-flex` is emitted after `.hidden` in the compiled CSS and
+            would override it, keeping the chip permanently visible. %>
+        <span data-inactive-toggle-target="upcomingBadge"
+              class="<%= "hidden" unless upcoming %> [&:not(.hidden)]:inline-flex mt-1 items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+          <i class="fa-solid fa-clock"></i>Upcoming
+        </span>
       </div>
 
       <div class="w-full sm:w-[150px] xl:w-auto min-w-0">
@@ -148,6 +142,10 @@
                         action: "change->inactive-toggle#endDateChanged change->affiliation-dates#recalculate"
                       }
                     } %>
+        <span data-inactive-toggle-target="inactiveBadge"
+              class="<%= "hidden" unless expired %> [&:not(.hidden)]:inline-flex mt-1 items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+          <i class="fa-solid fa-circle-minus"></i>Inactive
+        </span>
       </div>
 
       <%# Address sits left of Primary at every width; on mobile the two share the

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -12,6 +12,7 @@
     past = light). Kept in sync as you type by the inactive-toggle controller. A
     blank title displays and saves as "Facilitator", so treat it as one here too. %>
 <% expired = @affiliation.inactive? || (@affiliation.end_date.present? && @affiliation.end_date < Date.current) %>
+<% upcoming = !expired && @affiliation.start_date.present? && @affiliation.start_date > Date.current %>
 <% displayed_title = @affiliation.title.presence || Affiliation::FACILITATOR_TITLE %>
 <% facilitator = displayed_title.strip == Affiliation::FACILITATOR_TITLE %>
 <% row_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-blue-50 border-blue-200" %>
@@ -167,8 +168,15 @@
                     type: "date",
                     value: @affiliation.start_date&.strftime("%Y-%m-%d"),
                     class: field_bg.call(@affiliation.start_date.present?),
-                    data: { inactive_toggle_target: "valueField", action: "change->inactive-toggle#paintFields" }
+                    data: { inactive_toggle_target: "valueField startDate", action: "change->inactive-toggle#paintFields change->inactive-toggle#updateBadges" }
                   } %>
+            <%# `[&:not(.hidden)]:inline-flex` so the chip lays out only when shown — a
+                plain `inline-flex` is emitted after `.hidden` in the compiled CSS and
+                would override it, keeping the chip permanently visible. %>
+            <span data-inactive-toggle-target="upcomingBadge"
+                  class="<%= "hidden" unless upcoming %> mt-1 items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 [&:not(.hidden)]:inline-flex">
+              <i class="fa-solid fa-clock"></i>Upcoming
+            </span>
           </div>
           <div class="w-40">
             <%= f.input :end_date,
@@ -181,6 +189,10 @@
                     class: field_bg.call(@affiliation.end_date.present?),
                     data: { inactive_toggle_target: "endDate valueField", action: "change->inactive-toggle#endDateChanged" }
                   } %>
+            <span data-inactive-toggle-target="inactiveBadge"
+                  class="<%= "hidden" unless expired %> mt-1 items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 [&:not(.hidden)]:inline-flex">
+              <i class="fa-solid fa-circle-minus"></i>Inactive
+            </span>
           </div>
         </div>
         <div class="w-40 self-center">

--- a/app/views/affiliations/edit.html.erb
+++ b/app/views/affiliations/edit.html.erb
@@ -15,6 +15,7 @@
 <% upcoming = !expired && @affiliation.start_date.present? && @affiliation.start_date > Date.current %>
 <% displayed_title = @affiliation.title.presence || Affiliation::FACILITATOR_TITLE %>
 <% facilitator = displayed_title.strip == Affiliation::FACILITATOR_TITLE %>
+<% accent = facilitator ? (expired ? "bg-purple-300" : "bg-purple-500") : (expired ? "bg-blue-300" : "bg-blue-500") %>
 <% row_bg = facilitator ? "bg-purple-50 border-purple-200" : "bg-blue-50 border-blue-200" %>
 <% fill_color = if facilitator
      expired ? "bg-purple-50!" : "bg-purple-100!"
@@ -146,6 +147,10 @@
 
       <div data-controller="inactive-toggle" data-inactive-toggle-expired-value="<%= expired %>"
            data-inactive-toggle-today-value="<%= Date.current.iso8601 %>">
+        <div class="relative">
+        <%# Left accent rendered outside the row so it keeps full color regardless of the row's border. %>
+        <span class="absolute inset-y-0 left-0 w-1 rounded-l-lg <%= accent %>"
+              data-inactive-toggle-target="accentBar"></span>
         <div class="flex flex-wrap items-start gap-4 rounded-lg border p-3 <%= row_bg %> <%= 'aff-ended' if expired %>"
              data-inactive-toggle-target="row">
           <div class="min-w-[200px] flex-1">
@@ -194,6 +199,7 @@
               <i class="fa-solid fa-circle-minus"></i>Inactive
             </span>
           </div>
+        </div>
         </div>
         <div class="w-40 self-center">
           <%= f.input :inactive,

--- a/config/features.yml
+++ b/config/features.yml
@@ -2823,3 +2823,17 @@
     (e.g. "Desktop · Windows 10 · Firefox 5.0") instead of the raw user agent string.
   pro_tips:
     - "Hover the browser column to see the full raw user agent when you need the exact string."
+
+- name: "Clearer status chips on the affiliation editor"
+  area: people
+  display_status: user_facing
+  released_on: 2026-08-30
+  pr_number: 2438
+  summary: >-
+    The affiliation editor shows a status chip under the dates — "Upcoming" below
+    the start date for one that hasn't begun, "Inactive" below the end date for one
+    that has ended, and nothing for a currently active affiliation. A row no longer
+    shows both labels at once.
+  pro_tips:
+    - "No chip means the affiliation is active right now — a chip only appears for a future start or a past end."
+    - "The chips look and behave the same on the person editor, the organization editor, and the standalone affiliation edit page."

--- a/spec/requests/people_affiliation_status_badges_spec.rb
+++ b/spec/requests/people_affiliation_status_badges_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Affiliation status badges on the person edit form", type: :reque
     end
   end
 
-  it "renders Inactive for not-active rows and adds Upcoming for a future start" do
+  it "renders at most one badge: Inactive for ended/flagged, Upcoming for a future start, none for active" do
     create(:affiliation, person: person, organization: org, title: "PastActive",
                          start_date: 1.year.ago.to_date, end_date: nil)
     create(:affiliation, person: person, organization: org, title: "Ended",
@@ -40,7 +40,7 @@ RSpec.describe "Affiliation status badges on the person edit form", type: :reque
       "PastActive" => [],
       "StartsToday" => [],
       "Ended" => [ "inactiveBadge" ],
-      "FutureUp" => [ "inactiveBadge", "upcomingBadge" ]
+      "FutureUp" => [ "upcomingBadge" ]
     )
   end
 end

--- a/spec/system/affiliation_edit_live_styling_spec.rb
+++ b/spec/system/affiliation_edit_live_styling_spec.rb
@@ -150,4 +150,21 @@ RSpec.describe "Affiliation editor live styling", type: :system do
 
     expect(row[:class]).to include("bg-blue-50")
   end
+
+  describe "the left accent bar" do
+    def accent = find("[data-inactive-toggle-target='accentBar']", visible: :all)
+
+    it "is purple for an active facilitator row" do
+      expect(accent[:class]).to include("bg-purple-500")
+    end
+
+    it "switches to blue when the title stops being Facilitator" do
+      page.execute_script(
+        "arguments[0].value = 'Counselor'; arguments[0].dispatchEvent(new Event('input', { bubbles: true }))",
+        find("[data-inactive-toggle-target~='title']")
+      )
+
+      expect(accent[:class]).to include("bg-blue-500")
+    end
+  end
 end

--- a/spec/system/affiliation_edit_live_styling_spec.rb
+++ b/spec/system/affiliation_edit_live_styling_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe "Affiliation editor live styling", type: :system do
     )
   end
 
+  def set_start_date(value)
+    page.execute_script(
+      "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('change', { bubbles: true }))",
+      find("[data-inactive-toggle-target~='startDate']"), value
+    )
+  end
+
+  # classList, not visibility: the fast test path skips the Tailwind build.
+  def badge_hidden?(target)
+    page.evaluate_script(
+      "document.querySelector(\"[data-inactive-toggle-target='#{target}']\").classList.contains('hidden')"
+    )
+  end
+
 
   it "tints an active facilitator row without striking it through" do
     expect(row[:class]).to include("bg-purple-50")
@@ -103,6 +117,27 @@ RSpec.describe "Affiliation editor live styling", type: :system do
 
       expect(checkbox).to be_checked
       expect(row[:class]).to include("aff-ended")
+    end
+  end
+
+  describe "the status chips under the date fields" do
+    it "starts with neither chip for an active row" do
+      expect(badge_hidden?("upcomingBadge")).to be true
+      expect(badge_hidden?("inactiveBadge")).to be true
+    end
+
+    it "shows Upcoming only for a future start date" do
+      set_start_date(1.month.from_now.to_date.iso8601)
+
+      expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge']:not(.hidden)", wait: 5)
+      expect(badge_hidden?("inactiveBadge")).to be true
+    end
+
+    it "shows Inactive only once the Inactive box is ticked" do
+      find("[data-inactive-toggle-target='inactiveCheckbox']").click
+
+      expect(page).to have_css("[data-inactive-toggle-target='inactiveBadge']:not(.hidden)", wait: 5)
+      expect(badge_hidden?("upcomingBadge")).to be true
     end
   end
 

--- a/spec/system/upcoming_badge_spec.rb
+++ b/spec/system/upcoming_badge_spec.rb
@@ -42,13 +42,16 @@ RSpec.describe "Affiliation status badges", type: :system do
     expect(badge_hidden?(row, "inactiveBadge")).to be true
     expect(badge_hidden?(row, "upcomingBadge")).to be true
 
+    # A future start shows Upcoming only — never Inactive alongside it.
     set_start_date(row, 1.month.from_now.to_date.iso8601)
     expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge']:not(.hidden)", wait: 5)
-    expect(badge_hidden?(row, "inactiveBadge")).to be false
+    expect(badge_hidden?(row, "inactiveBadge")).to be true
 
-    # Back to a started date: both badges go away again.
+    # Back to a started date: the badge goes away again. `visible: :all` because a
+    # hidden badge is now genuinely display:none (the fix), so a visible-only match
+    # would never find it.
     set_start_date(row, 1.year.ago.to_date.iso8601)
-    expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge'].hidden", wait: 5)
+    expect(page).to have_css("[data-inactive-toggle-target='upcomingBadge'].hidden", visible: :all, wait: 5)
     expect(badge_hidden?(row, "inactiveBadge")).to be true
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 display-logic fix + chip/accent alignment across the three affiliation editors

Affiliation editor rows were showing both "Inactive" and "Upcoming" on every row — even active ones — because the badges could never be hidden.

## The bug
- Each pill used `hidden ... inline-flex` on the **same element**. In the compiled Tailwind CSS `.inline-flex` is emitted after `.hidden`, so at equal specificity `inline-flex` always won and the badge stayed visible — the `hidden` toggle (server *and* live JS) did nothing.
- That's why an active row (start today/past, no end) — and even a row with no dates — displayed both badges.

## Fix
- Scope the layout behind `[&:not(.hidden)]:inline-flex` so `hidden` genuinely hides (`display:none`).
- Make the two badges **mutually exclusive**: Inactive for an ended/flagged row, Upcoming for a future start, nothing for a currently-active row.
- **Placed each chip under its date**: Upcoming under Start, Inactive under End.

## Consistency across all three affiliation editors
Person edit and org edit already share `affiliations/_fields`; the standalone `affiliations/edit` form used `inactive-toggle` but rendered less. Brought it in line:
- Added the same live status chips.
- Added the left **role+status accent bar** it was missing (purple/blue, full/light — same as the inline rows).

## Also
- Logged the status-chip clarity work in the Features & tips seed (`config/features.yml`).
- Kept server ERB and the `inactive-toggle` Stimulus controller in sync throughout.

## Tests
- Request spec: active/starts-today → no badge; ended → Inactive only; future → Upcoming only.
- System spec (inline editor): live badges as the start date is edited; matcher updated to `visible: :all` now that a hidden badge is truly `display:none`.
- System spec (standalone editor): new cases for the chips (none when active, Upcoming-only future, Inactive-only when ticked) and the accent bar (purple facilitator → blue on title change).