### PR TITLE
Make whole archived-event row clickable, not just the title

### DIFF
--- a/app/views/events/_archived_events.html.erb
+++ b/app/views/events/_archived_events.html.erb
@@ -5,18 +5,20 @@
   <ul class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white">
     <% events.each do |event| %>
       <% event = event.decorate %>
-      <li class="flex items-center justify-between gap-4 px-4 py-2.5">
+      <li>
         <%= link_to event_path(event),
-                    class: "min-w-0 text-sm font-medium text-gray-800 hover:underline truncate",
+                    class: "flex items-center justify-between gap-4 px-4 py-2.5 hover:bg-gray-50",
                     data: { turbo_prefetch: false, turbo: false } do %>
-          <%= event.title %>
-        <% end %>
-        <div class="shrink-0 flex items-center gap-3 text-xs text-gray-500">
-          <span><%= event.short_date_range %></span>
-          <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600">
-            <%= event.archive_status_label %>
+          <span class="min-w-0 text-sm font-medium text-gray-800 hover:underline truncate">
+            <%= event.title %>
           </span>
-        </div>
+          <span class="shrink-0 flex items-center gap-3 text-xs text-gray-500">
+            <span><%= event.short_date_range %></span>
+            <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600">
+              <%= event.archive_status_label %>
+            </span>
+          </span>
+        <% end %>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup change to one partial, no logic

Makes the entire "Drafts and past events" row clickable — the date range and Ended status now link to the event, not just the title, so admins get a full-width hit area instead of a narrow title-only target.

### What is the goal of this PR and why is this important?
On the admin "Drafts and past events" list, only the event title was a link. Clicking the date or status did nothing, which felt broken. Now the whole row navigates to the event.

### How did you approach the change?
Wrapped the full row (`app/views/events/_archived_events.html.erb`) in the existing `link_to` instead of just the title, converted the inner `div`/link markup to `span`s, and added a `hover:bg-gray-50` row hover so it reads as one clickable target. The title keeps its own underline-on-hover.

### Anything else to add?
View-only; no logic or data changes.
