### PR TITLE
Give every app model created_by/updated_by; read audit footers from columns, not Ahoy

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,19 +40,6 @@ class UsersController < ApplicationController
     user_auth_events = user_auth_events_base(@user)
     @last_admin_event = user_auth_events.where(name: %w[auth.admin_granted auth.admin_revoked]).order(time: :desc).first
     @last_lock_event = user_auth_events.where(name: %w[auth.account_locked auth.account_unlocked]).order(time: :desc).first
-
-    # Fall back to ahoy events for created_by/updated_by if not set on the model
-    unless @user.created_by
-      create_event = Ahoy::Event.where(name: "create.user", resource_type: "User", resource_id: @user.id)
-                                .order(time: :asc).first
-      @created_by_fallback = create_event&.user
-    end
-
-    unless @user.updated_by
-      update_event = Ahoy::Event.where(name: "update.user", resource_type: "User", resource_id: @user.id)
-                                .order(time: :desc).first
-      @updated_by_fallback = update_event&.user
-    end
   end
 
   def new

--- a/app/models/action_text_mention.rb
+++ b/app/models/action_text_mention.rb
@@ -1,4 +1,6 @@
 class ActionTextMention < ApplicationRecord
   belongs_to :action_text_rich_text, class_name: "ActionText::RichText"
   belongs_to :mentionable, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,7 @@
 class Address < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   LOCALITIES = [ "LA City", "LA County", "Southern CA", "Northern CA",
                 "Central CA", "Orange County", "Outside CA", "Outside USA", "Unknown" ]
   CONTACT_TYPES = [ nil, "work", "personal", "mailing", "unknown" ].freeze

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -15,6 +15,8 @@ class Affiliation < ApplicationRecord
 
   belongs_to :organization, inverse_of: :affiliations
   belongs_to :person, touch: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   # Which of the organization's addresses this person is affiliated with (optional).
   belongs_to :organization_address, class_name: "Address", optional: true
   # The registration that auto-minted this affiliation, when it came from one. NULL

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -3,6 +3,8 @@ class Allocation < ApplicationRecord
   belongs_to :source, polymorphic: true
   belongs_to :allocatable, polymorphic: true
   belongs_to :reverted, class_name: "Allocation", optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   has_one :revert_record, class_name: "Allocation", foreign_key: "reverted_id", inverse_of: :reverted
 

