### PR TITLE
Selectable display templates for the event show page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,6 +38,15 @@ class EventsController < ApplicationController
     track_view(@event)
   end
 
+  # Admin-facing gallery that renders every display template with a real recent
+  # event, so admins can compare layouts before picking one on the event form.
+  # Read-only (`sample: true`) so it never builds live registration routes or
+  # duplicate registration_section dom_ids across the stacked templates.
+  def templates_gallery
+    authorize!
+    @sample_event = authorized_scope(Event.all).order(start_date: :desc).first&.decorate
+  end
+
   # Cross-event revenue report over paid events, grouped by year. Shares the
   # event-type + time-period filters with the participation report, and leads the
   # KPI strip with the year of the event navigated from (when arriving from a

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,6 +34,12 @@ class EventsController < ApplicationController
 
   def show
     authorize! @event
+    # Editors can preview any display template via ?template= without saving it
+    # (used by the templates gallery). Ignored for everyone else so the public
+    # page stays deterministic.
+    if params[:template].present? && Event::TEMPLATE_KEYS.include?(params[:template]) && allowed_to?(:edit?, @event)
+      @event.template = params[:template]
+    end
     @event = @event.decorate
     track_view(@event)
   end
@@ -158,6 +164,9 @@ class EventsController < ApplicationController
     # Materialize any missing built-in callouts so the editor shows them all
     # (idempotent; heals events created before a built-in existed).
     BuiltinCallouts.seed(@event)
+    # Arriving from a template preview ("Apply & edit") pre-selects that template
+    # in the form so submitting saves it; the admin can still change or cancel.
+    @event.template = params[:template] if params[:template].present? && Event::TEMPLATE_KEYS.include?(params[:template])
     set_form_variables
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,13 +38,17 @@ class EventsController < ApplicationController
     track_view(@event)
   end
 
-  # Admin-facing gallery that renders every display template with a real recent
-  # event, so admins can compare layouts before picking one on the event form.
-  # Read-only (`sample: true`) so it never builds live registration routes or
-  # duplicate registration_section dom_ids across the stacked templates.
+  # Admin-facing gallery that renders every display template as a scaled preview,
+  # so admins can compare layouts before picking one on the event form. Previews
+  # the event named by ?event_id (scoped to what the viewer may see), else the most
+  # recent one. Read-only (`sample: true`) so it never builds live registration
+  # routes or duplicate registration_section dom_ids across the previews.
   def templates_gallery
     authorize!
-    @sample_event = authorized_scope(Event.all).order(start_date: :desc).first&.decorate
+    scope = authorized_scope(Event.all)
+    @sample_event = scope.find_by(id: params[:event_id]) if params[:event_id].present?
+    @sample_event ||= scope.order(start_date: :desc).first
+    @sample_event = @sample_event&.decorate
   end
 
   # Cross-event revenue report over paid events, grouped by year. Shares the

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -44,14 +44,15 @@ class EventsController < ApplicationController
     track_view(@event)
   end
 
-  # Admin-facing gallery that renders every display template as a scaled preview,
-  # so admins can compare layouts before picking one on the event form. Previews
-  # the event named by ?event_id (scoped to what the viewer may see), else the most
-  # recent one. Read-only (`sample: true`) so it never builds live registration
-  # routes or duplicate registration_section dom_ids across the previews.
+  # Gallery that renders every display template as a scaled preview, so admins and
+  # event owners can compare layouts before picking one on the event form. Previews
+  # the event named by ?event_id, else the most recent one — drawn from the
+  # :reportable scope, so an owner only ever previews their own events' content.
+  # Read-only (`sample: true`) so it never builds live registration routes or
+  # duplicate registration_section dom_ids across the previews.
   def templates_gallery
     authorize!
-    scope = authorized_scope(Event.all)
+    scope = authorized_scope(Event.all, as: :reportable)
     @sample_event = scope.find_by(id: params[:event_id]) if params[:event_id].present?
     @sample_event ||= scope.order(start_date: :desc).first
     @sample_event = @sample_event&.decorate

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,6 +1,8 @@
 class EventDecorator < ApplicationDecorator
   decorates_association :bookmarkable
 
+  LEGACY_CTA_FONT = "font-family: 'Telefon Bold', sans-serif;".freeze
+
   def videoconference_domain
     URI.parse(videoconference_url).host&.split(".")&.[](-2)&.capitalize rescue "video call"
   end
@@ -394,6 +396,28 @@ class EventDecorator < ApplicationDecorator
 
   def breadcrumbs
     "#{bookmarks_link} >> #{bookmarkable_link}".html_safe
+  end
+
+  # Whether the show page is wearing a branded frame. "none" is the frozen legacy
+  # layout, so it keeps the orange/green buttons it shipped with; every other
+  # template gets the gold brand CTA.
+  def branded_page?
+    template != Event::TEMPLATE_NONE
+  end
+
+  # Classes for the show page's calls to action (register, view ticket). Read off
+  # the event rather than passed in as a view local so a Turbo re-render of the
+  # registration section matches whichever page it lands in.
+  def cta_classes(register: false)
+    return h.brand_cta_classes(register: register, extra: "px-10 py-3 text-2xl") if branded_page?
+
+    h.button_classes(register ? :accent : :success, size: nil, extra: "px-10 py-2 text-2xl uppercase")
+  end
+
+  # The legacy buttons carry the Telefon Bold face inline; the brand CTA gets it
+  # from font-display, so this is nil there and the attribute is dropped.
+  def cta_style
+    LEGACY_CTA_FONT unless branded_page?
   end
 
   def labelled_cost

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -49,4 +49,14 @@ module ButtonHelper
     tokens << extra if extra.present?
     tokens.join(" ")
   end
+
+  # The AWBW brand CTA button (marketing "Donate" / "Explore" style): gold fill,
+  # navy label, with a raised darker-gold bottom edge that presses on click.
+  # Register buttons layer on `font-display uppercase` — see BRAND_CTA_REGISTER.
+  BRAND_CTA = "inline-flex items-center justify-center gap-2 rounded-lg bg-brand-yellow-400 font-bold text-brand-navy-900 shadow-[0_4px_0_#bd9500] transition hover:bg-brand-yellow-300 active:translate-y-0.5 active:shadow-[0_2px_0_#bd9500]".freeze
+  BRAND_CTA_REGISTER = "font-display tracking-wide uppercase".freeze
+
+  def brand_cta_classes(register: false, extra: nil)
+    [ BRAND_CTA, (BRAND_CTA_REGISTER if register), extra ].compact.join(" ")
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,20 @@ class Event < ApplicationRecord
   # who see past and unpublished events there).
   CARD_ARCHIVE_AGE = 1.month
 
+  # Display templates for the public show page. "none" is the plain current
+  # layout (white page, content as-authored); the rest wrap the same
+  # admin-curated content (header image, details, description) — respecting every
+  # autoshow_* toggle — in a branded frame. Keyed hash carries the picker label
+  # and blurb; render each via app/views/events/templates/_<key>.html.erb.
+  TEMPLATES = {
+    "none" => { label: "None (current)", blurb: "Plain white page — your content exactly as authored." },
+    "centered" => { label: "Centered", blurb: "Brand-polished centered layout with a rainbow accent and gold button." },
+    "editorial" => { label: "Editorial", blurb: "Warm cream page with the description on a white paper card. Best for text-heavy events." },
+    "sidebar" => { label: "Details sidebar", blurb: "Two columns: description on the left, a sticky details and register card on the right." },
+    "hero" => { label: "Navy hero", blurb: "Bold navy hero with the title and details beside your framed header image." }
+  }.freeze
+  TEMPLATE_KEYS = TEMPLATES.keys.freeze
+
   has_rich_text :rhino_header
   has_rich_text :rhino_description
 
@@ -60,6 +74,7 @@ class Event < ApplicationRecord
   # Validations
   validates_presence_of :title, :start_date, :end_date
   validates_inclusion_of :published, in: [ true, false ]
+  validates :template, inclusion: { in: TEMPLATE_KEYS }
   validates_numericality_of :cost_cents, greater_than_or_equal_to: 0, allow_nil: true
   validates :title, length: { maximum: 255 }
   validates :abbreviation, length: { maximum: 255 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,7 +22,7 @@ class Event < ApplicationRecord
     "centered" => { label: "Centered", blurb: "Brand-polished centered layout with a rainbow accent and gold button." },
     "editorial" => { label: "Editorial", blurb: "Warm cream page with the description on a white paper card. Best for text-heavy events." },
     "sidebar" => { label: "Details sidebar", blurb: "Two columns: description on the left, a sticky details and register card on the right." },
-    "hero" => { label: "Navy hero", blurb: "Bold navy hero with the title and details beside your framed header image." }
+    "hero" => { label: "Navy hero", blurb: "Bold navy hero with the title and details beside your header image." }
   }.freeze
   TEMPLATE_KEYS = TEMPLATES.keys.freeze
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,8 +17,9 @@ class Event < ApplicationRecord
   # admin-curated content (header image, details, description) — respecting every
   # autoshow_* toggle — in a branded frame. Keyed hash carries the picker label
   # and blurb; render each via app/views/events/templates/_<key>.html.erb.
