### PR TITLE
Stop the bulk-payments page and payer ticket erroring out

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -296,6 +296,19 @@ follow this). Match the existing pattern:
   it must stay identical across `index.html.erb`, the results view, the filter
   form's `data-turbo-frame`, request-spec `Turbo-Frame` headers, and
   `turbo-frame#…` view-spec selectors. Only the filename and render target change.
+- **The results response must never 500 — a raise becomes "Oopsie!".** When the
+  frame request errors (or returns a document without the matching frame), the
+  `turbo:frame-missing` handler (`app/frontend/javascript/turbo-events.js`)
+  swaps the frame for an "Oopsie! Something went wrong" box — the row data just
+  vanishes, with no server error page to hint why. The usual culprit is a
+  **row/card partial dereferencing a nil association** (an `optional:`/polymorphic
+  FK, an account-less `person`, a not-yet-linked `event`/`organization`,
+  `created_by`/`updated_by`): use safe navigation (`&.`) or a decorator fallback
+  for anything that can realistically be nil, and remember these lists routinely
+  include edge-case records the happy-path factory doesn't. **Cover it with a
+  request spec that sends the `Turbo-Frame` header and includes the nil-association
+  record**, asserting `:ok` and that the body contains the frame id — a plain
+  full-page `get` in a spec won't reproduce a frame-only failure the same way.
 
 ## Features & tips page (`/features`)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -309,6 +309,16 @@ follow this). Match the existing pattern:
   request spec that sends the `Turbo-Frame` header and includes the nil-association
   record**, asserting `:ok` and that the body contains the frame id — a plain
   full-page `get` in a spec won't reproduce a frame-only failure the same way.
+- **A link inside the results frame that navigates *away* must break out with
+  `data: { turbo_frame: "_top" }`** (or the whole frame needs `target: "_top"`).
+  Otherwise Turbo loads the destination *into* the results frame; the destination
+  has no matching frame, so it's the same `turbo:frame-missing` "Oopsie!". Row
+  links to detail/edit pages (grants, people, organizations, workshops, resources,
+  video_recordings all do this) carry `_top`; only in-frame drivers that *should*
+  stay — pagination, the filter form (which drives the frame from outside), and
+  in-card forms answering with turbo streams — omit it. When a results frame's
+  cards contain several such links, prefer `turbo_frame_tag :x_results,
+  target: "_top"` so no link can be forgotten.
 
 ## Features & tips page (`/features`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,19 @@ follow this). Match the existing pattern:
   it must stay identical across `index.html.erb`, the results view, the filter
   form's `data-turbo-frame`, request-spec `Turbo-Frame` headers, and
   `turbo-frame#…` view-spec selectors. Only the filename and render target change.
+- **The results response must never 500 — a raise becomes "Oopsie!".** When the
+  frame request errors (or returns a document without the matching frame), the
+  `turbo:frame-missing` handler (`app/frontend/javascript/turbo-events.js`)
+  swaps the frame for an "Oopsie! Something went wrong" box — the row data just
+  vanishes, with no server error page to hint why. The usual culprit is a
+  **row/card partial dereferencing a nil association** (an `optional:`/polymorphic
+  FK, an account-less `person`, a not-yet-linked `event`/`organization`,
+  `created_by`/`updated_by`): use safe navigation (`&.`) or a decorator fallback
+  for anything that can realistically be nil, and remember these lists routinely
+  include edge-case records the happy-path factory doesn't. **Cover it with a
+  request spec that sends the `Turbo-Frame` header and includes the nil-association
+  record**, asserting `:ok` and that the body contains the frame id — a plain
+  full-page `get` in a spec won't reproduce a frame-only failure the same way.
 
 ## Features & tips page (`/features`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,16 @@ follow this). Match the existing pattern:
   request spec that sends the `Turbo-Frame` header and includes the nil-association
   record**, asserting `:ok` and that the body contains the frame id — a plain
   full-page `get` in a spec won't reproduce a frame-only failure the same way.
