### PR TITLE
Restyle bulk-payment submission cards + unify section headers

### DIFF
--- a/app/views/bulk_payments/index.html.erb
+++ b/app/views/bulk_payments/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, "Bulk payment form submissions") %>
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
 <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -103,69 +103,63 @@
 
   <div id="<%= content_id %>" class="hidden mt-3 pt-3 border-t border-primary/10 space-y-3" data-dropdown-target="content">
     <% if linked_regs.any? %>
-      <div class="space-y-1.5">
-        <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Linked registrations</h4>
+      <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
+        <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>Linked registrants</span><span>Allocations</span></div>
 
-        <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
-          <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>Linked registrant</span><span>Allocations</span></div>
+        <div class="px-3 divide-y divide-gray-100">
+          <% linked_regs.each do |reg| %>
+            <% allocated_cents = allocated_by_registration.fetch(reg.id, 0) %>
+            <% remaining_cents = [event_cost_cents - allocated_cents, 0].max %>
+            <% reg_paid_in_full = allocated_cents >= event_cost_cents %>
 
-          <div class="px-3 divide-y divide-gray-100">
-            <% linked_regs.each do |reg| %>
-              <% allocated_cents = allocated_by_registration.fetch(reg.id, 0) %>
-              <% remaining_cents = [event_cost_cents - allocated_cents, 0].max %>
-              <% reg_paid_in_full = allocated_cents >= event_cost_cents %>
+            <div class="grid grid-cols-2 gap-x-4 items-center py-2">
+              <div class="min-w-0"><%= person_profile_button(reg.registrant, subtitle: reg.registrant.preferred_email, path_params: { return_to: "bulk_payments", event_id: @event.id, expand: submission.id }) %></div>
 
-              <div class="grid grid-cols-2 gap-x-4 items-center py-2">
-                <div class="min-w-0"><%= person_profile_button(reg.registrant, subtitle: reg.registrant.preferred_email, path_params: { return_to: "bulk_payments", event_id: @event.id, expand: submission.id }) %></div>
+              <div class="flex flex-wrap items-center gap-4">
+                <%= link_to edit_event_registration_path(reg, return_to: "bulk_payments", expand: submission.id),
+                            title: "View #{reg.registrant.name}'s registration for #{@event.title}",
+                            class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
+                  <i class="fa-solid fa-clipboard-list text-gray-400"></i>
 
-                <div class="flex flex-wrap items-center gap-4">
-                  <%= link_to edit_event_registration_path(reg, return_to: "bulk_payments", expand: submission.id),
-                              title: "View #{reg.registrant.name}'s registration for #{@event.title}",
-                              class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
-                    <i class="fa-solid fa-clipboard-list text-gray-400"></i>
-
-                    <% if remaining_cents.zero? %>
-                      <span class="text-gray-500 whitespace-nowrap">Paid</span>
-                    <% else %>
-                      <span class="text-orange-600 tabular-nums whitespace-nowrap"><%= dollars_from_cents(remaining_cents) %> left</span>
-                    <% end %>
+                  <% if remaining_cents.zero? %>
+                    <span class="text-gray-500 whitespace-nowrap">Paid</span>
+                  <% else %>
+                    <span class="text-orange-600 tabular-nums whitespace-nowrap"><%= dollars_from_cents(remaining_cents) %> left</span>
                   <% end %>
+                <% end %>
 
-                  <%= link_to allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "bulk_payments", expand: submission.id),
-                              title: "View registration allocations",
-                              class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
-                    <i class="fa-solid fa-list-check text-gray-400"></i>
-                    <span class="text-green-600 tabular-nums"><%= dollars_from_cents(allocated_cents) %></span>
-                  <% end %>
+                <%= link_to allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "bulk_payments", expand: submission.id),
+                            title: "View registration allocations",
+                            class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
+                  <i class="fa-solid fa-list-check text-gray-400"></i>
+                  <span class="text-green-600 tabular-nums"><%= dollars_from_cents(allocated_cents) %></span>
+                <% end %>
 