+  TEMPLATE_NONE = "none".freeze
   TEMPLATES = {
-    "none" => { label: "None (current)", blurb: "Plain white page — your content exactly as authored." },
+    TEMPLATE_NONE => { label: "None (current)", blurb: "Plain white page — your content exactly as authored." },
     "centered" => { label: "Centered", blurb: "Brand-polished centered layout with a rainbow accent and gold button." },
     "editorial" => { label: "Editorial", blurb: "Warm cream page with the description on a white paper card. Best for text-heavy events." },
     "sidebar" => { label: "Details sidebar", blurb: "Two columns: description on the left, a sticky details and register card on the right." },

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -188,6 +188,7 @@ class EventPolicy < ApplicationPolicy
                   :public_registration_enabled,
                   :signed_in_one_click_enabled,
                   :autoshow_registration_details,
+                  :template,
                   :hint_dates,
                   :hint_times,
                   :hint_registration_cost,

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -23,6 +23,16 @@ class EventPolicy < ApplicationPolicy
     admin? || owns_events?
   end
 
+  # The display-template gallery, reached from the event form's layout picker.
+  # Its own rule rather than an alias of new?: the controller authorizes without a
+  # record, so owner? has no Event to check and any manage?-derived rule would
+  # collapse to admin-only — locking out the event owners who reach it from the
+  # form. Gated on "has events to preview", with the :reportable scope narrowing
+  # the sample event to their own.
+  def templates_gallery?
+    admin? || owns_events?
+  end
+
   # A single-event slice of those reports — reached from the per-event Reports and
   # Roster tabs, which pass event_id — is visible to that event's owner too. The
   # controller resolves event_id to the Event and authorizes against it here, so
@@ -42,8 +52,11 @@ class EventPolicy < ApplicationPolicy
     relation.where(created_by_id: user.id)
   end
 
+  # Owners see their own event's page unconditionally — same as an admin — so they
+  # can preview a draft (unpublished, not yet publicly visible) or a past event
+  # before anyone else can, which is what the layout-template previews rely on.
   def show?
-    return true if admin?
+    return true if admin? || owner?
 
     if record.ended?
       authenticated? && record.published? && record.actively_registered?(user.person)
@@ -218,7 +231,6 @@ class EventPolicy < ApplicationPolicy
   end
 
   alias_rule :preview?, to: :edit?
-  alias_rule :templates_gallery?, to: :new?
 
   private
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -218,6 +218,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   alias_rule :preview?, to: :edit?
+  alias_rule :templates_gallery?, to: :new?
 
   private
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -530,19 +530,22 @@
     <% end %>
 
     <%# ---- PAGE CONTENT (header + description) ---- %>
+    <%# Opened + scrolled to when arriving from the templates preview/gallery
+        (?section=page_content) so the layout picker is right there. %>
+    <% open_show_page = params[:section] == "page_content" %>
     <div class="page-content-section" data-controller="dropdown">
       <button
         type="button"
         id="page_content_button"
-        class="flex w-full cursor-pointer items-center justify-between rounded-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
+        class="flex w-full cursor-pointer scroll-mt-24 items-center justify-between <%= open_show_page ? "rounded-t-md" : "rounded-md" %> bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"page_content":"hidden"}, {"page_content_arrow":"rotate-180"}, {"page_content_button":"rounded-md rounded-t-md"}]'
       >
         Event show page
-        <i id="page_content_arrow" class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300"></i>
+        <i id="page_content_arrow" class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300 <%= "rotate-180" if open_show_page %>"></i>
       </button>
 
-      <div id="page_content" class="hidden rounded-b-md border border-gray-300 p-4">
+      <div id="page_content" class="<%= "hidden" unless open_show_page %> rounded-b-md border border-gray-300 p-4">
         <div class="form-group mb-6">
           <label class="control-label mb-1 block font-semibold">Layout template</label>
           <p class="mb-3 text-sm text-gray-500">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -543,6 +543,25 @@
       </button>
 
       <div id="page_content" class="hidden rounded-b-md border border-gray-300 p-4">
+        <div class="form-group mb-6">
+          <label class="control-label mb-1 block font-semibold">Layout template</label>
+          <p class="mb-3 text-sm text-gray-500">
+            How the public event page frames your header, details, and description — the same content and show/hide toggles, in a different design.
+            <%= link_to "Preview all templates", templates_gallery_events_path, target: "_blank", rel: "noopener", class: "text-blue-700 underline" %>.
+          </p>
+          <div class="space-y-2">
+            <% Event::TEMPLATES.each do |key, meta| %>
+              <label class="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 hover:bg-gray-50 has-[:checked]:border-blue-400 has-[:checked]:bg-blue-50">
+                <%= f.radio_button :template, key, class: "mt-1" %>
+                <span>
+                  <span class="font-medium text-gray-800"><%= meta[:label] %></span>
+                  <span class="block text-sm text-gray-500"><%= meta[:blurb] %></span>
+                </span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+
         <%= f.input :autoshow_title, as: :boolean, label: "Show title on event show page" %>
 
         <div class="form-group <%= 'has-error' if f.object.errors[:rhino_header].present? %>">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -549,14 +549,17 @@
             How the public event page frames your header, details, and description — the same content and show/hide toggles, in a different design.
             <%= link_to "Preview all templates", templates_gallery_events_path, target: "_blank", rel: "noopener", class: "text-blue-700 underline" %>.
           </p>
-          <div class="space-y-2">
+          <div class="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
             <% Event::TEMPLATES.each do |key, meta| %>
-              <label class="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 hover:bg-gray-50 has-[:checked]:border-blue-400 has-[:checked]:bg-blue-50">
-                <%= f.radio_button :template, key, class: "mt-1" %>
-                <span>
-                  <span class="font-medium text-gray-800"><%= meta[:label] %></span>
-                  <span class="block text-sm text-gray-500"><%= meta[:blurb] %></span>
-                </span>
+              <label class="flex cursor-pointer flex-col gap-2 rounded-md border border-gray-200 p-3 hover:bg-gray-50 has-[:checked]:border-blue-400 has-[:checked]:bg-blue-50 has-[:checked]:ring-1 has-[:checked]:ring-blue-400">
+                <%= render "events/template_wireframe", key: key %>
+                <div class="flex items-start gap-2">
+                  <%= f.radio_button :template, key, class: "mt-0.5" %>
+                  <span class="min-w-0">
+                    <span class="block font-medium text-gray-800"><%= meta[:label] %></span>
+                    <span class="block text-xs text-gray-500"><%= meta[:blurb] %></span>
+                  </span>
+                </div>
               </label>
             <% end %>
           </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -547,7 +547,7 @@
           <label class="control-label mb-1 block font-semibold">Layout template</label>
           <p class="mb-3 text-sm text-gray-500">
             How the public event page frames your header, details, and description — the same content and show/hide toggles, in a different design.
-            <%= link_to "Preview all templates", templates_gallery_events_path, target: "_blank", rel: "noopener", class: "text-blue-700 underline" %>.
+            <%= link_to "Preview all templates", templates_gallery_events_path(event_id: @event.persisted? ? @event.id : nil), target: "_blank", rel: "noopener", class: "text-blue-700 underline" %>.
           </p>
           <div class="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
             <% Event::TEMPLATES.each do |key, meta| %>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -25,19 +25,16 @@
             <%= button_to button_text,
                           event_registrant_registration_path(event_id: event),
                           data: { turbo: !event.object.cost_cents.to_i.positive? },
-                          class: button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                          style: "font-family: 'Telefon Bold', sans-serif;" %>
+                          class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
           <% else %>
             <%= link_to button_text,
                         new_event_public_registration_path(event),
-                        class: button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                        style: "font-family: 'Telefon Bold', sans-serif;" %>
+                        class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
           <% end %>
         <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
           <%= link_to button_text,
                       new_event_public_registration_path(event),
-                      class: button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                      style: "font-family: 'Telefon Bold', sans-serif;" %>
+                      class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
         <% end %>
       <% else %>
         <span class="text-2xl font-bold text-blue-400 italic">Registration closed</span>
@@ -47,27 +44,25 @@
     <% if registered %>
       <% registration = event.active_registration_for(current_user&.person) %>
       <%= link_to "View ticket", registration_ticket_path(registration.slug),
-                  class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                  style: "font-family: 'Telefon Bold', sans-serif;" %>
+                  class: brand_cta_classes(extra: "px-10 py-3 text-2xl") %>
     <% elsif slug_registered %>
       <%= link_to "View ticket", registration_ticket_path(slug_registration.slug),
-                  class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                  style: "font-family: 'Telefon Bold', sans-serif;" %>
+                  class: brand_cta_classes(extra: "px-10 py-3 text-2xl") %>
     <% end %>
   </div>
 
   <% if (registered || slug_registered) && !event.ended? %>
     <!-- CALENDAR LINKS -->
     <% calendar_registration = registered ? event.active_registration_for(current_user&.person) : slug_registration %>
-    <div class="flex flex-col items-center mt-4">
-      <div class="flex items-center gap-1 mb-2">
-        <p class="text-xs font-bold text-gray-400 uppercase tracking-wide">
+    <div class="mt-4 flex flex-col items-center">
+      <div class="mb-2 flex items-center gap-1">
+        <p class="text-xs font-bold tracking-wide text-gray-400 uppercase">
           Add to Your Calendar
         </p>
         <%= render "events/videoconference_calendar_notice", event: event, registration: calendar_registration %>
       </div>
       <% calendar_re_add_url = calendar_registration ? registration_videoconference_url(calendar_registration.slug) : event_url(event) %>
-      <div class="flex gap-2 items-center text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?, re_add_url: calendar_re_add_url, payment_pending: calendar_registration ? !calendar_registration.payment_access_granted? : false) %></div>
+      <div class="flex items-center gap-2 text-sm text-gray-700"><%= event.calendar_links(show_videoconference_details: calendar_registration&.videoconference_details_visible?, re_add_url: calendar_re_add_url, payment_pending: calendar_registration ? !calendar_registration.payment_access_granted? : false) %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/_registration_section.html.erb
+++ b/app/views/events/_registration_section.html.erb
@@ -25,16 +25,16 @@
             <%= button_to button_text,
                           event_registrant_registration_path(event_id: event),
                           data: { turbo: !event.object.cost_cents.to_i.positive? },
-                          class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
+                          class: event.cta_classes(register: true), style: event.cta_style %>
           <% else %>
             <%= link_to button_text,
                         new_event_public_registration_path(event),
-                        class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
+                        class: event.cta_classes(register: true), style: event.cta_style %>
           <% end %>
         <% elsif event.object.public_registration_enabled? && event.object.event_forms.registration.exists? %>
           <%= link_to button_text,
                       new_event_public_registration_path(event),
-                      class: brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>
+                      class: event.cta_classes(register: true), style: event.cta_style %>
         <% end %>
       <% else %>
         <span class="text-2xl font-bold text-blue-400 italic">Registration closed</span>
@@ -44,10 +44,10 @@
     <% if registered %>
       <% registration = event.active_registration_for(current_user&.person) %>
       <%= link_to "View ticket", registration_ticket_path(registration.slug),
-                  class: brand_cta_classes(extra: "px-10 py-3 text-2xl") %>
+                  class: event.cta_classes, style: event.cta_style %>
     <% elsif slug_registered %>
       <%= link_to "View ticket", registration_ticket_path(slug_registration.slug),
-                  class: brand_cta_classes(extra: "px-10 py-3 text-2xl") %>
+                  class: event.cta_classes, style: event.cta_style %>
     <% end %>
   </div>
 

--- a/app/views/events/_template_wireframe.html.erb
+++ b/app/views/events/_template_wireframe.html.erb
@@ -1,0 +1,65 @@
+<%# Tiny schematic of each display template for the layout picker. Custom
+    illustrative graphics (not domain theming), so the brand hexes are inline. %>
+<% case key %>
+<% when "none" %>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Plain centered layout">
+    <rect x="30" y="10" width="60" height="18" rx="2" fill="#e2e8f0"/>
+    <rect x="38" y="34" width="44" height="4" rx="2" fill="#94a3b8"/>
+    <rect x="46" y="42" width="28" height="3" rx="1.5" fill="#cbd5e1"/>
+    <rect x="24" y="54" width="72" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="24" y="60" width="72" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="24" y="66" width="52" height="3" rx="1.5" fill="#e2e8f0"/>
+  </svg>
+<% when "centered" %>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Centered brand layout">
+    <rect x="0" y="0" width="24" height="4" fill="#4e8324"/>
+    <rect x="24" y="0" width="24" height="4" fill="#d56027"/>
+    <rect x="48" y="0" width="24" height="4" fill="#e0b528"/>
+    <rect x="72" y="0" width="24" height="4" fill="#9b2c5e"/>
+    <rect x="96" y="0" width="24" height="4" fill="#24479e"/>
+    <rect x="34" y="12" width="52" height="16" rx="2" fill="#fcfaeb"/>
+    <rect x="38" y="14" width="44" height="12" rx="1" fill="#e2e8f0"/>
+    <rect x="40" y="34" width="40" height="4" rx="2" fill="#253f7b"/>
+    <rect x="48" y="42" width="24" height="3" rx="1.5" fill="#cbd5e1"/>
+    <rect x="50" y="49" width="20" height="6" rx="3" fill="#ffcb05"/>
+    <rect x="30" y="61" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="30" y="67" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+  </svg>
+<% when "editorial" %>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200" role="img" aria-label="Cream editorial layout">
+    <rect width="120" height="80" fill="#fcfaeb"/>
+    <rect x="30" y="8" width="60" height="16" rx="2" fill="#ffffff" stroke="#e2e8f0"/>
+    <rect x="34" y="10" width="52" height="12" rx="1" fill="#e2e8f0"/>
+    <rect x="42" y="28" width="36" height="4" rx="2" fill="#253f7b"/>
+    <rect x="48" y="35" width="24" height="2.5" rx="1" fill="#cbd5e1"/>
+    <rect x="24" y="42" width="72" height="32" rx="3" fill="#ffffff" stroke="#e2e8f0"/>
+    <rect x="30" y="48" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="30" y="54" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="30" y="60" width="44" height="3" rx="1.5" fill="#e2e8f0"/>
+  </svg>
+<% when "sidebar" %>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Details sidebar layout">
+    <rect x="12" y="8" width="96" height="16" rx="2" fill="#e2e8f0"/>
+    <rect x="12" y="30" width="40" height="4" rx="2" fill="#253f7b"/>
+    <rect x="12" y="38" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="12" y="44" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="12" y="50" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="12" y="56" width="48" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="80" y="30" width="28" height="40" rx="3" fill="#ffffff" stroke="#24479e"/>
+    <rect x="84" y="35" width="20" height="3" rx="1.5" fill="#cbd5e1"/>
+    <rect x="84" y="41" width="20" height="3" rx="1.5" fill="#cbd5e1"/>
+    <rect x="84" y="52" width="20" height="6" rx="3" fill="#ffcb05"/>
+  </svg>
+<% when "hero" %>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Navy hero layout">
+    <rect x="0" y="0" width="120" height="40" fill="#24479e"/>
+    <rect x="10" y="10" width="30" height="4" rx="2" fill="#ffcb05"/>
+    <rect x="10" y="18" width="40" height="4" rx="2" fill="#ffffff"/>
+    <rect x="10" y="26" width="24" height="3" rx="1.5" fill="#a8c1f4"/>
+    <rect x="70" y="8" width="40" height="24" rx="2" fill="#ffffff"/>
+    <rect x="73" y="11" width="34" height="18" rx="1" fill="#cbd5e1"/>
+    <rect x="20" y="50" width="80" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="20" y="56" width="80" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="20" y="62" width="56" height="3" rx="1.5" fill="#e2e8f0"/>
+  </svg>
+<% end %>

--- a/app/views/events/_template_wireframe.html.erb
+++ b/app/views/events/_template_wireframe.html.erb
@@ -2,62 +2,59 @@
     illustrative graphics (not domain theming), so the brand hexes are inline. %>
 <% case key %>
 <% when "none" %>
-  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Plain centered layout">
-    <rect x="30" y="10" width="60" height="18" rx="2" fill="#e2e8f0"/>
-    <rect x="38" y="34" width="44" height="4" rx="2" fill="#94a3b8"/>
-    <rect x="46" y="42" width="28" height="3" rx="1.5" fill="#cbd5e1"/>
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Plain full-width layout">
+    <rect x="8" y="8" width="104" height="22" rx="2" fill="#cbd5e1"/>
+    <rect x="38" y="36" width="44" height="4" rx="2" fill="#94a3b8"/>
+    <rect x="46" y="44" width="28" height="3" rx="1.5" fill="#cbd5e1"/>
     <rect x="24" y="54" width="72" height="3" rx="1.5" fill="#e2e8f0"/>
     <rect x="24" y="60" width="72" height="3" rx="1.5" fill="#e2e8f0"/>
     <rect x="24" y="66" width="52" height="3" rx="1.5" fill="#e2e8f0"/>
   </svg>
 <% when "centered" %>
-  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Centered brand layout">
+  <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Centered layout">
     <rect x="0" y="0" width="24" height="4" fill="#4e8324"/>
     <rect x="24" y="0" width="24" height="4" fill="#d56027"/>
     <rect x="48" y="0" width="24" height="4" fill="#e0b528"/>
     <rect x="72" y="0" width="24" height="4" fill="#9b2c5e"/>
     <rect x="96" y="0" width="24" height="4" fill="#24479e"/>
-    <rect x="34" y="12" width="52" height="16" rx="2" fill="#fcfaeb"/>
-    <rect x="38" y="14" width="44" height="12" rx="1" fill="#e2e8f0"/>
-    <rect x="40" y="34" width="40" height="4" rx="2" fill="#253f7b"/>
-    <rect x="48" y="42" width="24" height="3" rx="1.5" fill="#cbd5e1"/>
-    <rect x="50" y="49" width="20" height="6" rx="3" fill="#ffcb05"/>
-    <rect x="30" y="61" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="30" y="67" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="8" y="9" width="104" height="26" rx="2" fill="#cbd5e1"/>
+    <rect x="8" y="40" width="104" height="34" rx="3" fill="#fcfaeb"/>
+    <rect x="42" y="47" width="36" height="4" rx="2" fill="#253f7b"/>
+    <rect x="48" y="55" width="24" height="3" rx="1.5" fill="#cbd5e1"/>
+    <rect x="50" y="62" width="20" height="6" rx="3" fill="#ffcb05"/>
   </svg>
 <% when "editorial" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200" role="img" aria-label="Cream editorial layout">
     <rect width="120" height="80" fill="#fcfaeb"/>
-    <rect x="30" y="8" width="60" height="16" rx="2" fill="#ffffff" stroke="#e2e8f0"/>
-    <rect x="34" y="10" width="52" height="12" rx="1" fill="#e2e8f0"/>
-    <rect x="42" y="28" width="36" height="4" rx="2" fill="#253f7b"/>
-    <rect x="48" y="35" width="24" height="2.5" rx="1" fill="#cbd5e1"/>
-    <rect x="24" y="42" width="72" height="32" rx="3" fill="#ffffff" stroke="#e2e8f0"/>
-    <rect x="30" y="48" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="8" y="8" width="104" height="22" rx="2" fill="#ffffff" stroke="#e2e8f0"/>
+    <rect x="10" y="10" width="100" height="18" rx="1" fill="#cbd5e1"/>
+    <rect x="42" y="35" width="36" height="4" rx="2" fill="#253f7b"/>
+    <rect x="48" y="42" width="24" height="2.5" rx="1" fill="#94a3b8"/>
+    <rect x="24" y="48" width="72" height="26" rx="3" fill="#ffffff" stroke="#e2e8f0"/>
     <rect x="30" y="54" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="30" y="60" width="44" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="30" y="60" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="30" y="66" width="44" height="3" rx="1.5" fill="#e2e8f0"/>
   </svg>
 <% when "sidebar" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Details sidebar layout">
-    <rect x="12" y="8" width="96" height="16" rx="2" fill="#e2e8f0"/>
-    <rect x="12" y="30" width="40" height="4" rx="2" fill="#253f7b"/>
-    <rect x="12" y="38" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="12" y="44" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="12" y="50" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="12" y="56" width="48" height="3" rx="1.5" fill="#e2e8f0"/>
-    <rect x="80" y="30" width="28" height="40" rx="3" fill="#ffffff" stroke="#24479e"/>
-    <rect x="84" y="35" width="20" height="3" rx="1.5" fill="#cbd5e1"/>
-    <rect x="84" y="41" width="20" height="3" rx="1.5" fill="#cbd5e1"/>
-    <rect x="84" y="52" width="20" height="6" rx="3" fill="#ffcb05"/>
+    <rect x="8" y="8" width="104" height="20" rx="2" fill="#cbd5e1"/>
+    <rect x="8" y="34" width="40" height="4" rx="2" fill="#253f7b"/>
+    <rect x="8" y="42" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="8" y="48" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="8" y="54" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="8" y="60" width="48" height="3" rx="1.5" fill="#e2e8f0"/>
+    <rect x="80" y="34" width="32" height="40" rx="3" fill="#fcfaeb" stroke="#24479e"/>
+    <rect x="85" y="39" width="22" height="3" rx="1.5" fill="#94a3b8"/>
+    <rect x="85" y="45" width="22" height="3" rx="1.5" fill="#94a3b8"/>
+    <rect x="85" y="56" width="22" height="6" rx="3" fill="#ffcb05"/>
   </svg>
 <% when "hero" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Navy hero layout">
-    <rect x="0" y="0" width="120" height="40" fill="#24479e"/>
+    <rect x="0" y="0" width="120" height="42" fill="#24479e"/>
     <rect x="10" y="10" width="30" height="4" rx="2" fill="#ffcb05"/>
     <rect x="10" y="18" width="40" height="4" rx="2" fill="#ffffff"/>
     <rect x="10" y="26" width="24" height="3" rx="1.5" fill="#a8c1f4"/>
-    <rect x="70" y="8" width="40" height="24" rx="2" fill="#ffffff"/>
-    <rect x="73" y="11" width="34" height="18" rx="1" fill="#cbd5e1"/>
+    <rect x="70" y="9" width="40" height="24" rx="2" fill="#cbd5e1"/>
     <rect x="20" y="50" width="80" height="3" rx="1.5" fill="#e2e8f0"/>
     <rect x="20" y="56" width="80" height="3" rx="1.5" fill="#e2e8f0"/>
     <rect x="20" y="62" width="56" height="3" rx="1.5" fill="#e2e8f0"/>

--- a/app/views/events/_template_wireframe.html.erb
+++ b/app/views/events/_template_wireframe.html.erb
@@ -25,8 +25,13 @@
   </svg>
 <% when "editorial" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200" role="img" aria-label="Cream editorial layout">
-    <rect width="120" height="80" fill="#fcfaeb"/>
-    <rect x="8" y="8" width="104" height="22" rx="2" fill="#ffffff" stroke="#e2e8f0"/>
+    <rect y="4" width="120" height="76" fill="#fcfaeb"/>
+    <rect x="0" y="0" width="24" height="4" fill="#4e8324"/>
+    <rect x="24" y="0" width="24" height="4" fill="#d56027"/>
+    <rect x="48" y="0" width="24" height="4" fill="#e0b528"/>
+    <rect x="72" y="0" width="24" height="4" fill="#9b2c5e"/>
+    <rect x="96" y="0" width="24" height="4" fill="#24479e"/>
+    <rect x="8" y="9" width="104" height="21" rx="2" fill="#ffffff" stroke="#e2e8f0"/>
     <rect x="10" y="10" width="100" height="18" rx="1" fill="#cbd5e1"/>
     <rect x="42" y="35" width="36" height="4" rx="2" fill="#253f7b"/>
     <rect x="48" y="42" width="24" height="2.5" rx="1" fill="#94a3b8"/>
@@ -37,7 +42,12 @@
   </svg>
 <% when "sidebar" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Details sidebar layout">
-    <rect x="8" y="8" width="104" height="20" rx="2" fill="#cbd5e1"/>
+    <rect x="0" y="0" width="24" height="4" fill="#4e8324"/>
+    <rect x="24" y="0" width="24" height="4" fill="#d56027"/>
+    <rect x="48" y="0" width="24" height="4" fill="#e0b528"/>
+    <rect x="72" y="0" width="24" height="4" fill="#9b2c5e"/>
+    <rect x="96" y="0" width="24" height="4" fill="#24479e"/>
+    <rect x="8" y="10" width="104" height="18" rx="2" fill="#cbd5e1"/>
     <rect x="8" y="34" width="40" height="4" rx="2" fill="#253f7b"/>
     <rect x="8" y="42" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
     <rect x="8" y="48" width="60" height="3" rx="1.5" fill="#e2e8f0"/>
@@ -50,7 +60,12 @@
   </svg>
 <% when "hero" %>
   <svg viewBox="0 0 120 80" class="w-full rounded border border-gray-200 bg-white" role="img" aria-label="Navy hero layout">
-    <rect x="0" y="0" width="120" height="42" fill="#24479e"/>
+    <rect x="0" y="4" width="120" height="38" fill="#24479e"/>
+    <rect x="0" y="0" width="24" height="4" fill="#4e8324"/>
+    <rect x="24" y="0" width="24" height="4" fill="#d56027"/>
+    <rect x="48" y="0" width="24" height="4" fill="#e0b528"/>
+    <rect x="72" y="0" width="24" height="4" fill="#9b2c5e"/>
+    <rect x="96" y="0" width="24" height="4" fill="#24479e"/>
     <rect x="10" y="10" width="30" height="4" rx="2" fill="#ffcb05"/>
     <rect x="10" y="18" width="40" height="4" rx="2" fill="#ffffff"/>
     <rect x="10" y="26" width="24" height="3" rx="1.5" fill="#a8c1f4"/>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
+<% content_for(:page_bg_class, "admin-or-owner-or-public-or-authpublished") %>
 <%# Full width so each display template controls its own measure and can run its
     background edge-to-edge (navy hero, cream editorial). The admin nav row and
     preview banners below restore a standard container. %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,6 +14,16 @@
 <% end %>
 
 <div class="mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">
+  <% if params[:template].present? && allowed_to?(:edit?, @event) %>
+    <div class="border-brand-navy-200 bg-brand-navy-50 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
+      <span class="text-brand-navy-800 text-sm">
+        Previewing the <span class="font-semibold"><%= Event::TEMPLATES.dig(@event.template, :label) %></span> template — not yet saved.
+      </span>
+      <%= link_to "Apply & edit", edit_event_path(@event, template: @event.template),
+                  class: "rounded-md bg-brand-navy-800 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-navy-900" %>
+    </div>
+  <% end %>
+
   <% if @preview %>
     <div class="mb-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
       <span><span class="font-medium">Preview</span> — unsaved changes</span>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,8 @@
 <% content_for(:page_bg_class, "admin-or-public-or-authpublished") %>
+<%# Full width so each display template controls its own measure and can run its
+    background edge-to-edge (navy hero, cream editorial). The admin nav row and
+    preview banners below restore a standard container. %>
+<% content_for(:full_width, true) %>
 
 <% content_for :head do %>
   <%= @event.ga4_snippet&.html_safe %>
@@ -9,128 +13,44 @@
   <%= @event.gtm_body_snippet&.html_safe %>
 <% end %>
 
-<% if @preview %>
-  <div class="mb-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
-    <span><span class="font-medium">Preview</span> — unsaved changes</span>
-    <button onclick="window.close()" class="<%= button_classes(:secondary_outline, size: :sm) %>">Close preview</button>
-  </div>
-<% else %>
-<!-- Top Right Actions -->
-<div class="mb-4 flex flex-wrap items-center gap-2">
-  <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-  <div class="ml-auto flex flex-wrap gap-1">
-  <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-  <% if @event.event_registrations.active.exists? %>
-    <%= link_to "Meet the staff", staff_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-  <% end %>
-  <% if allowed_to?(:dashboard?, @event) %>
-    <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
-  <% end %>
-  <% if allowed_to?(:manage?, @event) %>
-    <%= link_to "Registrations", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
-  <% end %>
-  <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
-  </div>
-</div>
-<% end %>
-
-<%# ---- SOCIAL SHARE SIDEBAR ---- %>
-<%= render "events/social_share_sidebar", share_url: event_url(@event), share_title: @event.title %>
-
-<%# ---- HEADER CONTENT ---- %>
-<% if @event.rhino_header.present? %>
-  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
-    <%= @event.rhino_header %>
-  </div>
-<% end %>
-
-<%# ---- TITLE ---- %>
-<% if @event.autoshow_title %>
-  <div class="mx-auto mb-4 max-w-2xl text-center">
-    <% if @event.pre_title.present? %>
-      <p class="mb-2 font-telefon text-base font-semibold text-gray-700" style="font-size: 42px"><%= @event.pre_title %></p>
-    <% end %>
-    <h1 class="text-primary font-display" style="font-size: 53px"><%= @event.title %></h1>
-  </div>
-<% end %>
-
-<%# ---- EVENT DETAILS (conditional on autoshow) ---- %>
-<div class="mb-4 space-y-2 text-center">
-  <% if @event.autoshow_pre_date_text && @event.pre_date_text.present? %>
-    <div class="text-primary font-bold uppercase" style="font-size: 24px"><%= @event.pre_date_text %></div>
-  <% end %>
-
-  <% if @event.autoshow_date || @event.autoshow_time %>
-    <%# Date is the headline (upper-cased, no weekday, includes the year); the
-        time sits smaller below in natural case so am/pm read lowercase. %>
-    <div>
-      <% if @event.autoshow_date %>
-        <div class="text-primary font-bold uppercase" style="font-size: 35px">
-          <%= event_dates_label(@event) %>
-        </div>
-      <% end %>
-      <% if @event.autoshow_time %>
-        <div class="text-primary mt-2 font-bold" style="font-size: 24px">
-          <%= event_times_label(@event) %>
-        </div>
-      <% end %>
+<div class="mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">
+  <% if @preview %>
+    <div class="mb-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
+      <span><span class="font-medium">Preview</span> — unsaved changes</span>
+      <button onclick="window.close()" class="<%= button_classes(:secondary_outline, size: :sm) %>">Close preview</button>
     </div>
-  <% end %>
-
-  <% if @event.autoshow_cost && @event.labelled_cost %>
-    <div class="text-primary text-xl font-bold uppercase"><%= @event.labelled_cost %></div>
-  <% end %>
-
-  <% if @event.autoshow_location && @event.location.present? %>
-    <div class="text-base text-gray-700"><%= @event.location.name %></div>
-  <% end %>
-
-  <% if @event.autoshow_videoconference_label && @event.videoconference_label.present? %>
-    <div class="text-base text-gray-700"><%= @event.videoconference_label %></div>
-  <% end %>
-
-  <%= render "events/videoconference_link", event: @event %>
-
-  <% unless current_user && @event.actively_registered?(current_user.person) %>
-    <% if @event.autoshow_registration_close && @event.registration_close_date %>
-      <div class="text-base text-gray-700">
-        <% tz_abbr = @event.start_date.in_time_zone(Time.zone).strftime("%Z") %>
-        Registration closes <%= @event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %l:%M %P") %> <%= tz_abbr %>
+  <% else %>
+    <!-- Top Right Actions -->
+    <div class="mb-4 flex flex-wrap items-center gap-2">
+      <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <div class="ml-auto flex flex-wrap gap-1">
+        <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% if @event.event_registrations.active.exists? %>
+          <%= link_to "Meet the staff", staff_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:dashboard?, @event) %>
+          <%= link_to "Dashboard", dashboard_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
+        <% end %>
+        <% if allowed_to?(:manage?, @event) %>
+          <%= link_to "Registrations", registrants_event_path(@event), class: "text-sm #{eyebrow_link_class} px-2 py-1 admin-only bg-blue-100" %>
+        <% end %>
+        <span class="inline-block text-sm"><%= render "bookmarks/editable_bookmark_button", resource: @event.object %></span>
       </div>