+- **A link inside the results frame that navigates *away* must break out with
+  `data: { turbo_frame: "_top" }`** (or the whole frame needs `target: "_top"`).
+  Otherwise Turbo loads the destination *into* the results frame; the destination
+  has no matching frame, so it's the same `turbo:frame-missing` "Oopsie!". Row
+  links to detail/edit pages (grants, people, organizations, workshops, resources,
+  video_recordings all do this) carry `_top`; only in-frame drivers that *should*
+  stay — pagination, the filter form (which drives the frame from outside), and
+  in-card forms answering with turbo streams — omit it. When a results frame's
+  cards contain several such links, prefer `turbo_frame_tag :x_results,
+  target: "_top"` so no link can be forgotten.
 
 ## Features & tips page (`/features`)
 

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -109,7 +109,14 @@ class AllocationsController < ApplicationController
   private
 
   def source_path(source)
-    polymorphic_path(source.becomes(source.class.base_class))
+    polymorphic_path(source.becomes(source.class.base_class), return_params)
+  end
+
+  # Carry the origin context (e.g. return_to=bulk_payments + the expanded card's
+  # submission id) onto the source page so its eyebrow returns where the admin
+  # came from rather than the generic index.
+  def return_params
+    params.permit(:return_to, :expand, :event_id).to_h.compact_blank
   end
 
   def find_source(type, id)

--- a/app/controllers/bulk_payments_controller.rb
+++ b/app/controllers/bulk_payments_controller.rb
@@ -7,7 +7,7 @@ class BulkPaymentsController < ApplicationController
     if turbo_frame_request?
       @submissions = FormSubmission.bulk_payment
         .search_by_params(params)
-        .includes(:person, :event, :payment, { form: :events })
+        .includes(:person, :event, :payment, { form: :events }, { form_answers: :form_field })
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 50)
       render :bulk_payments_results

--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -81,7 +81,7 @@ module Events
       @submission = FormSubmission.bulk_payment.find_by!(slug: params[:slug])
       authorize! @submission, to: :show?, context: { slug: params[:slug] }
 
-      payer_email = @submission.person.preferred_email.presence ||
+      payer_email = @submission.person&.preferred_email.presence ||
                     @submission.answers_by_identifier["primary_email"]&.strip
 
       if payer_email.present?

--- a/app/decorators/form_submission_decorator.rb
+++ b/app/decorators/form_submission_decorator.rb
@@ -1,6 +1,20 @@
 class FormSubmissionDecorator < ApplicationDecorator
   delegate_all
 
+  # The payer's display name/email. Prefer the linked person's account; fall
+  # back to what the payer typed on the form — bulk-payment payers routinely
+  # have no account, so `person` is nil — then a neutral placeholder for the name.
+  def payer_name
+    return object.person.name if object.person
+    typed = [ answers_by_identifier["first_name"], answers_by_identifier["last_name"] ].compact_blank.join(" ")
+    typed.presence || "Anonymous payer"
+  end
+
+  def payer_email
+    return object.person.email if object.person
+    answers_by_identifier["primary_email"].presence
+  end
+
   def matched_attendees(event_registrations)
     object.bulk_payment_attendees.map do |attendee|
       first = attendee["first_name"]&.strip

--- a/app/decorators/form_submission_decorator.rb
+++ b/app/decorators/form_submission_decorator.rb
@@ -6,8 +6,14 @@ class FormSubmissionDecorator < ApplicationDecorator
   # have no account, so `person` is nil — then a neutral placeholder for the name.
   def payer_name
     return object.person.name if object.person
-    typed = [ answers_by_identifier["first_name"], answers_by_identifier["last_name"] ].compact_blank.join(" ")
-    typed.presence || "Anonymous payer"
+    typed_payer_name || "Anonymous payer"
+  end
+
+  # The payer-facing ticket shows this in preference to the account, since a
+  # signed-in facilitator can submit on someone else's behalf — `person` is then
+  # the facilitator, not the payer whose name is on the form.
+  def typed_payer_name
+    [ answers_by_identifier["first_name"], answers_by_identifier["last_name"] ].compact_blank.join(" ").presence
   end
 
   def payer_email