--- a/app/models/answer_option.rb
+++ b/app/models/answer_option.rb
@@ -1,3 +1,6 @@
 class AnswerOption < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   default_scope { order(position: :asc) }
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,6 +1,9 @@
 class Asset < ApplicationRecord
   self.inheritance_column = :type
 
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   ACCEPTED_CONTENT_TYPES = [
     "image/jpeg",
     "image/png",

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,5 +1,7 @@
 class Attachment < ApplicationRecord
   belongs_to :owner, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   # Images
   has_one_attached :file
 

--- a/app/models/categorizable_item.rb
+++ b/app/models/categorizable_item.rb
@@ -1,6 +1,8 @@
 class CategorizableItem < ApplicationRecord
   belongs_to :categorizable, polymorphic: true
   belongs_to :category
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   # Validations
   validates_presence_of :categorizable_type, :categorizable_id, :category_id

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,8 @@ class Category < ApplicationRecord
   positioned on: :category_type_id
 
   belongs_to :category_type, class_name: "CategoryType", foreign_key: :category_type_id
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :categorizable_items, dependent: :destroy
   has_many :workshops, through: :categorizable_items, source: :categorizable, source_type: "Workshop"
 

--- a/app/models/category_type.rb
+++ b/app/models/category_type.rb
@@ -1,6 +1,9 @@
 class CategoryType < ApplicationRecord
   include Publishable
 
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   has_many :categories, class_name: "Category", foreign_key: :category_type_id, dependent: :destroy
   has_many :categorizable_items, through: :categories, dependent: :destroy
 

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -2,6 +2,8 @@ class ContactMethod < ApplicationRecord
   CONTACT_TYPES = [ nil, "work", "personal" ].freeze
 
   belongs_to :contactable, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :address, optional: true
 
   enum :kind, {

--- a/app/models/discount.rb
+++ b/app/models/discount.rb
@@ -1,6 +1,8 @@
 class Discount < ApplicationRecord
   has_paper_trail
   has_many :allocations, as: :source, dependent: :destroy
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   validates :amount_cents, numericality: { greater_than: 0 }
 

--- a/app/models/event_form.rb
+++ b/app/models/event_form.rb
@@ -1,6 +1,8 @@
 class EventForm < ApplicationRecord
   belongs_to :event
   belongs_to :form
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   ROLES = %w[registration scholarship bulk_payment continuing_education].freeze
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -11,6 +11,8 @@ class EventRegistration < ApplicationRecord
 
   belongs_to :registrant, class_name: "Person"
   belongs_to :event
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :event_registration_organizations, dependent: :destroy
   has_many :organizations, through: :event_registration_organizations

--- a/app/models/event_registration_checklist_completion.rb
+++ b/app/models/event_registration_checklist_completion.rb
@@ -1,6 +1,8 @@
 class EventRegistrationChecklistCompletion < ApplicationRecord
   belongs_to :event_registration
   belongs_to :completed_by, class_name: "User", optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   validates :step,
     presence: true,

--- a/app/models/event_registration_organization.rb
+++ b/app/models/event_registration_organization.rb
@@ -1,6 +1,8 @@
 class EventRegistrationOrganization < ApplicationRecord
   belongs_to :event_registration
   belongs_to :organization
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   # The submission whose answers describe this org, pinned when the link is made.
   # Optional: an org an admin linked by hand matches no submission, and links
   # predate the column. Nullified rather than blocking if the submission is deleted.

--- a/app/models/event_staff.rb
+++ b/app/models/event_staff.rb
@@ -1,6 +1,8 @@
 class EventStaff < ApplicationRecord
   belongs_to :event
   belongs_to :person
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   validates :person_id, uniqueness: { scope: :event_id }
   validates :title, length: { maximum: 255 }

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -2,6 +2,9 @@ class Faq < ApplicationRecord
   include Publishable
   positioned
 
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
 
   # Validations

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,4 +1,7 @@
 class Feature < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   # `rhino_`-prefixed per the app's ActionText/Rhino convention (see rhino_editor helper).
   has_rich_text :rhino_description
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,7 @@
 class Form < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   # Public-facing name for the "bulk payment" form — what visitors see on the
   # event page CTA and the form heading. Internal/admin labels still say "Bulk
   # payment" (the form role). Single source of truth so both ends stay in sync.

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -10,6 +10,8 @@
 class FormAnswer < ApplicationRecord
   belongs_to :form_field, optional: true
   belongs_to :form_submission
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   # A file-upload answer stores its file on a polymorphic Asset (the same
   # attachment/validation/display machinery story ideas use). Text answers leave

--- a/app/models/form_builder.rb
+++ b/app/models/form_builder.rb
@@ -1,5 +1,7 @@
 class FormBuilder < ApplicationRecord
   belongs_to :windows_type
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :forms, as: :owner
 
   # Validations

--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -1,5 +1,7 @@
 class FormField < ApplicationRecord
   belongs_to :form, inverse_of: :form_fields
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :form_field_answer_options, dependent: :destroy
   has_many :report_form_field_answers, dependent: :destroy
   has_many :form_answers, dependent: :nullify

--- a/app/models/form_field_answer_option.rb
+++ b/app/models/form_field_answer_option.rb
@@ -1,6 +1,8 @@
 class FormFieldAnswerOption < ApplicationRecord
   belongs_to :form_field
   belongs_to :answer_option
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   def name
     answer_option.name if answer_option

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -4,6 +4,8 @@ class FormSubmission < ApplicationRecord
   belongs_to :person, optional: true
   belongs_to :form
   belongs_to :event, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :form_answers, dependent: :destroy
   has_one :payment
   # A submission is a quote source: answers to a "quote" smart field are captured

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,5 +1,7 @@
 class Location < ApplicationRecord # TODO remove this class if unused
   has_many :events, dependent: :nullify
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   # Validations
   validates_presence_of :city, :country

--- a/app/models/media_file.rb
+++ b/app/models/media_file.rb
@@ -1,6 +1,8 @@
 class MediaFile < ApplicationRecord
   belongs_to :report, optional: true
   belongs_to :workshop_log, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   # Images
   has_one_attached :file
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,7 @@
 class Membership < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   # TODO enable for production when the full membership feature is complete
   def self.enabled?
     !Rails.env.production?

--- a/app/models/membership_invoice.rb
+++ b/app/models/membership_invoice.rb
@@ -4,6 +4,8 @@ class MembershipInvoice < ApplicationRecord
   has_paper_trail
 
   belongs_to :membership
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :allocations, as: :allocatable, dependent: :destroy
   has_many :payments, through: :allocations, source: :source, source_type: "Payment"
 

--- a/app/models/monthly_report.rb
+++ b/app/models/monthly_report.rb
@@ -14,6 +14,7 @@ class MonthlyReport < Report
   # Associations (override Report's)
   belongs_to :owner, polymorphic: true, optional: true
   belongs_to :created_by, class_name: "User"
+  belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :author, class_name: "Person", optional: true
   belongs_to :organization
   belongs_to :windows_type

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,7 @@
 class Notification < ApplicationRecord
   belongs_to :sender, class_name: "User", optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :noticeable, polymorphic: true, optional: true
   belongs_to :parent_notification, class_name: "Notification", optional: true
   belongs_to :root_notification, class_name: "Notification", optional: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,6 +2,8 @@ class Organization < ApplicationRecord
   include RemoteSearchable, TagFilterable, Trendable, WindowsTypeFilterable, SectorsTaggable, AgeGroupTaggable # Publishable
   include Communicable
   belongs_to :organization_status
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :organization_obligation, optional: true
   belongs_to :location, optional: true # TODO - remove Location if unused
   belongs_to :windows_type, optional: true

--- a/app/models/organization_obligation.rb
+++ b/app/models/organization_obligation.rb
@@ -1,4 +1,7 @@
 class OrganizationObligation < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   OBLIGATION_TYPES = [ "Current Grant Funded", "Previous Grant Funded",
                       "Voluntary Reporting", "Intermittent Reporting",
                       "Active Non-Reporting" ]

--- a/app/models/organization_status.rb
+++ b/app/models/organization_status.rb
@@ -1,4 +1,7 @@
 class OrganizationStatus < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   ORGANIZATION_STATUSES = [ "Active", "Inactive", "Pending", "Reinstate", "Suspended", "Unknown" ]
 
   # Legacy: nothing derives program status from these any more (ADR-0001 D3). The

--- a/app/models/other_response.rb
+++ b/app/models/other_response.rb
@@ -1,4 +1,7 @@
 class OtherResponse < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   # A free-text "Other" someone typed on a form question whose "Other" can (or
   # will) become a real tag. Captured at submission time so a curator can
   # promote / keep / dismiss it. The `owner` is polymorphic because the answer's

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -7,6 +7,8 @@ class Payment < ApplicationRecord
   belongs_to :person, optional: true
   belongs_to :organization, optional: true
   belongs_to :form_submission, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   validates :amount_cents, numericality: { greater_than: 0 }
   validates :currency, presence: true

--- a/app/models/quotable_item_quote.rb
+++ b/app/models/quotable_item_quote.rb
@@ -1,6 +1,8 @@
 class QuotableItemQuote < ApplicationRecord
   belongs_to :quote
   belongs_to :quotable, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   # Nested attributes
   accepts_nested_attributes_for :quote, allow_destroy: true

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -4,6 +4,8 @@ class Refund < ApplicationRecord
 
   belongs_to :refundable, polymorphic: true
   belongs_to :recipient, polymorphic: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :allocations, as: :source
 
   validates :amount_cents, numericality: true

--- a/app/models/registration_ticket_callout.rb
+++ b/app/models/registration_ticket_callout.rb
@@ -53,6 +53,8 @@ class RegistrationTicketCallout < ApplicationRecord
   attribute :icon_class, :string, default: -> { DEFAULT_ICONS["action"] }
 
   belongs_to :event
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   belongs_to :form, optional: true
 

--- a/app/models/registration_ticket_callout_resource.rb
+++ b/app/models/registration_ticket_callout_resource.rb
@@ -1,4 +1,7 @@
 class RegistrationTicketCalloutResource < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   # Ordered join between a callout and the resources it links to (e.g. the
   # Handouts card's worksheets, or a custom callout's supporting documents).
   # Reordered like the callouts themselves via the positioning gem.

--- a/app/models/report_form_field_answer.rb
+++ b/app/models/report_form_field_answer.rb
@@ -2,6 +2,8 @@ class ReportFormFieldAnswer < ApplicationRecord
   attr_accessor :_create
 
   belongs_to :report, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   belongs_to :workshop_log, optional: true
   belongs_to :form_field
   belongs_to :answer_option, optional: true

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -2,6 +2,8 @@ class Scholarship < ApplicationRecord
   include Communicable
   belongs_to :recipient, class_name: "Person"
   belongs_to :grant, optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_one :allocation, as: :source, dependent: :destroy
   has_many :comments, -> { newest_first }, as: :commentable, dependent: :destroy
   has_many :agreement_responses, -> { chronological }, class_name: "ScholarshipAgreementResponse", dependent: :destroy

--- a/app/models/scholarship_agreement_response.rb
+++ b/app/models/scholarship_agreement_response.rb
@@ -9,6 +9,8 @@ class ScholarshipAgreementResponse < ApplicationRecord
   # public recipient flow). The `responder` role string still records recipient/
   # admin/system regardless.
   belongs_to :responded_by, class_name: "User", optional: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   validates :status, inclusion: { in: STATUSES }
   validates :responder, inclusion: { in: RESPONDERS }, allow_nil: true

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,6 +1,8 @@
 class Sector < ApplicationRecord
   include NameFilterable, Publishable, RemoteSearchable
   remote_searchable_by :name
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   # Canonical sector tags, in display order. "Other" is kept at the end
   # as the catch-all free-text fallback for additional sectors (see
   # OTHER_SECTOR_NAME below) — it isn't a selectable tag itself. Descriptions for

--- a/app/models/sectorable_item.rb
+++ b/app/models/sectorable_item.rb
@@ -1,6 +1,8 @@
 class SectorableItem < ApplicationRecord
   belongs_to :sector
   belongs_to :sectorable, polymorphic: true, touch: true
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :people, through: :sectorable_items, source: :sectorable, source_type: "Person"
 
   # Validations

--- a/app/models/user_form.rb
+++ b/app/models/user_form.rb
@@ -1,6 +1,8 @@
 class UserForm < ApplicationRecord
   belongs_to :user
   belongs_to :form
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
   has_many :user_form_form_fields
 
   # Nested attributes

--- a/app/models/user_form_form_field.rb
+++ b/app/models/user_form_form_field.rb
@@ -1,6 +1,8 @@
 class UserFormFormField < ApplicationRecord
   belongs_to :form_field
   belongs_to :user_form
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   def name
     "#{form_field.name}: #{text}"

--- a/app/models/video_recording.rb
+++ b/app/models/video_recording.rb
@@ -3,6 +3,9 @@ class VideoRecording < ApplicationRecord
 
   has_rich_text :rhino_body
 
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   has_many :bookmarks, as: :bookmarkable, dependent: :destroy
   has_many :categorizable_items, dependent: :destroy, inverse_of: :categorizable, as: :categorizable
   has_many :sectorable_items, dependent: :destroy, inverse_of: :sectorable, as: :sectorable

--- a/app/models/windows_type.rb
+++ b/app/models/windows_type.rb
@@ -1,4 +1,7 @@
 class WindowsType < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
+
   TYPES = [ "Adult", "Children", "Combined" ]
 
   has_many :categorizable_items, dependent: :destroy, as: :categorizable

--- a/app/models/workshop_resource.rb
+++ b/app/models/workshop_resource.rb
@@ -1,4 +1,6 @@
 class WorkshopResource < ApplicationRecord
   belongs_to :workshop
   belongs_to :resource
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 end

--- a/app/models/workshop_series_membership.rb
+++ b/app/models/workshop_series_membership.rb
@@ -1,6 +1,8 @@
 class WorkshopSeriesMembership < ApplicationRecord
   belongs_to :workshop_parent, class_name: "Workshop"
   belongs_to :workshop_child, class_name: "Workshop"
+  belongs_to :created_by, class_name: "User", optional: true
+  belongs_to :updated_by, class_name: "User", optional: true
 
   # Validations
   validates :position, presence: true, numericality: { only_integer: true, greater_than: 0 }

--- a/app/views/shared/_audit_info.html.erb
+++ b/app/views/shared/_audit_info.html.erb
@@ -4,13 +4,8 @@
   return unless resource&.persisted?
 
   model = resource.respond_to?(:object) ? resource.object : resource
-  ahoy_scope = Ahoy::Event.where(resource_type: model.class.name, resource_id: model.id)
-
-  created_by_user = resource.try(:created_by) || resource.try(:user) ||
-    ahoy_scope.where("name LIKE 'create.%'").order(time: :asc).first&.user
-
-  updated_by_user = resource.try(:updated_by) || resource.try(:user) ||
-    ahoy_scope.where("name LIKE 'update.%'").order(time: :desc).first&.user
+  created_by_user = resource.try(:created_by)
+  updated_by_user = resource.try(:updated_by)
 %>
 
 <div class="flex justify-end mt-6 pt-4 border-t border-gray-200">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -172,13 +172,13 @@
               <dd class="text-gray-900"><%= @user.created_at.present? ? l(@user.created_at, format: :long) : "—" %></dd>
 
               <dt class="font-medium text-gray-500">Created by</dt>
-              <dd class="text-gray-900"><%= (@user.created_by || @created_by_fallback)&.name.presence || "—" %></dd>
+              <dd class="text-gray-900"><%= @user.created_by&.name.presence || "—" %></dd>
 
               <dt class="font-medium text-gray-500">Updated at</dt>
               <dd class="text-gray-900"><%= l(@user.updated_at, format: :long) %></dd>
 
               <dt class="font-medium text-gray-500">Updated by</dt>
-              <dd class="text-gray-900"><%= (@user.updated_by || @updated_by_fallback)&.name.presence || "—" %></dd>
+              <dd class="text-gray-900"><%= @user.updated_by&.name.presence || "—" %></dd>
             </dl>
           </div>
 

--- a/db/migrate/20260830184319_add_user_stamps_to_remaining_audited_tables.rb
+++ b/db/migrate/20260830184319_add_user_stamps_to_remaining_audited_tables.rb
@@ -7,6 +7,8 @@ class AddUserStampsToRemainingAuditedTables < ActiveRecord::Migration[8.1]
     payments forms sectors faqs categories category_types
     memberships membership_invoices organization_statuses video_recordings windows_types
     organizations affiliations scholarships event_registrations features
+    refunds discounts allocations registration_ticket_callouts form_submissions
+    scholarship_agreement_responses
   ].freeze
 
   def up

--- a/db/migrate/20260830184319_add_user_stamps_to_remaining_audited_tables.rb
+++ b/db/migrate/20260830184319_add_user_stamps_to_remaining_audited_tables.rb
@@ -1,0 +1,33 @@
+class AddUserStampsToRemainingAuditedTables < ActiveRecord::Migration[8.1]
+  # Tables whose edit pages render the shared audit footer but had no stamp columns,
+  # so the footer read attribution from Ahoy. With these columns UserStampable records
+  # who created/last-edited each row, and the footer reads the model instead of Ahoy.
+  # Stamped forward-only (no backfill); pre-existing rows show "—" until next edited.
+  TABLES = %i[
+    payments forms sectors faqs categories category_types
+    memberships membership_invoices organization_statuses video_recordings windows_types
+    organizations affiliations scholarships event_registrations features
+  ].freeze
+
+  def up
+    TABLES.each do |table|
+      add_column table, :created_by_id, :integer, null: true unless column_exists?(table, :created_by_id)
+      add_column table, :updated_by_id, :integer, null: true unless column_exists?(table, :updated_by_id)
+      add_index table, :created_by_id unless index_exists?(table, :created_by_id)
+      add_index table, :updated_by_id unless index_exists?(table, :updated_by_id)
+      add_foreign_key table, :users, column: :created_by_id unless foreign_key_exists?(table, :users, column: :created_by_id)
+      add_foreign_key table, :users, column: :updated_by_id unless foreign_key_exists?(table, :users, column: :updated_by_id)
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      remove_foreign_key table, :users, column: :created_by_id if foreign_key_exists?(table, :users, column: :created_by_id)
+      remove_foreign_key table, :users, column: :updated_by_id if foreign_key_exists?(table, :users, column: :updated_by_id)
+      remove_index table, :created_by_id if index_exists?(table, :created_by_id)
+      remove_index table, :updated_by_id if index_exists?(table, :updated_by_id)
+      remove_column table, :created_by_id if column_exists?(table, :created_by_id)
+      remove_column table, :updated_by_id if column_exists?(table, :updated_by_id)
+    end
+  end
+end

--- a/db/migrate/20260830192350_add_user_stamps_to_child_and_join_tables.rb
+++ b/db/migrate/20260830192350_add_user_stamps_to_child_and_join_tables.rb
@@ -1,0 +1,36 @@
+class AddUserStampsToChildAndJoinTables < ActiveRecord::Migration[8.1]
+  # Child, join, asset, and reference tables that carry no stamp columns. Now that
+  # editing an associated record no longer bumps its parent's updated_by, these need
+  # their own stamps so an edit to one is attributable on its own. UserStampable fills
+  # them going forward; data:backfill_user_stamps fills legacy rows from the Ahoy trail.
+  TABLES = %i[
+    action_text_mentions addresses answer_options assets attachments categorizable_items
+    contact_methods event_forms event_registration_checklist_completions
+    event_registration_organizations event_staffs form_answers form_builders form_fields
+    form_field_answer_options locations media_files organization_obligations other_responses
+    quotable_item_quotes registration_ticket_callout_resources report_form_field_answers
+    sectorable_items user_forms user_form_form_fields workshop_resources workshop_series_memberships
+  ].freeze
+
+  def up
+    TABLES.each do |table|
+      add_column table, :created_by_id, :integer, null: true unless column_exists?(table, :created_by_id)
+      add_column table, :updated_by_id, :integer, null: true unless column_exists?(table, :updated_by_id)
+      add_index table, :created_by_id unless index_exists?(table, :created_by_id)
+      add_index table, :updated_by_id unless index_exists?(table, :updated_by_id)
+      add_foreign_key table, :users, column: :created_by_id unless foreign_key_exists?(table, :users, column: :created_by_id)
+      add_foreign_key table, :users, column: :updated_by_id unless foreign_key_exists?(table, :users, column: :updated_by_id)
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      remove_foreign_key table, :users, column: :created_by_id if foreign_key_exists?(table, :users, column: :created_by_id)
+      remove_foreign_key table, :users, column: :updated_by_id if foreign_key_exists?(table, :users, column: :updated_by_id)
+      remove_index table, :created_by_id if index_exists?(table, :created_by_id)
+      remove_index table, :updated_by_id if index_exists?(table, :updated_by_id)
+      remove_column table, :created_by_id if column_exists?(table, :created_by_id)
+      remove_column table, :updated_by_id if column_exists?(table, :updated_by_id)
+    end
+  end
+end

--- a/db/migrate/20260830200153_add_user_stamps_to_notifications.rb
+++ b/db/migrate/20260830200153_add_user_stamps_to_notifications.rb
@@ -1,0 +1,22 @@
+class AddUserStampsToNotifications < ActiveRecord::Migration[8.1]
+  # Notifications keep their own sender_id (who a communication is from); these add
+  # the standard created_by/updated_by so the record is attributable like every other,
+  # in addition to sender. UserStampable fills them going forward.
+  def up
+    add_column :notifications, :created_by_id, :integer, null: true unless column_exists?(:notifications, :created_by_id)
+    add_column :notifications, :updated_by_id, :integer, null: true unless column_exists?(:notifications, :updated_by_id)
+    add_index :notifications, :created_by_id unless index_exists?(:notifications, :created_by_id)
+    add_index :notifications, :updated_by_id unless index_exists?(:notifications, :updated_by_id)
+    add_foreign_key :notifications, :users, column: :created_by_id unless foreign_key_exists?(:notifications, :users, column: :created_by_id)
+    add_foreign_key :notifications, :users, column: :updated_by_id unless foreign_key_exists?(:notifications, :users, column: :updated_by_id)
+  end
+
+  def down
+    remove_foreign_key :notifications, :users, column: :created_by_id if foreign_key_exists?(:notifications, :users, column: :created_by_id)
+    remove_foreign_key :notifications, :users, column: :updated_by_id if foreign_key_exists?(:notifications, :users, column: :updated_by_id)
+    remove_index :notifications, :created_by_id if index_exists?(:notifications, :created_by_id)
+    remove_index :notifications, :updated_by_id if index_exists?(:notifications, :updated_by_id)
+    remove_column :notifications, :created_by_id if column_exists?(:notifications, :created_by_id)
+    remove_column :notifications, :updated_by_id if column_exists?(:notifications, :updated_by_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_192350) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_200153) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -1107,6 +1107,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_192350) do
     t.boolean "bulk", default: false, null: false
     t.string "channel", default: "autoemail", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.text "custom_message"
     t.string "custom_subject"
     t.datetime "delivered_at"