-    <% end %>
-  <% end %>
-
-  <% if @event.autoshow_registration %>
-    <div class="mt-4">
-      <%= render "events/registration_section", event: @event, instance: 1, button_text: "Register" %>
     </div>
   <% end %>
 
-  <% if @event.bulk_payment_form %>
-    <div class="mt-4">
-      <%= link_to Form::BULK_PAYMENT_PUBLIC_NAME,
-                  new_event_bulk_payment_path(@event),
-                  class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
-                  style: "font-family: 'Telefon Bold', sans-serif;" %>
-    </div>
-  <% end %>
+  <%# ---- SOCIAL SHARE SIDEBAR ---- %>
+  <%= render "events/social_share_sidebar", share_url: event_url(@event), share_title: @event.title %>
 </div>
 
-<%# ---- DESCRIPTION ---- %>
-<% if @event.rhino_description.present? %>
-  <div class="mb-12 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
-    <%= @event.rhino_description %>
-  </div>
-<% end %>
-
-<%# ---- GALLERY IMAGES ---- %>
-<div class="mb-12">
-  <%= render "assets/display_gallery_media", resource: @event, link: true %>
-</div>
+<%# ---- DISPLAY TEMPLATE ---- (frames the admin-curated content; honors autoshow_*) %>
+<%= render "events/templates/#{@event.template}", event: @event, sample: false %>
 
 <% if @preview %>