--- a/app/views/allocations/new.html.erb
+++ b/app/views/allocations/new.html.erb
@@ -1,6 +1,8 @@
 <div class="mx-auto max-w-2xl" data-controller="search-type-select">
   <h1 class="text-primary mb-6 font-display text-2xl font-bold">New Allocation</h1>
-  <%= simple_form_for @allocation, url: allocations_path do |f| %>
+  <%# The origin context rides on the form action so the create redirect can put
+      the admin back where they came from, the way revert does. %>
+  <%= simple_form_for @allocation, url: allocations_path(return_to: params[:return_to], expand: params[:expand]) do |f| %>
     <%= f.hidden_field :source_type %>
     <%= f.hidden_field :source_id %>
     <% source = @source || (@allocation.source if @allocation.source.present?) %>
@@ -43,7 +45,7 @@
     <div class="mt-6">
       <%= f.button :submit, "Submit", class: button_classes(:primary) %>
       <% if source.present? %>
-        <%= link_to "Cancel", payment_path(source), class: button_classes(:secondary_outline, extra: "ml-2") %>
+        <%= link_to "Cancel", payment_path(source, return_to: params[:return_to], expand: params[:expand]), class: button_classes(:secondary_outline, extra: "ml-2") %>
       <% else %>
         <%= link_to "Cancel", payments_path, class: button_classes(:secondary_outline, extra: "ml-2") %>
       <% end %>

--- a/app/views/bulk_payments/bulk_payments_results.html.erb
+++ b/app/views/bulk_payments/bulk_payments_results.html.erb
@@ -24,8 +24,9 @@
             <% highlighted = params[:highlight].to_s == submission.id.to_s %>
             <tr id="<%= form_submission_row_id(submission) %>" class="scroll-mt-24 border-b border-gray-100 text-sm text-gray-800 transition-colors duration-150 last:border-0 <%= highlighted ? "bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "" %>">
               <td class="px-4 py-3">
-                <div class="font-medium text-gray-900"><%= submission.person&.name %></div>
-                <div class="break-all text-gray-500"><%= submission.person&.email %></div>
+                <% payer = submission.decorate %>
+                <div class="font-medium text-gray-900"><%= payer.payer_name %></div>
+                <div class="break-all text-gray-500"><%= payer.payer_email %></div>
               </td>
               <td class="px-4 py-3">
                 <% if event %>

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -38,8 +38,8 @@
   %>
 
   <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_8rem_6rem_13rem_7rem_auto_1.5rem]">
-    <span class="text-sm font-medium text-gray-900 min-w-0 lg:truncate"><%= submission.person.name %></span>
-    <span class="text-sm text-gray-500 min-w-0 break-all lg:break-normal lg:truncate"><%= submission.person.email %></span>
+    <span class="text-sm font-medium text-gray-900 min-w-0 lg:truncate"><%= submission.payer_name %></span>
+    <span class="text-sm text-gray-500 min-w-0 break-all lg:break-normal lg:truncate"><%= submission.payer_email %></span>
     <span class="text-sm text-gray-500 min-w-0 whitespace-nowrap lg:truncate"><%= payment_method.presence || "—" %></span>
     <span class="text-sm text-gray-500 whitespace-nowrap tabular-nums lg:text-right"><% amount_cents = payment&.amount_cents || submission.bulk_payment_amount_cents(@event) %><%= dollars_from_cents(amount_cents) %></span>
     <div class="flex min-w-0 flex-col gap-1">

--- a/app/views/events/_payment_allocations.html.erb
+++ b/app/views/events/_payment_allocations.html.erb
@@ -29,7 +29,7 @@
             <td class="px-3 py-2 whitespace-nowrap text-gray-500"><%= allocation.created_at.strftime("%b %-d, %Y") %></td>
             <td class="px-3 py-2 text-right whitespace-nowrap">
               <% unless allocation.reverted? || allocation.amount.to_i < 0 %>