-                  <% if payment && payment.amount_cents_remaining > 0 && !reg_paid_in_full %>
-                    <%= form_tag allocate_bulk_payment_event_path(@event), class: "flex items-center gap-1" do %>
-                      <%= hidden_field_tag :payment_id, payment.id %>
-                      <%= hidden_field_tag :event_registration_id, reg.id %>
-
-                      <span class="text-xs text-gray-500">$</span>
-                      <%= number_field_tag :amount_dollars, nil, step: "0.01", min: "0.01", class: "w-20 rounded-lg border border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none", placeholder: "0.00" %>
-                      <%= button_tag "Allocate", class: button_classes(:primary, extra: "cursor-pointer") %>
-                    <% end %>
-                  <% end %>
-
-                  <%= form_tag unlink_bulk_payment_event_path(@event), method: :delete, class: "inline" do %>
-                    <%= hidden_field_tag :submission_id, submission.id %>
+                <% if payment && payment.amount_cents_remaining > 0 && !reg_paid_in_full %>
+                  <%= form_tag allocate_bulk_payment_event_path(@event), class: "flex items-center gap-1" do %>
+                    <%= hidden_field_tag :payment_id, payment.id %>
                     <%= hidden_field_tag :event_registration_id, reg.id %>
-                    <%= button_tag "Unlink", class: "text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer" %>
+
+                    <span class="text-xs text-gray-500">$</span>
+                    <%= number_field_tag :amount_dollars, nil, step: "0.01", min: "0.01", class: "w-20 rounded-lg border border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none", placeholder: "0.00" %>
+                    <%= button_tag "Allocate", class: button_classes(:primary, extra: "cursor-pointer") %>
                   <% end %>
-                </div>
+                <% end %>
+
+                <%= form_tag unlink_bulk_payment_event_path(@event), method: :delete, class: "inline" do %>
+                  <%= hidden_field_tag :submission_id, submission.id %>
+                  <%= hidden_field_tag :event_registration_id, reg.id %>
+                  <%= button_tag "Unlink", class: "text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer" %>
+                <% end %>
               </div>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
         </div>
       </div>
     <% end %>
 
-    <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Submitted names</h4>
-
     <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
-      <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>First Last Email</span><span>Potential match</span></div>
+      <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>Submitted names</span><span>Potential match</span></div>
 
       <% if attendee_matches.present? %>
         <div class="px-3">
@@ -219,9 +213,9 @@
     </div>
 
     <% if payment %>
-      <div class="space-y-1.5">
-        <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Payment allocations</h4>
-        <div id="<%= dom_id(payment, :allocations) %>" class="border border-gray-200 rounded-lg overflow-hidden bg-white"><%= render "events/payment_allocations", payment: payment, bordered: false, return_params: { return_to: "bulk_payments", expand: submission.id } %></div>
+      <div id="<%= dom_id(payment, :allocations) %>" class="border border-gray-200 rounded-lg overflow-hidden bg-white">
+        <div class="bg-gray-100 px-3 py-2 text-xs font-medium tracking-wide text-gray-400 uppercase">Payment allocations</div>
+        <%= render "events/payment_allocations", payment: payment, bordered: false, return_params: { return_to: "bulk_payments", expand: submission.id } %>
       </div>
     <% else %>
       <%= render "events/bulk_payment_form", submission: submission %>

--- a/app/views/events/_bulk_payment_card.html.erb
+++ b/app/views/events/_bulk_payment_card.html.erb
@@ -31,7 +31,7 @@
     attendee[:matches].present? && attendee[:matches].none? { |reg| allocated_by_registration.fetch(reg.id, 0) >= event_cost_cents }
   } %>
 