-  <div class="mt-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
-    <span><span class="font-medium">Preview</span> — unsaved changes</span>
-    <button onclick="window.close()" class="<%= button_classes(:secondary_outline, size: :sm) %>">Close preview</button>
+  <div class="mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">
+    <div class="mt-4 flex items-center justify-between rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
+      <span><span class="font-medium">Preview</span> — unsaved changes</span>
+      <button onclick="window.close()" class="<%= button_classes(:secondary_outline, size: :sm) %>">Close preview</button>
+    </div>
   </div>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,7 +19,7 @@
       <span class="text-brand-navy-800 text-sm">
         Previewing the <span class="font-semibold"><%= Event::TEMPLATES.dig(@event.template, :label) %></span> template — not yet saved.
       </span>
-      <%= link_to "Apply & edit", edit_event_path(@event, template: @event.template),
+      <%= link_to "Apply & edit", edit_event_path(@event, template: @event.template, section: "page_content", anchor: "page_content_button"),
                   class: "rounded-md bg-brand-navy-800 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-navy-900" %>
     </div>
   <% end %>

--- a/app/views/events/show/_actions.html.erb
+++ b/app/views/events/show/_actions.html.erb
@@ -5,7 +5,7 @@
     registration_section dom_ids. %>
 <% if local_assigns.fetch(:sample, false) %>
   <div class="flex flex-col items-center gap-2">
-    <span class="bg-brand-yellow-400 text-brand-navy-950 rounded-full px-8 py-3 font-semibold shadow-sm">Register</span>
+    <span class="<%= brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>">Register</span>
     <span class="text-xs text-gray-500 italic">Sample preview</span>
   </div>
 <% else %>

--- a/app/views/events/show/_actions.html.erb
+++ b/app/views/events/show/_actions.html.erb
@@ -5,7 +5,7 @@
     registration_section dom_ids. %>
 <% if local_assigns.fetch(:sample, false) %>
   <div class="flex flex-col items-center gap-2">
-    <span class="rounded-full bg-brand-yellow-400 px-8 py-3 font-semibold text-brand-navy-950 shadow-sm">Register</span>
+    <span class="bg-brand-yellow-400 text-brand-navy-950 rounded-full px-8 py-3 font-semibold shadow-sm">Register</span>
     <span class="text-xs text-gray-500 italic">Sample preview</span>
   </div>
 <% else %>

--- a/app/views/events/show/_actions.html.erb
+++ b/app/views/events/show/_actions.html.erb
@@ -1,0 +1,26 @@
+<%# Registration + payment actions. Real events reuse the existing
+    registration_section (ended/closed/register/view-ticket + calendar links) and
+    bulk-payment button. In sample mode (the templates gallery) a static button
+    stands in, so the read-only preview never builds live routes or duplicate
+    registration_section dom_ids. %>
+<% if local_assigns.fetch(:sample, false) %>
+  <div class="flex flex-col items-center gap-2">
+    <span class="rounded-full bg-brand-yellow-400 px-8 py-3 font-semibold text-brand-navy-950 shadow-sm">Register</span>
+    <span class="text-xs text-gray-500 italic">Sample preview</span>
+  </div>
+<% else %>
+  <%= render "events/videoconference_link", event: event %>
+
+  <% if event.autoshow_registration %>
+    <%= render "events/registration_section", event: event, instance: local_assigns.fetch(:instance, 1), button_text: "Register" %>
+  <% end %>
+
+  <% if event.bulk_payment_form %>
+    <div class="mt-4 flex justify-center">
+      <%= link_to Form::BULK_PAYMENT_PUBLIC_NAME,
+                  new_event_bulk_payment_path(event),
+                  class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
+                  style: "font-family: 'Telefon Bold', sans-serif;" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/events/show/_actions.html.erb
+++ b/app/views/events/show/_actions.html.erb
@@ -19,7 +19,7 @@
     <div class="mt-4 flex justify-center">
       <%= link_to Form::BULK_PAYMENT_PUBLIC_NAME,
                   new_event_bulk_payment_path(event),
-                  class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
+                  class: button_classes(:secondary_outline, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
                   style: "font-family: 'Telefon Bold', sans-serif;" %>
     </div>
   <% end %>

--- a/app/views/events/show/_description.html.erb
+++ b/app/views/events/show/_description.html.erb
@@ -2,14 +2,8 @@
     so whatever headings / lists / quotes / images / links the admin writes come
     out on-brand. The calling template sets width via prose_extra. %>
 <% if event.rhino_description.present? %>
-  <div class="prose prose-slate prose-lg max-w-none <%= local_assigns.fetch(:prose_extra, "") %>
-              prose-headings:font-display prose-headings:font-semibold prose-headings:text-brand-navy-900
-              prose-h2:text-2xl prose-h3:text-xl
-              prose-a:text-brand-navy-700 prose-a:font-semibold hover:prose-a:text-brand-magenta-700
-              prose-blockquote:border-l-4 prose-blockquote:border-brand-magenta-400 prose-blockquote:bg-brand-cream
-              prose-blockquote:not-italic prose-blockquote:rounded-r-lg prose-blockquote:font-display prose-blockquote:text-brand-navy-900
-              prose-li:marker:text-brand-yellow-500
-              prose-img:w-full prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+  <div class="prose-slate max-w-none prose prose-lg <%= local_assigns.fetch(:prose_extra, "") %>
+              prose-headings:text-brand-navy-900 prose-a:text-brand-navy-700 hover:prose-a:text-brand-magenta-700 prose-blockquote:border-brand-magenta-400 prose-blockquote:bg-brand-cream prose-blockquote:text-brand-navy-900 prose-li:marker:text-brand-yellow-500 prose-img:w-full prose-img:max-w-full prose-img:rounded-xl prose-blockquote:rounded-r-lg prose-blockquote:border-l-4 prose-blockquote:font-display prose-headings:font-display prose-h2:text-2xl prose-h3:text-xl prose-a:font-semibold prose-headings:font-semibold prose-em:text-inherit prose-strong:text-inherit prose-blockquote:not-italic">
     <%= event.rhino_description %>
   </div>
 <% end %>

--- a/app/views/events/show/_description.html.erb
+++ b/app/views/events/show/_description.html.erb
@@ -1,0 +1,19 @@
+<%# Admin-authored body (Rhino WYSIWYG) + gallery, under the branded prose theme
+    so whatever headings / lists / quotes / images / links the admin writes come
+    out on-brand. The calling template sets width via prose_extra. %>
+<% if event.rhino_description.present? %>
+  <div class="prose prose-slate prose-lg max-w-none <%= local_assigns.fetch(:prose_extra, "") %>
+              prose-headings:font-display prose-headings:font-semibold prose-headings:text-brand-navy-900
+              prose-h2:text-2xl prose-h3:text-xl
+              prose-a:text-brand-navy-700 prose-a:font-semibold hover:prose-a:text-brand-magenta-700
+              prose-blockquote:border-l-4 prose-blockquote:border-brand-magenta-400 prose-blockquote:bg-brand-cream
+              prose-blockquote:not-italic prose-blockquote:rounded-r-lg prose-blockquote:font-display prose-blockquote:text-brand-navy-900
+              prose-li:marker:text-brand-yellow-500
+              prose-img:w-full prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+    <%= event.rhino_description %>
+  </div>
+<% end %>
+
+<div class="mt-10">
+  <%= render "assets/display_gallery_media", resource: event, link: true %>
+</div>

--- a/app/views/events/show/_details.html.erb
+++ b/app/views/events/show/_details.html.erb
@@ -29,12 +29,9 @@
 <% if variant == "rail" %>
   <div class="divide-y divide-brand-navy-100">
     <% rows.each do |row| %>
-      <div class="flex items-start gap-3 py-2.5">
-        <i class="fa-solid <%= row[:icon] %> mt-1 text-brand-navy-400" aria-hidden="true"></i>
-        <div>
-          <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= row[:label] %></div>
-          <div class="font-semibold text-brand-navy-900"><%= row[:value] %></div>
-        </div>
+      <div class="py-2.5">
+        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= row[:label] %></div>
+        <div class="font-semibold text-brand-navy-900"><%= row[:value] %></div>
       </div>
     <% end %>
   </div>

--- a/app/views/events/show/_details.html.erb
+++ b/app/views/events/show/_details.html.erb
@@ -52,11 +52,18 @@
 
 <% else %>
   <% chip_class = variant == "chips_navy" ? "bg-white/10 text-white" : "border border-brand-navy-200 bg-white text-brand-navy-800" %>
-  <div class="flex flex-wrap <%= "justify-center" unless variant == "chips_navy" && local_assigns[:align] == "start" %> gap-2">
-    <% rows.each do |row| %>
-      <span class="rounded-full px-4 py-1.5 text-sm font-medium <%= chip_class %>"><%= row[:value] %></span>
-    <% end %>
-  </div>
+  <% justify = "justify-center" unless variant == "chips_navy" && local_assigns[:align] == "start" %>
+  <%# Two rows: "when" (date/time) then "where + cost", so cost sits with the
+      format/location chip on its own line instead of orphaning it. %>
+  <% when_rows = rows.select { |row| %w[Date Time].include?(row[:label]) } %>
+  <% where_rows = rows - when_rows %>
+  <% [ when_rows, where_rows ].reject(&:empty?).each_with_index do |group, i| %>
+    <div class="flex flex-wrap <%= justify %> gap-2 <%= "mt-2" if i.positive? %>">
+      <% group.each do |row| %>
+        <span class="rounded-full px-4 py-1.5 text-sm font-medium <%= chip_class %>"><%= row[:value] %></span>
+      <% end %>
+    </div>
+  <% end %>
   <% if close_text %>
     <p class="mt-3 text-sm <%= variant == "chips_navy" ? "text-brand-navy-100" : "text-gray-500" %>"><%= close_text %></p>
   <% end %>

--- a/app/views/events/show/_details.html.erb
+++ b/app/views/events/show/_details.html.erb
@@ -1,0 +1,68 @@
+<%# Structured event metadata, each row gated on its own autoshow_* toggle so the
+    admin's show/hide choices carry across every template. One source of truth for
+    that logic; the calling template picks a visual variant.
+    variant: chips (light pills) | chips_navy (pills on navy) | line (dot-separated) | rail (stacked rows) %>
+<%
+  variant = local_assigns.fetch(:variant, "chips")
+  rows = []
+  rows << { icon: "fa-calendar-day", label: "Date", value: event_dates_label(event) } if event.autoshow_date && event_dates_label(event).present?
+  rows << { icon: "fa-clock", label: "Time", value: event_times_label(event) } if event.autoshow_time && event_times_label(event).present?
+  rows << { icon: "fa-ticket", label: "Cost", value: event_fee_label(event) } if event.autoshow_cost && event_fee_label(event).present?
+  rows << { icon: "fa-video", label: "Format", value: event.videoconference_label } if event.autoshow_videoconference_label && event.videoconference_label.present?
+  rows << { icon: "fa-location-dot", label: "Location", value: event.location.name } if event.autoshow_location && event.location&.name.present?
+
+  registered = current_user && event.actively_registered?(current_user.person)
+  show_close = event.autoshow_registration_close && event.registration_close_date && !registered
+  close_text = if show_close
+    tz = event.start_date.in_time_zone(Time.zone).strftime("%Z")
+    "Registration closes #{event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %l:%M %P")} #{tz}"
+  end
+%>
+
+<% if event.autoshow_pre_date_text && event.pre_date_text.present? %>
+  <p class="<%= { "chips" => "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-orange-600",
+                  "chips_navy" => "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-yellow-400",
+                  "line" => "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-orange-600",
+                  "rail" => "mb-3 text-xs font-bold uppercase tracking-wide text-brand-orange-600" }[variant] %>"><%= event.pre_date_text %></p>
+<% end %>
+
+<% if variant == "rail" %>
+  <div class="divide-y divide-brand-navy-100">
+    <% rows.each do |row| %>
+      <div class="flex items-start gap-3 py-2.5">
+        <i class="fa-solid <%= row[:icon] %> mt-1 text-brand-navy-400" aria-hidden="true"></i>
+        <div>
+          <div class="text-xs font-semibold uppercase tracking-wide text-gray-500"><%= row[:label] %></div>
+          <div class="font-semibold text-brand-navy-900"><%= row[:value] %></div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <% if close_text %>
+    <p class="mt-3 text-xs text-gray-500"><%= close_text %></p>
+  <% end %>
+
+<% elsif variant == "line" %>
+  <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-brand-navy-800">
+    <% rows.each_with_index do |row, i| %>
+      <% if i.positive? %><span class="text-brand-navy-300" aria-hidden="true">&bull;</span><% end %>
+      <span class="inline-flex items-center gap-1.5"><i class="fa-solid <%= row[:icon] %> text-brand-navy-400" aria-hidden="true"></i><%= row[:value] %></span>
+    <% end %>
+  </div>
+  <% if close_text %>
+    <p class="mt-2 text-sm text-gray-500"><%= close_text %></p>
+  <% end %>
+
+<% else %>
+  <% chip_class = variant == "chips_navy" ? "bg-white/10 text-white" : "border border-brand-navy-200 bg-white text-brand-navy-800" %>
+  <div class="flex flex-wrap <%= "justify-center" unless variant == "chips_navy" && local_assigns[:align] == "start" %> gap-2">
+    <% rows.each do |row| %>
+      <span class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium <%= chip_class %>">
+        <i class="fa-solid <%= row[:icon] %>" aria-hidden="true"></i><%= row[:value] %>
+      </span>
+    <% end %>
+  </div>
+  <% if close_text %>
+    <p class="mt-3 text-sm <%= variant == "chips_navy" ? "text-brand-navy-100" : "text-gray-500" %>"><%= close_text %></p>
+  <% end %>
+<% end %>

