### PR TITLE
Bind a notification's created_by/updated_by to its sender

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,7 +532,7 @@ RuboCop linting on PRs and pushes to main.
 
 ## Rake Tasks
 
-Located in `lib/tasks/` (11 files):
+Located in `lib/tasks/` (12 files):
 - `dev.rake` — Development database seeding from XML/CSV
 - `rhino_migrator.rake` — Rich text editor migration
 - `attachment_report.rake` — Attachment reporting
@@ -543,3 +543,4 @@ Located in `lib/tasks/` (11 files):
 - `import_stories.rake` — Imports stories from a WordPress Posts Export CSV (`StoryImporter`)
 - `migrate_workshop_logs.rake` — Workshop log migration
 - `backfill_user_stamps.rake` — Backfill `created_by_id`/`updated_by_id` on legacy rows from the Ahoy trail (`data:backfill_user_stamps`)
+- `backfill_notification_stamps.rake` — Backfill notifications' `created_by_id`/`updated_by_id` from `sender_id`, nil-only (`data:backfill_notification_stamps`)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -168,6 +168,12 @@ class Notification < ApplicationRecord
   before_validation :force_manual_log_channel, if: :manual_log?
   # A contact_us_fyi is always something a person sent us — stamp it incoming.
   before_validation :mark_incoming, on: :create, if: -> { kind == "contact_us_fyi" }
+  # A notification's audit stamps follow its sender (the staff member the
+  # communication is from), not whoever's request created the row — a bulk send
+  # runs in a background job with no Current.user, and a system send has no sender
+  # at all. Set both at create, overriding the Current.user-based UserStampable
+  # default (this callback runs after it); later edits still stamp the editor.
+  before_validation :match_stamps_to_sender, on: :create
 
   def manual_log?
     kind == "manual_log"
@@ -351,6 +357,11 @@ class Notification < ApplicationRecord
   end
 
   private
+
+  def match_stamps_to_sender
+    self.created_by_id = sender_id
+    self.updated_by_id = sender_id
+  end
 
   def apply_manual_log_defaults
     self.kind = "manual_log"

--- a/lib/tasks/backfill_notification_stamps.rake
+++ b/lib/tasks/backfill_notification_stamps.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc "Backfill notifications' created_by_id/updated_by_id from sender_id (nil-only)"
+  task backfill_notification_stamps: :environment do
+    # A notification's creator/editor is its sender (see Notification#match_stamps_to_sender,
+    # which sets this at create going forward). Fill legacy rows from sender_id without
+    # overwriting any stamp already set. Idempotent.
+    filled = 0
+    scope = Notification.where.not(sender_id: nil)
+                        .where("created_by_id IS NULL OR updated_by_id IS NULL")
+
+    scope.find_each do |notification|
+      notification.update_columns(
+        created_by_id: notification.created_by_id || notification.sender_id,
+        updated_by_id: notification.updated_by_id || notification.sender_id
+      )
+      filled += 1
+    end
+
+    puts "Notification: backfilled #{filled} #{"row".pluralize(filled)} from sender"
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,6 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe Notification do
+  describe "audit stamps follow the sender" do
+    after { Current.reset }
+
+    it "stamps created_by and updated_by from the sender on create" do
+      sender = create(:user)
+
+      notification = create(:notification, sender: sender)
+
+      expect(notification.created_by).to eq(sender)
+      expect(notification.updated_by).to eq(sender)
+    end
+
+    it "matches the sender even when a different user is current (bulk/async sends)" do
+      sender = create(:user)
+      Current.user = create(:user)
+
+      notification = create(:notification, sender: sender)
+
+      expect(notification.created_by).to eq(sender)
+      expect(notification.updated_by).to eq(sender)
+    end
+
+    it "leaves the stamps nil for a system send with no sender" do
+      Current.user = create(:user)
+
+      notification = create(:notification, sender: nil)
+
+      expect(notification.created_by).to be_nil
+      expect(notification.updated_by).to be_nil
+    end
+
+    it "stamps updated_by from the editor on a later edit, keeping created_by as the sender" do
+      sender = create(:user)
+      notification = create(:notification, sender: sender)
+      editor = create(:user)
+
+      Current.set(user: editor) { notification.update!(custom_message: "Edited") }
+
+      expect(notification.reload.created_by).to eq(sender)
+      expect(notification.updated_by).to eq(editor)
+    end
+  end
+
   describe "Ahoy lifecycle tracking" do
     after { Current.reset }
 