@@ -1130,11 +1131,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_192350) do
     t.integer "root_notification_id"
     t.integer "sender_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_notifications_on_created_by_id"
     t.index ["kind"], name: "index_notifications_on_kind"
     t.index ["noticeable_type", "noticeable_id"], name: "index_notifications_on_noticeable_type_and_noticeable_id"
     t.index ["parent_notification_id"], name: "index_notifications_on_parent_notification_id"
     t.index ["root_notification_id"], name: "index_notifications_on_root_notification_id"
     t.index ["sender_id"], name: "index_notifications_on_sender_id"
+    t.index ["updated_by_id"], name: "index_notifications_on_updated_by_id"
   end
 
   create_table "organization_obligations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -2376,7 +2380,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_192350) do
   add_foreign_key "monthly_reports", "organizations"
   add_foreign_key "notifications", "notifications", column: "parent_notification_id"
   add_foreign_key "notifications", "notifications", column: "root_notification_id"
+  add_foreign_key "notifications", "users", column: "created_by_id"
   add_foreign_key "notifications", "users", column: "sender_id"
+  add_foreign_key "notifications", "users", column: "updated_by_id"
   add_foreign_key "organization_obligations", "users", column: "created_by_id"
   add_foreign_key "organization_obligations", "users", column: "updated_by_id"
   add_foreign_key "organization_statuses", "users", column: "created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -106,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
 
   create_table "affiliations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.date "end_date"
     t.bigint "event_registration_id"
     t.string "filemaker_code"
@@ -117,11 +118,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.date "start_date"
     t.string "title"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_affiliations_on_created_by_id"
     t.index ["event_registration_id"], name: "index_affiliations_on_event_registration_id"
     t.index ["organization_address_id"], name: "index_affiliations_on_organization_address_id"
     t.index ["organization_id"], name: "index_affiliations_on_organization_id"
     t.index ["person_id"], name: "index_affiliations_on_person_id"
     t.index ["title"], name: "index_affiliations_on_title"
+    t.index ["updated_by_id"], name: "index_affiliations_on_updated_by_id"
   end
 
   create_table "age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -317,6 +321,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   create_table "categories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "category_type_id"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.text "description"
     t.integer "legacy_id"
     t.string "name"
@@ -324,9 +329,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.boolean "published", default: false
     t.integer "story_share_position"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.index ["category_type_id", "position"], name: "index_categories_on_category_type_id_and_position", unique: true
     t.index ["category_type_id"], name: "index_categories_on_category_type_id"
+    t.index ["created_by_id"], name: "index_categories_on_created_by_id"
     t.index ["story_share_position"], name: "index_categories_on_story_share_position"
+    t.index ["updated_by_id"], name: "index_categories_on_updated_by_id"
   end
 
   create_table "categorizable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -344,6 +352,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
 
   create_table "category_types", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "display_text"
     t.string "legacy_id"
     t.string "name"
@@ -351,6 +360,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.boolean "published", default: false
     t.boolean "story_specific", default: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_category_types_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_category_types_on_updated_by_id"
   end
 
   create_table "ckeditor_assets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -505,6 +517,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.boolean "completed_day_4", default: false, null: false
     t.boolean "completed_day_5", default: false, null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_id"
     t.string "expected_payment_method"
     t.text "fee_note"
@@ -520,14 +533,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.string "status_before_transfer"
     t.bigint "transferred_from_registration_id"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.boolean "w9_requested", default: false, null: false
     t.index ["checkout_session_id"], name: "index_event_registrations_on_checkout_session_id"
+    t.index ["created_by_id"], name: "index_event_registrations_on_created_by_id"
     t.index ["event_id"], name: "index_event_registrations_on_event_id"
     t.index ["payment_unresolved"], name: "index_event_registrations_on_payment_unresolved"
     t.index ["registrant_id", "event_id"], name: "index_event_registrations_on_registrant_id_and_event_id", unique: true
     t.index ["registrant_id"], name: "index_event_registrations_on_registrant_id"
     t.index ["slug"], name: "index_event_registrations_on_slug", unique: true
     t.index ["transferred_from_registration_id"], name: "index_event_registrations_on_transferred_from_registration_id"