--- a/app/views/events/show/_details.html.erb
+++ b/app/views/events/show/_details.html.erb
@@ -5,11 +5,11 @@
 <%
   variant = local_assigns.fetch(:variant, "chips")
   rows = []
-  rows << { icon: "fa-calendar-day", label: "Date", value: event_dates_label(event) } if event.autoshow_date && event_dates_label(event).present?
-  rows << { icon: "fa-clock", label: "Time", value: event_times_label(event) } if event.autoshow_time && event_times_label(event).present?
-  rows << { icon: "fa-ticket", label: "Cost", value: event_fee_label(event) } if event.autoshow_cost && event_fee_label(event).present?
-  rows << { icon: "fa-video", label: "Format", value: event.videoconference_label } if event.autoshow_videoconference_label && event.videoconference_label.present?
-  rows << { icon: "fa-location-dot", label: "Location", value: event.location.name } if event.autoshow_location && event.location&.name.present?
+  rows << { label: "Date", value: event_dates_label(event) } if event.autoshow_date && event_dates_label(event).present?
+  rows << { label: "Time", value: event_times_label(event) } if event.autoshow_time && event_times_label(event).present?
+  rows << { label: "Cost", value: event_fee_label(event) } if event.autoshow_cost && event_fee_label(event).present?
+  rows << { label: "Format", value: event.videoconference_label } if event.autoshow_videoconference_label && event.videoconference_label.present?
+  rows << { label: "Location", value: event.location.name } if event.autoshow_location && event.location&.name.present?
 
   registered = current_user && event.actively_registered?(current_user.person)
   show_close = event.autoshow_registration_close && event.registration_close_date && !registered
@@ -43,7 +43,7 @@
   <div class="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-brand-navy-800">
     <% rows.each_with_index do |row, i| %>
       <% if i.positive? %><span class="text-brand-navy-300" aria-hidden="true">&bull;</span><% end %>
-      <span class="inline-flex items-center gap-1.5"><i class="fa-solid <%= row[:icon] %> text-brand-navy-400" aria-hidden="true"></i><%= row[:value] %></span>
+      <span><%= row[:value] %></span>
     <% end %>
   </div>
   <% if close_text %>
@@ -54,9 +54,7 @@
   <% chip_class = variant == "chips_navy" ? "bg-white/10 text-white" : "border border-brand-navy-200 bg-white text-brand-navy-800" %>
   <div class="flex flex-wrap <%= "justify-center" unless variant == "chips_navy" && local_assigns[:align] == "start" %> gap-2">
     <% rows.each do |row| %>
-      <span class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium <%= chip_class %>">
-        <i class="fa-solid <%= row[:icon] %>" aria-hidden="true"></i><%= row[:value] %>
-      </span>
+      <span class="rounded-full px-4 py-1.5 text-sm font-medium <%= chip_class %>"><%= row[:value] %></span>
     <% end %>
   </div>
   <% if close_text %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -1,0 +1,7 @@
+<%# Admin-uploaded header content (usually a banner image). Rendered as-authored;
+    the template frames it. Shared by every branded template. %>
+<% if event.rhino_header.present? %>
+  <div class="rhino-centered max-w-none prose prose-img:w-full prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+    <%= event.rhino_header %>
+  </div>
+<% end %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -1,14 +1,19 @@
 <%# Admin-uploaded header content (usually a banner image).
-    Default: rendered as-authored, images capped to a banner height and centered
-    so a large or square image can't swallow the page.
-    fill: true (navy hero) — the image covers its frame edge-to-edge, no mat. %>
+    Default: rendered as-authored, images capped to a banner height and centered.
+    fill "cover" (navy hero) — image covers its frame edge-to-edge (crops).
+    fill "width" (details sidebar) — image spans full width at its natural aspect. %>
+<% fill = local_assigns.fetch(:fill, false) %>
 <% if event.rhino_header.present? %>
-  <% if local_assigns.fetch(:fill, false) %>
+  <% if fill == "cover" %>
     <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
       <%= event.rhino_header %>
     </div>
+  <% elsif fill == "width" %>
+    <div class="[&_img]:block [&_img]:w-full">
+      <%= event.rhino_header %>
+    </div>
   <% else %>
-    <div class="rhino-centered prose max-w-none prose-img:mx-auto prose-img:max-h-80 prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+    <div class="rhino-centered max-w-none prose prose-img:mx-auto prose-img:max-h-80 prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
       <%= event.rhino_header %>
     </div>
   <% end %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -1,15 +1,11 @@
 <%# Admin-uploaded header content (usually a banner image).
     Default: rendered as-authored, images capped to a banner height and centered.
-    fill "cover" (navy hero) — image covers its frame edge-to-edge (crops).
-    fill "width" (details sidebar) — image spans full width at its natural aspect. %>
+    fill "cover": the image covers its frame edge-to-edge — used by the branded
+    templates inside a fixed-aspect, rounded, overflow-hidden frame. %>
 <% fill = local_assigns.fetch(:fill, false) %>
 <% if event.rhino_header.present? %>
   <% if fill == "cover" %>
     <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
-      <%= event.rhino_header %>
-    </div>
-  <% elsif fill == "width" %>
-    <div class="[&_img]:block [&_img]:w-full">
       <%= event.rhino_header %>
     </div>
   <% else %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -1,7 +1,9 @@
-<%# Admin-uploaded header content (usually a banner image). Rendered as-authored;
-    the template frames it. Shared by every branded template. %>
+<%# Admin-uploaded header content (usually a banner image). Rendered as-authored,
+    but images are capped to a banner height and centered so a large or square
+    image can't swallow the whole page — applies to the live page and the gallery
+    preview alike. %>
 <% if event.rhino_header.present? %>
-  <div class="rhino-centered max-w-none prose prose-img:w-full prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+  <div class="rhino-centered prose max-w-none prose-img:mx-auto prose-img:max-h-80 prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
     <%= event.rhino_header %>
   </div>
 <% end %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -5,7 +5,10 @@
 <% fill = local_assigns.fetch(:fill, false) %>
 <% if event.rhino_header.present? %>
   <% if fill == "cover" %>
-    <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
+    <%# Round the <img> itself, not just an overflow-hidden frame: overflow
+        clipping can fail to round the top corners, so the image carries its own
+        radius. %>
+    <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:rounded-2xl [&_img]:object-cover">
       <%= event.rhino_header %>
     </div>
   <% else %>

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -1,9 +1,15 @@
-<%# Admin-uploaded header content (usually a banner image). Rendered as-authored,
-    but images are capped to a banner height and centered so a large or square
-    image can't swallow the whole page — applies to the live page and the gallery
-    preview alike. %>
+<%# Admin-uploaded header content (usually a banner image).
+    Default: rendered as-authored, images capped to a banner height and centered
+    so a large or square image can't swallow the page.
+    fill: true (navy hero) — the image covers its frame edge-to-edge, no mat. %>
 <% if event.rhino_header.present? %>
-  <div class="rhino-centered prose max-w-none prose-img:mx-auto prose-img:max-h-80 prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
-    <%= event.rhino_header %>
-  </div>
+  <% if local_assigns.fetch(:fill, false) %>
+    <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
+      <%= event.rhino_header %>
+    </div>
+  <% else %>
+    <div class="rhino-centered prose max-w-none prose-img:mx-auto prose-img:max-h-80 prose-img:max-w-full prose-img:rounded-xl prose-em:text-inherit prose-strong:text-inherit">
+      <%= event.rhino_header %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/events/show/_rainbow.html.erb
+++ b/app/views/events/show/_rainbow.html.erb
@@ -1,0 +1,2 @@
+<%# The AWBW brand rainbow accent strip (matches the marketing site + story-share footer). %>
+<div class="h-1.5 w-full" style="background:linear-gradient(to right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)"></div>

--- a/app/views/events/show/_title.html.erb
+++ b/app/views/events/show/_title.html.erb
@@ -1,0 +1,10 @@
+<%# Event title + optional pre-title, gated on autoshow_title. Presentation
+    classes come from the calling template so each frame controls size/colour. %>
+<% if event.autoshow_title %>
+  <div class="<%= local_assigns.fetch(:wrapper_class, "") %>">
+    <% if event.pre_title.present? %>
+      <p class="<%= local_assigns.fetch(:pretitle_class, "mb-2 text-sm font-semibold uppercase tracking-widest text-brand-orange-600") %>"><%= event.pre_title %></p>
+    <% end %>
+    <h1 class="<%= local_assigns.fetch(:heading_class, "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl") %>"><%= event.title %></h1>
+  </div>
+<% end %>

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -1,0 +1,25 @@
+<%# Centered — today's centred layout, brand-polished: rainbow accent, Fraunces
+    title, chip details, gold register button, readable-measure body. White page. %>
+<% sample = local_assigns.fetch(:sample, false) %>
+<%= render "events/show/rainbow" %>
+
+<div class="mx-auto max-w-4xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
+  <% if event.rhino_header.present? %>
+    <div class="rounded-2xl bg-brand-cream p-2">
+      <%= render "events/show/header_media", event: event %>
+    </div>
+  <% end %>
+
+  <div class="mx-auto mt-10 max-w-2xl text-center">
+    <%= render "events/show/title", event: event,
+          heading_class: "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl" %>
+    <div class="mt-6"><%= render "events/show/details", event: event, variant: "chips" %></div>
+    <div class="mt-7 flex flex-col items-center gap-2"><%= render "events/show/actions", event: event, sample: sample %></div>
+  </div>
+
+  <hr class="mx-auto my-10 max-w-2xl border-brand-navy-100">
+
+  <div class="mx-auto max-w-2xl">
+    <%= render "events/show/description", event: event %>
+  </div>
+</div>

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -1,25 +1,27 @@
-<%# Centered — today's centred layout, brand-polished: rainbow accent, Fraunces
-    title, chip details, gold register button, readable-measure body. White page. %>
+<%# Centered — brand-polished centered layout: a cream card holds the header
+    image, and a second cream card below holds the title, details and body. %>
 <% sample = local_assigns.fetch(:sample, false) %>
 <%= render "events/show/rainbow" %>
 
-<div class="mx-auto max-w-4xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
+<div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
-    <div class="rounded-2xl bg-brand-cream p-2">
-      <%= render "events/show/header_media", event: event %>
+    <div class="bg-brand-cream rounded-2xl p-3">
+      <div class="aspect-video">
+        <%= render "events/show/header_media", event: event, fill: "cover" %>
+      </div>
     </div>
   <% end %>
 
-  <div class="mx-auto mt-10 max-w-2xl text-center">
+  <div class="bg-brand-cream mt-8 rounded-2xl p-8 text-center sm:p-12">
     <%= render "events/show/title", event: event,
           heading_class: "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl" %>
     <div class="mt-6"><%= render "events/show/details", event: event, variant: "chips" %></div>
     <div class="mt-7 flex flex-col items-center gap-2"><%= render "events/show/actions", event: event, sample: sample %></div>
-  </div>
 
-  <hr class="mx-auto my-10 max-w-2xl border-brand-navy-100">
+    <hr class="border-brand-navy-200 mx-auto my-8 max-w-3xl">
 
-  <div class="mx-auto max-w-2xl">
-    <%= render "events/show/description", event: event %>
+    <div class="mx-auto max-w-3xl text-left">
+      <%= render "events/show/description", event: event %>
+    </div>
   </div>
 </div>

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -6,7 +6,7 @@
 <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
     <div class="bg-brand-cream rounded-2xl p-3">
-      <div class="aspect-video">
+      <div class="aspect-video overflow-hidden rounded-2xl">
         <%= render "events/show/header_media", event: event, fill: "cover" %>
       </div>
     </div>

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -5,10 +5,8 @@
 
 <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
-    <div class="bg-brand-cream rounded-2xl p-3">
-      <div class="aspect-video overflow-hidden rounded-2xl">
-        <%= render "events/show/header_media", event: event, fill: "cover" %>
-      </div>
+    <div class="aspect-video overflow-hidden rounded-2xl">
+      <%= render "events/show/header_media", event: event, fill: "cover" %>
     </div>
   <% end %>
 

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -1,0 +1,26 @@
+<%# Editorial — warm cream page, centred masthead with a hairline meta line, the
+    description on a white paper card. Best for text-heavy events. %>
+<% sample = local_assigns.fetch(:sample, false) %>
+<%= render "events/show/rainbow" %>
+
+<div class="w-full bg-brand-cream">
+  <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+    <% if event.rhino_header.present? %>
+      <div class="rounded-2xl bg-white p-2 shadow-sm">
+        <%= render "events/show/header_media", event: event %>
+      </div>
+    <% end %>
+
+    <div class="mx-auto mt-10 max-w-2xl text-center">
+      <%= render "events/show/title", event: event,
+            heading_class: "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl" %>
+      <div class="mx-auto my-5 h-px w-24 bg-brand-navy-200"></div>
+      <%= render "events/show/details", event: event, variant: "line" %>
+      <div class="mt-7 flex flex-col items-center gap-2"><%= render "events/show/actions", event: event, sample: sample %></div>
+    </div>
+
+    <div class="mx-auto mt-10 max-w-2xl rounded-2xl bg-white p-8 shadow-sm sm:p-12">
+      <%= render "events/show/description", event: event %>
+    </div>
+  </div>
+</div>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -4,10 +4,10 @@
 <%= render "events/show/rainbow" %>
 
 <div class="bg-brand-cream w-full">
-  <div class="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
     <% if event.rhino_header.present? %>
       <div class="rounded-2xl bg-white p-2 shadow-sm">
-        <div class="aspect-video overflow-hidden rounded-xl">
+        <div class="aspect-video overflow-hidden rounded-2xl">
           <%= render "events/show/header_media", event: event, fill: "cover" %>
         </div>
       </div>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -3,7 +3,7 @@
 <% sample = local_assigns.fetch(:sample, false) %>
 <%= render "events/show/rainbow" %>
 
-<div class="w-full bg-brand-cream">
+<div class="bg-brand-cream w-full">
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
     <% if event.rhino_header.present? %>
       <div class="rounded-2xl bg-white p-2 shadow-sm">