--- a/spec/tasks/backfill_notification_stamps_spec.rb
+++ b/spec/tasks/backfill_notification_stamps_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "data:backfill_notification_stamps" do
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("data:backfill_notification_stamps")
+  end
+
+  before { Rake::Task["data:backfill_notification_stamps"].reenable }
+
+  def run_task
+    original = $stdout
+    $stdout = StringIO.new
+    Rake::Task["data:backfill_notification_stamps"].invoke
+  ensure
+    $stdout = original
+  end
+
+  let(:sender) { create(:user) }
+
+  it "fills nil created_by/updated_by from the sender" do
+    notification = create(:notification, sender: sender)
+    notification.update_columns(created_by_id: nil, updated_by_id: nil)
+
+    run_task
+
+    notification.reload
+    expect(notification.created_by).to eq(sender)
+    expect(notification.updated_by).to eq(sender)
+  end
+
+  it "leaves a sender-less notification untouched" do
+    notification = create(:notification, sender: nil)
+    notification.update_columns(created_by_id: nil, updated_by_id: nil)
+
+    run_task
+
+    notification.reload
+    expect(notification.created_by).to be_nil
+    expect(notification.updated_by).to be_nil
+  end
+
+  it "does not overwrite a stamp that is already set" do
+    editor = create(:user)
+    notification = create(:notification, sender: sender)
+    notification.update_columns(created_by_id: nil, updated_by_id: editor.id)
+
+    run_task
+
+    notification.reload
+    expect(notification.created_by).to eq(sender)
+    expect(notification.updated_by).to eq(editor)
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one model callback that overrides the UserStampable default for notifications, plus a nil-only backfill task

Notifications now attribute `created_by`/`updated_by` to **who the communication is from** (`sender`), not whoever’s request happened to create the row.

## Why
`UserStampable` stamps from `Current.user`, which is **nil** for two common notification paths:
- **Bulk sends** run in a background job (`BulkInviteEmailJob` → Devise mailer) — no `Current.user`, so an admin-initiated bulk email got no `created_by`.
- **System sends** (registration/form confirmations, password resets) have no signed-in user at all.

Meanwhile `sender_id` is already threaded through jobs and is the domain-correct "who sent this."

## What
- **`Notification#match_stamps_to_sender`** (`before_validation … on: :create`) sets `created_by_id` and `updated_by_id` from `sender_id`. It runs after `UserStampable`, so it wins on create. A system send (no sender) stays nil; a later edit still stamps the editor via `UserStampable` (`created_by` unchanged).
- **`data:backfill_notification_stamps`** fills legacy rows from `sender_id`, nil-only (never overwrites a stamp already set). Run after deploy.

## Notes
- `sender` is a **User** (`belongs_to :sender, class_name: "User"`), matching `created_by`’s type — the person-y display is just `sender.person` in the decorator.
- Builds on #2439 (already merged), which added the Notification stamp columns.

## Tests
- `spec/models/notification_spec.rb` — stamps from sender on create; matches sender even when a different user is `Current`; stays nil with no sender; edit stamps the editor while keeping `created_by`.
- `spec/tasks/backfill_notification_stamps_spec.rb` — nil-fill from sender, skips sender-less rows, never overwrites a set stamp.
- Re-ran the notification-creating flows (events, story ideas, contact us, registrations, bulk payment, invites) — all green.