### PR TITLE
Style navbar Log In as the brand yellow button

### DIFF
--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -4,7 +4,7 @@ module ButtonHelper
   # markup via a helper rather than extracting them into @apply CSS). Tailwind
   # scans this file (see the @source in application.tailwind.css), so the class
   # strings below generate exactly like inline utilities.
-  BUTTON_BASE = "inline-flex items-center gap-2 rounded-lg font-medium shadow-sm " \
+  BUTTON_BASE = "inline-flex items-center gap-2 font-medium shadow-sm " \
                 "transition-colors duration-200 focus:outline-none focus:ring-2 " \
                 "focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed".freeze
 
@@ -17,8 +17,18 @@ module ButtonHelper
     sm: "px-3 py-1 text-xs"
   }.freeze
 
+  # Shape owns the border-radius so a call site can pick the marketing pill
+  # (`shape: :pill`) without splicing a conflicting `rounded-*` into `extra:`.
+  # `:default` keeps the standard rounded-lg every existing button already used.
+  BUTTON_SHAPES = {
+    default: "rounded-lg",
+    pill: "rounded-full"
+  }.freeze
+
   BUTTON_VARIANTS = {
     primary: "border border-primary bg-primary text-white hover:bg-white hover:text-primary",
+    brand: "bg-brand-yellow-400 text-brand-navy-900 hover:bg-brand-yellow-600",
+    brand_raised: "bg-brand-yellow-400 text-brand-navy-900 font-bold border-b-4 border-brand-yellow-600 hover:bg-brand-yellow-500 hover:border-brand-yellow-700",
     accent: "border-2 border-accent bg-accent text-white hover:bg-white hover:text-accent",
     success: "border-2 border-success bg-success text-white hover:bg-white hover:text-success",
     secondary: "border border-secondary bg-secondary text-white hover:bg-white hover:text-secondary",
@@ -36,16 +46,18 @@ module ButtonHelper
     utility_outline: "border border-gray-200 text-gray-600 hover:bg-gray-200 hover:text-gray-800"
   }.freeze
 
-  # `variant` and `size` each take `nil` to opt that layer out and let the call
-  # site supply its own: `variant: nil` drops the color (a custom/dynamic fill),
-  # `size: nil` drops the padding + text-size (call site sets its own via
-  # `extra:` — see BUTTON_SIZES for why they'd otherwise collide). The `if`
-  # guards are what make those nils skip the `fetch` instead of raising; base
-  # stays the single source of truth either way rather than being inlined.
-  def button_classes(variant = :primary, size: :md, extra: nil)
+  # `variant`, `size`, and `shape` each take `nil` to opt that layer out and let
+  # the call site supply its own: `variant: nil` drops the color (a custom/dynamic
+  # fill), `size: nil` drops the padding + text-size, `shape: nil` drops the
+  # border-radius (call site sets its own via `extra:` — see BUTTON_SIZES for why
+  # they'd otherwise collide). The `if` guards are what make those nils skip the
+  # `fetch` instead of raising; base stays the single source of truth either way
+  # rather than being inlined.
+  def button_classes(variant = :primary, size: :md, shape: :default, extra: nil)
     tokens = [ BUTTON_BASE ]
     tokens << BUTTON_VARIANTS.fetch(variant) if variant
     tokens << BUTTON_SIZES.fetch(size) if size
+    tokens << BUTTON_SHAPES.fetch(shape) if shape
     tokens << extra if extra.present?
     tokens.join(" ")
   end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -56,13 +56,13 @@
       </div>
 
       <% unless user_signed_in? %>
-        <%= link_to "Log In", 
-            new_user_session_path, 
-            class: button_classes(:primary_outline, extra: "justify-self-end bg-white hover:bg-primary hover:border-white") %>
+        <%= link_to "Log In",
+            new_user_session_path,
+            class: button_classes(:brand_raised, extra: "justify-self-end") %>
       <% end %>
 
+      <% if user_signed_in? %>
       <div class="absolute inset-y-0 right-0 flex items-center pr-2 md:static md:inset-auto md:ml-6 md:pr-0">
-        <% if user_signed_in? %>
           <div class="relative mr-2 md:hidden" data-controller="dropdown">
             <button
               type="button"
@@ -137,13 +137,13 @@
               <% end %>
             </div>
           </div>
-        <% end %>
 
         <!-- Profile dropdown -->
         <% if current_user %>
           <%= render "shared/navbar_user" %>
         <% end %>
       </div>
+      <% end %>
     </div>
   </div>
 

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -40,6 +40,37 @@ RSpec.describe ButtonHelper, type: :helper do
       expect(helper.button_classes(:primary, extra: "whitespace-nowrap")).to include("whitespace-nowrap")
     end
 
+    it "renders the yellow brand variant" do
+      result = helper.button_classes(:brand)
+
+      expect(result).to include("bg-brand-yellow-400", "hover:bg-brand-yellow-600", "text-brand-navy-900")
+    end
+
+    it "renders the raised yellow brand variant with a darker bottom lip" do
+      result = helper.button_classes(:brand_raised)
+
+      expect(result).to include("bg-brand-yellow-400", "text-brand-navy-900", "font-bold")
+      expect(result).to include("border-b-4", "border-brand-yellow-600", "hover:border-brand-yellow-700")
+    end
+
+    it "defaults to the rounded-lg shape" do
+      expect(helper.button_classes(:primary)).to include("rounded-lg")
+    end
+
+    it "swaps in the pill shape" do
+      result = helper.button_classes(:brand, shape: :pill)
+
+      expect(result).to include("rounded-full")
+      expect(result).not_to include("rounded-lg")
+    end
+
+    it "omits the radius when shape is nil so a call site can supply its own" do
+      result = helper.button_classes(:primary, shape: nil, extra: "rounded-none")
+
+      expect(result).not_to include("rounded-lg")
+      expect(result).to include("rounded-none")
+    end
+
     it "raises for an unknown variant so typos fail loudly" do
       expect { helper.button_classes(:nope) }.to raise_error(KeyError)
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small helper + navbar logic, low blast radius

Gives the signed-out navbar its AWBW brand identity — the yellow CTA from the new designs — and centralizes that styling in the button helper so it's reusable, not hand-written per call site.

### What is the goal of this PR and why is this important?
The Log In button was a plain white outline; the designs call for the brand yellow button. Putting the yellow styling in `ButtonHelper` (rather than inline classes) keeps it consistent and reusable for future call sites.

### How did you approach the change?
- Added two variants to `ButtonHelper`: `brand` (flat gold pill) and `brand_raised` (raised gold with a darker bottom lip), and a `shape` axis (`default` rounded-lg / `pill` rounded-full) so shape can be chosen without fighting the base radius — behavior-preserving for all existing callers.
- Pointed the navbar Log In button at `brand_raised`, and only render the right-hand nav group when signed in so its empty spacer's margin no longer pushed the button off the container edge.
- All token-based (no arbitrary values / no Tailwind safelist change); added helper specs.

### Anything else to add?
The darker bottom lip is a real `border-b-4` in the next-darker gold token rather than an arbitrary box-shadow, so it stays within the design tokens. The flat `brand` pill variant is available for other CTAs but isn't used yet.