@@ -14,7 +14,7 @@
     <div class="mx-auto mt-10 max-w-2xl text-center">
       <%= render "events/show/title", event: event,
             heading_class: "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl" %>
-      <div class="mx-auto my-5 h-px w-24 bg-brand-navy-200"></div>
+      <div class="bg-brand-navy-200 mx-auto my-5 h-px w-24"></div>
       <%= render "events/show/details", event: event, variant: "line" %>
       <div class="mt-7 flex flex-col items-center gap-2"><%= render "events/show/actions", event: event, sample: sample %></div>
     </div>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -4,16 +4,16 @@
 <%= render "events/show/rainbow" %>
 
 <div class="bg-brand-cream w-full">
-  <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+  <div class="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
     <% if event.rhino_header.present? %>
       <div class="rounded-2xl bg-white p-2 shadow-sm">
-        <div class="overflow-hidden rounded-xl">
-          <%= render "events/show/header_media", event: event, fill: "width" %>
+        <div class="aspect-video overflow-hidden rounded-xl">
+          <%= render "events/show/header_media", event: event, fill: "cover" %>
         </div>
       </div>
     <% end %>
 
-    <div class="mx-auto mt-10 max-w-2xl text-center">
+    <div class="mx-auto mt-10 max-w-3xl text-center">
       <%= render "events/show/title", event: event,
             heading_class: "font-display text-4xl font-semibold leading-tight text-brand-navy-900 sm:text-5xl" %>
       <div class="bg-brand-navy-200 mx-auto my-5 h-px w-24"></div>
@@ -21,7 +21,7 @@
       <div class="mt-7 flex flex-col items-center gap-2"><%= render "events/show/actions", event: event, sample: sample %></div>
     </div>
 
-    <div class="mx-auto mt-10 max-w-2xl rounded-2xl bg-white p-8 shadow-sm sm:p-12">
+    <div class="mx-auto mt-10 max-w-3xl rounded-2xl bg-white p-8 shadow-sm sm:p-12">
       <%= render "events/show/description", event: event %>
     </div>
   </div>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -7,7 +7,9 @@
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
     <% if event.rhino_header.present? %>
       <div class="rounded-2xl bg-white p-2 shadow-sm">
-        <%= render "events/show/header_media", event: event %>
+        <div class="overflow-hidden rounded-xl">
+          <%= render "events/show/header_media", event: event, fill: "width" %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -4,7 +4,7 @@
 <%= render "events/show/rainbow" %>
 
 <section class="from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 w-full bg-gradient-to-br text-white">
-  <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
+  <div class="mx-auto grid max-w-6xl items-stretch gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
     <div>
       <%= render "events/show/title", event: event,
             pretitle_class: "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-yellow-400",
@@ -14,8 +14,8 @@
     </div>
 
     <% if event.rhino_header.present? %>
-      <div class="rounded-2xl bg-white/95 p-2 shadow-xl">
-        <%= render "events/show/header_media", event: event %>
+      <div class="min-h-64 overflow-hidden rounded-2xl shadow-xl">
+        <%= render "events/show/header_media", event: event, fill: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -1,0 +1,26 @@
+<%# Navy hero — bold navy gradient band with the title, details and register beside
+    the framed header image; the description sits below on a light page. %>
+<% sample = local_assigns.fetch(:sample, false) %>
+<%= render "events/show/rainbow" %>
+
+<section class="w-full bg-gradient-to-br from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 text-white">
+  <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
+    <div>
+      <%= render "events/show/title", event: event,
+            pretitle_class: "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-yellow-400",
+            heading_class: "font-display text-4xl font-semibold leading-tight sm:text-5xl" %>
+      <div class="mt-6"><%= render "events/show/details", event: event, variant: "chips_navy", align: "start" %></div>
+      <div class="mt-7"><%= render "events/show/actions", event: event, sample: sample %></div>
+    </div>
+
+    <% if event.rhino_header.present? %>
+      <div class="rounded-2xl bg-white/95 p-2 shadow-xl">
+        <%= render "events/show/header_media", event: event %>
+      </div>
+    <% end %>
+  </div>
+</section>
+
+<div class="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+  <%= render "events/show/description", event: event %>
+</div>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -3,7 +3,7 @@
 <% sample = local_assigns.fetch(:sample, false) %>
 <%= render "events/show/rainbow" %>
 
-<section class="w-full bg-gradient-to-br from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 text-white">
+<section class="from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 w-full bg-gradient-to-br text-white">
   <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
     <div>
       <%= render "events/show/title", event: event,

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <% if event.rhino_header.present? %>
-      <div class="aspect-[4/3] rounded-2xl shadow-xl">
+      <div class="aspect-[4/3] overflow-hidden rounded-2xl shadow-xl">
         <%= render "events/show/header_media", event: event, fill: "cover" %>
       </div>
     <% end %>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -14,10 +14,8 @@
     </div>
 
     <% if event.rhino_header.present? %>
-      <div class="rounded-2xl bg-white/95 p-2 shadow-xl">
-        <div class="aspect-[4/3] overflow-hidden rounded-xl">
-          <%= render "events/show/header_media", event: event, fill: "cover" %>
-        </div>
+      <div class="aspect-[4/3] rounded-2xl shadow-xl">
+        <%= render "events/show/header_media", event: event, fill: "cover" %>
       </div>
     <% end %>
   </div>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -14,8 +14,10 @@
     </div>
 
     <% if event.rhino_header.present? %>
-      <div class="min-h-64 overflow-hidden rounded-2xl shadow-xl">
-        <%= render "events/show/header_media", event: event, fill: true %>
+      <div class="min-h-64 rounded-2xl bg-white/95 p-2 shadow-xl">
+        <div class="h-full overflow-hidden rounded-xl">
+          <%= render "events/show/header_media", event: event, fill: true %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -16,7 +16,7 @@
     <% if event.rhino_header.present? %>
       <div class="min-h-64 rounded-2xl bg-white/95 p-2 shadow-xl">
         <div class="h-full overflow-hidden rounded-xl">
-          <%= render "events/show/header_media", event: event, fill: true %>
+          <%= render "events/show/header_media", event: event, fill: "cover" %>
         </div>
       </div>
     <% end %>

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -4,7 +4,7 @@
 <%= render "events/show/rainbow" %>
 
 <section class="from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 w-full bg-gradient-to-br text-white">
-  <div class="mx-auto grid max-w-6xl items-stretch gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
+  <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">
     <div>
       <%= render "events/show/title", event: event,
             pretitle_class: "mb-3 text-sm font-semibold uppercase tracking-widest text-brand-yellow-400",
@@ -14,8 +14,8 @@
     </div>
 
     <% if event.rhino_header.present? %>
-      <div class="min-h-64 rounded-2xl bg-white/95 p-2 shadow-xl">
-        <div class="h-full overflow-hidden rounded-xl">
+      <div class="rounded-2xl bg-white/95 p-2 shadow-xl">
+        <div class="aspect-[4/3] overflow-hidden rounded-xl">
           <%= render "events/show/header_media", event: event, fill: "cover" %>
         </div>
       </div>

--- a/app/views/events/templates/_none.html.erb
+++ b/app/views/events/templates/_none.html.erb
@@ -1,0 +1,102 @@
+<%# "None" — the plain, pre-brand layout, preserved as-is (white page, centred,
+    content exactly as authored). This is the frozen legacy frame; new display
+    logic belongs in the shared events/show partials and the branded templates,
+    not here. `sample` swaps live registration for a static button in the gallery.
+    The show page runs full-width, so this frame restores the standard container. %>
+<div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
+<%# ---- HEADER CONTENT ---- %>
+<% if event.rhino_header.present? %>
+  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
+    <%= event.rhino_header %>
+  </div>
+<% end %>
+
+<%# ---- TITLE ---- %>
+<% if event.autoshow_title %>
+  <div class="mx-auto mb-4 max-w-2xl text-center">
+    <% if event.pre_title.present? %>
+      <p class="mb-2 font-telefon text-base font-semibold text-gray-700" style="font-size: 42px"><%= event.pre_title %></p>
+    <% end %>
+    <h1 class="text-primary font-display" style="font-size: 53px"><%= event.title %></h1>
+  </div>
+<% end %>
+
+<%# ---- EVENT DETAILS (conditional on autoshow) ---- %>
+<div class="mb-4 space-y-2 text-center">
+  <% if event.autoshow_pre_date_text && event.pre_date_text.present? %>
+    <div class="text-primary font-bold uppercase" style="font-size: 24px"><%= event.pre_date_text %></div>
+  <% end %>
+
+  <% if event.autoshow_date || event.autoshow_time %>
+    <div>
+      <% if event.autoshow_date %>
+        <div class="text-primary font-bold uppercase" style="font-size: 35px">
+          <%= event_dates_label(event) %>
+        </div>
+      <% end %>
+      <% if event.autoshow_time %>
+        <div class="text-primary mt-2 font-bold" style="font-size: 24px">
+          <%= event_times_label(event) %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if event.autoshow_cost && event.labelled_cost %>
+    <div class="text-primary text-xl font-bold uppercase"><%= event.labelled_cost %></div>
+  <% end %>
+
+  <% if event.autoshow_location && event.location.present? %>
+    <div class="text-base text-gray-700"><%= event.location.name %></div>
+  <% end %>
+
+  <% if event.autoshow_videoconference_label && event.videoconference_label.present? %>
+    <div class="text-base text-gray-700"><%= event.videoconference_label %></div>
+  <% end %>
+
+  <%= render "events/videoconference_link", event: event %>
+
+  <% unless current_user && event.actively_registered?(current_user.person) %>
+    <% if event.autoshow_registration_close && event.registration_close_date %>
+      <div class="text-base text-gray-700">
+        <% tz_abbr = event.start_date.in_time_zone(Time.zone).strftime("%Z") %>
+        Registration closes <%= event.registration_close_date.in_time_zone(Time.zone).strftime("%B %-d, %Y %l:%M %P") %> <%= tz_abbr %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if local_assigns.fetch(:sample, false) %>
+    <div class="mt-4 flex flex-col items-center gap-2">
+      <span class="<%= button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase") %>" style="font-family: 'Telefon Bold', sans-serif;">Register</span>
+      <span class="text-xs text-gray-500 italic">Sample preview</span>
+    </div>
+  <% else %>
+    <% if event.autoshow_registration %>
+      <div class="mt-4">
+        <%= render "events/registration_section", event: event, instance: 1, button_text: "Register" %>
+      </div>
+    <% end %>
+
+    <% if event.bulk_payment_form %>
+      <div class="mt-4">
+        <%= link_to Form::BULK_PAYMENT_PUBLIC_NAME,
+                    new_event_bulk_payment_path(event),
+                    class: button_classes(:success, size: nil, extra: "px-10 py-2 text-2xl uppercase"),
+                    style: "font-family: 'Telefon Bold', sans-serif;" %>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<%# ---- DESCRIPTION ---- %>
+<% if event.rhino_description.present? %>
+  <div class="mb-12 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
+    <%= event.rhino_description %>
+  </div>
+<% end %>
+
+<%# ---- GALLERY IMAGES ---- %>
+<div class="mb-12">
+  <%= render "assets/display_gallery_media", resource: event, link: true %>
+</div>
+</div>

--- a/app/views/events/templates/_none.html.erb
+++ b/app/views/events/templates/_none.html.erb
@@ -4,10 +4,10 @@
     not here. `sample` swaps live registration for a static button in the gallery.
     The show page runs full-width, so this frame restores the standard container. %>
 <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
-<%# ---- HEADER CONTENT ---- %>
+<%# ---- HEADER CONTENT ---- (full width, as authored — legacy behavior) %>
 <% if event.rhino_header.present? %>
-  <div class="mb-4">
-    <%= render "events/show/header_media", event: event %>
+  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
+    <%= event.rhino_header %>
   </div>
 <% end %>
 
@@ -67,7 +67,7 @@
 
   <% if local_assigns.fetch(:sample, false) %>
     <div class="mt-4 flex flex-col items-center gap-2">
-      <span class="<%= button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase") %>" style="font-family: 'Telefon Bold', sans-serif;">Register</span>
+      <span class="<%= brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>">Register</span>
       <span class="text-xs text-gray-500 italic">Sample preview</span>
     </div>
   <% else %>

--- a/app/views/events/templates/_none.html.erb
+++ b/app/views/events/templates/_none.html.erb
@@ -4,9 +4,10 @@
     not here. `sample` swaps live registration for a static button in the gallery.
     The show page runs full-width, so this frame restores the standard container. %>
 <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
-<%# ---- HEADER CONTENT ---- (full width, as authored — legacy behavior) %>
+<%# ---- HEADER CONTENT ---- (full width, as authored — legacy behavior).
+    Tall images are capped so they don't dominate; wide banners are unaffected. %>
 <% if event.rhino_header.present? %>
-  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
+  <div class="rhino-centered mb-4 max-h-[42rem] overflow-hidden max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
     <%= event.rhino_header %>
   </div>
 <% end %>

--- a/app/views/events/templates/_none.html.erb
+++ b/app/views/events/templates/_none.html.erb
@@ -68,7 +68,8 @@
 
   <% if local_assigns.fetch(:sample, false) %>
     <div class="mt-4 flex flex-col items-center gap-2">
-      <span class="<%= brand_cta_classes(register: true, extra: "px-10 py-3 text-2xl") %>">Register</span>
+      <span class="<%= button_classes(:accent, size: nil, extra: "px-10 py-2 text-2xl uppercase") %>"
+            style="<%= EventDecorator::LEGACY_CTA_FONT %>">Register</span>
       <span class="text-xs text-gray-500 italic">Sample preview</span>
     </div>
   <% else %>

--- a/app/views/events/templates/_none.html.erb
+++ b/app/views/events/templates/_none.html.erb
@@ -6,8 +6,8 @@
 <div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
 <%# ---- HEADER CONTENT ---- %>
 <% if event.rhino_header.present? %>
-  <div class="rhino-centered mb-4 max-w-none prose prose-img:w-full prose-img:max-w-full prose-em:text-inherit prose-strong:text-inherit">
-    <%= event.rhino_header %>
+  <div class="mb-4">
+    <%= render "events/show/header_media", event: event %>
   </div>
 <% end %>
 

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -5,7 +5,7 @@
 
 <div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