+    t.index ["updated_by_id"], name: "index_event_registrations_on_updated_by_id"
   end
 
   create_table "event_staffs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -605,19 +621,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   create_table "faqs", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "answer", size: :long
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.boolean "inactive"
     t.integer "position", null: false
     t.boolean "publicly_visible", default: false, null: false
     t.boolean "published", default: false, null: false
     t.string "question"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_faqs_on_created_by_id"
     t.index ["published"], name: "index_faqs_on_published"
+    t.index ["updated_by_id"], name: "index_faqs_on_updated_by_id"
   end
 
   create_table "features", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "action_path"
     t.string "area", null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.string "display_status", default: "user_facing", null: false
     t.string "external_url"
     t.string "name", null: false
@@ -627,9 +648,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.date "released_on", null: false
     t.text "summary", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.index ["area"], name: "index_features_on_area"
+    t.index ["created_by_id"], name: "index_features_on_created_by_id"
     t.index ["display_status"], name: "index_features_on_display_status"
     t.index ["released_on"], name: "index_features_on_released_on"
+    t.index ["updated_by_id"], name: "index_features_on_updated_by_id"
   end
 
   create_table "fm_activities", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -875,6 +899,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
 
   create_table "forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "form_builder_id"
     t.text "header"
     t.boolean "hide_answered_form_questions", default: false, null: false
@@ -887,8 +912,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.json "sections"
     t.string "slug"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_forms_on_created_by_id"
     t.index ["form_builder_id"], name: "index_forms_on_form_builder_id"
     t.index ["slug"], name: "index_forms_on_slug", unique: true
+    t.index ["updated_by_id"], name: "index_forms_on_updated_by_id"
   end
 
   create_table "grants", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -947,21 +975,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   create_table "membership_invoices", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "cost_cents", default: 0, null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.date "end_date", null: false
     t.bigint "membership_id", null: false
     t.date "start_date", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_membership_invoices_on_created_by_id"
     t.index ["membership_id"], name: "index_membership_invoices_on_membership_id"
     t.index ["start_date", "end_date"], name: "index_membership_invoices_on_start_date_and_end_date"
+    t.index ["updated_by_id"], name: "index_membership_invoices_on_updated_by_id"
   end
 
   create_table "memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "cancelled_at"
     t.integer "cost_cents"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "person_id", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_memberships_on_created_by_id"
     t.index ["person_id"], name: "index_memberships_on_person_id"
+    t.index ["updated_by_id"], name: "index_memberships_on_updated_by_id"
   end
 
   create_table "monthly_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1031,14 +1067,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
 
   create_table "organization_statuses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "name"
     t.boolean "published", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_organization_statuses_on_created_by_id"
     t.index ["published"], name: "index_organization_statuses_on_published"
+    t.index ["updated_by_id"], name: "index_organization_statuses_on_updated_by_id"
   end
 
   create_table "organizations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.text "description", size: :long
     t.string "email"
     t.date "end_date"
@@ -1066,10 +1107,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.boolean "profile_show_workshops", default: true, null: false
     t.date "start_date"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.string "website_url"
     t.integer "windows_type_id"
+    t.index ["created_by_id"], name: "index_organizations_on_created_by_id"
     t.index ["location_id"], name: "index_organizations_on_location_id"
     t.index ["organization_status_id"], name: "index_organizations_on_organization_status_id"
+    t.index ["updated_by_id"], name: "index_organizations_on_updated_by_id"
     t.index ["windows_type_id"], name: "index_organizations_on_windows_type_id"
   end
 
@@ -1196,6 +1240,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.integer "amount_cents_remaining", null: false
     t.string "check_number"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.string "currency", default: "usd", null: false
     t.text "description"
     t.boolean "external_origin", default: true, null: false
@@ -1210,11 +1255,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.string "stripe_charge_id"
     t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_payments_on_created_by_id"
     t.index ["filemaker_code"], name: "index_payments_on_filemaker_code"
     t.index ["form_submission_id"], name: "index_payments_on_form_submission_id"
     t.index ["organization_id"], name: "index_payments_on_organization_id"
     t.index ["person_id"], name: "index_payments_on_person_id"
     t.index ["stripe_charge_id"], name: "index_payments_on_stripe_charge_id", unique: true
+    t.index ["updated_by_id"], name: "index_payments_on_updated_by_id"
   end
 
   create_table "people", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1492,12 +1540,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.string "agreement_response_status", default: "pending", null: false
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "grant_id"
     t.bigint "recipient_id", null: false
     t.boolean "tasks_completed", default: false, null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_scholarships_on_created_by_id"
     t.index ["grant_id"], name: "index_scholarships_on_grant_id"
     t.index ["recipient_id"], name: "index_scholarships_on_recipient_id"
+    t.index ["updated_by_id"], name: "index_scholarships_on_updated_by_id"
   end
 
   create_table "sectorable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1515,12 +1567,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
 
   create_table "sectors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.text "description"
     t.string "name"
     t.boolean "published", default: false
     t.integer "story_share_position"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_sectors_on_created_by_id"
     t.index ["story_share_position"], name: "index_sectors_on_story_share_position"
+    t.index ["updated_by_id"], name: "index_sectors_on_updated_by_id"
   end
 
   create_table "staff_taggings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1755,6 +1811,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   create_table "video_recordings", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.boolean "featured", default: false, null: false
     t.boolean "is_instructional", default: true, null: false
     t.boolean "is_podcast", default: false, null: false
@@ -1764,20 +1821,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
     t.boolean "published", default: false, null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.string "youtube_url"
+    t.index ["created_by_id"], name: "index_video_recordings_on_created_by_id"
     t.index ["featured"], name: "index_video_recordings_on_featured"
     t.index ["is_instructional"], name: "index_video_recordings_on_is_instructional"
     t.index ["is_podcast"], name: "index_video_recordings_on_is_podcast"
     t.index ["published"], name: "index_video_recordings_on_published"
     t.index ["title"], name: "index_video_recordings_on_title"
+    t.index ["updated_by_id"], name: "index_video_recordings_on_updated_by_id"
   end
 
   create_table "windows_types", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "legacy_id"
     t.string "name"
     t.string "short_name"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_windows_types_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_windows_types_on_updated_by_id"
   end
 
   create_table "workshop_age_ranges", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -2065,6 +2129,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "affiliations", "event_registrations", on_delete: :nullify
   add_foreign_key "affiliations", "organizations"
   add_foreign_key "affiliations", "people"
+  add_foreign_key "affiliations", "users", column: "created_by_id"
+  add_foreign_key "affiliations", "users", column: "updated_by_id"
   add_foreign_key "age_ranges", "windows_types"
   add_foreign_key "allocations", "allocations", column: "reverted_id"
   add_foreign_key "banners", "users", column: "created_by_id"
@@ -2080,6 +2146,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "bookmark_annotations", "bookmarks"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "categories", "category_types"
+  add_foreign_key "categories", "users", column: "created_by_id"
+  add_foreign_key "categories", "users", column: "updated_by_id"
+  add_foreign_key "category_types", "users", column: "created_by_id"
+  add_foreign_key "category_types", "users", column: "updated_by_id"
   add_foreign_key "comments", "users", column: "created_by_id"
   add_foreign_key "comments", "users", column: "updated_by_id"
   add_foreign_key "community_news", "organizations"
@@ -2101,11 +2171,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "event_registrations", "event_registrations", column: "transferred_from_registration_id", on_delete: :nullify
   add_foreign_key "event_registrations", "events"
   add_foreign_key "event_registrations", "people", column: "registrant_id"
+  add_foreign_key "event_registrations", "users", column: "created_by_id"
+  add_foreign_key "event_registrations", "users", column: "updated_by_id"
   add_foreign_key "event_staffs", "events"
   add_foreign_key "event_staffs", "people"
   add_foreign_key "events", "locations"
   add_foreign_key "events", "users", column: "created_by_id"
   add_foreign_key "events", "users", column: "updated_by_id"
+  add_foreign_key "faqs", "users", column: "created_by_id"
+  add_foreign_key "faqs", "users", column: "updated_by_id"
+  add_foreign_key "features", "users", column: "created_by_id"
+  add_foreign_key "features", "users", column: "updated_by_id"
   add_foreign_key "form_answers", "form_fields"
   add_foreign_key "form_answers", "form_submissions"
   add_foreign_key "form_builders", "windows_types"
@@ -2116,15 +2192,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "form_submissions", "forms"
   add_foreign_key "form_submissions", "people"
   add_foreign_key "forms", "form_builders"
+  add_foreign_key "forms", "users", column: "created_by_id"
+  add_foreign_key "forms", "users", column: "updated_by_id"
   add_foreign_key "membership_invoices", "memberships"
+  add_foreign_key "membership_invoices", "users", column: "created_by_id"
+  add_foreign_key "membership_invoices", "users", column: "updated_by_id"
   add_foreign_key "memberships", "people"
+  add_foreign_key "memberships", "users", column: "created_by_id"
+  add_foreign_key "memberships", "users", column: "updated_by_id"
   add_foreign_key "monthly_reports", "affiliations", column: "organization_user_id"
   add_foreign_key "monthly_reports", "organizations"
   add_foreign_key "notifications", "notifications", column: "parent_notification_id"
   add_foreign_key "notifications", "notifications", column: "root_notification_id"
   add_foreign_key "notifications", "users", column: "sender_id"
+  add_foreign_key "organization_statuses", "users", column: "created_by_id"
+  add_foreign_key "organization_statuses", "users", column: "updated_by_id"
   add_foreign_key "organizations", "locations"
   add_foreign_key "organizations", "organization_statuses"
+  add_foreign_key "organizations", "users", column: "created_by_id"
+  add_foreign_key "organizations", "users", column: "updated_by_id"
   add_foreign_key "organizations", "windows_types"
   add_foreign_key "other_responses", "form_answers", column: "source_form_answer_id"
   add_foreign_key "pay_charges", "pay_customers", column: "customer_id"