-<div id="payment-card-<%= submission.id %>" data-controller="dropdown" class="bg-white border rounded-xl shadow-sm px-4 py-3 hover:shadow-md transition-shadow transition-colors duration-150 scroll-mt-4 <%= highlighted ? "border-yellow-500 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200" %>">
+<div id="payment-card-<%= submission.id %>" data-controller="dropdown" class="bg-brand-cream border rounded-xl shadow-sm px-4 py-3 hover:shadow-md transition-shadow transition-colors duration-150 scroll-mt-4 <%= highlighted ? "border-yellow-500 bg-yellow-50 ring-2 ring-inset ring-yellow-500" : "border-gray-200" %>">
   <%#
     Fixed column template (shared by every card so columns align row-to-row):
     name | email | method | amount | badge | date | submission | chevron.
@@ -101,66 +101,70 @@
     </button>
   </div>
 
-  <div id="<%= content_id %>" class="hidden mt-3 pt-3 border-t border-gray-100 space-y-3" data-dropdown-target="content">
+  <div id="<%= content_id %>" class="hidden mt-3 pt-3 border-t border-primary/10 space-y-3" data-dropdown-target="content">
     <% if linked_regs.any? %>
-      <div class="border-b border-gray-200 pt-2 space-y-1.5">
+      <div class="space-y-1.5">
         <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Linked registrations</h4>
 
-        <div class="divide-y divide-gray-100">
-          <% linked_regs.each do |reg| %>
-            <% allocated_cents = allocated_by_registration.fetch(reg.id, 0) %>
-            <% remaining_cents = [event_cost_cents - allocated_cents, 0].max %>
-            <% reg_paid_in_full = allocated_cents >= event_cost_cents %>
+        <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
+          <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>Linked registrant</span><span>Allocations</span></div>
 
-            <div class="grid grid-cols-2 gap-x-4 items-center py-2">
-              <div class="min-w-0"><%= person_profile_button(reg.registrant, subtitle: reg.registrant.preferred_email, path_params: { return_to: "bulk_payments", event_id: @event.id, expand: submission.id }) %></div>
+          <div class="px-3 divide-y divide-gray-100">
+            <% linked_regs.each do |reg| %>
+              <% allocated_cents = allocated_by_registration.fetch(reg.id, 0) %>
+              <% remaining_cents = [event_cost_cents - allocated_cents, 0].max %>
+              <% reg_paid_in_full = allocated_cents >= event_cost_cents %>
 
-              <div class="flex flex-wrap items-center gap-4">
-                <%= link_to edit_event_registration_path(reg, return_to: "bulk_payments", expand: submission.id),
-                            title: "View #{reg.registrant.name}'s registration for #{@event.title}",
-                            class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
-                  <i class="fa-solid fa-clipboard-list text-gray-400"></i>
+              <div class="grid grid-cols-2 gap-x-4 items-center py-2">
+                <div class="min-w-0"><%= person_profile_button(reg.registrant, subtitle: reg.registrant.preferred_email, path_params: { return_to: "bulk_payments", event_id: @event.id, expand: submission.id }) %></div>
 
-                  <% if remaining_cents.zero? %>
-                    <span class="text-gray-500 whitespace-nowrap">Paid</span>
-                  <% else %>
-                    <span class="text-orange-600 tabular-nums whitespace-nowrap"><%= dollars_from_cents(remaining_cents) %> left</span>
+                <div class="flex flex-wrap items-center gap-4">
+                  <%= link_to edit_event_registration_path(reg, return_to: "bulk_payments", expand: submission.id),
+                              title: "View #{reg.registrant.name}'s registration for #{@event.title}",
+                              class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
+                    <i class="fa-solid fa-clipboard-list text-gray-400"></i>
+
+                    <% if remaining_cents.zero? %>
+                      <span class="text-gray-500 whitespace-nowrap">Paid</span>
+                    <% else %>
+                      <span class="text-orange-600 tabular-nums whitespace-nowrap"><%= dollars_from_cents(remaining_cents) %> left</span>
+                    <% end %>
                   <% end %>