-    <div class="rounded-2xl bg-brand-cream p-2">
+    <div class="bg-brand-cream rounded-2xl p-2">
       <%= render "events/show/header_media", event: event %>
     </div>
   <% end %>
@@ -17,8 +17,8 @@
       <div class="mt-6"><%= render "events/show/description", event: event %></div>
     </div>
 
-    <aside class="h-fit rounded-2xl border-2 border-brand-navy-200 bg-white p-6 shadow-sm lg:sticky lg:top-6">
-      <div class="mb-2 text-xs font-bold uppercase tracking-wide text-brand-navy-900">Event details</div>
+    <aside class="border-brand-navy-200 h-fit rounded-2xl border-2 bg-white p-6 shadow-sm lg:sticky lg:top-6">
+      <div class="text-brand-navy-900 mb-2 text-xs font-bold tracking-wide uppercase">Event details</div>
       <%= render "events/show/details", event: event, variant: "rail" %>
       <div class="mt-5"><%= render "events/show/actions", event: event, sample: sample %></div>
     </aside>

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -5,8 +5,8 @@
 
 <div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
-    <div class="bg-brand-cream rounded-2xl p-2">
-      <%= render "events/show/header_media", event: event %>
+    <div class="overflow-hidden rounded-2xl">
+      <%= render "events/show/header_media", event: event, fill: "width" %>
     </div>
   <% end %>
 
@@ -17,7 +17,7 @@
       <div class="mt-6"><%= render "events/show/description", event: event %></div>
     </div>
 
-    <aside class="border-brand-navy-200 h-fit rounded-2xl border-2 bg-white p-6 shadow-sm lg:sticky lg:top-6">
+    <aside class="border-brand-navy-200 bg-brand-cream h-fit rounded-2xl border-2 p-6 shadow-sm lg:sticky lg:top-24">
       <div class="text-brand-navy-900 mb-2 text-xs font-bold tracking-wide uppercase">Event details</div>
       <%= render "events/show/details", event: event, variant: "rail" %>
       <div class="mt-5"><%= render "events/show/actions", event: event, sample: sample %></div>

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -1,0 +1,26 @@
+<%# Details sidebar — description flows left; a sticky card on the right holds the
+    details and register actions. Best for long, info-dense events. %>
+<% sample = local_assigns.fetch(:sample, false) %>
+<%= render "events/show/rainbow" %>
+
+<div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
+  <% if event.rhino_header.present? %>
+    <div class="rounded-2xl bg-brand-cream p-2">
+      <%= render "events/show/header_media", event: event %>
+    </div>
+  <% end %>
+
+  <div class="mt-10 grid gap-10 lg:grid-cols-3">
+    <div class="lg:col-span-2">
+      <%= render "events/show/title", event: event,
+            heading_class: "font-display text-3xl font-semibold leading-tight text-brand-navy-900 sm:text-4xl" %>
+      <div class="mt-6"><%= render "events/show/description", event: event %></div>
+    </div>
+
+    <aside class="h-fit rounded-2xl border-2 border-brand-navy-200 bg-white p-6 shadow-sm lg:sticky lg:top-6">
+      <div class="mb-2 text-xs font-bold uppercase tracking-wide text-brand-navy-900">Event details</div>
+      <%= render "events/show/details", event: event, variant: "rail" %>
+      <div class="mt-5"><%= render "events/show/actions", event: event, sample: sample %></div>
+    </aside>
+  </div>
+</div>

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -5,8 +5,8 @@
 
 <div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>
-    <div class="overflow-hidden rounded-2xl">
-      <%= render "events/show/header_media", event: event, fill: "width" %>
+    <div class="aspect-[16/6] overflow-hidden rounded-2xl">
+      <%= render "events/show/header_media", event: event, fill: "cover" %>
     </div>
   <% end %>
 

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -2,7 +2,11 @@
 <% content_for(:full_width, true) %>
 
 <div class="mx-auto w-full max-w-7xl px-4 pt-6 pb-16 sm:px-6 lg:px-8">
-  <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% if @sample_event && params[:event_id].present? %>
+    <%= link_to "← Back to event", edit_event_path(@sample_event, section: "page_content", anchor: "page_content_button"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% else %>
+    <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% end %>
   <h1 class="text-brand-navy-900 mt-2 font-display text-3xl font-semibold">Event display templates</h1>
   <p class="mt-2 max-w-2xl text-gray-600">
     Every template frames the same content — header image, details, description — and respects each event's show/hide toggles.

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -29,7 +29,7 @@
               <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
             </div>
           </div>
-          <div class="flex items-start justify-between gap-2 p-4">
+          <div class="flex items-start justify-between gap-2 border-t border-gray-200 bg-gray-50 p-4">
             <div>
               <h2 class="text-brand-navy-900 font-display text-lg font-semibold"><%= meta[:label] %></h2>
               <p class="mt-1 text-sm text-gray-500"><%= meta[:blurb] %></p>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -16,8 +16,11 @@
 
     <div class="mt-6 flex flex-wrap justify-center gap-6 sm:justify-start">
       <% Event::TEMPLATES.each do |key, meta| %>
-        <%= link_to event_path(@sample_event, template: key), target: "_blank", rel: "noopener",
-              class: "group block w-[360px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:border-brand-navy-400 hover:shadow-md" do %>
+        <%# Card is a div, not a link: the scaled preview contains its own <a> links
+            (from the description), and nesting anchors is invalid HTML — the browser
+            would eject the preview out of the card. A transparent stretched link
+            sits over the whole card instead. %>
+        <div class="group hover:border-brand-navy-400 relative w-[360px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md">
           <%# Render the real template at desktop width, then zoom the whole thing
               down so the card shows a faithful reduced-size preview. zoom (not
               transform) also shrinks the layout box, so the cards tile cleanly. %>
@@ -33,7 +36,10 @@
             </div>
             <span class="text-brand-navy-600 mt-0.5 shrink-0 text-xs font-semibold opacity-0 transition group-hover:opacity-100">Open →</span>
           </div>
-        <% end %>
+          <%= link_to event_path(@sample_event, template: key), target: "_blank", rel: "noopener", class: "absolute inset-0" do %>
+            <span class="sr-only">Open <%= meta[:label] %> preview</span>
+          <% end %>
+        </div>
       <% end %>
     </div>
   <% else %>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -16,7 +16,8 @@
 
     <div class="mt-6 flex flex-wrap justify-center gap-6 sm:justify-start">
       <% Event::TEMPLATES.each do |key, meta| %>
-        <div class="w-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <%= link_to event_path(@sample_event, template: key), target: "_blank", rel: "noopener",
+              class: "group block w-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:border-brand-navy-400 hover:shadow-md" do %>
           <%# Render the real template at desktop width, then scale the whole thing
               down so the card shows a faithful reduced-size preview of the page. %>
           <div class="relative h-80 overflow-hidden border-b border-gray-200 bg-white">
@@ -24,11 +25,14 @@
               <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
             </div>
           </div>
-          <div class="p-4">
-            <h2 class="text-brand-navy-900 font-display text-lg font-semibold"><%= meta[:label] %></h2>
-            <p class="mt-1 text-sm text-gray-500"><%= meta[:blurb] %></p>
+          <div class="flex items-start justify-between gap-2 p-4">
+            <div>
+              <h2 class="text-brand-navy-900 font-display text-lg font-semibold"><%= meta[:label] %></h2>
+              <p class="mt-1 text-sm text-gray-500"><%= meta[:blurb] %></p>
+            </div>
+            <span class="text-brand-navy-600 mt-0.5 shrink-0 text-xs font-semibold opacity-0 transition group-hover:opacity-100">Open →</span>
           </div>
-        </div>
+        <% end %>
       <% end %>
     </div>
   <% else %>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto w-full max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
+<div class="mx-auto w-full max-w-7xl px-4 pt-6 pb-16 sm:px-6 lg:px-8">
   <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <h1 class="text-brand-navy-900 mt-2 font-display text-3xl font-semibold">Event display templates</h1>
   <p class="mt-2 max-w-2xl text-gray-600">
@@ -9,29 +9,31 @@
     Pick one per event under <span class="font-semibold">Event show page → Layout template</span>.
   </p>
 
-  <% unless @sample_event %>
+  <% if @sample_event %>
+    <p class="mt-3 text-sm text-gray-500">
+      Previewing <span class="text-brand-navy-800 font-semibold"><%= @sample_event.title %></span>. Previews are scaled down and not interactive.
+    </p>
+
+    <div class="mt-6 flex flex-wrap justify-center gap-6 sm:justify-start">
+      <% Event::TEMPLATES.each do |key, meta| %>
+        <div class="w-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <%# Render the real template at desktop width, then scale the whole thing
+              down so the card shows a faithful reduced-size preview of the page. %>
+          <div class="relative h-80 overflow-hidden border-b border-gray-200 bg-white">
+            <div class="pointer-events-none absolute top-0 left-0 origin-top-left" style="width: 1200px; transform: scale(0.32)">
+              <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
+            </div>
+          </div>
+          <div class="p-4">
+            <h2 class="text-brand-navy-900 font-display text-lg font-semibold"><%= meta[:label] %></h2>
+            <p class="mt-1 text-sm text-gray-500"><%= meta[:blurb] %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
     <p class="mt-6 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
       No event to preview yet — create an event, then reopen this page.
     </p>
   <% end %>
 </div>
-
-<% if @sample_event %>
-  <p class="mx-auto mt-4 w-full max-w-7xl px-4 text-sm text-gray-500 sm:px-6 lg:px-8">
-    Previewing with <span class="text-brand-navy-800 font-semibold"><%= @sample_event.title %></span>. Register buttons are inert here.
-  </p>
-
-  <% Event::TEMPLATES.each do |key, meta| %>
-    <section class="border-brand-navy-200 mt-8 border-t-4">
-      <div class="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
-        <div class="flex flex-wrap items-baseline justify-between gap-x-4">
-          <h2 class="text-brand-navy-900 font-display text-xl font-semibold"><%= meta[:label] %></h2>
-          <span class="text-sm text-gray-500"><%= meta[:blurb] %></span>
-        </div>
-      </div>
-      <div class="border-y border-gray-200 bg-white">
-        <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
-      </div>
-    </section>
-  <% end %>
-<% end %>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -3,7 +3,7 @@
 
 <div class="mx-auto w-full max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
   <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-  <h1 class="mt-2 font-display text-3xl font-semibold text-brand-navy-900">Event display templates</h1>
+  <h1 class="text-brand-navy-900 mt-2 font-display text-3xl font-semibold">Event display templates</h1>
   <p class="mt-2 max-w-2xl text-gray-600">
     Every template frames the same content — header image, details, description — and respects each event's show/hide toggles.
     Pick one per event under <span class="font-semibold">Event show page → Layout template</span>.
@@ -18,14 +18,14 @@
 
 <% if @sample_event %>
   <p class="mx-auto mt-4 w-full max-w-7xl px-4 text-sm text-gray-500 sm:px-6 lg:px-8">
-    Previewing with <span class="font-semibold text-brand-navy-800"><%= @sample_event.title %></span>. Register buttons are inert here.
+    Previewing with <span class="text-brand-navy-800 font-semibold"><%= @sample_event.title %></span>. Register buttons are inert here.
   </p>
 
   <% Event::TEMPLATES.each do |key, meta| %>
-    <section class="mt-8 border-t-4 border-brand-navy-200">
+    <section class="border-brand-navy-200 mt-8 border-t-4">
       <div class="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
         <div class="flex flex-wrap items-baseline justify-between gap-x-4">
-          <h2 class="font-display text-xl font-semibold text-brand-navy-900"><%= meta[:label] %></h2>
+          <h2 class="text-brand-navy-900 font-display text-xl font-semibold"><%= meta[:label] %></h2>
           <span class="text-sm text-gray-500"><%= meta[:blurb] %></span>
         </div>
       </div>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
+<% content_for(:full_width, true) %>
+
+<div class="mx-auto w-full max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
+  <%= link_to "← Events", events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <h1 class="mt-2 font-display text-3xl font-semibold text-brand-navy-900">Event display templates</h1>
+  <p class="mt-2 max-w-2xl text-gray-600">
+    Every template frames the same content — header image, details, description — and respects each event's show/hide toggles.
+    Pick one per event under <span class="font-semibold">Event show page → Layout template</span>.
+  </p>
+
+  <% unless @sample_event %>
+    <p class="mt-6 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-800">
+      No event to preview yet — create an event, then reopen this page.
+    </p>
+  <% end %>
+</div>
+
+<% if @sample_event %>
+  <p class="mx-auto mt-4 w-full max-w-7xl px-4 text-sm text-gray-500 sm:px-6 lg:px-8">
+    Previewing with <span class="font-semibold text-brand-navy-800"><%= @sample_event.title %></span>. Register buttons are inert here.
+  </p>
+
+  <% Event::TEMPLATES.each do |key, meta| %>
+    <section class="mt-8 border-t-4 border-brand-navy-200">
+      <div class="mx-auto w-full max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+        <div class="flex flex-wrap items-baseline justify-between gap-x-4">
+          <h2 class="font-display text-xl font-semibold text-brand-navy-900"><%= meta[:label] %></h2>
+          <span class="text-sm text-gray-500"><%= meta[:blurb] %></span>
+        </div>
+      </div>
+      <div class="border-y border-gray-200 bg-white">
+        <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -17,11 +17,12 @@
     <div class="mt-6 flex flex-wrap justify-center gap-6 sm:justify-start">
       <% Event::TEMPLATES.each do |key, meta| %>
         <%= link_to event_path(@sample_event, template: key), target: "_blank", rel: "noopener",
-              class: "group block w-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:border-brand-navy-400 hover:shadow-md" do %>
-          <%# Render the real template at desktop width, then scale the whole thing
-              down so the card shows a faithful reduced-size preview of the page. %>
-          <div class="relative h-80 overflow-hidden border-b border-gray-200 bg-white">
-            <div class="pointer-events-none absolute top-0 left-0 origin-top-left" style="width: 1200px; transform: scale(0.32)">
+              class: "group block w-[360px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:border-brand-navy-400 hover:shadow-md" do %>
+          <%# Render the real template at desktop width, then zoom the whole thing
+              down so the card shows a faithful reduced-size preview. zoom (not
+              transform) also shrinks the layout box, so the cards tile cleanly. %>
+          <div class="h-80 overflow-hidden border-b border-gray-200 bg-white">
+            <div class="pointer-events-none" style="width: 1200px; zoom: 0.3">
               <%= render "events/templates/#{key}", event: @sample_event, sample: true %>
             </div>
           </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,22 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Pick a layout template for each event page"
+  area: events
+  display_status: user_facing
+  released_on: 2026-08-31
+  summary: >-
+    Each event can now choose a display template for its public page — from the
+    plain layout you have today to bold branded ones with a navy hero, a cream
+    editorial style, or a sticky details sidebar. Your header image, details, and
+    description stay the same; only the framing changes.
+  action_path: /events
+  pr_number: 2442
+  pro_tips:
+    - "Set it under Event show page → Layout template on the event form."
+    - "Use Preview all templates to compare them side by side before choosing."
+    - "Every template still honors your show/hide toggles for the title, date, cost, and more."
+
 - name: "Schedule site banners with start and end dates"
   area: communications
   display_status: admin_facing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,7 @@ Rails.application.routes.draw do
       get :program_statuses
       get :attendees
       get :signins
+      get :templates_gallery
     end
     member do
       get :dashboard

--- a/db/migrate/20260831011834_add_template_to_events.rb
+++ b/db/migrate/20260831011834_add_template_to_events.rb
@@ -1,0 +1,9 @@
+class AddTemplateToEvents < ActiveRecord::Migration[8.1]
+  def up
+    add_column :events, :template, :string, default: "none", null: false unless column_exists?(:events, :template)
+  end
+
+  def down
+    remove_column :events, :template, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_200153) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -657,6 +657,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_200153) do
     t.text "short_description"
     t.boolean "signed_in_one_click_enabled", default: false, null: false
     t.datetime "start_date", precision: nil