@@ -2134,6 +2220,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "payments", "form_submissions"
   add_foreign_key "payments", "organizations"
   add_foreign_key "payments", "people"
+  add_foreign_key "payments", "users", column: "created_by_id"
+  add_foreign_key "payments", "users", column: "updated_by_id"
   add_foreign_key "people", "users", column: "created_by_id"
   add_foreign_key "people", "users", column: "updated_by_id"
   add_foreign_key "professional_licenses", "people"
@@ -2165,7 +2253,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "scholarship_agreement_responses", "users", column: "responded_by_id"
   add_foreign_key "scholarships", "grants"
   add_foreign_key "scholarships", "people", column: "recipient_id"
+  add_foreign_key "scholarships", "users", column: "created_by_id"
+  add_foreign_key "scholarships", "users", column: "updated_by_id"
   add_foreign_key "sectorable_items", "sectors"
+  add_foreign_key "sectors", "users", column: "created_by_id"
+  add_foreign_key "sectors", "users", column: "updated_by_id"
   add_foreign_key "staff_taggings", "staff_tags"
   add_foreign_key "stories", "organizations"
   add_foreign_key "stories", "people", column: "author_id"
@@ -2195,6 +2287,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_150308) do
   add_foreign_key "users", "people"
   add_foreign_key "users", "users", column: "created_by_id"
   add_foreign_key "users", "users", column: "updated_by_id"
+  add_foreign_key "video_recordings", "users", column: "created_by_id"
+  add_foreign_key "video_recordings", "users", column: "updated_by_id"
+  add_foreign_key "windows_types", "users", column: "created_by_id"
+  add_foreign_key "windows_types", "users", column: "updated_by_id"
   add_foreign_key "workshop_age_ranges", "age_ranges"
   add_foreign_key "workshop_age_ranges", "workshops"
   add_foreign_key "workshop_ideas", "people", column: "author_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_192350) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "mentionable_id", null: false
     t.string "mentionable_type", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.index ["action_text_rich_text_id", "mentionable_type", "mentionable_id"], name: "index_at_mentions_on_rich_text_and_mentionable", unique: true
     t.index ["action_text_rich_text_id"], name: "index_action_text_mentions_on_action_text_rich_text_id"
+    t.index ["created_by_id"], name: "index_action_text_mentions_on_created_by_id"
     t.index ["mentionable_type", "mentionable_id"], name: "index_action_text_mentions_on_mentionable"
+    t.index ["updated_by_id"], name: "index_action_text_mentions_on_updated_by_id"
   end
 
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -70,6 +74,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "country"
     t.string "county"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.string "district"
     t.boolean "inactive", default: false, null: false
     t.integer "la_city_council_district"
@@ -81,8 +86,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "state", null: false
     t.string "street_address", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.string "zip_code", null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable"
+    t.index ["created_by_id"], name: "index_addresses_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_addresses_on_updated_by_id"
   end
 
   create_table "admins", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -204,26 +212,35 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "answer_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "name"
     t.integer "position"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_answer_options_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_answer_options_on_updated_by_id"
   end
 
   create_table "assets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.integer "owner_id"
     t.string "owner_type"
     t.integer "report_id"
     t.string "title"
     t.string "type", default: "PrimaryAsset", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_assets_on_created_by_id"
     t.index ["owner_id"], name: "index_assets_on_owner_id"
     t.index ["owner_type"], name: "index_assets_on_owner_type"
     t.index ["type"], name: "index_assets_on_type"
+    t.index ["updated_by_id"], name: "index_assets_on_updated_by_id"
   end
 
   create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "file_content_type"
     t.string "file_file_name"
     t.integer "file_file_size"
@@ -231,6 +248,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.integer "owner_id"
     t.string "owner_type"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_attachments_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_attachments_on_updated_by_id"
   end
 
   create_table "banners", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -346,12 +366,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "categorizable_type"
     t.integer "category_id"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.boolean "is_primary", default: false, null: false
     t.integer "legacy_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.index ["categorizable_type", "categorizable_id"], name: "idx_on_categorizable_type_categorizable_id_ccce65d80c"
     t.index ["category_id", "categorizable_type", "categorizable_id"], name: "index_categorizable_items_uniqueness", unique: true
     t.index ["category_id"], name: "index_categorizable_items_on_category_id"
+    t.index ["created_by_id"], name: "index_categorizable_items_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_categorizable_items_on_updated_by_id"
   end
 
   create_table "category_types", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -432,13 +456,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.bigint "contactable_id", null: false
     t.string "contactable_type", null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.boolean "inactive", default: false, null: false
     t.string "kind", null: false
     t.boolean "primary", default: false, null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.string "value", null: false
     t.index ["address_id"], name: "index_contact_methods_on_address_id"
     t.index ["contactable_type", "contactable_id"], name: "index_contact_methods_on_contactable"
+    t.index ["created_by_id"], name: "index_contact_methods_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_contact_methods_on_updated_by_id"
   end
 
   create_table "continuing_education_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -482,38 +510,50 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "event_forms", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_id", null: false
     t.integer "form_id", null: false
     t.string "role", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_event_forms_on_created_by_id"
     t.index ["event_id", "form_id", "role"], name: "index_event_forms_on_event_id_and_form_id_and_role", unique: true
     t.index ["event_id"], name: "index_event_forms_on_event_id"
     t.index ["form_id"], name: "index_event_forms_on_form_id"
+    t.index ["updated_by_id"], name: "index_event_forms_on_updated_by_id"
   end
 
   create_table "event_registration_checklist_completions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "completed_at"
     t.integer "completed_by_id"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_registration_id", null: false
     t.string "step", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.index ["completed_by_id"], name: "idx_on_completed_by_id_047522ef9d"
+    t.index ["created_by_id"], name: "idx_on_created_by_id_835f34748a"
     t.index ["event_registration_id", "step"], name: "index_checklist_completions_on_registration_and_step", unique: true
     t.index ["event_registration_id"], name: "idx_on_event_registration_id_e5177f655c"
+    t.index ["updated_by_id"], name: "idx_on_updated_by_id_045624c914"
   end
 
   create_table "event_registration_organizations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_registration_id", null: false
     t.json "form_autofill_changes"
     t.bigint "form_submission_id"
     t.integer "organization_id", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_event_registration_organizations_on_created_by_id"
     t.index ["event_registration_id", "organization_id"], name: "idx_event_reg_orgs_on_registration_and_org", unique: true
     t.index ["event_registration_id"], name: "idx_on_event_registration_id_806bdcd019"
     t.index ["form_submission_id"], name: "index_event_registration_organizations_on_form_submission_id"
     t.index ["organization_id"], name: "index_event_registration_organizations_on_organization_id"
+    t.index ["updated_by_id"], name: "index_event_registration_organizations_on_updated_by_id"
   end
 
   create_table "event_registrations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -557,14 +597,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   create_table "event_staffs", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "bio"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_id", null: false
     t.boolean "expected_to_attend", default: false, null: false
     t.bigint "person_id", null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_event_staffs_on_created_by_id"
     t.index ["event_id", "person_id"], name: "index_event_staffs_on_event_id_and_person_id", unique: true
     t.index ["event_id"], name: "index_event_staffs_on_event_id"
     t.index ["person_id"], name: "index_event_staffs_on_person_id"
+    t.index ["updated_by_id"], name: "index_event_staffs_on_updated_by_id"
   end
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -837,37 +881,50 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "form_answers", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.integer "form_field_id"
     t.bigint "form_submission_id", null: false
     t.string "question_name_when_answered"
     t.text "submitted_answer"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_form_answers_on_created_by_id"
     t.index ["form_field_id"], name: "index_form_answers_on_form_field_id"
     t.index ["form_submission_id"], name: "index_form_answers_on_form_submission_id"
+    t.index ["updated_by_id"], name: "index_form_answers_on_updated_by_id"
   end
 
   create_table "form_builders", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.text "description", size: :long
     t.string "name"
     t.integer "owner_type"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.integer "windows_type_id"
+    t.index ["created_by_id"], name: "index_form_builders_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_form_builders_on_updated_by_id"
     t.index ["windows_type_id"], name: "index_form_builders_on_windows_type_id"
   end
 
   create_table "form_field_answer_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "answer_option_id"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "form_field_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.index ["answer_option_id"], name: "index_form_field_answer_options_on_answer_option_id"
+    t.index ["created_by_id"], name: "index_form_field_answer_options_on_created_by_id"
     t.index ["form_field_id"], name: "index_form_field_answer_options_on_form_field_id"
+    t.index ["updated_by_id"], name: "index_form_field_answer_options_on_updated_by_id"
   end
 
   create_table "form_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "answer_type"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "field_identifier"
     t.integer "form_id"
     t.text "hint_text"
@@ -883,11 +940,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.integer "status", default: 1
     t.text "subtitle"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.integer "visibility", default: 0, null: false
     t.integer "width", default: 0, null: false
+    t.index ["created_by_id"], name: "index_form_fields_on_created_by_id"
     t.index ["field_identifier"], name: "index_form_fields_on_field_identifier"
     t.index ["form_id"], name: "index_form_fields_on_form_id"
     t.index ["section"], name: "index_form_fields_on_section"
+    t.index ["updated_by_id"], name: "index_form_fields_on_updated_by_id"
   end
 
   create_table "form_submissions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -971,17 +1031,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "city"
     t.string "country"
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "state"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_locations_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_locations_on_updated_by_id"
   end
 
   create_table "media_files", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "created_by_id"
     t.string "file_content_type"
     t.string "file_file_name"
     t.integer "file_file_size"
     t.datetime "file_updated_at", precision: nil
     t.integer "report_id"
+    t.integer "updated_by_id"
     t.integer "workshop_log_id"
+    t.index ["created_by_id"], name: "index_media_files_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_media_files_on_updated_by_id"
   end
 
   create_table "membership_invoices", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1071,10 +1139,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "organization_obligations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.string "name"
     t.boolean "published", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_organization_obligations_on_created_by_id"
     t.index ["published"], name: "index_organization_obligations_on_published"