-                <% end %>
 
-                <%= link_to allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "bulk_payments", expand: submission.id),
-                            title: "View registration allocations",
-                            class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
-                  <i class="fa-solid fa-list-check text-gray-400"></i>
-                  <span class="text-green-600 tabular-nums"><%= dollars_from_cents(allocated_cents) %></span>
-                <% end %>
+                  <%= link_to allocations_path(allocatable_sgid: reg.to_sgid.to_s, return_to: "bulk_payments", expand: submission.id),
+                              title: "View registration allocations",
+                              class: "inline-flex items-center w-24 gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 hover:text-gray-800 transition-colors" do %>
+                    <i class="fa-solid fa-list-check text-gray-400"></i>
+                    <span class="text-green-600 tabular-nums"><%= dollars_from_cents(allocated_cents) %></span>
+                  <% end %>
 
-                <% if payment && payment.amount_cents_remaining > 0 && !reg_paid_in_full %>
-                  <%= form_tag allocate_bulk_payment_event_path(@event), class: "flex items-center gap-1" do %>
-                    <%= hidden_field_tag :payment_id, payment.id %>
+                  <% if payment && payment.amount_cents_remaining > 0 && !reg_paid_in_full %>
+                    <%= form_tag allocate_bulk_payment_event_path(@event), class: "flex items-center gap-1" do %>
+                      <%= hidden_field_tag :payment_id, payment.id %>
+                      <%= hidden_field_tag :event_registration_id, reg.id %>
+
+                      <span class="text-xs text-gray-500">$</span>
+                      <%= number_field_tag :amount_dollars, nil, step: "0.01", min: "0.01", class: "w-20 rounded-lg border border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none", placeholder: "0.00" %>
+                      <%= button_tag "Allocate", class: button_classes(:primary, extra: "cursor-pointer") %>
+                    <% end %>
+                  <% end %>
+
+                  <%= form_tag unlink_bulk_payment_event_path(@event), method: :delete, class: "inline" do %>
+                    <%= hidden_field_tag :submission_id, submission.id %>
                     <%= hidden_field_tag :event_registration_id, reg.id %>
-
-                    <span class="text-xs text-gray-500">$</span>
-                    <%= number_field_tag :amount_dollars, nil, step: "0.01", min: "0.01", class: "w-20 rounded-lg border border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none", placeholder: "0.00" %>
-                    <%= button_tag "Allocate", class: button_classes(:primary, extra: "cursor-pointer") %>
+                    <%= button_tag "Unlink", class: "text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer" %>
                   <% end %>
-                <% end %>
-
-                <%= form_tag unlink_bulk_payment_event_path(@event), method: :delete, class: "inline" do %>
-                  <%= hidden_field_tag :submission_id, submission.id %>
-                  <%= hidden_field_tag :event_registration_id, reg.id %>
-                  <%= button_tag "Unlink", class: "text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer" %>
-                <% end %>
+                </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>
 
     <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Submitted names</h4>
 
-    <div class="border border-gray-200 rounded-lg overflow-hidden">
+    <div class="border border-gray-200 rounded-lg overflow-hidden bg-white">
       <div class="grid grid-cols-2 gap-x-4 text-xs font-medium text-gray-400 uppercase tracking-wide bg-gray-100 px-3 py-2"><span>First Last Email</span><span>Potential match</span></div>
 
       <% if attendee_matches.present? %>
@@ -180,7 +184,9 @@
                   <% end %>
                 </div>
 
-                <% if best && !linked_ids.include?(best.id) %>
+                <% if best && linked_ids.include?(best.id) %>
+                  <span class="text-xs text-gray-400 font-medium whitespace-nowrap">Linked above</span>
+                <% elsif best %>
                   <%= form_tag link_bulk_payment_event_path(@event), class: "p-4" do %>
                     <%= hidden_field_tag :submission_id, submission.id %>
                     <%= hidden_field_tag :event_registration_id, best.id %>