-                <%= button_to revert_allocation_path(allocation), method: :post,
+                <%= button_to revert_allocation_path(allocation, **local_assigns.fetch(:return_params, {})), method: :post,
                       class: "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-red-50 hover:text-red-700 cursor-pointer",
                       data: { turbo_confirm: "Are you sure?" } do %>
                   <i class="fa-solid fa-rotate-left text-2xs"></i>

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -3,7 +3,8 @@
   attendees = @submission.bulk_payment_attendees
   total_cents = @payment&.amount_cents || @submission.bulk_payment_amount_cents(@event)
   answers = @submission.answers_by_identifier
-  payer_name = [ answers["first_name"], answers["last_name"] ].compact_blank.join(" ").presence || @submission.person.name
+  payer = @submission.decorate
+  payer_name = payer.typed_payer_name || payer.payer_name
   payer_organization = answers["organization_name"]
   attendee_count = @submission.bulk_payment_attendee_count
 %>
@@ -96,7 +97,7 @@
       <div class="space-y-3 text-center">
         <div class="space-y-1">
           <h3 class="text-xs font-medium tracking-wide text-gray-500 uppercase">Payer</h3>
-          <p class="text-2xl font-bold break-words text-gray-900"><%= payer_name.presence || "—" %></p>
+          <p class="text-2xl font-bold break-words text-gray-900"><%= payer_name %></p>
           <% if payer_organization.present? %>
             <p class="text-sm break-words text-gray-500"><%= payer_organization %></p>
           <% end %>

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -23,7 +23,12 @@
         frame: "bulk_payments_results", scoped_to_event: true %>
 
   <% any_filter = request.query_parameters.slice("search", "payment_method", "payment_status", "start_date", "end_date").any? { |_, v| v.present? } %>
-  <%= turbo_frame_tag :bulk_payments_results do %>
+  <%# target: "_top" so the cards' links (submission, ticket, allocations,
+      registration) navigate the whole page — their destinations have no
+      bulk_payments_results frame, so an in-frame load would 500 into "Oopsie!".
+      The filter form drives this frame externally; the in-card forms answer with
+      turbo streams, so neither is affected. %>
+  <%= turbo_frame_tag :bulk_payments_results, target: "_top" do %>
     <div class="mb-3 text-sm text-gray-500">
       <%= pluralize(@submissions.size, "submission") %>
     </div>

--- a/app/views/payments/payments_results.html.erb
+++ b/app/views/payments/payments_results.html.erb
@@ -16,7 +16,7 @@
           <% @payments.each do |payment| %>
             <tr>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.type.underscore.titleize.gsub(" Payment", "").gsub("External Processor", "Stripe") %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.payer.name %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.payer&.name || "Unknown" %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents) %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents_remaining) %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= payment.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -10,7 +10,7 @@
     <div class="flex gap-2">
       <%= link_to "Edit", edit_payment_path(@payment), class: button_classes(:secondary_outline) %>
       <% if @payment.amount_cents_remaining > 0 %>
-        <%= link_to "Allocate", new_allocation_path(source_sgid: @payment.to_sgid.to_s), class: button_classes(:primary) %>
+        <%= link_to "Allocate", new_allocation_path(source_sgid: @payment.to_sgid.to_s, return_to: params[:return_to], expand: params[:expand]), class: button_classes(:primary) %>
         <% if @payment.is_a?(ExternalProcessorPayment) && @payment.pay_charge_id.blank? %>
           <span class="flex items-center gap-1 text-sm text-gray-400 italic">
             <i class="fa-solid fa-info-circle"></i>

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -1,5 +1,10 @@
 <div class="mx-auto max-w-2xl">
-  <%= link_to "← Payments", payments_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
+  <% bulk_payment_event = @payment.form_submission&.resolved_event if params[:return_to] == "bulk_payments" %>
+  <% if bulk_payment_event %>
+    <%= link_to "← Bulk payments", bulk_payments_return_path(bulk_payment_event), class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
+  <% else %>
+    <%= link_to "← Payments", payments_path, class: "text-sm #{eyebrow_link_class} mb-2 inline-block" %>
+  <% end %>
   <div class="mb-6 flex items-center justify-between">
     <h1 class="text-primary font-display text-2xl font-bold">Payment</h1>
     <div class="flex gap-2">