+    t.index ["updated_by_id"], name: "index_organization_obligations_on_updated_by_id"
   end
 
   create_table "organization_statuses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1131,6 +1203,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "other_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.string "field_identifier", null: false
     t.string "kind", null: false
     t.string "normalized_text", null: false
@@ -1142,10 +1215,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "status", default: "pending", null: false
     t.string "text", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_other_responses_on_created_by_id"
     t.index ["owner_type", "owner_id", "field_identifier", "normalized_text"], name: "index_other_responses_on_owner_field_text", unique: true
     t.index ["owner_type", "owner_id"], name: "index_other_responses_on_owner"
     t.index ["promotable_type", "promotable_id"], name: "index_other_responses_on_promotable"
     t.index ["source_form_answer_id"], name: "index_other_responses_on_source_form_answer_id"
+    t.index ["updated_by_id"], name: "index_other_responses_on_updated_by_id"
   end
 
   create_table "pay_charges", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1358,12 +1434,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "quotable_item_quotes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "legacy_id"
     t.integer "quotable_id"
     t.string "quotable_type"
     t.integer "quote_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_quotable_item_quotes_on_created_by_id"
     t.index ["quote_id"], name: "index_quotable_item_quotes_on_quote_id"
+    t.index ["updated_by_id"], name: "index_quotable_item_quotes_on_updated_by_id"
   end
 
   create_table "quotes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1413,15 +1493,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "registration_ticket_callout_resources", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.text "page_content"
     t.integer "position", null: false
     t.bigint "registration_ticket_callout_id", null: false
     t.integer "resource_id", null: false
     t.string "subtitle"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_registration_ticket_callout_resources_on_created_by_id"
     t.index ["registration_ticket_callout_id", "resource_id"], name: "index_callout_resources_on_callout_and_resource", unique: true
     t.index ["registration_ticket_callout_id"], name: "index_callout_resources_on_callout_id"
     t.index ["resource_id"], name: "index_callout_resources_on_resource_id"
+    t.index ["updated_by_id"], name: "index_registration_ticket_callout_resources_on_updated_by_id"
   end
 
   create_table "registration_ticket_callouts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1455,13 +1539,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.text "answer", size: :long
     t.integer "answer_option_id"
     t.datetime "created_at", precision: nil
+    t.integer "created_by_id"
     t.integer "form_field_id"
     t.integer "report_id"
     t.datetime "updated_at", precision: nil
+    t.integer "updated_by_id"
     t.integer "workshop_log_id"
     t.index ["answer_option_id"], name: "index_report_form_field_answers_on_answer_option_id"
+    t.index ["created_by_id"], name: "index_report_form_field_answers_on_created_by_id"
     t.index ["form_field_id"], name: "index_report_form_field_answers_on_form_field_id"
     t.index ["report_id"], name: "index_report_form_field_answers_on_report_id"
+    t.index ["updated_by_id"], name: "index_report_form_field_answers_on_updated_by_id"
     t.index ["workshop_log_id"], name: "index_report_form_field_answers_on_workshop_log_id"
   end
 
@@ -1578,15 +1666,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "sectorable_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.boolean "is_leader", default: false, null: false
     t.boolean "is_primary", default: false, null: false
     t.integer "sector_id"
     t.integer "sectorable_id"
     t.string "sectorable_type"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_sectorable_items_on_created_by_id"
     t.index ["sector_id", "sectorable_type", "sectorable_id"], name: "index_sectorable_items_uniqueness", unique: true
     t.index ["sector_id"], name: "index_sectorable_items_on_sector_id"
     t.index ["sectorable_type", "sectorable_id"], name: "index_sectorable_items_on_sectorable_type_and_sectorable_id"
+    t.index ["updated_by_id"], name: "index_sectorable_items_on_updated_by_id"
   end
 
   create_table "sectors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1726,20 +1818,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "user_form_form_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "form_field_id"
     t.text "text", size: :long
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.integer "user_form_id"
+    t.index ["created_by_id"], name: "index_user_form_form_fields_on_created_by_id"
     t.index ["form_field_id"], name: "index_user_form_form_fields_on_form_field_id"
+    t.index ["updated_by_id"], name: "index_user_form_form_fields_on_updated_by_id"
     t.index ["user_form_id"], name: "index_user_form_form_fields_on_user_form_id"
   end
 
   create_table "user_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "form_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.integer "user_id"
+    t.index ["created_by_id"], name: "index_user_forms_on_created_by_id"
     t.index ["form_id"], name: "index_user_forms_on_form_id"
+    t.index ["updated_by_id"], name: "index_user_forms_on_updated_by_id"
     t.index ["user_id"], name: "index_user_forms_on_user_id"
   end
 
@@ -1971,22 +2071,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "workshop_resources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
+    t.integer "created_by_id"
     t.integer "resource_id"
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "updated_by_id"
     t.integer "workshop_id"
+    t.index ["created_by_id"], name: "index_workshop_resources_on_created_by_id"
     t.index ["resource_id"], name: "index_workshop_resources_on_resource_id"
+    t.index ["updated_by_id"], name: "index_workshop_resources_on_updated_by_id"
     t.index ["workshop_id"], name: "index_workshop_resources_on_workshop_id"
   end
 
   create_table "workshop_series_memberships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.integer "position", default: 1, null: false
     t.string "series_description"
     t.string "series_description_spanish"
     t.string "theme_name"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.integer "workshop_child_id", null: false
     t.integer "workshop_parent_id", null: false
+    t.index ["created_by_id"], name: "index_workshop_series_memberships_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_workshop_series_memberships_on_updated_by_id"
     t.index ["workshop_child_id"], name: "fk_rails_c3357d1053"
     t.index ["workshop_parent_id", "workshop_child_id"], name: "index_workshop_series_memberships_on_parent_and_child", unique: true
   end
@@ -2147,8 +2255,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   end
 
   add_foreign_key "action_text_mentions", "action_text_rich_texts"
+  add_foreign_key "action_text_mentions", "users", column: "created_by_id"
+  add_foreign_key "action_text_mentions", "users", column: "updated_by_id"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "users", column: "created_by_id"
+  add_foreign_key "addresses", "users", column: "updated_by_id"
   add_foreign_key "affiliations", "addresses", column: "organization_address_id", on_delete: :nullify
   add_foreign_key "affiliations", "event_registrations", on_delete: :nullify
   add_foreign_key "affiliations", "organizations"
@@ -2159,6 +2271,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "allocations", "allocations", column: "reverted_id"
   add_foreign_key "allocations", "users", column: "created_by_id"
   add_foreign_key "allocations", "users", column: "updated_by_id"
+  add_foreign_key "answer_options", "users", column: "created_by_id"
+  add_foreign_key "answer_options", "users", column: "updated_by_id"
+  add_foreign_key "assets", "users", column: "created_by_id"
+  add_foreign_key "assets", "users", column: "updated_by_id"
+  add_foreign_key "attachments", "users", column: "created_by_id"
+  add_foreign_key "attachments", "users", column: "updated_by_id"
   add_foreign_key "banners", "users", column: "created_by_id"
   add_foreign_key "banners", "users", column: "updated_by_id"
   add_foreign_key "blazer_audits", "blazer_queries", column: "query_id"
@@ -2174,6 +2292,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "categories", "category_types"
   add_foreign_key "categories", "users", column: "created_by_id"
   add_foreign_key "categories", "users", column: "updated_by_id"
+  add_foreign_key "categorizable_items", "users", column: "created_by_id"
+  add_foreign_key "categorizable_items", "users", column: "updated_by_id"
   add_foreign_key "category_types", "users", column: "created_by_id"
   add_foreign_key "category_types", "users", column: "updated_by_id"
   add_foreign_key "comments", "users", column: "created_by_id"
@@ -2184,6 +2304,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "community_news", "users", column: "updated_by_id"
   add_foreign_key "community_news", "windows_types"
   add_foreign_key "contact_methods", "addresses"
+  add_foreign_key "contact_methods", "users", column: "created_by_id"
+  add_foreign_key "contact_methods", "users", column: "updated_by_id"
   add_foreign_key "continuing_education_registrations", "event_registrations"
   add_foreign_key "continuing_education_registrations", "professional_licenses"
   add_foreign_key "discounts", "users", column: "created_by_id"
@@ -2191,11 +2313,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "event_attendance_time_entries", "event_registrations"
   add_foreign_key "event_forms", "events"
   add_foreign_key "event_forms", "forms"
+  add_foreign_key "event_forms", "users", column: "created_by_id"
+  add_foreign_key "event_forms", "users", column: "updated_by_id"
   add_foreign_key "event_registration_checklist_completions", "event_registrations"
   add_foreign_key "event_registration_checklist_completions", "users", column: "completed_by_id"
+  add_foreign_key "event_registration_checklist_completions", "users", column: "created_by_id"
+  add_foreign_key "event_registration_checklist_completions", "users", column: "updated_by_id"
   add_foreign_key "event_registration_organizations", "event_registrations"
   add_foreign_key "event_registration_organizations", "form_submissions", on_delete: :nullify
   add_foreign_key "event_registration_organizations", "organizations"
+  add_foreign_key "event_registration_organizations", "users", column: "created_by_id"
+  add_foreign_key "event_registration_organizations", "users", column: "updated_by_id"
   add_foreign_key "event_registrations", "event_registrations", column: "transferred_from_registration_id", on_delete: :nullify
   add_foreign_key "event_registrations", "events"
   add_foreign_key "event_registrations", "people", column: "registrant_id"
@@ -2203,6 +2331,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "event_registrations", "users", column: "updated_by_id"
   add_foreign_key "event_staffs", "events"
   add_foreign_key "event_staffs", "people"
+  add_foreign_key "event_staffs", "users", column: "created_by_id"
+  add_foreign_key "event_staffs", "users", column: "updated_by_id"
   add_foreign_key "events", "locations"
   add_foreign_key "events", "users", column: "created_by_id"
   add_foreign_key "events", "users", column: "updated_by_id"