+    t.string "template", default: "none", null: false
     t.string "title"
     t.datetime "updated_at", null: false
     t.integer "updated_by_id"

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -1,6 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe EventDecorator do
+  describe "call-to-action styling" do
+    it "keeps the legacy orange register button on the none template" do
+      event = build(:event, template: "none").decorate
+      expect(event).not_to be_branded_page
+      expect(event.cta_classes(register: true)).to include("bg-accent")
+      expect(event.cta_style).to eq(described_class::LEGACY_CTA_FONT)
+    end
+
+    it "keeps the legacy green view-ticket button on the none template" do
+      event = build(:event, template: "none").decorate
+      expect(event.cta_classes).to include("bg-success")
+    end
+
+    it "uses the gold brand CTA on a branded template" do
+      event = build(:event, template: "hero").decorate
+      expect(event).to be_branded_page
+      expect(event.cta_classes(register: true)).to include("bg-brand-yellow-400")
+      expect(event.cta_style).to be_nil
+    end
+  end
+
   describe "#videoconference_domain" do
     it "extracts domain name from URL" do
       event = build(:event, videoconference_url: "https://www.zoom.us/j/123").decorate

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:start_date) }
     it { should validate_presence_of(:end_date) }
     it { should validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0).allow_nil }
+    it { should validate_inclusion_of(:template).in_array(Event::TEMPLATE_KEYS) }
+
+    describe "display template" do
+      it "defaults to none" do
+        expect(build(:event).template).to eq("none")
+      end
+
+      it "rejects an unknown template" do
+        event = build(:event, template: "bogus")
+        expect(event).not_to be_valid
+        expect(event.errors[:template]).to be_present
+      end
+
+      it "accepts each known template" do
+        Event::TEMPLATE_KEYS.each do |key|
+          expect(build(:event, template: key)).to be_valid
+        end
+      end
+    end
 
     describe "end date not before start date" do
       it "is invalid when the end date is before the start date" do

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe EventPolicy, type: :policy do
   let(:published_event) { build_stubbed :event, :published }
   let(:public_event) { build_stubbed :event, publicly_visible: true  }
   let(:unpublished_event) { build_stubbed :event, :unpublished }
+  let(:owned_unpublished_event) { build_stubbed :event, :unpublished, created_by: regular_user }
+  let(:owned_ended_event) { build_stubbed :event, :published, :ended, created_by: regular_user }
   let(:ended_event) { build_stubbed :event, :published, :ended }
   let(:open_registration_event) { build_stubbed :event, registration_close_date: 1.day.from_now }
   let(:closed_registration_event) { build_stubbed :event, registration_close_date: 1.day.ago }
@@ -123,6 +125,18 @@ RSpec.describe EventPolicy, type: :policy do
 
         it { is_expected.not_to be_allowed_to(:show?) }
       end
+
+      context "with the event's owner" do
+        subject { policy_for(record: owned_unpublished_event, user: regular_user) }
+
+        it { is_expected.to be_allowed_to(:show?) }
+      end
+    end
+
+    context "when the owner's event has ended" do
+      subject { policy_for(record: owned_ended_event, user: regular_user) }
+
+      it { is_expected.to be_allowed_to(:show?) }
     end
   end
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -242,6 +242,23 @@ RSpec.describe "Events", type: :request do
       expect(response.body).to include("Chosen event")
     end
 
+    it "lets an event owner in, previewing their own event rather than someone else's" do
+      create(:event, :published, title: "Owned event", created_by: user)
+      sign_in user
+      get templates_gallery_events_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Owned event")
+      expect(response.body).not_to include("Gallery sample")
+    end
+
+    it "does not let an owner preview an event_id they do not own" do
+      create(:event, :published, created_by: user)
+      sign_in user
+      get templates_gallery_events_path(event_id: sample.id)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Gallery sample")
+    end
+
     it "forbids a non-admin without events" do
       sign_in user
       get templates_gallery_events_path

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -196,15 +196,29 @@ RSpec.describe "Events", type: :request do
     context "display templates" do
       let(:templated_event) { create(:event, :published, :publicly_visible, title: "Templated event") }
 
-      before { sign_in admin }
-
       it "renders every template without error" do
+        sign_in admin
         Event::TEMPLATE_KEYS.each do |key|
           templated_event.update!(template: key)
           get event_path(templated_event)
           expect(response).to have_http_status(:ok), "template #{key} failed to render"
           expect(response.body).to include("Templated event")
         end
+      end
+
+      it "lets an editor preview an unsaved template via ?template" do
+        sign_in admin
+        templated_event.update!(template: "none")
+        get event_path(templated_event, template: "hero")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Apply &amp; edit")
+      end
+
+      it "ignores ?template for a non-editor" do
+        sign_in user
+        get event_path(templated_event, template: "hero")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Apply &amp; edit")
       end
     end
   end
@@ -1044,6 +1058,11 @@ RSpec.describe "Events", type: :request do
       get edit_event_path(event)
       expect(response.body).not_to include("Preview scholarship form")
       expect(response.body).not_to include("Preview bulk payment page")
+    end
+
+    it "pre-selects the template passed via ?template so submitting saves it" do
+      get edit_event_path(event, template: "hero")
+      expect(Capybara.string(response.body)).to have_checked_field("event[template]", with: "hero")
     end
 
     it "renders the visibility flags, including publicly registerable, with definitions" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -220,6 +220,14 @@ RSpec.describe "Events", type: :request do
       expect(response.body).to include("Gallery sample")
     end
 
+    it "previews the event named by event_id" do
+      chosen = create(:event, :published, title: "Chosen event", start_date: 2.years.ago, end_date: 2.years.ago + 1.day)
+      sign_in admin
+      get templates_gallery_events_path(event_id: chosen.id)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Chosen event")
+    end
+
     it "forbids a non-admin without events" do
       sign_in user
       get templates_gallery_events_path

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -192,6 +192,39 @@ RSpec.describe "Events", type: :request do
         expect(response.body).not_to include("88285411273")
       end
     end
+
+    context "display templates" do
+      let(:templated_event) { create(:event, :published, :publicly_visible, title: "Templated event") }
+
+      before { sign_in admin }
+
+      it "renders every template without error" do
+        Event::TEMPLATE_KEYS.each do |key|
+          templated_event.update!(template: key)
+          get event_path(templated_event)
+          expect(response).to have_http_status(:ok), "template #{key} failed to render"
+          expect(response.body).to include("Templated event")
+        end
+      end
+    end
+  end
+
+  describe "GET /templates_gallery" do
+    let!(:sample) { create(:event, :published, title: "Gallery sample") }
+
+    it "renders the gallery of all templates for an admin" do
+      sign_in admin
+      get templates_gallery_events_path
+      expect(response).to have_http_status(:ok)
+      Event::TEMPLATES.each_value { |meta| expect(response.body).to include(meta[:label]) }
+      expect(response.body).to include("Gallery sample")
+    end
+
+    it "forbids a non-admin without events" do
+      sign_in user
+      get templates_gallery_events_path
+      expect(response).not_to have_http_status(:ok)
+    end
   end
 
   describe "GET /revenue" do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1065,6 +1065,16 @@ RSpec.describe "Events", type: :request do
       expect(Capybara.string(response.body)).to have_checked_field("event[template]", with: "hero")
     end
 
+    it "opens the Event show page section when arriving with ?section=page_content" do
+      get edit_event_path(event, section: "page_content")
+      expect(Capybara.string(response.body).find("#page_content", visible: :all)[:class]).not_to include("hidden")
+    end
+
+    it "leaves the Event show page section collapsed by default" do
+      get edit_event_path(event)
+      expect(Capybara.string(response.body).find("#page_content", visible: :all)[:class]).to include("hidden")
+    end
+
     it "renders the visibility flags, including publicly registerable, with definitions" do
       get edit_event_path(event)
 

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     "app/views/events/scholarships.html.erb"           => "admin-or-owner bg-blue-100",
     "app/views/events/program_statuses.html.erb"       => "admin-or-owner bg-blue-100",
     "app/views/events/attendees.html.erb"              => "admin-or-owner bg-blue-100",
+    "app/views/events/templates_gallery.html.erb"      => "admin-or-owner bg-blue-100",
     "app/views/events/preview_reminder.html.erb"       => "admin-or-owner bg-blue-100",
     "app/views/events/confirm_reminder.html.erb"       => "admin-or-owner bg-blue-100",
     "app/views/event_registrations/index.html.erb"     => "admin-only bg-blue-100",

--- a/spec/views/page_bg_class_alignment_spec.rb
+++ b/spec/views/page_bg_class_alignment_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe "page_bg_class alignment with policies" do
   #   "public"                                        → true
   #   "admin-or-auth"                                 → authenticated?
   #   "admin-or-public-or-authpublished"              → admin? || publicly_visible? || (authenticated? && published?)
+  #   "admin-or-owner-or-public-or-authpublished"     → the same, plus owner? — an
+  #                                                     event owner sees their own
+  #                                                     draft/past event page
   #   "admin-or-owner"                                → admin? || owner? (manage?,
   #                                                     dashboard?, edit?, the report
   #                                                     suite — a bg-* utility may ride
@@ -62,7 +65,7 @@ RSpec.describe "page_bg_class alignment with policies" do
     # ─── admin-or-public-or-authpublished ───
     # (policy: admin? || publicly_visible? || (authenticated? && published?))
     "app/views/community_news/show.html.erb"           => "admin-or-public-or-authpublished",
-    "app/views/events/show.html.erb"                   => "admin-or-public-or-authpublished",
+    "app/views/events/show.html.erb"                   => "admin-or-owner-or-public-or-authpublished",
     "app/views/faqs/show.html.erb"                     => "admin-or-public-or-authpublished",
     "app/views/resources/show.html.erb"                => "admin-or-public-or-authpublished",
     "app/views/stories/show.html.erb"                  => "admin-or-public-or-authpublished",


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new per-event template system: schema + model + show-page refactor into shared partials + admin gallery, plus a widened `show?` rule, across ~30 files

Lets an admin or event owner pick a **display template** per event so the public event page can match the new AWBW brand (navy/cream/gold, Fraunces) — without hand-editing views. Facilitators get on-brand event pages, and every existing event keeps today's look (default `none`).

## What you get
- **Layout template** picker on the event form (Event show page section), with a **Preview all templates** link.
- A read-only **gallery** (`/events/templates_gallery`) rendering all templates with a real event.
- Five templates: **none** (current), **centered**, **editorial**, **sidebar**, **hero**.

## How it works
- The show page is refactored into shared content partials under `events/show/` (header, title, details, actions, description) that **centralize the `autoshow_*` show/hide logic once**. Each template in `events/templates/` just frames those pieces.
- Same content, same toggles, same `?preview` unpublished-preview flow — only the frame changes.
- The show page now runs **full-width** so templates control their own measure and can run backgrounds edge-to-edge.

## Notes for review
- **`show?` now allows `owner?`.** Owners previously could not view their own unpublished or past event page at all, so the gallery's live-preview links were dead for drafts. This widens public-page access for owners only, on their own events. `page_bg_class` marker moved to `admin-or-owner-or-public-or-authpublished` to match.
- **`templates_gallery?` is its own rule, not an alias of `new?`.** The action authorizes without a record, so `owner?` has no Event to check and any `manage?`-derived rule collapses to admin-only — locking out the owners who reach it from the form. Sample event comes from the `:reportable` scope, so an owner only previews their own.
- `none` is a faithful copy of the current layout (frozen legacy frame), **including its orange/green buttons** — CTA styling is read off `event.template` so a Turbo re-render of the registration section matches the page it lands in.
- Gallery renders in `sample: true` mode so it never builds live registration routes or duplicate `registration_section` dom_ids across the stacked templates.
- `template` column: `default "none", null: false`; constant + inclusion validation; permitted via `EventPolicy`.

## Tests
- Model: default + inclusion validation. Decorator: CTA styling per template.
- Policy: owner sees their own draft/past event.
- Request: every template renders on `/show`; gallery allows admins and owners, scopes an owner to their own events, forbids a user who owns none.
- Added the gallery view to `page_bg_class_alignment_spec`.

Screenshots to follow.