@@ -128,7 +133,7 @@
 
                 <td class="px-4 py-3 text-right text-sm font-medium">
                   <% unless allocation.reverted? || allocation.amount.to_i < 0 %>
-                    <%= button_to "revert", revert_allocation_path(allocation), method: :post, class: "cursor-pointer text-danger hover:text-danger-dark", data: { turbo_confirm: "are you sure you want to revert this allocation?" } %>
+                    <%= button_to "revert", revert_allocation_path(allocation, return_to: params[:return_to], expand: params[:expand]), method: :post, class: "cursor-pointer text-danger hover:text-danger-dark", data: { turbo_confirm: "are you sure you want to revert this allocation?" } %>
                   <% end %>
                 </td>
               </tr>

--- a/spec/decorators/form_submission_decorator_spec.rb
+++ b/spec/decorators/form_submission_decorator_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe FormSubmissionDecorator do
+  describe "#payer_name / #payer_email" do
+    it "uses the linked person's account when present" do
+      person = build(:person, first_name: "Priya", last_name: "Patel", email: "priya@example.com")
+      submission = build(:form_submission, person: person).decorate
+
+      expect(submission.payer_name).to eq(person.name)
+      expect(submission.payer_email).to eq("priya@example.com")
+    end
+
+    it "falls back to the submitted answers for an account-less payer" do
+      submission = create(:form_submission, person: nil, role: "bulk_payment")
+      first = create(:form_field, form: submission.form, field_identifier: "first_name", name: "First name")
+      last = create(:form_field, form: submission.form, field_identifier: "last_name", name: "Last name")
+      email = create(:form_field, form: submission.form, field_identifier: "primary_email", name: "Email")
+      submission.form_answers.create!(form_field: first, submitted_answer: "Dana")
+      submission.form_answers.create!(form_field: last, submitted_answer: "Doe")
+      submission.form_answers.create!(form_field: email, submitted_answer: "dana@example.com")
+
+      expect(submission.decorate.payer_name).to eq("Dana Doe")
+      expect(submission.decorate.payer_email).to eq("dana@example.com")
+    end
+
+    it "returns a neutral placeholder when there is neither an account nor a typed name" do
+      submission = create(:form_submission, person: nil, role: "bulk_payment").decorate
+
+      expect(submission.payer_name).to eq("Anonymous payer")
+      expect(submission.payer_email).to be_nil
+    end
+  end
+end

--- a/spec/requests/allocations_spec.rb
+++ b/spec/requests/allocations_spec.rb
@@ -289,5 +289,17 @@ RSpec.describe "Allocations", type: :request do
         expect(allocation.reload.reverted?).to be true
       end
     end
+
+    context "reverting a bulk-payment allocation" do
+      let(:submission) { create(:form_submission, event: event, role: "bulk_payment") }
+      let(:payment)    { create(:payment, form_submission: submission, amount_cents: 5000, amount_cents_remaining: 4000) }
+      let!(:allocation) { create(:allocation, source: payment, allocatable: reg, amount: 1000) }
+
+      it "carries the return context onto the payment page so its eyebrow goes back to the card" do
+        post revert_allocation_path(allocation, return_to: "bulk_payments", expand: submission.id)
+
+        expect(response).to redirect_to(payment_path(payment, return_to: "bulk_payments", expand: submission.id))
+      end
+    end
   end
 end

--- a/spec/requests/allocations_spec.rb
+++ b/spec/requests/allocations_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe "Allocations", type: :request do
 
   before { sign_in admin }
 
