### PR TITLE
Add Fraunces to the WYSIWYG font picker

### DIFF
--- a/app/frontend/javascript/rhino/custom-editor.js
+++ b/app/frontend/javascript/rhino/custom-editor.js
@@ -668,6 +668,7 @@ class CustomEditor extends TipTapEditor {
     const fonts = [
       { name: "Default Font", family: "" },
       { name: "Lato", family: "Lato, sans-serif" },
+      { name: "Fraunces", family: "Fraunces, serif" },
       { name: "Telefon Bold", family: "Telefon Bold" },
     ];
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 one-line addition to a static font list, no logic change

Adds **Fraunces** to the WYSIWYG (Rhino) editor's font-family dropdown, next to Lato, so rich-text content can use the marketing brand's display serif.

### What is the goal of this PR and why is this important?
Editors could only pick Lato or Telefon Bold in the rich-text toolbar. Fraunces is the awbw.org display serif, so adding it lets portal content match the marketing brand.

### How did you approach the change?
Added one option to the `renderFontPicker` font list in `custom-editor.js`. Fraunces is already loaded site-wide via the Google Fonts link in the app layout, so no font-loading changes were needed.

### Anything else to add?
View-only change to the editor toolbar.