@@ -2212,10 +2342,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "features", "users", column: "updated_by_id"
   add_foreign_key "form_answers", "form_fields"
   add_foreign_key "form_answers", "form_submissions"
+  add_foreign_key "form_answers", "users", column: "created_by_id"
+  add_foreign_key "form_answers", "users", column: "updated_by_id"
+  add_foreign_key "form_builders", "users", column: "created_by_id"
+  add_foreign_key "form_builders", "users", column: "updated_by_id"
   add_foreign_key "form_builders", "windows_types"
   add_foreign_key "form_field_answer_options", "answer_options"
   add_foreign_key "form_field_answer_options", "form_fields"
+  add_foreign_key "form_field_answer_options", "users", column: "created_by_id"
+  add_foreign_key "form_field_answer_options", "users", column: "updated_by_id"
   add_foreign_key "form_fields", "forms"
+  add_foreign_key "form_fields", "users", column: "created_by_id"
+  add_foreign_key "form_fields", "users", column: "updated_by_id"
   add_foreign_key "form_submissions", "events"
   add_foreign_key "form_submissions", "forms"
   add_foreign_key "form_submissions", "people"
@@ -2224,6 +2362,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "forms", "form_builders"
   add_foreign_key "forms", "users", column: "created_by_id"
   add_foreign_key "forms", "users", column: "updated_by_id"
+  add_foreign_key "locations", "users", column: "created_by_id"
+  add_foreign_key "locations", "users", column: "updated_by_id"
+  add_foreign_key "media_files", "users", column: "created_by_id"
+  add_foreign_key "media_files", "users", column: "updated_by_id"
   add_foreign_key "membership_invoices", "memberships"
   add_foreign_key "membership_invoices", "users", column: "created_by_id"
   add_foreign_key "membership_invoices", "users", column: "updated_by_id"
@@ -2235,6 +2377,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "notifications", "notifications", column: "parent_notification_id"
   add_foreign_key "notifications", "notifications", column: "root_notification_id"
   add_foreign_key "notifications", "users", column: "sender_id"
+  add_foreign_key "organization_obligations", "users", column: "created_by_id"
+  add_foreign_key "organization_obligations", "users", column: "updated_by_id"
   add_foreign_key "organization_statuses", "users", column: "created_by_id"
   add_foreign_key "organization_statuses", "users", column: "updated_by_id"
   add_foreign_key "organizations", "locations"
@@ -2243,6 +2387,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "organizations", "users", column: "updated_by_id"
   add_foreign_key "organizations", "windows_types"
   add_foreign_key "other_responses", "form_answers", column: "source_form_answer_id"
+  add_foreign_key "other_responses", "users", column: "created_by_id"
+  add_foreign_key "other_responses", "users", column: "updated_by_id"
   add_foreign_key "pay_charges", "pay_customers", column: "customer_id"
   add_foreign_key "pay_charges", "pay_subscriptions", column: "subscription_id"
   add_foreign_key "pay_payment_methods", "pay_customers", column: "customer_id"
@@ -2256,6 +2402,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "people", "users", column: "updated_by_id"
   add_foreign_key "professional_licenses", "people"
   add_foreign_key "quotable_item_quotes", "quotes"
+  add_foreign_key "quotable_item_quotes", "users", column: "created_by_id"
+  add_foreign_key "quotable_item_quotes", "users", column: "updated_by_id"
   add_foreign_key "quotes", "people", column: "author_id"
   add_foreign_key "quotes", "users", column: "created_by_id"
   add_foreign_key "quotes", "users", column: "updated_by_id"
@@ -2264,6 +2412,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "refunds", "users", column: "updated_by_id"
   add_foreign_key "registration_ticket_callout_resources", "registration_ticket_callouts", on_delete: :cascade
   add_foreign_key "registration_ticket_callout_resources", "resources", on_delete: :cascade
+  add_foreign_key "registration_ticket_callout_resources", "users", column: "created_by_id"
+  add_foreign_key "registration_ticket_callout_resources", "users", column: "updated_by_id"
   add_foreign_key "registration_ticket_callouts", "events"
   add_foreign_key "registration_ticket_callouts", "forms"
   add_foreign_key "registration_ticket_callouts", "users", column: "created_by_id"
@@ -2271,6 +2421,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "report_form_field_answers", "answer_options"
   add_foreign_key "report_form_field_answers", "form_fields"
   add_foreign_key "report_form_field_answers", "reports"
+  add_foreign_key "report_form_field_answers", "users", column: "created_by_id"
+  add_foreign_key "report_form_field_answers", "users", column: "updated_by_id"
   add_foreign_key "report_form_field_answers", "workshop_logs"
   add_foreign_key "reports", "organizations"
   add_foreign_key "reports", "people", column: "author_id"
@@ -2292,6 +2444,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "scholarships", "users", column: "created_by_id"
   add_foreign_key "scholarships", "users", column: "updated_by_id"
   add_foreign_key "sectorable_items", "sectors"
+  add_foreign_key "sectorable_items", "users", column: "created_by_id"
+  add_foreign_key "sectorable_items", "users", column: "updated_by_id"
   add_foreign_key "sectors", "users", column: "created_by_id"
   add_foreign_key "sectors", "users", column: "updated_by_id"
   add_foreign_key "staff_taggings", "staff_tags"
@@ -2315,8 +2469,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "topic_subscriptions", "topic_subscription_types"
   add_foreign_key "user_form_form_fields", "form_fields"
   add_foreign_key "user_form_form_fields", "user_forms"
+  add_foreign_key "user_form_form_fields", "users", column: "created_by_id"
+  add_foreign_key "user_form_form_fields", "users", column: "updated_by_id"
   add_foreign_key "user_forms", "forms"
   add_foreign_key "user_forms", "users"
+  add_foreign_key "user_forms", "users", column: "created_by_id"
+  add_foreign_key "user_forms", "users", column: "updated_by_id"
   add_foreign_key "user_permissions", "permissions"
   add_foreign_key "user_permissions", "users"
   add_foreign_key "users", "events", column: "favorite_event_id"
@@ -2340,7 +2498,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "workshop_logs", "windows_types"
   add_foreign_key "workshop_logs", "workshops"
   add_foreign_key "workshop_resources", "resources"
+  add_foreign_key "workshop_resources", "users", column: "created_by_id"
+  add_foreign_key "workshop_resources", "users", column: "updated_by_id"
   add_foreign_key "workshop_resources", "workshops"
+  add_foreign_key "workshop_series_memberships", "users", column: "created_by_id"
+  add_foreign_key "workshop_series_memberships", "users", column: "updated_by_id"
   add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_child_id"
   add_foreign_key "workshop_series_memberships", "workshops", column: "workshop_parent_id"
   add_foreign_key "workshop_variation_ideas", "organizations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -187,15 +187,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "allocatable_type", null: false
     t.integer "amount", default: 0, null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "reverted_id"
     t.bigint "source_id", null: false
     t.string "source_type", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
     t.index ["allocatable_type", "allocatable_id"], name: "index_allocations_on_allocatable"
     t.index ["allocatable_type", "allocatable_id"], name: "index_allocations_on_allocatable_type_and_allocatable_id"
+    t.index ["created_by_id"], name: "index_allocations_on_created_by_id"
     t.index ["reverted_id"], name: "fk_rails_4e7a74eb48"
     t.index ["source_type", "source_id"], name: "index_allocations_on_source"
     t.index ["source_type", "source_id"], name: "index_allocations_on_source_type_and_source_id"
+    t.index ["updated_by_id"], name: "index_allocations_on_updated_by_id"
   end
 
   create_table "answer_options", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -456,7 +460,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   create_table "discounts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "amount_cents", default: 0, null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_discounts_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_discounts_on_updated_by_id"
   end
 
   create_table "event_attendance_time_entries", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -884,6 +892,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
 
   create_table "form_submissions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.bigint "event_id"
     t.integer "form_id", null: false
     t.json "metadata"
@@ -891,10 +900,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "role"
     t.string "slug"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_form_submissions_on_created_by_id"
     t.index ["event_id"], name: "index_form_submissions_on_event_id"
     t.index ["form_id"], name: "index_form_submissions_on_form_id"
     t.index ["person_id"], name: "index_form_submissions_on_person_id"
     t.index ["slug"], name: "index_form_submissions_on_slug", unique: true
+    t.index ["updated_by_id"], name: "index_form_submissions_on_updated_by_id"
   end
 
   create_table "forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1383,6 +1395,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   create_table "refunds", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "amount_cents", null: false
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.string "method", null: false
     t.bigint "recipient_id", null: false
     t.string "recipient_type", null: false
@@ -1390,9 +1403,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "refundable_type", null: false
     t.string "stripe_refund_id"
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_refunds_on_created_by_id"
     t.index ["recipient_type", "recipient_id"], name: "index_refunds_on_recipient"
     t.index ["refundable_type", "refundable_id"], name: "index_refunds_on_refundable"
     t.index ["stripe_refund_id"], name: "index_refunds_on_stripe_refund_id", unique: true
+    t.index ["updated_by_id"], name: "index_refunds_on_updated_by_id"
   end
 
   create_table "registration_ticket_callout_resources", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1414,6 +1430,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.boolean "ce_payment_access_gated", default: false, null: false
     t.string "color_class"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.text "description"
     t.datetime "display_from"
     t.bigint "event_id", null: false
@@ -1425,10 +1442,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.string "subtitle"
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_registration_ticket_callouts_on_created_by_id"
     t.index ["event_id", "builtin_key"], name: "index_registration_ticket_callouts_on_event_id_and_builtin_key", unique: true
     t.index ["event_id", "position"], name: "index_registration_ticket_callouts_on_event_id_and_position"
     t.index ["event_id"], name: "index_registration_ticket_callouts_on_event_id"
     t.index ["form_id"], name: "index_registration_ticket_callouts_on_form_id"