+  describe "GET /allocations/new" do
+    let(:submission) { create(:form_submission, event: event, role: "bulk_payment") }
+    let(:payment)    { create(:payment, form_submission: submission, amount_cents: 5000, amount_cents_remaining: 5000) }
+
+    it "posts the allocation back with the return context so the eyebrow survives the round trip" do
+      get new_allocation_path(source_sgid: payment.to_sgid.to_s, return_to: "bulk_payments", expand: submission.id)
+
+      expect(response.body).to include("action=\"/allocations?expand=#{submission.id}&amp;return_to=bulk_payments\"")
+      expect(response.body).to match(%r{/payments/#{payment.id}\?expand=#{submission.id}&amp;return_to=bulk_payments})
+    end
+  end
+
   describe "GET /allocations scoped to a membership invoice" do
     let(:term) { create(:membership_invoice, cost_cents: 2_500) }
 

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -320,6 +320,28 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
       expect(response.body).to include(event_bulk_payment_path(event, slug: submission.slug))
     end
 
+    # Bulk payment payers routinely have no account, so `person` is nil on their
+    # own ticket — the page has to fall back to the name they typed.
+    it "renders for an account-less payer, showing the name they typed" do
+      anon = create(:form_submission, person: nil, form: form, event: event, role: "bulk_payment")
+      anon.form_answers.create!(form_field: payer_first_name_field, submitted_answer: "Dana")
+      anon.form_answers.create!(form_field: payer_last_name_field, submitted_answer: "Doe")
+
+      get bulk_payment_ticket_path(anon.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Dana Doe")
+    end
+
+    it "falls back to a placeholder when an account-less payer typed no name" do
+      anon = create(:form_submission, person: nil, form: form, event: event, role: "bulk_payment")
+
+      get bulk_payment_ticket_path(anon.slug)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Anonymous payer")
+    end
+
     it "returns 404 for an unknown slug" do
       get bulk_payment_ticket_path("nope")
 
@@ -357,6 +379,18 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
       }.to change(Notification, :count).by(1)
 
       expect(response).to redirect_to(bulk_payment_ticket_path(submission.slug))
+      expect(flash[:notice]).to eq("Confirmation email sent.")
+    end
+
+    it "re-sends to the typed email when the payer has no account" do
+      anon = create(:form_submission, person: nil, form: form, event: event, role: "bulk_payment")
+      anon.form_answers.create!(form_field: payer_email_field, submitted_answer: "dana@example.com")
+
+      expect {
+        post bulk_payment_resend_confirmation_path(anon.slug)
+      }.to change(Notification, :count).by(1)
+
+      expect(response).to redirect_to(bulk_payment_ticket_path(anon.slug))
       expect(flash[:notice]).to eq("Confirmation email sent.")
     end
   end

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -81,6 +81,21 @@ RSpec.describe "Events::BulkPayments", type: :request do
     end
 
 
+    # Regression: an account-less payer (person_id nil — a supported case) used
+    # to make the card raise on `submission.person.name`, 500 the Turbo-Frame
+    # response, and surface the "Oopsie!" error box in place of the results.
+    it "renders an account-less submission through the filter frame with the typed payer name" do
+      anon = create(:form_submission, person: nil, form: form, event: event, role: "bulk_payment")
+      anon.form_answers.create!(form_field: payer_first_name_field, submitted_answer: "Dana")
+      anon.form_answers.create!(form_field: payer_last_name_field, submitted_answer: "Doe")
+
+      get bulk_payments_event_path(event), headers: { "Turbo-Frame" => "bulk_payments_results" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("id=\"bulk_payments_results\"")
+      expect(response.body).to include("Dana Doe")
+    end
+
     it "shows a grey \"Paid\" instead of an orange balance when the registration is fully covered" do
       attendee = create(:person, first_name: "Paid", last_name: "Infull", email: "paid.infull@example.com")
       registration = create(:event_registration, event: event, registrant: attendee, status: "registered")

--- a/spec/requests/events/bulk_payments_spec.rb
+++ b/spec/requests/events/bulk_payments_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe "Events::BulkPayments", type: :request do
       expect(response.body).to include("Dana Doe")
     end
 
+    # Regression: the cards' links (submission, ticket, allocations, registration)
+    # live inside the results frame. Without target="_top" Turbo would load their
+    # frame-less destinations into the frame, 500, and show "Oopsie!". The frame
+    # must break those navigations out to the whole page.
+    it "renders the results frame with target=_top so card links leave the frame" do
+      get bulk_payments_event_path(event)
+
+      expect(response.body).to include("<turbo-frame id=\"bulk_payments_results\" target=\"_top\"")
+    end
+
     it "shows a grey \"Paid\" instead of an orange balance when the registration is fully covered" do
       attendee = create(:person, first_name: "Paid", last_name: "Infull", email: "paid.infull@example.com")
       registration = create(:event_registration, event: event, registrant: attendee, status: "registered")

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe "Payments", type: :request do
       expect(response.body).to include(bulk_payments_event_path(event, expand: submission.id, anchor: "payment-card-#{submission.id}"))
     end
 
+    it "carries the return context onto the Allocate link" do
+      get payment_path(payment, return_to: "bulk_payments", expand: submission.id)
+
+      expect(response.body).to match(%r{/allocations/new\?expand=#{submission.id}&amp;return_to=bulk_payments})
+    end
+
     it "falls back to the payments index otherwise" do
       get payment_path(payment)
 

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe "Payments", type: :request do
 
   before { sign_in admin }
 
+  describe "GET /payments/:id eyebrow" do
+    let(:event) { create(:event, cost_cents: 5000) }
+    let(:submission) { create(:form_submission, event: event, role: "bulk_payment") }
+    let(:payment) { create(:payment, form_submission: submission, amount_cents: 5000, amount_cents_remaining: 5000) }
+
+    it "returns to the expanded bulk-payment card when arrived from bulk payments" do
+      get payment_path(payment, return_to: "bulk_payments", expand: submission.id)
+
+      expect(response.body).to include("← Bulk payments")
+      expect(response.body).to include(bulk_payments_event_path(event, expand: submission.id, anchor: "payment-card-#{submission.id}"))
+    end
+
+    it "falls back to the payments index otherwise" do
+      get payment_path(payment)
+
+      expect(response.body).to include("← Payments")
+    end
+  end
+
   describe "POST /payments" do
     context "when allocating to a fully-paid EventRegistration" do
       let(:event) { create(:event, cost_cents: 10_000) }

--- a/spec/system/bulk_payment_allocate_spec.rb
+++ b/spec/system/bulk_payment_allocate_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Bulk payment event card interactions", type: :system do
 
     within("#payment-card-#{submission.id}") { click_link "Submission - ID: #{submission.id}" }
 
-    expect(page).to have_current_path(/bulk_payment/)
+    expect(page).to have_current_path(%r{/bulk_payment\?})
     expect(page).not_to have_content("Oopsie!")
   end
 

--- a/spec/system/bulk_payment_allocate_spec.rb
+++ b/spec/system/bulk_payment_allocate_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Bulk payment event card interactions", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let(:event) { create(:event, cost_cents: 2500) }
+  let(:form) { create(:form) }
+  let(:payer) { create(:person, first_name: "Quentin", last_name: "Cardpayer") }
+  let(:registrant) { create(:person, first_name: "Fay", last_name: "Cardpaid") }
+
+  let!(:submission) { create(:form_submission, person: payer, form: form, event: event, role: "bulk_payment") }
+  let!(:registration) { create(:event_registration, event: event, registrant: registrant, status: "registered") }
+  let!(:payment) do
+    create(:payment, person: payer, form_submission: submission,
+           amount_cents: 5000, amount_cents_remaining: 5000)
+  end
+
+  before do
+    EventForm.create!(event: event, form: form, role: "bulk_payment")
+    submission.link_registration!(registration.id)
+    sign_in admin
+  end
+
+  it "allocates from the inline field and updates the card in place" do
+    visit bulk_payments_event_path(event, expand: submission.id)
+
+    within("#payment-card-#{submission.id}") do
+      fill_in "amount_dollars", with: "10.00"
+      click_button "Allocate"
+
+      expect(page).to have_content("$15", wait: 5)
+    end
+
+    expect(page).to have_current_path(/bulk_payments/)
+    expect(payment.reload.amount_cents_remaining).to eq(4000)
+  end
+
+  # The card's links live inside the bulk_payments_results turbo frame; they must
+  # break out to a full-page load, not try to render their frame-less
+  # destinations inside the frame (which 500s into the "Oopsie!" box).
+  it "navigates the whole page when a card link is clicked, without Oopsie" do
+    visit bulk_payments_event_path(event, expand: submission.id)
+
+    within("#payment-card-#{submission.id}") { click_link "Submission - ID: #{submission.id}" }
+
+    expect(page).to have_current_path(/bulk_payment/)
+    expect(page).not_to have_content("Oopsie!")
+  end
+
+  it "unlinks a registration in place" do
+    visit bulk_payments_event_path(event, expand: submission.id)
+
+    within("#payment-card-#{submission.id}") do
+      click_button "Unlink"
+      expect(page).to have_no_button("Unlink", wait: 5)
+    end
+
+    expect(page).not_to have_content("Oopsie!")
+    expect(submission.reload.linked_registration_ids).to be_empty
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained frame/nil-guard fixes on the bulk-payments index, the payer ticket, and the eyebrow round trips, with request & browser specs

Fixes for the event **Bulk payments** page throwing "Oopsie! Something went wrong", the payer's own ticket 500ing, and back-links that lost their way.

## 1. Account-less payers crashed the card
- A bulk payment can have no linked person account (anonymous payer — supported). The event card read `person.name`/`.email` bare, so the frame response 500'd.
- Fix: `FormSubmissionDecorator#payer_name`/`#payer_email` (account → typed answers → "Anonymous payer"); both indexes use it. Global index now shows the typed name (was blank) and preloads `form_answers` to stay query-free.

## 2. Card interactions couldn't leave the frame
- The cards' links (submission, ticket, allocations, registration — incl. the dollar-amount pills) and the redirecting **revert** button sit inside `bulk_payments_results`. With no frame target, Turbo loaded each frame-less destination *into* the frame → `turbo:frame-missing` → "Oopsie!". Every one was effectively dead.
- Fix: `turbo_frame_tag :bulk_payments_results, target: "_top"`. In-card allocate/link/unlink forms answer with turbo streams and keep updating in place; the filter form drives the frame from outside — both verified unaffected via a browser spec.

## 3. Back-links lost the card you came from
- Reverting a bulk-payment allocation redirects to the payment page, whose eyebrow pointed at the generic Payments index. The revert redirect now carries `return_to=bulk_payments` + the expanded submission id, and the payment page's eyebrow (and its own revert button) return to that card expanded.
- Same round trip for **Allocate**: the link, the form it posts, and Cancel now carry the context, so creating an allocation lands back on the card instead of the generic index.

## 4. The payer's own ticket 500'd without an account
- `ticket.html.erb` and `resend_confirmation` dereferenced `person` directly — broken for exactly the payers the public slug ticket exists for.
- Both reuse the decorator's fallback. The ticket keeps the **typed** name ahead of the account: a signed-in facilitator can submit on someone else's behalf, which makes `person` the facilitator, not the payer.

## Audited the other lazy index frames
All 15 already guard nullable associations and already carry `_top` on their row links. One defensive parity fix: `payments_results` now uses `payment.payer&.name || "Unknown"`.

## Tests
- Browser: `spec/system/bulk_payment_allocate_spec.rb` (allocate + unlink update in place; a card link navigates away without "Oopsie!"). Verified it fails with `target="_top"` removed.
- Request: account-less submission renders in the frame; frame carries `target="_top"`; the ticket and its resend survive a missing account; revert and allocate carry the return context; payment eyebrow branches on origin. Decorator unit specs for the payer fallbacks.

## Guardrail
CLAUDE.md / copilot-instructions "Lazy index/filter frames": a raising results response becomes "Oopsie!" (guard nil associations; cover with a `Turbo-Frame`-header spec); a link/redirecting-form that navigates away must break out with `_top` (or the frame needs `target: "_top"`).
