### PR TITLE
Hide Register button on ended events for admins too

### DIFF
--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -8,11 +8,6 @@
   <div class="flex flex-col items-center justify-center gap-3">
     <% if event.ended? %>
       <span class="text-2xl font-bold text-gray-400 italic">Event ended</span>
-      <% if allowed_to?(:manage?, event) %>
-        <%= button_to "Register",
-                      event_registrant_registration_path(event_id: event),
-                      class: button_classes(:primary_outline, extra: "admin-only bg-blue-100") %>
-      <% end %>
     <% elsif !registered && !slug_registered %>
       <% if slug_cancelled && event.registerable? %>
         <%= button_to "Register again", registration_reactivate_path(slug_registration.slug),


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 removes a single admin-only button branch in one partial

Removes the admin-only "Register" button that appeared under "Event ended" on the event show page, so no one — admins included — is offered registration once an event has ended.

### What is the goal of this PR and why is this important?
An ended event shouldn't present a Register action. Previously admins still saw one below the "Event ended" label, which is misleading.

### How did you approach the change?
Dropped the `allowed_to?(:manage?, event)` Register button branch in `events/_registration_section.html.erb`. Admins keep their registration workflow via the roster/registrants admin pages.

### UI Testing Checklist
- [ ] On an ended event's show page, confirm no Register button appears for an admin (only "Event ended").

### Anything else to add?
Nothing.
