### PR TITLE
Plain white communications tables (drop admin-only blue wash inside)

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 </div>
 
-<div class="border border-primary/10 rounded-2xl shadow-sm overflow-hidden">
+<div class="border border-primary/10 rounded-2xl shadow-sm overflow-hidden bg-white">
   <div class="<%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> border-b <%= DomainTheme.border_class_for(:notifications) %> px-8 py-3">
     <div class="flex items-center gap-2">
       <i class="fa-solid fa-bell <%= DomainTheme.text_class_for(:notifications, intensity: 700) %>"></i>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -558,9 +558,10 @@
 
   <% if f.object.persisted? %>
     <%# Combined comments & communications — comment bodies/controls are admin-only
-        and communication subjects are visible to the person (gated in the partial). %>
-    <%= render "shared/comments_and_communications", f: f, mark_admin_only: true,
-          view_all_person: @person %>
+        and communication subjects are visible to the person (gated in the partial).
+        Only admins reach the profile, so the section skips the blue admin-only wash
+        and renders on a plain white card. %>
+    <%= render "shared/comments_and_communications", f: f, view_all_person: @person %>
   <% end %>
 
   <div class="action-buttons mt-8 flex justify-center gap-3">

--- a/spec/requests/people_notifications_spec.rb
+++ b/spec/requests/people_notifications_spec.rb
@@ -133,19 +133,17 @@ RSpec.describe "Person notifications", type: :request do
       expect(id_fields).not_to include(autoemail.id.to_s)
     end
 
-    it "flags the add buttons admin-only but leaves the comment cards untinted" do
+    it "leaves the whole comments & communications section untinted on the admin-only profile" do
       create(:comment, commentable: person, body: "Internal staff note", created_by: admin)
 
       get edit_person_path(person)
 
       doc = Nokogiri::HTML(response.body)
-      # The buttons carry the staff-only signal...
-      buttons = doc.css("#comments-section a").select { |a| a["class"].to_s.include?("admin-only") }
-      expect(buttons.map(&:text).map(&:strip)).to include(a_string_matching(/Add comment/))
-      # ...while the cards stay on the comments theme, so the page isn't a wall of blue.
-      card = doc.at_css("#comments-section .nested-fields > div")
-      expect(card["class"]).not_to include("admin-only")
-      expect(card["class"]).not_to include("bg-blue-100")
+      # Only admins reach the profile, so nothing inside the section carries the blue
+      # admin-only wash — buttons and cards alike render on the plain white card.
+      section = doc.at_css("#comments-section").to_s
+      expect(section).not_to include("admin-only")
+      expect(section).not_to include("bg-blue-100")
       expect(response.body).to include("Internal staff note")
     end
   end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only styling on two admin-only comms tables, no logic or data changes

Both pages keep their admin-only page background, but the comms tables inside were reading the blue wash straight through — a wall of blue that added no signal since only admins reach these pages. Now each table sits on a plain white card.

## Person profile comms section
- `people/_form` stops passing `mark_admin_only: true` to the shared comments & communications partial (the flag that tinted its rows and buttons blue).
- The `mark_admin_only` plumbing stays — it still flags internal notes on any page a non-admin can view; no page uses it today.

## Communications index (`/notifications`)
- The card wrapping the table had no background, so transparent rows showed the blue page wash. Added `bg-white` to that card.

Updated the person-profile request spec to assert the whole section is untinted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)