@@ -213,9 +219,9 @@
     </div>
 
     <% if payment %>
-      <div class="border-t border-gray-200 pt-2 space-y-2">
+      <div class="space-y-1.5">
         <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wide">Payment allocations</h4>
-        <div id="<%= dom_id(payment, :allocations) %>"><%= render "events/payment_allocations", payment: payment, return_params: { return_to: "bulk_payments", expand: submission.id } %></div>
+        <div id="<%= dom_id(payment, :allocations) %>" class="border border-gray-200 rounded-lg overflow-hidden bg-white"><%= render "events/payment_allocations", payment: payment, bordered: false, return_params: { return_to: "bulk_payments", expand: submission.id } %></div>
       </div>
     <% else %>
       <%= render "events/bulk_payment_form", submission: submission %>

--- a/app/views/events/_bulk_payment_form.html.erb
+++ b/app/views/events/_bulk_payment_form.html.erb
@@ -1,6 +1,7 @@
-<div class="rounded-lg border-2 border-green-400 bg-green-200 p-4" data-controller="conditional-fields">
-  <h3 class="mb-4 text-lg font-medium">Record Payment</h3>
-  <%= form_tag bulk_payments_event_path(@event) do %>
+<div class="overflow-hidden rounded-lg border <%= DomainTheme.border_class_for(:payments) %> <%= DomainTheme.bg_class_for(:payments) %>" data-controller="conditional-fields">
+  <div class="px-3 py-2 text-xs font-medium tracking-wide uppercase <%= DomainTheme.bg_class_for(:payments, intensity: 100) %> <%= DomainTheme.text_class_for(:payments, intensity: 700) %>">Add payment</div>
+
+  <%= form_tag bulk_payments_event_path(@event), class: "p-3" do %>
     <%= hidden_field_tag :submission_id, submission.id %>
     <%= hidden_field_tag :currency, "usd" %>
 
@@ -59,7 +60,7 @@
     </div>
 
     <div class="mt-4 flex gap-2">
-      <%= button_tag class: button_classes(:primary, extra: "inline-flex items-center gap-1.5") do %>
+      <%= button_tag class: button_classes(:success, extra: "inline-flex items-center gap-1.5") do %>
         <i class="fa-solid fa-plus text-xs"></i>
         Create payment
       <% end %>

--- a/app/views/events/_payment_allocations.html.erb
+++ b/app/views/events/_payment_allocations.html.erb
@@ -6,10 +6,10 @@
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="<%= "bg-gray-100" if bordered %>">
         <tr>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-gray-700">Allocated to</th>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-gray-700">Amount</th>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-gray-700">Date</th>
-          <th class="px-3 py-2 text-right text-sm font-semibold text-gray-700">Actions</th>
+          <th class="px-3 py-2 text-left text-xs font-medium tracking-wide text-gray-400 uppercase">Allocated to</th>
+          <th class="px-3 py-2 text-left text-xs font-medium tracking-wide text-gray-400 uppercase">Amount</th>
+          <th class="px-3 py-2 text-left text-xs font-medium tracking-wide text-gray-400 uppercase">Date</th>
+          <th class="px-3 py-2 text-right text-xs font-medium tracking-wide text-gray-400 uppercase">Actions</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">

--- a/app/views/events/_payment_allocations.html.erb
+++ b/app/views/events/_payment_allocations.html.erb
@@ -4,7 +4,7 @@
 <% if allocations.any? %>
   <div class="overflow-hidden <%= "rounded-lg border border-gray-200" if bordered %>">
     <table class="min-w-full divide-y divide-gray-200 text-sm">
-      <thead class="bg-gray-100">
+      <thead class="<%= "bg-gray-100" if bordered %>">
         <tr>
           <th class="px-3 py-2 text-left text-sm font-semibold text-gray-700">Allocated to</th>
           <th class="px-3 py-2 text-left text-sm font-semibold text-gray-700">Amount</th>