+    t.index ["updated_by_id"], name: "index_registration_ticket_callouts_on_updated_by_id"
   end
 
   create_table "report_form_field_answers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -1525,6 +1545,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.integer "amount_cents"
     t.integer "contribution_cents"
     t.datetime "created_at", null: false
+    t.integer "created_by_id"
     t.text "reason"
     t.datetime "responded_at", null: false
     t.integer "responded_by_id"
@@ -1532,8 +1553,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
     t.bigint "scholarship_id", null: false
     t.string "status", null: false
     t.datetime "updated_at", null: false
+    t.integer "updated_by_id"
+    t.index ["created_by_id"], name: "index_scholarship_agreement_responses_on_created_by_id"
     t.index ["responded_by_id"], name: "index_scholarship_agreement_responses_on_responded_by_id"
     t.index ["scholarship_id"], name: "index_scholarship_agreement_responses_on_scholarship_id"
+    t.index ["updated_by_id"], name: "index_scholarship_agreement_responses_on_updated_by_id"
   end
 
   create_table "scholarships", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -2133,6 +2157,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "affiliations", "users", column: "updated_by_id"
   add_foreign_key "age_ranges", "windows_types"
   add_foreign_key "allocations", "allocations", column: "reverted_id"
+  add_foreign_key "allocations", "users", column: "created_by_id"
+  add_foreign_key "allocations", "users", column: "updated_by_id"
   add_foreign_key "banners", "users", column: "created_by_id"
   add_foreign_key "banners", "users", column: "updated_by_id"
   add_foreign_key "blazer_audits", "blazer_queries", column: "query_id"
@@ -2160,6 +2186,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "contact_methods", "addresses"
   add_foreign_key "continuing_education_registrations", "event_registrations"
   add_foreign_key "continuing_education_registrations", "professional_licenses"
+  add_foreign_key "discounts", "users", column: "created_by_id"
+  add_foreign_key "discounts", "users", column: "updated_by_id"
   add_foreign_key "event_attendance_time_entries", "event_registrations"
   add_foreign_key "event_forms", "events"
   add_foreign_key "event_forms", "forms"
@@ -2191,6 +2219,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "form_submissions", "events"
   add_foreign_key "form_submissions", "forms"
   add_foreign_key "form_submissions", "people"
+  add_foreign_key "form_submissions", "users", column: "created_by_id"
+  add_foreign_key "form_submissions", "users", column: "updated_by_id"
   add_foreign_key "forms", "form_builders"
   add_foreign_key "forms", "users", column: "created_by_id"
   add_foreign_key "forms", "users", column: "updated_by_id"
@@ -2230,10 +2260,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "quotes", "users", column: "created_by_id"
   add_foreign_key "quotes", "users", column: "updated_by_id"
   add_foreign_key "quotes", "workshops"
+  add_foreign_key "refunds", "users", column: "created_by_id"
+  add_foreign_key "refunds", "users", column: "updated_by_id"
   add_foreign_key "registration_ticket_callout_resources", "registration_ticket_callouts", on_delete: :cascade
   add_foreign_key "registration_ticket_callout_resources", "resources", on_delete: :cascade
   add_foreign_key "registration_ticket_callouts", "events"
   add_foreign_key "registration_ticket_callouts", "forms"
+  add_foreign_key "registration_ticket_callouts", "users", column: "created_by_id"
+  add_foreign_key "registration_ticket_callouts", "users", column: "updated_by_id"
   add_foreign_key "report_form_field_answers", "answer_options"
   add_foreign_key "report_form_field_answers", "form_fields"
   add_foreign_key "report_form_field_answers", "reports"
@@ -2250,7 +2284,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_184319) do
   add_foreign_key "resources", "windows_types"
   add_foreign_key "resources", "workshops"
   add_foreign_key "scholarship_agreement_responses", "scholarships"
+  add_foreign_key "scholarship_agreement_responses", "users", column: "created_by_id"
   add_foreign_key "scholarship_agreement_responses", "users", column: "responded_by_id"
+  add_foreign_key "scholarship_agreement_responses", "users", column: "updated_by_id"
   add_foreign_key "scholarships", "grants"
   add_foreign_key "scholarships", "people", column: "recipient_id"
   add_foreign_key "scholarships", "users", column: "created_by_id"

--- a/lib/tasks/backfill_user_stamps.rake
+++ b/lib/tasks/backfill_user_stamps.rake
@@ -3,19 +3,23 @@
 namespace :data do
   desc "Backfill created_by_id/updated_by_id on legacy rows from the Ahoy lifecycle trail"
   task backfill_user_stamps: :environment do
-    # Concrete models carrying the stamp columns. Report is the STI base for
-    # MonthlyReport, so scanning it covers both (find_each yields the leaf instances,
-    # so record.class.name matches the Ahoy resource_type).
-    model_classes = [
-      Banner, Comment, CommunityNews, ContinuingEducationRegistration, Event, Grant,
-      Person, ProfessionalLicense, Report, Resource, Story, StoryIdea, User, Workshop,
-      WorkshopIdea, WorkshopLog, WorkshopVariation, WorkshopVariationIdea
-    ]
+    # Every concrete model carrying either stamp column, discovered rather than listed
+    # so new audited tables are covered automatically. Scanning only STI base classes
+    # (klass == klass.base_class) avoids visiting the same table twice; find_each still
+    # yields leaf instances, so record.class.name matches the Ahoy resource_type.
+    # Load just app/models (not a full eager_load!, which would boot the SolidCache /
+    # SolidQueue databases that aren't configured in every environment).
+    Rails.autoloaders.main.eager_load_dir(Rails.root.join("app/models"))
+
+    model_classes = ApplicationRecord.descendants.select do |klass|
+      klass == klass.base_class &&
+        !klass.abstract_class? &&
+        klass.table_exists? &&
+        (klass.column_names & %w[created_by_id updated_by_id]).any?
+    end.sort_by(&:name)
 
     model_classes.each do |klass|
       stamps = klass.column_names & %w[created_by_id updated_by_id]
-      next if stamps.empty?
-
       scope = klass.where(stamps.map { |c| "#{c} IS NULL" }.join(" OR "))
       filled = 0
 

--- a/spec/tasks/backfill_user_stamps_spec.rb
+++ b/spec/tasks/backfill_user_stamps_spec.rb
@@ -54,4 +54,23 @@ RSpec.describe "data:backfill_user_stamps" do
 
     expect(log.reload.updated_by_id).to eq(existing.id)
   end
+
+  it "backfills created_by_id and updated_by_id on a newly-stamped table via dynamic discovery" do
+    payment = create(:payment)
+    payment.update_columns(created_by_id: nil, updated_by_id: nil)
+
+    # Payment is STI; Ahoy records the leaf class (e.g. CashPayment) as resource_type,
+    # which is what find_each yields — re-find to get the persisted subclass name.
+    resource_type = Payment.find(payment.id).class.name
+    create(:ahoy_event, name: "create.payment", user: early_editor, time: 2.days.ago,
+                        properties: { resource_type: resource_type, resource_id: payment.id })
+    create(:ahoy_event, name: "update.payment", user: late_editor, time: 1.hour.ago,
+                        properties: { resource_type: resource_type, resource_id: payment.id })
+
+    run_task
+    payment.reload
+
+    expect(payment.created_by_id).to eq(early_editor.id)
+    expect(payment.updated_by_id).to eq(late_editor.id)
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 two migrations add stamp columns + FKs to ~49 tables, a generalized Ahoy backfill, and removes the Ahoy fallback from the shared audit footer

Attribution should live on each record as `created_by`/`updated_by`, read from the model — not reconstructed from Ahoy. Since association-only edits no longer bump a parent (PR #2026), child/join records need their own stamps to stay attributable.

## What changed
- **Stamp columns (+ index + FK to users) on ~49 tables**, in two migrations; `UserStampable` fills them going forward:
  - **Audit-footer models that lacked them (16):** payments, forms, sectors, faqs, categories, category_types, memberships, membership_invoices, organization_statuses, video_recordings, windows_types, organizations, affiliations, scholarships, event_registrations, features.
  - **Other staff-actioned records (6):** refunds, discounts, allocations, registration_ticket_callouts, form_submissions, scholarship_agreement_responses.
  - **Child / join / asset / reference records (27):** addresses, contact_methods, answer_options, form_fields, form_field_answer_options, form_answers, form_builders, event_forms, event_staffs, event_registration_organizations, event_registration_checklist_completions, categorizable_items, sectorable_items, quotable_item_quotes, workshop_resources, workshop_series_memberships, registration_ticket_callout_resources, report_form_field_answers, user_forms, user_form_form_fields, other_responses, organization_obligations, assets, attachments, media_files, action_text_mentions, locations.
- **Associations** (`belongs_to :created_by/:updated_by → User, optional`) on every one, plus explicit `updated_by` on `MonthlyReport`.
- **Footer reads columns only:** dropped the Ahoy fallback from `shared/_audit_info` (~40 edit pages) and `users#show`. The admin "view in Ahoy activity" link stays (navigation, not audit data).
- **Backfill:** `data:backfill_user_stamps` now **discovers every model carrying the stamp columns** (was a hardcoded list that missed many). Idempotent, nil-only, STI-safe (matches the leaf class name, e.g. `CashPayment`, as Ahoy recorded it).

## Intentionally not stamped
- **Bookmark** — its required `user_id` is the owner/creator, so no separate stamp. (**Notification** now carries `created_by`/`updated_by` in addition to its `sender_id`.)
- `fm_*` import staging (18) and vendored `Pay::*` / `Ahoy::*` gem tables.

## Verify / run
- Every `belongs_to :created_by/:updated_by` points to **User**, none to Person. Only **Bookmark** remains unstamped among app-owned tables (its `user_id` is the owner).
- Run **`rake data:backfill_user_stamps`** after deploy.
- Tests: 2,398 model examples + backfill (incl. new-table/STI case) + Ahoy-tracking/change-log specs + request specs across forms, tagging, reports, events, payments, submissions — all green.