--- a/app/views/events/_payment_allocations.html.erb
+++ b/app/views/events/_payment_allocations.html.erb
@@ -1,6 +1,8 @@
 <% allocations = payment.allocations.includes(:allocatable) %>
+<% bordered = local_assigns.fetch(:bordered, true) %>
+<% pad = bordered ? "" : "px-3 py-2" %>
 <% if allocations.any? %>
-  <div class="overflow-hidden rounded-lg border border-gray-200">
+  <div class="overflow-hidden <%= "rounded-lg border border-gray-200" if bordered %>">
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-100">
         <tr>
@@ -40,9 +42,9 @@
       </tbody>
     </table>
   </div>
-  <div class="text-right text-sm font-medium text-gray-500">
+  <div class="<%= pad %> text-right text-sm font-medium text-gray-500">
     <%= dollars_from_cents(payment.amount_cents_remaining) %> remaining
   </div>
 <% else %>
-  <p class="text-sm text-gray-400 italic">No allocations yet. <%= dollars_from_cents(payment.amount_cents_remaining) %> remaining.</p>
+  <p class="<%= pad %> text-sm text-gray-400 italic">No allocations yet. <%= dollars_from_cents(payment.amount_cents_remaining) %> remaining.</p>
 <% end %>

--- a/app/views/events/bulk_payments/index.html.erb
+++ b/app/views/events/bulk_payments/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_title, "Bulk payments — #{@event.title}") %>
+<% content_for(:page_title, "Bulk payment form submissions — #{@event.title}") %>
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-4 shadow-sm sm:p-6">
   <%# Top bar: eyelash + sub-nav, matching the other event pages %>
@@ -12,7 +12,7 @@
   </div>
 
   <div class="mb-6 flex flex-wrap items-center justify-between gap-4">
-    <h1 class="text-primary font-display text-2xl font-semibold">Bulk payments</h1>
+    <h1 class="text-primary font-display text-2xl font-semibold">Bulk payment form submissions</h1>
     <%= link_to event_invoice_path(@event),
                 class: "inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors" do %>
       <i class="fa-solid fa-file-invoice-dollar text-xs"></i> Blank invoice


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 presentational restyle across the bulk-payment pages plus a small shared-partial display flag

Facilitators found the expanded bulk-payment submission card jarring and hard to scan — a loud green form above a flat run of white sections that blurred together. This restyles the card so each section reads as its own panel and the primary action stands out.

### What is the goal of this PR and why is this important?
Make the bulk-payment submission card easy to scan: tell the sections apart, know where to record a payment, and match the AWBW brand surface.

### How did you approach the change?
- Card surface is `brand-cream`; each section (Linked registrants, Submitted names, Payment allocations) is a white card so it stands out against it.
- Section titles fold into a single gray uppercase header row (e.g. `Submitted names | Potential match`); Payment allocations keeps a title bar, with its table header restyled to match the other header rows.
- `Add payment` is the single green (payments-domain) call-to-action, with a green Create payment button; a match already linked above shows "Linked above" instead of a Link action.
- Event and global index titles now read "Bulk payment form submissions".

### Anything else to add?
- Pure presentation. The one logic touch is a `bordered:` local on the shared `_payment_allocations` partial (defaults true), so the ticket page is unchanged while the embedded card renders flush.
- The allocate button behavior is a known, separate issue being fixed elsewhere.

<img width="1191" height="632" alt="Screenshot 2026-08-31 at 9 32 32 AM" src="https://github.com/user-attachments/assets/0059a0d1-0043-4e62-8518-dbb5778b209a" />
<img width="1222" height="627" alt="Screenshot 2026-08-31 at 9 32 41 AM" src="https://github.com/user-attachments/assets/2923e4c4-d29b-49c7-9dd2-97c28b1fab62" />
