### PR TITLE
Sort Tailwind classes across the whole tree

### DIFF
--- a/app/frontend/javascript/controllers/event_staff_bio_controller.js
+++ b/app/frontend/javascript/controllers/event_staff_bio_controller.js
@@ -50,7 +50,7 @@ export default class extends Controller {
     const link = editPath
       ? `<a href="${editPath}" class="text-xs font-medium text-blue-600 hover:text-blue-800">Edit on profile</a>`
       : ""
-    return `<div class="flex items-center justify-between mb-1"><span class="text-sm font-medium text-gray-700">Profile bio</span>${link}</div>`
+    return `<div class="mb-1 flex items-center justify-between"><span class="text-sm font-medium text-gray-700">Profile bio</span>${link}</div>`
   }
 
   muted(text) {

--- a/app/frontend/javascript/controllers/paginated_fields_controller.js
+++ b/app/frontend/javascript/controllers/paginated_fields_controller.js
@@ -84,7 +84,7 @@ export default class extends Controller {
 
     this.navTarget.classList.remove("hidden");
     this.navTarget.innerHTML = `
-      <div class="flex items-center justify-center gap-3 mt-4">
+      <div class="mt-4 flex items-center justify-center gap-3">
         <button type="button" data-action="paginated-fields#previous"
                 class="px-3 py-1 border border-gray-200 rounded-md bg-white text-gray-500 hover:bg-gray-100 ${this.currentPage <= 1 ? 'opacity-30 cursor-default' : ''}"
                 ${this.currentPage <= 1 ? 'disabled' : ''}>

--- a/app/frontend/javascript/controllers/scholarship_preview_controller.js
+++ b/app/frontend/javascript/controllers/scholarship_preview_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
     const icon = paid ? "fa-thumbs-up" : "fa-circle-exclamation"
     const label = paid ? "Paid up" : this.formatDollars(owed)
     this.owedTarget.className = `rounded-lg border px-4 py-3 ${box}`
-    this.owedTarget.innerHTML = `<dt class="text-xs font-medium uppercase tracking-wide text-gray-400">Still owed</dt><dd class="mt-1 flex items-center gap-1.5 text-sm font-semibold tabular-nums ${text}"><i class="fa-solid ${icon}"></i>${label}</dd>`
+    this.owedTarget.innerHTML = `<dt class="text-xs font-medium tracking-wide text-gray-400 uppercase">Still owed</dt><dd class="mt-1 flex items-center gap-1.5 text-sm font-semibold tabular-nums ${text}"><i class="fa-solid ${icon}"></i>${label}</dd>`
   }
 
   renderAllocation(allocatedCents) {

--- a/app/frontend/javascript/turbo-events.js
+++ b/app/frontend/javascript/turbo-events.js
@@ -30,18 +30,18 @@ addEventListener("turbo:frame-missing", async (event) => {
   }
 
   event.target.innerHTML = `
-    <div class="flex flex-col items-center justify-center p-4 text-center border border-gray-200 rounded-md bg-gray-50">
-      <div class="text-3xl mb-2">Oopsie!</div>
-      <p class="text-gray-600 mb-2">Something went wrong</p>
-      <p class="text-sm text-gray-500 mb-2">
+    <div class="flex flex-col items-center justify-center rounded-md border border-gray-200 bg-gray-50 p-4 text-center">
+      <div class="mb-2 text-3xl">Oopsie!</div>
+      <p class="mb-2 text-gray-600">Something went wrong</p>
+      <p class="mb-2 text-sm text-gray-500">
         Try refreshing the page or check back later
       </p>
 
       ${
         isAdmin
           ? `
-            <div class="mt-4 p-3 text-left text-xs bg-red-50 border border-red-200 rounded w-full overflow-auto">
-              <div class="font-semibold text-red-700 mb-2">Debug Info</div>
+            <div class="mt-4 w-full overflow-auto rounded border border-red-200 bg-red-50 p-3 text-left text-xs">
+              <div class="mb-2 font-semibold text-red-700">Debug Info</div>
 
               <div><strong>Status:</strong> ${status ?? "unknown"}</div>
               <div><strong>Status Text:</strong> ${statusText ?? "unknown"}</div>
@@ -50,13 +50,13 @@ addEventListener("turbo:frame-missing", async (event) => {
               <div><strong>URL:</strong> ${url ?? "unknown"}</div>
 
               <div class="mt-3">
-                <div class="font-semibold mb-1">Headers</div>
+                <div class="mb-1 font-semibold">Headers</div>
                 ${headersHtml || "<div>None</div>"}
               </div>
 
               <div class="mt-3">
-                <div class="font-semibold mb-1">Body Preview (truncated)</div>
-                <pre class="whitespace-pre-wrap break-words max-h-60 overflow-auto bg-white p-2 border rounded">${bodyPreview || "Empty body"}</pre>
+                <div class="mb-1 font-semibold">Body Preview (truncated)</div>
+                <pre class="max-h-60 overflow-auto rounded border bg-white p-2 break-words whitespace-pre-wrap">${bodyPreview || "Empty body"}</pre>
               </div>
             </div>
           `

--- a/app/views/active_storage/blobs/_blob_thumbnail.html.erb
+++ b/app/views/active_storage/blobs/_blob_thumbnail.html.erb
@@ -4,9 +4,8 @@
 
 <figure
   class="
-    relative attachment attachment--<%= blob.previewable? || blob.image? ? "preview" : "file" %>
-    attachment--<%= blob.filename.extension %> w-fit rounded-md p-2
-    bg-gray-50 shadow-md
+    attachment relative attachment--<%= blob.previewable? || blob.image? ? "preview" : "file" %>
+    attachment--<%= blob.filename.extension %> w-fit rounded-md bg-gray-50 p-2 shadow-md
   "
 >
   <% if blob.previewable? %>
@@ -16,10 +15,7 @@
     <%= image_tag attachment.variant(:thumbnail), class: "w-48 h-48 object-contain" %>
   <% else %>
     <div
-      class="
-        w-48 h-48 flex items-center justify-center bg-gray-200 rounded text-center p-2
-        text-xs break-words whitespace-normal overflow-hidden
-      "
+      class="flex h-48 w-48 items-center justify-center overflow-hidden rounded bg-gray-200 p-2 text-center text-xs break-words whitespace-normal"
       title="<%= blob.filename.to_s %>"
     >
       <span class="line-clamp-3"><%= blob.filename.to_s %></span>
@@ -28,10 +24,7 @@
   <!-- Asset ID badge (top-right) -->
   <% if asset.type == "RichTextAsset" %>
     <span
-      class="
-        absolute top-1 right-1 bg-gray-700 text-white text-xs rounded px-1.5 py-0.5
-        pointer-events-none
-      "
+      class="pointer-events-none absolute top-1 right-1 rounded bg-gray-700 px-1.5 py-0.5 text-xs text-white"
     >
       <%= asset.id %>
     </span>

--- a/app/views/addresses/_address_fields.html.erb
+++ b/app/views/addresses/_address_fields.html.erb
@@ -1,8 +1,8 @@
 <%# Persisted addresses start collapsed to a single-line header; new/blank ones
     stay expanded so their fields are ready to fill in. Native <details>/<summary>
     toggles the editable fields on click — no JavaScript needed. %>
-<details class="nested-fields group rounded-lg bg-white border border-gray-200 p-6 mb-4"<%= " open".html_safe unless f.object.persisted? %>>
-  <summary class="flex items-center justify-between gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+<details class="nested-fields group mb-4 rounded-lg border border-gray-200 bg-white p-6"<%= " open".html_safe unless f.object.persisted? %>>
+  <summary class="flex cursor-pointer list-none items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
     <div class="text-lg font-semibold text-gray-800">
       Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
     </div>
@@ -12,7 +12,7 @@
   <hr class="my-6 border-gray-200">
 
   <!-- LOCATION + DISTRICT + LOCALITY -->
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
     <%= f.input :address_type,
                 as: :select,
                 required: true,
@@ -38,7 +38,7 @@
 
 
   <!-- LA-SPECIFIC FIELDS -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :locality,
                 label: "Locality",
                 as: :select,
@@ -82,7 +82,7 @@
   </div>
 
   <!-- ADDRESS BLOCK -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :street_address,
                 label: "Street Address",
                 input_html: {
@@ -112,7 +112,7 @@
 
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :district,
                 label: "District",
                 input_html: {

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,10 +1,10 @@
 <%# The Time column carries the timestamp, so the reused notification row drops
     its own leading date (show_date: false). %>
 <tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
-  <td data-label="Time" class="px-4 py-3 whitespace-nowrap align-top text-gray-500">
+  <td data-label="Time" class="px-4 py-3 align-top whitespace-nowrap text-gray-500">
     <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
-  <td data-label="Activity" class="px-4 py-3 whitespace-nowrap align-top font-medium text-gray-900">
+  <td data-label="Activity" class="px-4 py-3 align-top font-medium whitespace-nowrap text-gray-900">
     <i class="fa-solid fa-bell mr-1 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>"></i>
     <%= notification.timeline_activity_name %>
   </td>

--- a/app/views/admin/analytics/_popular_list.html.erb
+++ b/app/views/admin/analytics/_popular_list.html.erb
@@ -1,16 +1,16 @@
-<div class="<%= DomainTheme.bg_class_for(color) %> border border-gray-200 rounded-lg shadow-sm p-5">
+<div class="<%= DomainTheme.bg_class_for(color) %> rounded-lg border border-gray-200 p-5 shadow-sm">
   <div class="p-6">
-    <div class="text-xs font-semibold tracking-wide uppercase text-gray-500 mb-3">
+    <div class="mb-3 text-xs font-semibold tracking-wide text-gray-500 uppercase">
       <%= title %>
     </div>
 
     <ul class=""><!-- divide-y divide-gray-200-->
       <% records.each do |record| %>
-        <li class="py-1 flex justify-between items-center">
+        <li class="flex items-center justify-between py-1">
           <%= link_to record.title, public_send(path_method, record),
                       class: "text-gray-800 hover:underline truncate" %>
 
-          <span class="text-sm text-gray-600 font-mono">
+          <span class="font-mono text-sm text-gray-600">
           <%= record.public_send(metric) %>
         </span>
         </li>

--- a/app/views/admin/analytics/_zero_list.html.erb
+++ b/app/views/admin/analytics/_zero_list.html.erb
@@ -1,6 +1,6 @@
-<div class="<%= DomainTheme.bg_class_for(color) %> border border-gray-200 rounded-lg shadow-sm p-5">
+<div class="<%= DomainTheme.bg_class_for(color) %> rounded-lg border border-gray-200 p-5 shadow-sm">
   <div class="p-6">
-    <h3 class="font-semibold text-gray-900 mb-4">
+    <h3 class="mb-4 font-semibold text-gray-900">
       <%= title %>
     </h3>
 

--- a/app/views/admin/shared/_activities_tabs.html.erb
+++ b/app/views/admin/shared/_activities_tabs.html.erb
@@ -1,17 +1,17 @@
 <ul class="flex border-b border-gray-300">
-  <li class="-mb-px mr-1">
+  <li class="mr-1 -mb-px">
     <%= link_to "Counts", admin_activities_counts_path,
         class: "inline-block px-4 py-2 font-medium text-gray-700 border-b-2 border-transparent hover:text-gray-900 hover:border-gray-300 transition-colors duration-200 #{current_page?(admin_activities_counts_path) ? 'is-active' : ''}" %>
   </li>
-  <li class="-mb-px mr-1">
+  <li class="mr-1 -mb-px">
     <%= link_to "Charts", admin_activities_charts_path,
         class: "inline-block px-4 py-2 font-medium text-gray-700 border-b-2 border-transparent hover:text-gray-900 hover:border-gray-300 transition-colors duration-200 #{current_page?(admin_activities_charts_path) ? 'is-active' : ''}" %>
   </li>
-  <li class="-mb-px mr-1">
+  <li class="mr-1 -mb-px">
     <%= link_to "Activities", admin_activities_events_path,
         class: "inline-block px-4 py-2 font-medium text-gray-700 border-b-2 border-transparent hover:text-gray-900 hover:border-gray-300 transition-colors duration-200 #{current_page?(admin_activities_events_path) ? 'is-active' : ''}" %>
   </li>
-  <li class="-mb-px mr-1">
+  <li class="mr-1 -mb-px">
     <%= link_to "Visits", admin_activities_visits_path,
         class: "inline-block px-4 py-2 font-medium text-gray-700 border-b-2 border-transparent hover:text-gray-900 hover:border-gray-300 transition-colors duration-200 #{current_page?(admin_activities_visits_path) ? 'is-active' : ''}" %>
   </li>

--- a/app/views/admin/shared/_audience_dropdown.html.erb
+++ b/app/views/admin/shared/_audience_dropdown.html.erb
@@ -18,18 +18,18 @@
     <button type="button"
             data-action="dropdown#toggle"
             data-dropdown-payload-param='[{"<%= dropdown_id %>":"hidden"}]'
-            class="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 bg-transparent text-sm text-gray-700">
+            class="inline-flex items-center gap-2 rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring-blue-500">
       <span><%= button_label %></span>
-      <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
       </svg>
     </button>
 
     <div id="<%= dropdown_id %>"
          data-dropdown-target="content"
-         class="hidden absolute z-10 mt-1 bg-white border border-gray-200 rounded-md shadow-lg p-3 min-w-[160px]">
+         class="absolute z-10 mt-1 hidden min-w-[160px] rounded-md border border-gray-200 bg-white p-3 shadow-lg">
       <% labels_map.each do |value, label| %>
-        <label class="flex items-center gap-2 cursor-pointer py-1">
+        <label class="flex cursor-pointer items-center gap-2 py-1">
           <%= check_box_tag "audience[]", value, selected.include?(value),
                             onchange: (auto_submit ? "this.closest('form').submit()" : nil),
                             class: "rounded border-gray-300 text-blue-600 focus:ring-blue-500" %>

--- a/app/views/affiliations/_primary_contact_label.html.erb
+++ b/app/views/affiliations/_primary_contact_label.html.erb
@@ -1,9 +1,9 @@
 <%# "Primary contact" column label shortened to "Primary" with a hover tooltip,
     matching the Program status info-tooltip pattern on the organization form. %>
-<span class="group relative inline-flex items-center gap-1 whitespace-nowrap text-sm font-medium text-gray-700">
+<span class="group relative inline-flex items-center gap-1 text-sm font-medium whitespace-nowrap text-gray-700">
   Primary
   <i class="fa-solid fa-circle-info text-xs text-gray-400"></i>
-  <span class="hidden group-hover:block absolute z-50 left-0 top-full mt-1 w-56 whitespace-normal rounded-lg bg-blue-100 p-3 text-xs text-gray-700 shadow-lg ring-1 ring-blue-200">
+  <span class="absolute top-full left-0 z-50 mt-1 hidden w-56 rounded-lg bg-blue-100 p-3 text-xs whitespace-normal text-gray-700 shadow-lg ring-1 ring-blue-200 group-hover:block">
     <span class="block font-semibold">Primary contact</span>
     This person is best contact for this organization
   </span>

--- a/app/views/allocations/_results_skeleton.html.erb
+++ b/app/views/allocations/_results_skeleton.html.erb
@@ -1,7 +1,7 @@
-<div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
   <div class="overflow-x-auto">
     <table class="w-full border-collapse border border-gray-200">
-      <thead class="bg-gray-100 animate-pulse">
+      <thead class="animate-pulse bg-gray-100">
         <tr>
           <th class="px-4 py-2 text-left"><div class="h-4 w-8 rounded bg-gray-200"></div></th>
           <th class="px-4 py-2 text-left"><div class="h-4 w-16 rounded bg-gray-200"></div></th>
@@ -14,7 +14,7 @@
         </tr>
       </thead>
 
-      <tbody class="divide-y divide-gray-200 animate-pulse">
+      <tbody class="animate-pulse divide-y divide-gray-200">
         <% 10.times do %>
           <tr>
             <td class="px-4 py-2"><div class="h-4 w-8 rounded bg-gray-200"></div></td>
@@ -32,8 +32,8 @@
   </div>
 </div>
 
-<div class="flex justify-center mt-6 space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/application/_papertrail_versions.html.erb
+++ b/app/views/application/_papertrail_versions.html.erb
@@ -5,15 +5,15 @@
             data-dropdown-payload-param='[{"<%= dom_id(record, :versions) %>":"hidden"}]'
             class="inline-flex items-center gap-1.5 text-sm font-medium <%= eyebrow_link_class %> cursor-pointer">
       Change Log
-      <i class="fa-solid fa-chevron-down w-3 h-3 text-gray-400"></i>
+      <i class="fa-solid fa-chevron-down h-3 w-3 text-gray-400"></i>
     </button>
     <div id="<%= dom_id(record, :versions) %>"
          data-dropdown-target="content"
-         class="hidden mt-2 space-y-2">
+         class="mt-2 hidden space-y-2">
       <% record.versions.order(created_at: :desc).each do |version| %>
-        <div class="border border-gray-200 rounded-lg p-3 <%= version.event == 'create' ? 'bg-green-50' : version.event == 'destroy' ? 'bg-red-50' : 'bg-gray-50' %>">
-          <div class="flex items-center gap-2 mb-1">
-            <span class="px-2 py-0.5 text-xs font-medium rounded-full
+        <div class="rounded-lg border border-gray-200 p-3 <%= version.event == 'create' ? 'bg-green-50' : version.event == 'destroy' ? 'bg-red-50' : 'bg-gray-50' %>">
+          <div class="mb-1 flex items-center gap-2">
+            <span class="rounded-full px-2 py-0.5 text-xs font-medium
               <%= version.event == 'create' ? 'bg-green-100 text-green-700' :
                  version.event == 'update' ? 'bg-blue-100 text-blue-700' :
                  'bg-red-100 text-red-700' %>">
@@ -25,13 +25,13 @@
             </span>
           </div>
           <% if version.changeset.present? && version.event != 'destroy' %>
-            <div class="mt-1 font-mono text-xs text-gray-700 space-y-0.5">
+            <div class="mt-1 space-y-0.5 font-mono text-xs text-gray-700">
               <% version.changeset.each do |attr, (old_val, new_val)| %>
                 <% next if %w[id created_at updated_at].include?(attr) %>
                 <div>
                   <span class="text-gray-500"><%= attr %>:</span>
                   <span class="text-gray-400"><%= old_val.inspect %></span>
-                  <span class="text-gray-300 mx-1">→</span>
+                  <span class="mx-1 text-gray-300">→</span>
                   <span class="text-gray-900"><%= new_val.inspect %></span>
                 </div>
               <% end %>

--- a/app/views/assets/_display_icon.html.erb
+++ b/app/views/assets/_display_icon.html.erb
@@ -4,11 +4,7 @@
 <% width ||= nil %>
 
 <div
-  class="
-    flex items-center justify-center
-    bg-gray-100 border border-gray-300 rounded
-    w-full h-full
-  "
+  class="flex h-full w-full items-center justify-center rounded border border-gray-300 bg-gray-100"
 >
   <%= render "resources/resource_icon",
              kind: resource.try(:kind),

--- a/app/views/assets/_display_image.html.erb
+++ b/app/views/assets/_display_image.html.erb
@@ -31,12 +31,12 @@
                     class: result.image_classes,
                     alt: result.alt_text %>
     <% when :pdf_document %>
-      <div class="flex items-center gap-3 p-4 border rounded-lg bg-gray-50">
-        <i class="fas fa-file-pdf text-red-600 text-2xl"></i>
+      <div class="flex items-center gap-3 rounded-lg border bg-gray-50 p-4">
+        <i class="fas fa-file-pdf text-2xl text-red-600"></i>
         <span class="font-medium underline hover:no-underline"><%= result.filename %></span>
       </div>
     <% when :icon %>
-      <div class="<%= result.image_classes %> hover:opacity-95 transition-opacity">
+      <div class="<%= result.image_classes %> transition-opacity hover:opacity-95">
         <%= render "assets/display_icon",
                    resource: resource,
                    width: 18,

--- a/app/views/assets/_primary_image_picker.html.erb
+++ b/app/views/assets/_primary_image_picker.html.erb
@@ -11,6 +11,6 @@
 
     <%= hidden_field_tag :owner_sgid, owner.to_sgid.to_s, autocomplete: "off" %>
 
-    <button data-action="asset-picker#openFileDialog" type="button" class="admin-only hidden md:flex bg-blue-100 text-gray-700 rounded-full p-2 shadow hover:bg-blue-200 transition items-center"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change primary photo</span></button>
+    <button data-action="asset-picker#openFileDialog" type="button" class="admin-only hidden items-center rounded-full bg-blue-100 p-2 text-gray-700 shadow transition hover:bg-blue-200 md:flex"><i class="fa-solid fa-camera"></i><span class="pl-2 text-nowrap">Change primary photo</span></button>
   <% end %>
 <% end %>

--- a/app/views/assets/_resource_display.html.erb
+++ b/app/views/assets/_resource_display.html.erb
@@ -1,11 +1,11 @@
 <% file = resource.downloadable_asset&.file&.attached? ? resource.downloadable_asset.file : resource.display_image %>
 
 <% if file.respond_to?(:content_type) && file.content_type == "application/pdf" %>
-  <div class="max-w-7xl mx-auto h-[95vh] rounded-lg border border-gray-200 overflow-hidden">
+  <div class="mx-auto h-[95vh] max-w-7xl overflow-hidden rounded-lg border border-gray-200">
     <object
       data="<%= rails_storage_proxy_path(file, disposition: :inline) %>"
       type="application/pdf"
-      class="w-full h-full"
+      class="h-full w-full"
       aria-label="<%= resource.title %> (PDF preview)"
     >
       <%= render "assets/display_assets",

--- a/app/views/author_credit_divergences/_legacy_group.html.erb
+++ b/app/views/author_credit_divergences/_legacy_group.html.erb
@@ -1,6 +1,6 @@
 <%# Reported per column: clearing one is what makes that column safe to drop. %>
 <div class="mb-6">
-  <h3 class="text-sm font-semibold text-gray-800 mb-2">
+  <h3 class="mb-2 text-sm font-semibold text-gray-800">
     <%= group.model.name.underscore.humanize %>
     <code class="text-xs font-normal text-gray-500"><%= group.column %></code>
   </h3>

--- a/app/views/author_credit_divergences/_results_skeleton.html.erb
+++ b/app/views/author_credit_divergences/_results_skeleton.html.erb
@@ -1,9 +1,9 @@
 <div class="animate-pulse space-y-4">
   <% 3.times do %>
     <div class="rounded-lg border border-gray-200 bg-white p-4">
-      <div class="h-5 w-48 bg-gray-200 rounded mb-3"></div>
-      <div class="h-4 w-full bg-gray-100 rounded mb-2"></div>
-      <div class="h-4 w-3/4 bg-gray-100 rounded"></div>
+      <div class="mb-3 h-5 w-48 rounded bg-gray-200"></div>
+      <div class="mb-2 h-4 w-full rounded bg-gray-100"></div>
+      <div class="h-4 w-3/4 rounded bg-gray-100"></div>
     </div>
   <% end %>
 </div>

--- a/app/views/author_credit_divergences/_unlinked_table.html.erb
+++ b/app/views/author_credit_divergences/_unlinked_table.html.erb
@@ -1,8 +1,8 @@
 <%# Locals: rows (responding to #record and #suggested_author), name_header,
     suggestion_note (optional). %>
-<div class="rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+<div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
   <table class="w-full text-sm">
-    <thead class="text-left text-xs uppercase text-gray-500 bg-gray-50">
+    <thead class="bg-gray-50 text-left text-xs text-gray-500 uppercase">
       <tr>
         <th class="px-4 py-2 font-medium">Content</th>
         <th class="px-4 py-2 font-medium">Type</th>
@@ -24,6 +24,6 @@
     </tbody>
   </table>
   <% if local_assigns[:suggestion_note].present? %>
-    <p class="px-4 py-2 text-xs text-gray-500 border-t border-gray-100"><%= suggestion_note %></p>
+    <p class="border-t border-gray-100 px-4 py-2 text-xs text-gray-500"><%= suggestion_note %></p>
   <% end %>
 </div>

--- a/app/views/bookmarks/_bookmarks_count.html.erb
+++ b/app/views/bookmarks/_bookmarks_count.html.erb
@@ -1,7 +1,7 @@
 <div id="bookmarks_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Bookmarks (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Bookmarks (<%= @count_display %>)</h3>
   </div>
-  <hr class="border-gray-300 my-6">
+  <hr class="my-6 border-gray-300">
 </div>

--- a/app/views/bookmarks/_bookmarks_results.html.erb
+++ b/app/views/bookmarks/_bookmarks_results.html.erb
@@ -3,7 +3,7 @@
   sort_base = params.permit(:keyword, :user_id, :bookmarkable_type, :windows_type, :number_of_items_per_page).to_h.symbolize_keys
   sort_link = sort_header_link(frame: "bookmarks_results", path: ->(p) { bookmarks_path(p) }, base: sort_base)
 %>
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm <%= 'animate-fade blur-on-submit' if @bookmarks.any? %>">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm <%= 'animate-fade blur-on-submit' if @bookmarks.any? %>">
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
@@ -33,8 +33,8 @@
         <% end %>
       <% else %>
         <tr>
-          <td colspan="6" class="text-center py-16">
-            <h2 class="text-gray-600 text-lg mb-2">No bookmarks found.</h2>
+          <td colspan="6" class="py-16 text-center">
+            <h2 class="mb-2 text-lg text-gray-600">No bookmarks found.</h2>
           </td>
         </tr>
       <% end %>

--- a/app/views/bookmarks/_editable_bookmark_button.html.erb
+++ b/app/views/bookmarks/_editable_bookmark_button.html.erb
@@ -14,8 +14,8 @@
                     turbo_confirm: "Remove bookmark?",
                     action: "click->optimistic-bookmark#toggle"
                   } do %>
-        <i data-optimistic-bookmark-target="icon" class="fas fa-bookmark text-base flex-shrink-0"></i>
-        <span data-optimistic-bookmark-target="text" class="leading-none text-sm py-[2.75px]">Bookmarked</span>
+        <i data-optimistic-bookmark-target="icon" class="fas fa-bookmark flex-shrink-0 text-base"></i>
+        <span data-optimistic-bookmark-target="text" class="py-[2.75px] text-sm leading-none">Bookmarked</span>
       <% end %>
     <% else %>
       <%= button_to bookmarks_path(bookmark: { bookmarkable_id: resource.id, bookmarkable_type: resource.class.name }),
@@ -24,8 +24,8 @@
        hover:bg-primary hover:text-white transition-colors duration-200
        font-medium shadow-sm leading-none",
                   data: { action: "click->optimistic-bookmark#toggle" } do %>
-        <i data-optimistic-bookmark-target="icon" class="far fa-bookmark text-base flex-shrink-0"></i>
-        <span data-optimistic-bookmark-target="text" class="leading-none text-sm py-[2.75px]">Bookmark</span>
+        <i data-optimistic-bookmark-target="icon" class="far fa-bookmark flex-shrink-0 text-base"></i>
+        <span data-optimistic-bookmark-target="text" class="py-[2.75px] text-sm leading-none">Bookmark</span>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/bookmarks/_editable_bookmark_icon.html.erb
+++ b/app/views/bookmarks/_editable_bookmark_icon.html.erb
@@ -12,14 +12,14 @@
                     data: { action: "optimistic-bookmark#toggle",
                             turbo_confirm: "Remove bookmark?" },
                     class: "inline-block" do %>
-          <i data-optimistic-bookmark-target="icon" class="fas fa-bookmark w-5 h-5 text-blue-500 hover:text-gray-400"></i>
+          <i data-optimistic-bookmark-target="icon" class="fas fa-bookmark h-5 w-5 text-blue-500 hover:text-gray-400"></i>
         <% end %>
       <% else %>
         <%= button_to bookmarks_path(bookmark: { bookmarkable_id: resource.id,
                                                bookmarkable_type: resource.class.name }),
                     data: { action: "optimistic-bookmark#toggle" },
                     class: "inline-block" do %>
-          <i data-optimistic-bookmark-target="icon" class="far fa-bookmark w-5 h-5 text-gray-400 hover:text-blue-500"></i>
+          <i data-optimistic-bookmark-target="icon" class="far fa-bookmark h-5 w-5 text-gray-400 hover:text-blue-500"></i>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/bookmarks/_personal_bookmarks_results.html.erb
+++ b/app/views/bookmarks/_personal_bookmarks_results.html.erb
@@ -11,7 +11,7 @@
 %>
 <div class="<%= 'animate-fade blur-on-submit' if @bookmarks.any? %>">
   <!-- Sort bar -->
-  <div class="flex flex-wrap items-center gap-4 mb-6">
+  <div class="mb-6 flex flex-wrap items-center gap-4">
     <span class="font-semibold">Sort by:</span>
     <% [ [ "created_at", "Newest" ], [ "title", "Title" ], [ "popularity", "Most Bookmarked" ] ].each do |col, label| %>
       <%= link_to personal_bookmarks_path(sort_base.merge(sort: col, direction: (@sort == col && @sort_direction == "desc") ? "asc" : "desc", page: nil)),
@@ -23,7 +23,7 @@
     <% end %>
   </div>
 
-  <div class="border-b border-gray-300 my-6"></div>
+  <div class="my-6 border-b border-gray-300"></div>
 
   <% if @bookmarks.any? %>
     <div id="bookmarks-list" class="space-y-4">

--- a/app/views/bookmarks/_personal_results_skeleton.html.erb
+++ b/app/views/bookmarks/_personal_results_skeleton.html.erb
@@ -1,14 +1,14 @@
-<div class="space-y-4 animate-pulse">
+<div class="animate-pulse space-y-4">
   <% 3.times do %>
-    <div class="flex flex-col md:flex-row border-b border-gray-200 gap-4 py-4">
-      <div class="w-5 h-5 rounded bg-gray-200"></div>
-      <div class="w-12 h-8 rounded bg-gray-200"></div>
-      <div class="flex flex-col gap-2 flex-1">
+    <div class="flex flex-col gap-4 border-b border-gray-200 py-4 md:flex-row">
+      <div class="h-5 w-5 rounded bg-gray-200"></div>
+      <div class="h-8 w-12 rounded bg-gray-200"></div>
+      <div class="flex flex-1 flex-col gap-2">
         <div class="h-5 w-48 rounded bg-gray-200"></div>
         <div class="h-4 w-32 rounded bg-gray-200"></div>
         <div class="h-4 w-40 rounded bg-gray-200"></div>
       </div>
-      <div class="flex flex-col gap-2 flex-1">
+      <div class="flex flex-1 flex-col gap-2">
         <div class="h-4 w-28 rounded bg-gray-200"></div>
         <div class="h-4 w-24 rounded bg-gray-200"></div>
       </div>

--- a/app/views/bookmarks/_personal_row.html.erb
+++ b/app/views/bookmarks/_personal_row.html.erb
@@ -3,8 +3,7 @@
 <div
   id="bookmarkable-<%= bookmarkable.id %>"
   class="
-    flex flex-col md:flex-row <%= "admin-only bg-blue-100" unless bookmarkable.published? %> border-b
-    border-gray-200 list-group-item-custom gap-4 py-4 mb-0">
+    flex flex-col md:flex-row <%= "admin-only bg-blue-100" unless bookmarkable.published? %> mb-0 list-group-item-custom gap-4 border-b border-gray-200 py-4">
   <div
     id="bookmarkable-<%= bookmarkable.id %>-anchor"
     style="position: relative; top: -200px;"></div>
@@ -12,7 +11,7 @@
   <%= render "bookmarks/editable_bookmark_icon", resource: bookmarkable.object %>
 
   <!-- 1️⃣ Media -->
-  <div class="flex flex-col items-center w-12">
+  <div class="flex w-12 flex-col items-center">
     <!-- Assets -->
     <%= render "assets/display_image",
                resource: bookmarkable,
@@ -21,15 +20,15 @@
                file: bookmark.decorate.display_image %>
 
     <!-- Type -->
-    <div class="mt-1 text-xs text-gray-600 font-medium text-center">
+    <div class="mt-1 text-center text-xs font-medium text-gray-600">
       <%= bookmarkable.object.class.model_name.human.upcase %>
     </div>
   </div>
 
 
   <!-- 2️⃣ Title / author / metadata -->
-  <div class="flex flex-col gap-1 min-w-[60ch] max-w-[60ch] break-words">
-    <h3 class="text-lg font-bold text-gray-800 flex items-center gap-2">
+  <div class="flex max-w-[60ch] min-w-[60ch] flex-col gap-1 break-words">
+    <h3 class="flex items-center gap-2 text-lg font-bold text-gray-800">
       <% if bookmarkable.respond_to?(:type) %>
         <% type_name = " (#{bookmarkable.type})" %>
       <% elsif bookmarkable.respond_to?(:windows_type) %>
@@ -49,7 +48,7 @@
     </div>
     <% tag_list = bookmark.bookmarkable_type == "Workshop" ? collect_all_tags(bookmarkable) : [] %>
     <div class="text-sm text-gray-600">
-      Bookmarked by community <%= bookmark.bookmarkable.bookmarks_count %> times<% if tag_list.any? %>, <span class="group relative inline-block"><span class="cursor-help">Tags: <%= tag_list.count %></span><div class="hidden group-hover:block absolute left-0 top-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg p-3 z-10 min-w-[300px] max-w-[500px]"><div class="text-sm text-gray-800"><%= tag_list.join(", ") %></div></div></span><% end %>
+      Bookmarked by community <%= bookmark.bookmarkable.bookmarks_count %> times<% if tag_list.any? %>, <span class="group relative inline-block"><span class="cursor-help">Tags: <%= tag_list.count %></span><div class="absolute top-full left-0 z-10 mt-1 hidden max-w-[500px] min-w-[300px] rounded-lg border border-gray-300 bg-white p-3 shadow-lg group-hover:block"><div class="text-sm text-gray-800"><%= tag_list.join(", ") %></div></div></span><% end %>
     </div>
   </div>
 

--- a/app/views/bookmarks/_results_skeleton.html.erb
+++ b/app/views/bookmarks/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-4 py-2 text-left"><div class="h-4 w-8 rounded bg-gray-200"></div></th>
         <th class="px-4 py-2 text-left"><div class="h-4 w-20 rounded bg-gray-200"></div></th>
@@ -10,7 +10,7 @@
         <th class="px-4 py-2 text-left"><div class="h-4 w-16 rounded bg-gray-200"></div></th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 3.times do %>
         <tr>
           <td class="px-4 py-3"><div class="h-4 w-8 rounded bg-gray-200"></div></td>

--- a/app/views/bookmarks/_search_boxes.html.erb
+++ b/app/views/bookmarks/_search_boxes.html.erb
@@ -7,7 +7,7 @@
   <%= render "search_fields" %>
 
   <!-- Clear filters -->
-  <div class="flex sm:justify-end items-end">
+  <div class="flex items-end sm:justify-end">
     <%= render "shared/search_clear", url: url %>
   </div>
 <% end %>

--- a/app/views/bookmarks/_search_fields.html.erb
+++ b/app/views/bookmarks/_search_fields.html.erb
@@ -1,5 +1,5 @@
 <% show_created_by = allowed_to?(:index?, Bookmark) && params[:user_id].present? %>
-<div class="grid grid-cols-1 md:grid-cols-<%= show_created_by ? 4 : 3 %> gap-4 items-end mb-6">
+<div class="grid grid-cols-1 md:grid-cols-<%= show_created_by ? 4 : 3 %> mb-6 items-end gap-4">
   <!-- Keyword -->
   <div>
     <%= label_tag :keyword, "Keyword", class: search_label_class %>

--- a/app/views/categories/_search_boxes.html.erb
+++ b/app/views/categories/_search_boxes.html.erb
@@ -1,5 +1,5 @@
 <!-- Filters -->
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
+<div class="mb-6 rounded-lg border border-gray-200 bg-white p-4">
   <%= form_with url: categories_path,
                 method: :get,
                 local: true,
@@ -30,7 +30,7 @@
     </div>
 
     <!-- PUBLISHED -->
-    <div class="min-w-[150px] p-2 rounded-md">
+    <div class="min-w-[150px] rounded-md p-2">
       <label for="published" class="<%= search_label_class %>">
         Published
       </label>

--- a/app/views/comments/_search_boxes.html.erb
+++ b/app/views/comments/_search_boxes.html.erb
@@ -10,10 +10,10 @@
               html: { autocomplete: "off" }, class: "bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3" do |f| %>
   <div class="flex items-center gap-2 text-gray-600">
     <i class="fa-solid fa-filter text-xs"></i>
-    <span class="text-xs font-semibold uppercase tracking-wide">Filter</span>
+    <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
   </div>
   <div class="flex flex-wrap items-end gap-3">
-    <div class="grow min-w-[150px]">
+    <div class="min-w-[150px] grow">
       <label for="query" class="<%= search_label_class %>">Keyword</label>
       <div class="relative">
         <%= f.text_field :query, value: params[:query],
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <div class="grow min-w-[150px]">
+    <div class="min-w-[150px] grow">
       <label for="author_id" class="<%= search_label_class %>">Author</label>
       <%= select_tag :author_id,
                      options_for_select(User.where(id: params[:author_id]).map { |user| [ user.full_name_with_email, user.id ] }, params[:author_id]),
@@ -55,7 +55,7 @@
     </div>
 
     <div class="pb-1">
-      <label class="inline-flex items-center cursor-pointer select-none" title="Flagged for follow-up">
+      <label class="inline-flex cursor-pointer items-center select-none" title="Flagged for follow-up">
         <%= check_box_tag :flagged, "1", params[:flagged] == "1", class: "peer sr-only", onchange: "this.form.requestSubmit()" %>
         <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
         <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flagged</span>

--- a/app/views/comments/comments_results.html.erb
+++ b/app/views/comments/comments_results.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "comments_results" do %>
-  <div class="border-t border-gray-100 pt-4 mb-3">
+  <div class="mb-3 border-t border-gray-100 pt-4">
     <h2 class="text-sm font-semibold text-gray-700">Comments <span class="font-normal text-gray-400">· <%= @count_display %> shown</span></h2>
   </div>
   <%= render "comments/feed",

--- a/app/views/community_news/_community_news_count.html.erb
+++ b/app/views/community_news/_community_news_count.html.erb
@@ -1,7 +1,7 @@
 <div id="community_news_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Community news (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Community news (<%= @count_display %>)</h3>
   </div>
-  <hr class="border-gray-300 my-6">
+  <hr class="my-6 border-gray-300">
 </div>

--- a/app/views/community_news/_results_skeleton.html.erb
+++ b/app/views/community_news/_results_skeleton.html.erb
@@ -1,7 +1,7 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
     <!-- Header skeleton -->
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left">
           <div class="h-4 w-24 rounded bg-gray-200"></div>
@@ -16,33 +16,33 @@
         </th>
 
         <th class="px-6 py-3 text-center">
-          <div class="h-4 w-16 mx-auto rounded bg-gray-200"></div>
+          <div class="mx-auto h-4 w-16 rounded bg-gray-200"></div>
         </th>
 
         <th class="px-6 py-3 text-center">
-          <div class="h-4 w-16 mx-auto rounded bg-gray-200"></div>
+          <div class="mx-auto h-4 w-16 rounded bg-gray-200"></div>
         </th>
 
         <th class="px-6 py-3 text-right">
-          <div class="h-4 w-20 ml-auto rounded bg-gray-200"></div>
+          <div class="ml-auto h-4 w-20 rounded bg-gray-200"></div>
         </th>
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 3.times do %>
         <tr>
           <!-- Title -->
           <td class="px-4 py-3">
             <div class="flex items-center gap-3">
               <!-- Bookmark -->
-              <div class="w-5 h-5 rounded bg-gray-200"></div>
+              <div class="h-5 w-5 rounded bg-gray-200"></div>
 
               <!-- Image -->
-              <div class="w-24 h-14 rounded border border-gray-200 bg-gray-200"></div>
+              <div class="h-14 w-24 rounded border border-gray-200 bg-gray-200"></div>
 
               <!-- Title + badge -->
-              <div class="flex flex-col gap-2 flex-1">
+              <div class="flex flex-1 flex-col gap-2">
                 <div class="h-5 w-40 rounded bg-gray-200"></div>
                 <div class="h-4 w-24 rounded-full bg-gray-200"></div>
               </div>
@@ -61,17 +61,17 @@
 
           <!-- Created At -->
           <td class="px-6 py-4 text-center">
-            <div class="h-4 w-20 mx-auto rounded bg-gray-200"></div>
+            <div class="mx-auto h-4 w-20 rounded bg-gray-200"></div>
           </td>
 
           <!-- Updated -->
           <td class="px-6 py-4 text-center">
-            <div class="h-4 w-20 mx-auto rounded bg-gray-200"></div>
+            <div class="mx-auto h-4 w-20 rounded bg-gray-200"></div>
           </td>
 
           <!-- Actions -->
           <td class="px-6 py-4 text-right">
-            <div class="inline-flex gap-2 justify-end">
+            <div class="inline-flex justify-end gap-2">
               <div class="h-8 w-14 rounded bg-gray-200"></div>
               <div class="h-8 w-14 rounded bg-gray-200"></div>
             </div>

--- a/app/views/community_news/_search_boxes.html.erb
+++ b/app/views/community_news/_search_boxes.html.erb
@@ -5,7 +5,7 @@
                     turbo_frame: "community_news_results" },
                     autocomplete: "off",
               class: "space-y-2" do |f| %>
-  <div class="flex flex-wrap md:flex-nowrap items-end gap-6">
+  <div class="flex flex-wrap items-end gap-6 md:flex-nowrap">
     <!-- TITLE -->
     <div class="min-w-[150px] pb-2">
       <label for="title" class="<%= search_label_class %>">
@@ -19,7 +19,7 @@
     </div>
 
     <!-- KEYWORDS -->
-    <div class="flex-1 min-w-[200px] pb-2">
+    <div class="min-w-[200px] flex-1 pb-2">
       <label for="query" class="<%= search_label_class %>">
         Keywords
       </label>

--- a/app/views/contact_methods/_contact_method_fields.html.erb
+++ b/app/views/contact_methods/_contact_method_fields.html.erb
@@ -1,6 +1,6 @@
-<div class="nested-fields rounded-lg bg-white border border-gray-200 p-6 mb-4">
+<div class="nested-fields mb-4 rounded-lg border border-gray-200 bg-white p-6">
   <%= f.hidden_field :kind, value: :phone %>
-  <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-5">
     <!-- Contact Type -->
     <div>
       <%= f.input :contact_type,
@@ -22,7 +22,7 @@
     </div>
 
     <!-- Primary -->
-    <div class="flex items-center h-[42px]">
+    <div class="flex h-[42px] items-center">
       <%= f.input :primary,
                   as: :boolean,
                   wrapper: false,
@@ -31,7 +31,7 @@
     </div>
 
     <!-- Inactive -->
-    <div class="flex items-center h-[42px]">
+    <div class="flex h-[42px] items-center">
       <%= f.input :inactive,
                   as: :boolean,
                   wrapper: false,
@@ -39,7 +39,7 @@
                   input_html: { class: "mr-2 text-blue-600 focus:ring-blue-500" } %>
     </div>
 
-    <div class="text-right text-end">
+    <div class="text-end text-right">
       <!-- Remove button -->
       <%= link_to_remove_association "Remove",
                                      f,

--- a/app/views/contact_us/_portal_contact_info.html.erb
+++ b/app/views/contact_us/_portal_contact_info.html.erb
@@ -1,23 +1,23 @@
-<div class="grid grid-cols-1 sm:grid-cols-3 gap-8">
+<div class="grid grid-cols-1 gap-8 sm:grid-cols-3">
   <div>
-    <div class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-1">
+    <div class="mb-1 text-sm font-semibold tracking-wide text-gray-500 uppercase">
       Phone
     </div>
     <%= link_to "(310) 396-0317", "tel:310-396-0317",
                 class: "text-blue-600 hover:text-blue-800 font-medium" %>
   </div>
   <div>
-    <div class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-1">
+    <div class="mb-1 text-sm font-semibold tracking-wide text-gray-500 uppercase">
       Email
     </div>
     <%= mail_to "info@awbw.org",
                 class: "text-blue-600 hover:text-blue-800 font-medium" %>
   </div>
   <div>
-    <div class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-1">
+    <div class="mb-1 text-sm font-semibold tracking-wide text-gray-500 uppercase">
       Mailing address
     </div>
-    <address class="not-italic text-gray-700 leading-relaxed">
+    <address class="leading-relaxed text-gray-700 not-italic">
       Attn: Zachery Scott, Executive Director<br>
       A Window Between Worlds<br>
       1029 1/2 W 24th Street<br>

--- a/app/views/continuing_education_registrations/_results_skeleton.html.erb
+++ b/app/views/continuing_education_registrations/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <% [ "w-24", "w-28", "w-20", "w-12", "w-16", "w-16", "w-20", "w-12" ].each_with_index do |w, i| %>
           <th class="px-4 py-3 <%= i >= 3 && i <= 4 ? "text-right" : (i == 7 ? "text-right" : "text-left") %>">
@@ -10,7 +10,7 @@
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 10.times do %>
         <tr>
           <% [ "w-28", "w-32", "w-20", "w-8", "w-16", "w-16", "w-20", "w-10" ].each_with_index do |w, i| %>

--- a/app/views/devise/_auth_card.html.erb
+++ b/app/views/devise/_auth_card.html.erb
@@ -9,7 +9,7 @@
     <div class="p-8">
       <%= render "layouts/mailer/logo" %>
 
-      <h1 class="text-primary font-display mb-2 text-center text-3xl"><%= title %></h1>
+      <h1 class="text-primary mb-2 text-center font-display text-3xl"><%= title %></h1>
       <% if local_assigns[:subtitle].present? %>
         <p class="mb-6 text-center text-gray-600"><%= subtitle %></p>
       <% else %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -9,7 +9,7 @@
         <h3 class="text-sm font-medium <%= classes[:text] %> mb-2">
           <%= pluralize(resource.errors.count, "error") %> prevented this from being saved:
         </h3>
-        <ul class="list-disc list-inside text-sm <%= classes[:text] %> space-y-1">
+        <ul class="list-inside list-disc text-sm <%= classes[:text] %> space-y-1">
           <% resource.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>

--- a/app/views/event_registrations/_callout_card.html.erb
+++ b/app/views/event_registrations/_callout_card.html.erb
@@ -21,12 +21,12 @@
 <% linked = local_assigns.fetch(:linked, true) && links_to_page %>
 <% card_class = "flex items-center gap-3 rounded-xl border-2 #{theme[:border]} #{theme[:bg]} px-4 py-3 #{theme[:hover]} transition-colors" %>
 <% card_body = capture do %>
-  <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> text-xl shrink-0"></i>
+  <i class="<%= callout.display_icon_class %> <%= theme[:icon] %> shrink-0 text-xl"></i>
 
-  <div class="flex-1 min-w-0 text-left">
+  <div class="min-w-0 flex-1 text-left">
     <p class="font-semibold <%= theme[:title] %>"><%= callout.title %></p>
     <% if badge.present? || callout.subtitle.present? %>
-      <p class="text-sm <%= theme[:subtitle] %> flex items-center gap-1.5 flex-wrap">
+      <p class="text-sm <%= theme[:subtitle] %> flex flex-wrap items-center gap-1.5">
         <% if badge.present? %>
           <%= render "shared/badge", label: badge, classes: badge_classes %>
         <% end %>

--- a/app/views/event_registrations/_search_boxes.html.erb
+++ b/app/views/event_registrations/_search_boxes.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag(event_registrations_path, method: :get, class: "space-y-4") do |f| %>
-  <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mb-6">
+  <div class="mb-6 flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
     <div class="w-full md:flex-1">
       <%= label_tag :event_id, "Event", class: search_label_class %>
       <%= select_tag :event_id,
@@ -56,6 +56,6 @@
                      onchange: "this.form.submit();" %>
     </div>
     <!-- Clear filters -->
-    <div class="w-full md:w-auto flex justify-end"><%= render "shared/search_clear", url: event_registrations_path %></div>
+    <div class="flex w-full justify-end md:w-auto"><%= render "shared/search_clear", url: event_registrations_path %></div>
   </div>
 <% end %>

--- a/app/views/events/_archived_events.html.erb
+++ b/app/views/events/_archived_events.html.erb
@@ -1,18 +1,18 @@
 <%# Compact linked list of admin-only events kept off the cards grid: unpublished
     drafts and events that ended more than a month ago. %>
-<div class="admin-only bg-blue-100 mt-10 rounded-lg p-4">
-  <h2 class="text-lg font-semibold text-gray-700 mb-3">Drafts and past events</h2>
-  <ul class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white">
+<div class="admin-only mt-10 rounded-lg bg-blue-100 p-4">
+  <h2 class="mb-3 text-lg font-semibold text-gray-700">Drafts and past events</h2>
+  <ul class="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
     <% events.each do |event| %>
       <% event = event.decorate %>
       <li>
         <%= link_to event_path(event),
                     class: "flex items-center justify-between gap-4 px-4 py-2.5 hover:bg-gray-50",
                     data: { turbo_prefetch: false, turbo: false } do %>
-          <span class="min-w-0 text-sm font-medium text-gray-800 hover:underline truncate">
+          <span class="min-w-0 truncate text-sm font-medium text-gray-800 hover:underline">
             <%= event.title %>
           </span>
-          <span class="shrink-0 flex items-center gap-3 text-xs text-gray-500">
+          <span class="flex shrink-0 items-center gap-3 text-xs text-gray-500">
             <span><%= event.short_date_range %></span>
             <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600">
               <%= event.archive_status_label %>

--- a/app/views/events/_attendees_skeleton.html.erb
+++ b/app/views/events/_attendees_skeleton.html.erb
@@ -12,7 +12,7 @@
         <% 8.times do %>
           <tr>
             <% 8.times do %>
-              <td class="px-4 py-3"><div class="h-4 w-20 bg-gray-200 rounded"></div></td>
+              <td class="px-4 py-3"><div class="h-4 w-20 rounded bg-gray-200"></div></td>
             <% end %>
           </tr>
         <% end %>
@@ -21,8 +21,8 @@
   </div>
 </div>
 
-<div class="mt-6 flex justify-center space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/events/_ce_config_fields.html.erb
+++ b/app/views/events/_ce_config_fields.html.erb
@@ -13,7 +13,7 @@
   <div>
     <%= f.label :ce_hours_cost, "Total CE cost", class: "block text-xs font-medium text-gray-600 mb-1" %>
     <div class="relative">
-      <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
+      <span class="absolute top-1/2 left-3 -translate-y-1/2 text-gray-500">$</span>
       <%= f.number_field :ce_hours_cost, min: 0, step: 1,
             class: "w-full rounded border-gray-300 shadow-sm pl-7 pr-3 py-2 bg-white tabular-nums focus:ring-blue-500 focus:border-blue-500" %>
     </div>

--- a/app/views/events/_event_filter.html.erb
+++ b/app/views/events/_event_filter.html.erb
@@ -2,7 +2,7 @@
     forms. Scopes the report(s) to the chosen event. `all_label` overrides the
     blank option (revenue lists paid events only). %>
 <div class="w-full sm:w-96">
-  <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" for="event_id">Event</label>
+  <label class="mb-1 block text-xs font-semibold tracking-wide text-gray-500 uppercase" for="event_id">Event</label>
   <%= select_tag :event_id,
         options_from_collection_for_select(@filter_events, :id, :date_title, params[:event_id].to_i),
         include_blank: local_assigns.fetch(:all_label, "All events"),

--- a/app/views/events/_event_staff_fields.html.erb
+++ b/app/views/events/_event_staff_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields rounded-lg border border-gray-300 bg-white p-4 shadow-sm relative"
+<div class="nested-fields relative rounded-lg border border-gray-300 bg-white p-4 shadow-sm"
      data-controller="event-staff-bio expandable-card"
      data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse"
      data-event-staff-bio-url-template-value="<%= bio_person_path("__ID__") %>"
@@ -16,7 +16,7 @@
   <div class="flex flex-wrap items-end gap-x-4 gap-y-2 pr-8">
     <div style="width: 320px; min-width: 320px; flex-shrink: 0;">
       <% if f.object.persisted? && f.object.person.present? %>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Person</label>
+        <label class="mb-1 block text-sm font-medium text-gray-700">Person</label>
         <% show_email = f.object.person.profile_show_email? || allowed_to?(:manage?, Person) %>
         <%= person_profile_button(f.object.person, truncate_at: 30, subtitle: (f.object.person.preferred_email if show_email)) %>
         <%= f.hidden_field :person_id %>
@@ -36,17 +36,17 @@
     </div>
 
     <div class="w-full sm:w-auto" style="min-width: 200px;">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Title</label>
+      <label class="mb-1 block text-sm font-medium text-gray-700">Title</label>
       <%= f.text_field :title,
                        value: f.object.title.presence || "Staff",
                        class: "w-full h-14 rounded-lg border-gray-300 shadow-sm px-3 focus:ring-blue-500 focus:border-blue-500" %>
     </div>
 
-    <div class="w-full sm:w-auto pb-2">
-      <label class="block text-sm font-medium text-gray-700 mb-1">Expected to attend</label>
-      <label class="relative inline-flex items-center cursor-pointer">
+    <div class="w-full pb-2 sm:w-auto">
+      <label class="mb-1 block text-sm font-medium text-gray-700">Expected to attend</label>
+      <label class="relative inline-flex cursor-pointer items-center">
         <%= f.check_box :expected_to_attend, class: "sr-only peer" %>
-        <div class="relative w-11 h-6 bg-gray-200 rounded-full peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+        <div class="relative h-6 w-11 rounded-full bg-gray-200 peer-checked:bg-blue-600 after:absolute after:top-0.5 after:left-0.5 after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full"></div>
       </label>
     </div>
   </div>

--- a/app/views/events/_event_type_filter.html.erb
+++ b/app/views/events/_event_type_filter.html.erb
@@ -5,7 +5,7 @@
     these reports drill into, so a value means the same thing on both. `all_label`
     overrides the blank option (revenue lists paid events only). %>
 <div class="w-full sm:w-52">
-  <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" for="event_type">Event type</label>
+  <label class="mb-1 block text-xs font-semibold tracking-wide text-gray-500 uppercase" for="event_type">Event type</label>
   <%= select_tag :event_type,
         options_for_select(EventRegistration::EVENT_TYPE_FILTER_OPTIONS, @event_type),
         include_blank: local_assigns.fetch(:all_label, "All events"),

--- a/app/views/events/_filter_bar.html.erb
+++ b/app/views/events/_filter_bar.html.erb
@@ -41,19 +41,19 @@
     <%# The applied-filter chips share the heading's row, pushed to the far right —
         they read as a summary of the bar rather than a band above it. They wrap to
         their own line when the chips outgrow the row. %>
-    <div class="flex flex-wrap items-center gap-x-3 gap-y-2 mb-3">
+    <div class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2">
       <div class="flex items-center gap-2 text-gray-600">
         <i class="fa-solid fa-filter text-xs"></i>
-        <span class="text-xs font-semibold uppercase tracking-wide">Filters</span>
+        <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>
       </div>
       <%= applied %>
     </div>
 
     <%# Row 1: the most meaningful filters + More filters toggle + Clear. %>
-    <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4">
+    <div class="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
       <%= primary %>
 
-      <div class="w-full md:w-auto md:ml-auto flex items-end gap-4">
+      <div class="flex w-full items-end gap-4 md:ml-auto md:w-auto">
         <% if has_more %>
           <label for="more-filters-toggle"
                  class="inline-flex items-center gap-1.5 text-sm <%= eyebrow_link_class %> cursor-pointer transition">
@@ -71,7 +71,7 @@
         collapsed filter is already active. %>
     <% if has_more %>
       <div class="hidden group-has-[#more-filters-toggle:checked]:block">
-        <div class="flex flex-col md:flex-row md:flex-wrap md:items-end gap-4 mt-4">
+        <div class="mt-4 flex flex-col gap-4 md:flex-row md:flex-wrap md:items-end">
           <%= more %>
         </div>
       </div>

--- a/app/views/events/_person_profile_button.html.erb
+++ b/app/views/events/_person_profile_button.html.erb
@@ -17,11 +17,11 @@
     <%= image_tag profile_person.avatar.variant(:thumbnail),
                   class: "h-5 w-5 rounded-full object-cover border border-sky-300" %>
   <% else %>
-    <span class="h-5 w-5 rounded-full flex items-center justify-center bg-sky-200 text-sky-700 font-bold text-xs border border-sky-300">
+    <span class="flex h-5 w-5 items-center justify-center rounded-full border border-sky-300 bg-sky-200 text-xs font-bold text-sky-700">
       <%= profile_person.name.first.upcase %>
     </span>
   <% end %>
   <% if show_name %>
-    <span class="font-semibold text-sky-800 truncate"><%= profile_person.name %></span>
+    <span class="truncate font-semibold text-sky-800"><%= profile_person.name %></span>
   <% end %>
 <% end %>

--- a/app/views/events/_program_status_report.html.erb
+++ b/app/views/events/_program_status_report.html.erb
@@ -3,8 +3,8 @@
     it attended. Pass `report:` (an EventProgramStatusReport) and `all_time:`. %>
 <% years = report.years %>
 <% multi_year = years.size > 1 %>
-<section id="program-status-report" class="rounded-xl border border-emerald-300 bg-white overflow-hidden">
-  <div class="flex items-center justify-between gap-3 px-4 py-3 bg-emerald-50 border-b border-emerald-300">
+<section id="program-status-report" class="overflow-hidden rounded-xl border border-emerald-300 bg-white">
+  <div class="flex items-center justify-between gap-3 border-b border-emerald-300 bg-emerald-50 px-4 py-3">
     <h3 class="flex items-center gap-2 text-base font-semibold text-emerald-900">
       <i class="fa-solid fa-seedling text-emerald-500"></i>
       <%= all_time ? "All facilitator trainings" : "#{years.first.year || "Undated"} facilitator trainings" %>
@@ -13,55 +13,55 @@
   </div>
 
   <div class="overflow-x-auto">
-    <table class="w-full text-sm border-collapse">
+    <table class="w-full border-collapse text-sm">
       <thead>
         <tr class="bg-emerald-50 text-emerald-900">
-          <th class="text-left font-semibold px-3 py-2 border border-gray-200">Training</th>
-          <th class="text-left font-semibold px-3 py-2 border border-gray-200 whitespace-nowrap">Status as of</th>
-          <th class="text-right font-medium px-3 py-2 border border-gray-200 border-l-2 border-l-emerald-300">New</th>
-          <th class="text-right font-medium px-3 py-2 border border-gray-200">Ongoing</th>
-          <th class="text-right font-medium px-3 py-2 border border-gray-200">Reinstated</th>
-          <th class="text-right font-semibold px-3 py-2 border border-gray-200">Organizations</th>
+          <th class="border border-gray-200 px-3 py-2 text-left font-semibold">Training</th>
+          <th class="border border-gray-200 px-3 py-2 text-left font-semibold whitespace-nowrap">Status as of</th>
+          <th class="border border-l-2 border-gray-200 border-l-emerald-300 px-3 py-2 text-right font-medium">New</th>
+          <th class="border border-gray-200 px-3 py-2 text-right font-medium">Ongoing</th>
+          <th class="border border-gray-200 px-3 py-2 text-right font-medium">Reinstated</th>
+          <th class="border border-gray-200 px-3 py-2 text-right font-semibold">Organizations</th>
         </tr>
       </thead>
       <tbody class="tabular-nums">
         <% years.each do |group| %>
           <% if multi_year %>
             <tr class="bg-emerald-100 text-emerald-900">
-              <th colspan="6" class="text-left font-semibold px-3 py-1.5 border border-gray-200"><%= group.year || "Undated" %></th>
+              <th colspan="6" class="border border-gray-200 px-3 py-1.5 text-left font-semibold"><%= group.year || "Undated" %></th>
             </tr>
           <% end %>
           <% group.columns.each do |column| %>
             <tr id="<%= training_report_row_id(column.event) %>" class="scroll-mt-24">
-              <td class="px-3 py-2 border border-gray-200">
+              <td class="border border-gray-200 px-3 py-2">
                 <%= link_to column.label, dashboard_event_path(column.event), class: "text-blue-600 hover:underline", title: column.event.title %>
-                <% if column.date_label %><span class="text-gray-400 text-xs ml-1"><%= column.date_label %></span><% end %>
+                <% if column.date_label %><span class="ml-1 text-xs text-gray-400"><%= column.date_label %></span><% end %>
               </td>
-              <td class="px-3 py-2 border border-gray-200 whitespace-nowrap text-gray-600">
+              <td class="border border-gray-200 px-3 py-2 whitespace-nowrap text-gray-600">
                 <%= column.anchor_date&.strftime("%b %-d, %Y") || "—" %>
               </td>
-              <td class="px-3 py-2 border border-gray-200 text-right border-l-2 border-l-emerald-300"><%= column.new_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right"><%= column.ongoing_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right"><%= column.reinstated_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right font-semibold"><%= column.organization_count %></td>
+              <td class="border border-l-2 border-gray-200 border-l-emerald-300 px-3 py-2 text-right"><%= column.new_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right"><%= column.ongoing_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right"><%= column.reinstated_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right font-semibold"><%= column.organization_count %></td>
             </tr>
           <% end %>
           <% if multi_year %>
             <tr class="bg-gray-50 font-semibold text-gray-900">
-              <td class="px-3 py-2 border border-gray-200" colspan="2"><%= group.year || "Undated" %> total</td>
-              <td class="px-3 py-2 border border-gray-200 text-right border-l-2 border-l-emerald-300"><%= group.new_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right"><%= group.ongoing_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right"><%= group.reinstated_count %></td>
-              <td class="px-3 py-2 border border-gray-200 text-right"><%= group.organization_count %></td>
+              <td class="border border-gray-200 px-3 py-2" colspan="2"><%= group.year || "Undated" %> total</td>
+              <td class="border border-l-2 border-gray-200 border-l-emerald-300 px-3 py-2 text-right"><%= group.new_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right"><%= group.ongoing_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right"><%= group.reinstated_count %></td>
+              <td class="border border-gray-200 px-3 py-2 text-right"><%= group.organization_count %></td>
             </tr>
           <% end %>
         <% end %>
         <tr class="bg-gray-100 font-bold text-gray-900">
-          <td class="px-3 py-2 border border-gray-200" colspan="2"><%= all_time ? "All-time total" : "Total" %></td>
-          <td class="px-3 py-2 border border-gray-200 text-right border-l-2 border-l-emerald-300"><%= report.new_count %></td>
-          <td class="px-3 py-2 border border-gray-200 text-right"><%= report.ongoing_count %></td>
-          <td class="px-3 py-2 border border-gray-200 text-right"><%= report.reinstated_count %></td>
-          <td class="px-3 py-2 border border-gray-200 text-right"><%= report.organization_count %></td>
+          <td class="border border-gray-200 px-3 py-2" colspan="2"><%= all_time ? "All-time total" : "Total" %></td>
+          <td class="border border-l-2 border-gray-200 border-l-emerald-300 px-3 py-2 text-right"><%= report.new_count %></td>
+          <td class="border border-gray-200 px-3 py-2 text-right"><%= report.ongoing_count %></td>
+          <td class="border border-gray-200 px-3 py-2 text-right"><%= report.reinstated_count %></td>
+          <td class="border border-gray-200 px-3 py-2 text-right"><%= report.organization_count %></td>
         </tr>
       </tbody>
     </table>
@@ -70,39 +70,39 @@
   <%# The figure to report when "how many programs" means distinct programs rather
       than program-events. %>
   <div class="border-t border-emerald-200 bg-emerald-50 px-4 py-3">
-    <p class="text-xs font-semibold text-emerald-900 mb-2">
+    <p class="mb-2 text-xs font-semibold text-emerald-900">
       Distinct organizations
-      <i class="fa-solid fa-circle-info text-emerald-400 ml-0.5"
+      <i class="fa-solid fa-circle-info ml-0.5 text-emerald-400"
          title="Each organization counted once for this period, classified at the earliest training it appeared at. The table above counts it once per training, so these are smaller whenever an organization attended more than one."></i>
     </p>
     <% groups = multi_year ? years : [] %>
     <div class="overflow-x-auto">
-      <table class="w-full text-sm border-collapse bg-white">
+      <table class="w-full border-collapse bg-white text-sm">
         <thead>
           <tr class="bg-emerald-50 text-emerald-900">
-            <th class="text-left font-semibold px-3 py-1.5 border border-gray-200">Period</th>
-            <th class="text-right font-medium px-3 py-1.5 border border-gray-200">New</th>
-            <th class="text-right font-medium px-3 py-1.5 border border-gray-200">Ongoing</th>
-            <th class="text-right font-medium px-3 py-1.5 border border-gray-200">Reinstated</th>
-            <th class="text-right font-semibold px-3 py-1.5 border border-gray-200">Organizations</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-left font-semibold">Period</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-medium">New</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-medium">Ongoing</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-medium">Reinstated</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-semibold">Organizations</th>
           </tr>
         </thead>
         <tbody class="tabular-nums">
           <% groups.each do |group| %>
             <tr>
-              <td class="px-3 py-1.5 border border-gray-200"><%= group.year || "Undated" %></td>
-              <td class="px-3 py-1.5 border border-gray-200 text-right"><%= group.distinct_new_count %></td>
-              <td class="px-3 py-1.5 border border-gray-200 text-right"><%= group.distinct_ongoing_count %></td>
-              <td class="px-3 py-1.5 border border-gray-200 text-right"><%= group.distinct_reinstated_count %></td>
-              <td class="px-3 py-1.5 border border-gray-200 text-right font-semibold"><%= group.distinct_organization_count %></td>
+              <td class="border border-gray-200 px-3 py-1.5"><%= group.year || "Undated" %></td>
+              <td class="border border-gray-200 px-3 py-1.5 text-right"><%= group.distinct_new_count %></td>
+              <td class="border border-gray-200 px-3 py-1.5 text-right"><%= group.distinct_ongoing_count %></td>
+              <td class="border border-gray-200 px-3 py-1.5 text-right"><%= group.distinct_reinstated_count %></td>
+              <td class="border border-gray-200 px-3 py-1.5 text-right font-semibold"><%= group.distinct_organization_count %></td>
             </tr>
           <% end %>
           <tr class="bg-gray-100 font-bold text-gray-900">
-            <td class="px-3 py-1.5 border border-gray-200"><%= all_time ? "All time" : (years.first&.year || "Total") %></td>
-            <td class="px-3 py-1.5 border border-gray-200 text-right"><%= report.distinct_new_count %></td>
-            <td class="px-3 py-1.5 border border-gray-200 text-right"><%= report.distinct_ongoing_count %></td>
-            <td class="px-3 py-1.5 border border-gray-200 text-right"><%= report.distinct_reinstated_count %></td>
-            <td class="px-3 py-1.5 border border-gray-200 text-right"><%= report.distinct_organization_count %></td>
+            <td class="border border-gray-200 px-3 py-1.5"><%= all_time ? "All time" : (years.first&.year || "Total") %></td>
+            <td class="border border-gray-200 px-3 py-1.5 text-right"><%= report.distinct_new_count %></td>
+            <td class="border border-gray-200 px-3 py-1.5 text-right"><%= report.distinct_ongoing_count %></td>
+            <td class="border border-gray-200 px-3 py-1.5 text-right"><%= report.distinct_reinstated_count %></td>
+            <td class="border border-gray-200 px-3 py-1.5 text-right"><%= report.distinct_organization_count %></td>
           </tr>
         </tbody>
       </table>

--- a/app/views/events/_program_status_summary.html.erb
+++ b/app/views/events/_program_status_summary.html.erb
@@ -1,8 +1,8 @@
 <%# Reports-hub headline. Expects `report` (an EventProgramStatusReport) and
     `period` (its resolved PeriodScope). The tiles count organizations once per
     training; the footnote gives the distinct-organization figure. %>
-<div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-  <div class="flex items-start justify-between mb-4">
+<div class="flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+  <div class="mb-4 flex items-start justify-between">
     <h3 class="text-base font-semibold text-gray-900">Program status</h3>
     <%= link_to "Details →", program_statuses_events_path(hub_to_report_params),
           class: "text-xs font-medium #{DomainTheme.text_class_for(:events, intensity: 700)} hover:underline" %>
@@ -10,22 +10,22 @@
 
   <% if report.any? %>
     <% metrics = period.metrics %>
-    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2"><%= period.label %></div>
-    <div class="grid grid-cols-3 gap-3 mb-4">
+    <div class="mb-2 text-xs font-semibold tracking-wide text-gray-400 uppercase"><%= period.label %></div>
+    <div class="mb-4 grid grid-cols-3 gap-3">
       <div class="rounded-lg border border-indigo-200 bg-indigo-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">New</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-indigo-700"><%= number_with_delimiter(metrics.new_count) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">New</div>
+        <div class="mt-1 text-xl font-bold text-indigo-700 tabular-nums"><%= number_with_delimiter(metrics.new_count) %></div>
       </div>
       <div class="rounded-lg border border-blue-200 bg-blue-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Ongoing</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-blue-700"><%= number_with_delimiter(metrics.ongoing_count) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Ongoing</div>
+        <div class="mt-1 text-xl font-bold text-blue-700 tabular-nums"><%= number_with_delimiter(metrics.ongoing_count) %></div>
       </div>
       <div class="rounded-lg border border-purple-200 bg-purple-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Reinstated</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-purple-700"><%= number_with_delimiter(metrics.reinstated_count) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Reinstated</div>
+        <div class="mt-1 text-xl font-bold text-purple-700 tabular-nums"><%= number_with_delimiter(metrics.reinstated_count) %></div>
       </div>
     </div>
-    <p class="text-xs text-gray-500 mb-3">
+    <p class="mb-3 text-xs text-gray-500">
       <%= pluralize(metrics.organization_count, "organization-training") %> ·
       <span class="font-medium text-gray-700"><%= metrics.distinct_organization_count %></span> distinct organizations
     </p>
@@ -38,6 +38,6 @@
             library: { borderRadius: 3 } %>
     </div>
   <% else %>
-    <p class="text-sm text-gray-500 my-auto">No facilitator trainings match these filters.</p>
+    <p class="my-auto text-sm text-gray-500">No facilitator trainings match these filters.</p>
   <% end %>
 </div>

--- a/app/views/events/_registrant_city_row.html.erb
+++ b/app/views/events/_registrant_city_row.html.erb
@@ -20,12 +20,12 @@
 <% end %>
 <tr class="border-t border-gray-100 group hover:bg-gray-50 <%= "cursor-pointer" if row_path %> transition-colors"
     <% if row_path %>onclick="window.location='<%= row_path %>'"<% end %>>
-  <td class="py-1 text-gray-700 w-full"><span class="<%= "group-hover:underline" if row_path %>"><%= row.city %></span></td>
+  <td class="w-full py-1 text-gray-700"><span class="<%= "group-hover:underline" if row_path %>"><%= row.city %></span></td>
   <% unless metrics == :scholarships %>
-    <td class="py-1 pl-3 text-right tabular-nums whitespace-nowrap font-medium text-gray-700 min-w-[3ch]"><%= row.registrant_count %></td>
+    <td class="min-w-[3ch] py-1 pl-3 text-right font-medium whitespace-nowrap text-gray-700 tabular-nums"><%= row.registrant_count %></td>
   <% end %>
   <% unless metrics == :registrants %>
-    <td class="py-1 pl-2 text-right tabular-nums whitespace-nowrap text-gray-400 min-w-[4ch]">
+    <td class="min-w-[4ch] py-1 pl-2 text-right whitespace-nowrap text-gray-400 tabular-nums">
       <% if row.scholarship_count.positive? %>
         <% scholarship_figure = capture do %><% if metrics == :both %>(<% end %><i class="fa-solid fa-graduation-cap <%= DomainTheme.text_class_for(:scholarships, intensity: 600) %>" aria-hidden="true"></i> <span class="font-medium <%= DomainTheme.text_class_for(:scholarships, intensity: 700) %>"><%= row.scholarship_count %></span><% if metrics == :both %>)<% end %><% end %>
         <% if scholarship_path %>

--- a/app/views/events/_report_subnav.html.erb
+++ b/app/views/events/_report_subnav.html.erb
@@ -35,7 +35,7 @@
      ] %>
   <% tabs.each do |tab| %>
     <% if tab[:key] == current %>
-      <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
+      <span aria-current="page" class="border-b-2 border-indigo-600 px-2 py-1 text-sm font-semibold text-gray-900"><%= tab[:label] %></span>
     <% else %>
       <%= link_to tab[:label], tab[:path], class: "text-sm #{eyebrow_link_class} border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
     <% end %>

--- a/app/views/events/_scholarship_summary.html.erb
+++ b/app/views/events/_scholarship_summary.html.erb
@@ -2,8 +2,8 @@
     (Details) plus the recipient attendees/breakdowns. Expects `report` (an
     EventScholarshipReport) and `period` (its resolved PeriodScope: #label, #year
     and #metrics). %>
-<div class="h-full flex flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-  <div class="flex items-start justify-between mb-4">
+<div class="flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+  <div class="mb-4 flex items-start justify-between">
     <h3 class="text-base font-semibold text-gray-900">Scholarships</h3>
     <div class="flex flex-col items-end gap-1">
       <%= link_to "Details →", scholarships_events_path(hub_to_report_params),
@@ -21,26 +21,26 @@
 
   <% if report.any? %>
     <% metrics = period.metrics %>
-    <div class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2"><%= period.label %></div>
-    <div class="grid grid-cols-2 gap-3 mb-4">
+    <div class="mb-2 text-xs font-semibold tracking-wide text-gray-400 uppercase"><%= period.label %></div>
+    <div class="mb-4 grid grid-cols-2 gap-3">
       <div class="rounded-lg border border-purple-200 bg-purple-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Recipients attended</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-purple-700"><%= number_with_delimiter(metrics.recipients_attended_count) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Recipients attended</div>
+        <div class="mt-1 text-xl font-bold text-purple-700 tabular-nums"><%= number_with_delimiter(metrics.recipients_attended_count) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= metrics.live_recipients_attended_count %> live · <%= metrics.on_demand_recipients_attended_count %> on-demand</div>
       </div>
       <div class="rounded-lg border border-gray-200 bg-gray-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Scholarships awarded</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-gray-900"><%= dollars_from_cents(metrics.scholarship_cents) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Scholarships awarded</div>
+        <div class="mt-1 text-xl font-bold text-gray-900 tabular-nums"><%= dollars_from_cents(metrics.scholarship_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= pluralize(metrics.scholarship_count, "award") %> · funded + unfunded</div>
       </div>
       <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Funded</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-emerald-700"><%= dollars_from_cents(metrics.funded_cents) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Funded</div>
+        <div class="mt-1 text-xl font-bold text-emerald-700 tabular-nums"><%= dollars_from_cents(metrics.funded_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= pluralize(metrics.funded_count, "award") %></div>
       </div>
       <div class="rounded-lg border border-red-200 bg-red-50 p-3">
-        <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">Unfunded</div>
-        <div class="mt-1 text-xl font-bold tabular-nums text-red-600"><%= dollars_from_cents(metrics.unfunded_cents) %></div>
+        <div class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Unfunded</div>
+        <div class="mt-1 text-xl font-bold text-red-600 tabular-nums"><%= dollars_from_cents(metrics.unfunded_cents) %></div>
         <div class="mt-1 text-xs text-gray-500 tabular-nums"><%= pluralize(metrics.unfunded_count, "award") %></div>
       </div>
     </div>
@@ -54,6 +54,6 @@
             library: { borderRadius: 3 } %>
     </div>
   <% else %>
-    <p class="text-sm text-gray-500 my-auto">No facilitator trainings match these filters.</p>
+    <p class="my-auto text-sm text-gray-500">No facilitator trainings match these filters.</p>
   <% end %>
 </div>

--- a/app/views/events/_scholarships_report.html.erb
+++ b/app/views/events/_scholarships_report.html.erb
@@ -10,7 +10,7 @@
         combined: params[:view] == "combined",
         all_time: @time_period.blank? || @time_period == "all_time" %>
 <% else %>
-  <div class="text-center py-8 text-gray-500">
+  <div class="py-8 text-center text-gray-500">
     No facilitator trainings yet — mark an event as a facilitator training to see it here.
   </div>
 <% end %>

--- a/app/views/events/_scholarships_report_combined_cell.html.erb
+++ b/app/views/events/_scholarships_report_combined_cell.html.erb
@@ -1,7 +1,7 @@
 <%# A single combined scholarship cell: award count stacked over its dollars.
     `count`, `cents`; `start:` draws the group's left divider; `emphasis:` bolds
     the count for a training's Total column. %>
-<td class="px-3 py-2 border border-gray-200 text-right<%= " border-l-2 border-l-fuchsia-200" if start %>">
+<td class="border border-gray-200 px-3 py-2 text-right<%= " border-l-2 border-l-fuchsia-200" if start %>">
   <div class="<%= emphasis ? "font-semibold text-gray-900" : "text-gray-900" %>"><%= count %></div>
   <div class="text-xs text-gray-500"><%= dollars_from_cents(cents) %></div>
 </td>

--- a/app/views/events/_scholarships_report_figures.html.erb
+++ b/app/views/events/_scholarships_report_figures.html.erb
@@ -7,7 +7,7 @@
 <%# Attended is a completed attendance only; a partial one is reported beside it
     rather than folded in, since its scholarship and fees still count in the money
     columns to the right. %>
-<td class="px-3 py-2 border border-gray-200 text-right whitespace-nowrap">
+<td class="border border-gray-200 px-3 py-2 text-right whitespace-nowrap">
   <% if event && source.attended_count.positive? %>
     <%= link_to source.attended_count, attended_registrants_path(event),
           class: "text-blue-600 hover:text-blue-800 hover:underline",
@@ -24,10 +24,10 @@
   <%= render "scholarships_report_combined_cell", count: source.unfunded_count, cents: source.unfunded_cents, start: false, emphasis: false %>
   <%= render "scholarships_report_combined_cell", count: source.scholarship_count, cents: source.scholarship_cents, start: false, emphasis: true %>
 <% else %>
-  <td class="px-3 py-2 border border-gray-200 text-right border-l-2 border-l-fuchsia-200"><%= source.funded_count %></td>
-  <td class="px-3 py-2 border border-gray-200 text-right"><%= source.unfunded_count %></td>
-  <td class="px-3 py-2 border border-gray-200 text-right font-semibold text-gray-900"><%= source.scholarship_count %></td>
-  <td class="px-3 py-2 border border-gray-200 text-right border-l-2 border-l-fuchsia-200"><%= dollars_from_cents(source.funded_cents) %></td>
-  <td class="px-3 py-2 border border-gray-200 text-right"><%= dollars_from_cents(source.unfunded_cents) %></td>
-  <td class="px-3 py-2 border border-gray-200 text-right font-semibold text-gray-900"><%= dollars_from_cents(source.scholarship_cents) %></td>
+  <td class="border border-l-2 border-gray-200 border-l-fuchsia-200 px-3 py-2 text-right"><%= source.funded_count %></td>
+  <td class="border border-gray-200 px-3 py-2 text-right"><%= source.unfunded_count %></td>
+  <td class="border border-gray-200 px-3 py-2 text-right font-semibold text-gray-900"><%= source.scholarship_count %></td>
+  <td class="border border-l-2 border-gray-200 border-l-fuchsia-200 px-3 py-2 text-right"><%= dollars_from_cents(source.funded_cents) %></td>
+  <td class="border border-gray-200 px-3 py-2 text-right"><%= dollars_from_cents(source.unfunded_cents) %></td>
+  <td class="border border-gray-200 px-3 py-2 text-right font-semibold text-gray-900"><%= dollars_from_cents(source.scholarship_cents) %></td>
 <% end %>

--- a/app/views/events/_scholarships_report_table.html.erb
+++ b/app/views/events/_scholarships_report_table.html.erb
@@ -8,8 +8,8 @@
 <% years = report.years %>
 <% multi_year = years.size > 1 %>
 <% col_span = combined ? 5 : 8 %>
-<section class="rounded-xl border border-fuchsia-300 bg-white overflow-hidden">
-  <div class="flex items-center justify-between gap-3 px-4 py-3 bg-fuchsia-50 border-b border-fuchsia-300">
+<section class="overflow-hidden rounded-xl border border-fuchsia-300 bg-white">
+  <div class="flex items-center justify-between gap-3 border-b border-fuchsia-300 bg-fuchsia-50 px-4 py-3">
     <h3 class="flex items-center gap-2 text-base font-semibold text-fuchsia-900">
       <i class="fa-solid fa-graduation-cap text-fuchsia-500"></i>
       <%= all_time ? "All facilitator trainings" : "#{years.first.year || "Undated"} facilitator trainings" %>
@@ -21,35 +21,35 @@
   </div>
 
   <div class="overflow-x-auto">
-    <table class="w-full text-sm border-collapse">
+    <table class="w-full border-collapse text-sm">
       <thead>
         <tr class="bg-fuchsia-50 text-fuchsia-900">
-          <th rowspan="2" class="text-left font-semibold px-3 py-2 border border-gray-200 align-bottom">Training</th>
-          <th rowspan="2" class="text-right font-semibold px-3 py-2 border border-gray-200 align-bottom">
-            <i class="fa-solid fa-user-check text-fuchsia-500 mr-1"></i>Registrants attended
+          <th rowspan="2" class="border border-gray-200 px-3 py-2 text-left align-bottom font-semibold">Training</th>
+          <th rowspan="2" class="border border-gray-200 px-3 py-2 text-right align-bottom font-semibold">
+            <i class="fa-solid fa-user-check mr-1 text-fuchsia-500"></i>Registrants attended
           </th>
           <% if combined %>
-            <th colspan="3" class="text-center font-semibold px-3 py-2 border border-gray-200 whitespace-nowrap border-l-2 border-l-fuchsia-300">
-              <i class="fa-solid fa-graduation-cap text-fuchsia-500 mr-1"></i>Scholarships
+            <th colspan="3" class="border border-l-2 border-gray-200 border-l-fuchsia-300 px-3 py-2 text-center font-semibold whitespace-nowrap">
+              <i class="fa-solid fa-graduation-cap mr-1 text-fuchsia-500"></i>Scholarships
               <span class="font-normal text-gray-500">(#&nbsp;/&nbsp;$)</span>
             </th>
           <% else %>
-            <th colspan="3" class="text-center font-semibold px-3 py-2 border border-gray-200 whitespace-nowrap border-l-2 border-l-fuchsia-300">
-              <i class="fa-solid fa-graduation-cap text-fuchsia-500 mr-1"></i># of scholarships
+            <th colspan="3" class="border border-l-2 border-gray-200 border-l-fuchsia-300 px-3 py-2 text-center font-semibold whitespace-nowrap">
+              <i class="fa-solid fa-graduation-cap mr-1 text-fuchsia-500"></i># of scholarships
             </th>
-            <th colspan="3" class="text-center font-semibold px-3 py-2 border border-gray-200 whitespace-nowrap border-l-2 border-l-fuchsia-300">
-              <i class="fa-solid fa-hand-holding-dollar text-fuchsia-500 mr-1"></i>$ of scholarships
+            <th colspan="3" class="border border-l-2 border-gray-200 border-l-fuchsia-300 px-3 py-2 text-center font-semibold whitespace-nowrap">
+              <i class="fa-solid fa-hand-holding-dollar mr-1 text-fuchsia-500"></i>$ of scholarships
             </th>
           <% end %>
         </tr>
-        <tr class="bg-fuchsia-50 text-fuchsia-900 text-xs">
-          <th class="text-right font-medium px-3 py-1.5 border border-gray-200 border-l-2 border-l-fuchsia-300">Funded</th>
-          <th class="text-right font-medium px-3 py-1.5 border border-gray-200">Unfunded</th>
-          <th class="text-right font-semibold px-3 py-1.5 border border-gray-200">Total</th>
+        <tr class="bg-fuchsia-50 text-xs text-fuchsia-900">
+          <th class="border border-l-2 border-gray-200 border-l-fuchsia-300 px-3 py-1.5 text-right font-medium">Funded</th>
+          <th class="border border-gray-200 px-3 py-1.5 text-right font-medium">Unfunded</th>
+          <th class="border border-gray-200 px-3 py-1.5 text-right font-semibold">Total</th>
           <% unless combined %>
-            <th class="text-right font-medium px-3 py-1.5 border border-gray-200 border-l-2 border-l-fuchsia-300">Funded</th>
-            <th class="text-right font-medium px-3 py-1.5 border border-gray-200">Unfunded</th>
-            <th class="text-right font-semibold px-3 py-1.5 border border-gray-200">Total</th>
+            <th class="border border-l-2 border-gray-200 border-l-fuchsia-300 px-3 py-1.5 text-right font-medium">Funded</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-medium">Unfunded</th>
+            <th class="border border-gray-200 px-3 py-1.5 text-right font-semibold">Total</th>
           <% end %>
         </tr>
       </thead>
@@ -57,7 +57,7 @@
         <% years.each do |group| %>
           <% if multi_year %>
             <tr class="bg-fuchsia-100 text-fuchsia-900">
-              <th colspan="<%= col_span %>" class="text-left font-semibold px-3 py-1.5 border border-gray-200">
+              <th colspan="<%= col_span %>" class="border border-gray-200 px-3 py-1.5 text-left font-semibold">
                 <%= group.year || "Undated" %>
               </th>
             </tr>
@@ -71,19 +71,19 @@
           <% end %>
           <% if multi_year %>
             <tr class="bg-gray-50 font-semibold text-gray-900">
-              <td class="px-3 py-2 border border-gray-200"><%= group.year || "Undated" %> total</td>
+              <td class="border border-gray-200 px-3 py-2"><%= group.year || "Undated" %> total</td>
               <%= render "scholarships_report_figures", source: group, combined: combined, event: nil %>
             </tr>
           <% end %>
         <% end %>
         <tr class="bg-gray-100 font-bold text-gray-900">
-          <td class="px-3 py-2 border border-gray-200"><%= all_time ? "All-time total" : "Total" %></td>
+          <td class="border border-gray-200 px-3 py-2"><%= all_time ? "All-time total" : "Total" %></td>
           <%= render "scholarships_report_figures", source: report.all_trainings_group, combined: combined, event: nil %>
         </tr>
       </tbody>
     </table>
   </div>
-  <div class="px-4 py-2 text-xs text-gray-500 border-t border-fuchsia-200 bg-fuchsia-50">
+  <div class="border-t border-fuchsia-200 bg-fuchsia-50 px-4 py-2 text-xs text-gray-500">
     Attended breakdown:
     <span class="font-medium text-gray-700"><%= report.live_attended_count %></span> live
     · <span class="font-medium text-gray-700"><%= report.on_demand_attended_count %></span> on-demand

--- a/app/views/events/_section_heading.html.erb
+++ b/app/views/events/_section_heading.html.erb
@@ -29,7 +29,7 @@
 <% anchor_attrs = tag.attributes(id: anchor_id, data: { controller: "reveal-section", reveal_section_anchor_value: anchor_id }) if anchor_id %>
 <% text_class = intensity ? DomainTheme.text_class_for(theme, intensity: intensity) : DomainTheme.text_class_for(theme) %>
 <div <%= anchor_attrs %> class="flex flex-wrap items-center gap-3 <%= "scroll-mt-24" if anchor_id %> <%= local_assigns.fetch(:margin, "mb-4") %> <%= local_assigns[:spacing] %>">
-  <h2 class="text-xl font-bold flex items-center gap-2 <%= text_class %>">
+  <h2 class="flex items-center gap-2 text-xl font-bold <%= text_class %>">
     <i class="fa-solid <%= icon %>"></i>
     <%= title %>
   </h2>

--- a/app/views/events/_subnav.html.erb
+++ b/app/views/events/_subnav.html.erb
@@ -17,7 +17,7 @@
   <% tabs.each do |tab| %>
     <% next unless tab[:visible] %>
     <% if tab[:key] == current %>
-      <span aria-current="page" class="text-sm font-semibold text-gray-900 border-b-2 border-indigo-600 px-2 py-1"><%= tab[:label] %></span>
+      <span aria-current="page" class="border-b-2 border-indigo-600 px-2 py-1 text-sm font-semibold text-gray-900"><%= tab[:label] %></span>
     <% else %>
       <%= link_to tab[:label], tab[:path], class: "text-sm #{eyebrow_link_class} border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
     <% end %>

--- a/app/views/events/_time_period_filter.html.erb
+++ b/app/views/events/_time_period_filter.html.erb
@@ -2,7 +2,7 @@
     report forms (all time / this year / a specific year). The reports hub
     uses its own this-year/last-year/all-time period select. %>
 <div class="w-full sm:w-40">
-  <label class="block text-xs font-semibold uppercase text-gray-500 tracking-wide mb-1" for="time_period">Time period</label>
+  <label class="mb-1 block text-xs font-semibold tracking-wide text-gray-500 uppercase" for="time_period">Time period</label>
   <% year_choices = @year_options.map { |year| [ year.to_s, year.to_s ] } %>
   <%= select_tag :time_period,
         options_for_select([ [ "All time", "all_time" ], [ "This year", "this_year" ] ] + year_choices, @time_period),

--- a/app/views/events/attendees_results.html.erb
+++ b/app/views/events/attendees_results.html.erb
@@ -28,11 +28,11 @@
       <%= render "events/section_heading", title: "Attendees", icon: "fa-user-pen",
             theme: :event_registrations, intensity: 700, toggle: false, actions: toggle_bar %>
       <div data-panel-toggle-target="panel" data-panel-toggle-name="attendees">
-        <div class="rounded-xl bg-white overflow-hidden animate-fade blur-on-submit">
+        <div class="animate-fade overflow-hidden rounded-xl bg-white blur-on-submit">
           <%# Page-level toggle: expand every row's Training cell to all events, or
               collapse back to the most recent one. Broadcasts to each row's
               expandable-card via @window (see _registrant_roster). %>
-          <div class="flex items-center justify-end px-4 py-3 border-b border-gray-100">
+          <div class="flex items-center justify-end border-b border-gray-100 px-4 py-3">
             <button type="button"
                     data-controller="expandable-cards"
                     data-expandable-cards-expanded-value="false"
@@ -68,8 +68,8 @@
       </div>
     </div>
   <% else %>
-    <div class="rounded-xl bg-white overflow-hidden animate-fade blur-on-submit">
-      <p class="text-gray-500 text-center px-6 py-8">No attendees found.</p>
+    <div class="animate-fade overflow-hidden rounded-xl bg-white blur-on-submit">
+      <p class="px-6 py-8 text-center text-gray-500">No attendees found.</p>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/callouts/_rich_content.html.erb
+++ b/app/views/events/callouts/_rich_content.html.erb
@@ -7,12 +7,12 @@
   <% CalloutContent.segments(content).each do |segment| %>
     <% if segment.type == :toggle %>
       <%= render layout: "events/callouts/toggle", locals: { summary: segment.summary, open: segment.open } do %>
-        <div class="rich-label prose prose-sm max-w-none prose-a:text-blue-700 prose-li:my-0.5">
+        <div class="rich-label max-w-none prose prose-sm prose-li:my-0.5 prose-a:text-blue-700">
           <%= form_label_html(segment.html) %>
         </div>
       <% end %>
     <% else %>
-      <div class="rich-label prose max-w-none text-gray-700 leading-relaxed prose-headings:text-gray-800 prose-a:text-blue-700">
+      <div class="rich-label max-w-none prose leading-relaxed text-gray-700 prose-a:text-blue-700 prose-headings:text-gray-800">
         <%= form_label_html(segment.html) %>
       </div>
     <% end %>

--- a/app/views/events/callouts/_toggle.html.erb
+++ b/app/views/events/callouts/_toggle.html.erb
@@ -5,13 +5,13 @@
     Native <details> so it works without JavaScript. %>
 <% open = local_assigns.fetch(:open, false) %>
 <details class="group/card rounded-lg border border-gray-200 bg-white" <%= "open" if open %>>
-  <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-4 py-3 hover:bg-gray-50 rounded-lg">
+  <summary class="cursor-pointer list-none rounded-lg px-4 py-3 select-none hover:bg-gray-50 [&::-webkit-details-marker]:hidden">
     <div class="flex items-center justify-between gap-3">
       <span class="font-medium text-gray-900"><%= summary %></span>
-      <i class="fa-solid fa-chevron-down text-gray-400 text-xs shrink-0 transition-transform group-open/card:rotate-180"></i>
+      <i class="fa-solid fa-chevron-down shrink-0 text-xs text-gray-400 transition-transform group-open/card:rotate-180"></i>
     </div>
   </summary>
-  <div class="px-4 pb-4 pt-1 space-y-3 text-sm text-gray-600 leading-relaxed">
+  <div class="space-y-3 px-4 pt-1 pb-4 text-sm leading-relaxed text-gray-600">
     <%= yield %>
   </div>
 </details>

--- a/app/views/events/callouts/faq.html.erb
+++ b/app/views/events/callouts/faq.html.erb
@@ -2,10 +2,10 @@
 <% content_for(:page_title, "Frequently asked questions — #{@event.title}") %>
 
 <%= render layout: "events/callouts/callout_page", locals: { title: "Frequently asked questions" } do %>
-  <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">2-day training — general questions</h2>
+  <h2 class="mb-3 text-xs font-semibold tracking-wide text-gray-400 uppercase">2-day training — general questions</h2>
   <%= render "events/callouts/rich_content", content: @faq_content %>
 
-  <div class="mt-6 border-t border-gray-100 pt-5 text-sm text-gray-600 leading-relaxed">
+  <div class="mt-6 border-t border-gray-100 pt-5 text-sm leading-relaxed text-gray-600">
     <p class="font-semibold text-gray-900">Still have questions?</p>
     <p class="mt-1">You'll receive more details as we get closer to the training dates. In the meantime, please <%= link_to "reach out", contact_us_path, class: "text-blue-700 underline hover:text-blue-900" %> — we're always happy to help. We look forward to creating and connecting with you!</p>
   </div>

--- a/app/views/events/invoices/_actions.html.erb
+++ b/app/views/events/invoices/_actions.html.erb
@@ -1,12 +1,12 @@
 <%# Eyebrow + "Download PDF" controls above an invoice. Hidden when printing so
     only the invoice document lands in the PDF. `back_path` / `back_label` set
     the return link to wherever the invoice was opened from. %>
-<div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 sm:px-8 pt-4 print:hidden">
+<div class="mx-auto flex max-w-3xl flex-wrap items-center gap-2 px-4 pt-4 sm:px-8 print:hidden">
   <%= link_to back_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> <%= back_label %>
   <% end %>
   <button onclick="window.print();"
-          class="ml-auto inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors">
+          class="ml-auto inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50">
     <i class="fa-solid fa-file-arrow-down"></i> Download PDF
   </button>
 </div>

--- a/app/views/events/invoices/_invoice.html.erb
+++ b/app/views/events/invoices/_invoice.html.erb
@@ -1,9 +1,9 @@
 <%# Renders one EventInvoice as a printable document. Shared by the per-
     registration and bulk-payment invoice pages. `invoice` is an EventInvoice. %>
-<article class="mx-auto max-w-3xl bg-white text-gray-800 px-8 py-10 print:px-0 print:py-0 print:max-w-none">
+<article class="mx-auto max-w-3xl bg-white px-8 py-10 text-gray-800 print:max-w-none print:px-0 print:py-0">
   <%# Header: issuer details (left) + brand logo (right) %>
   <header class="flex items-start justify-between gap-6">
-    <address class="not-italic text-sm leading-snug">
+    <address class="text-sm leading-snug not-italic">
       <p class="font-medium"><%= invoice.issuer_name %></p>
       <% invoice.issuer_address_lines.each do |line| %>
         <p><%= line %></p>
@@ -13,7 +13,7 @@
     <%= image_tag "logo-with-tagline.png", alt: invoice.issuer_name, class: "h-16 w-auto shrink-0" %>
   </header>
 
-  <h1 class="text-center text-3xl font-semibold tracking-wide my-8">INVOICE</h1>
+  <h1 class="my-8 text-center text-3xl font-semibold tracking-wide">INVOICE</h1>
 
   <%# Bill-to %>
   <div class="space-y-1">
@@ -30,7 +30,7 @@
   </div>
 
   <%# Attention %>
-  <div class="space-y-1 mt-5">
+  <div class="mt-5 space-y-1">
     <p class="text-sm font-bold">Attention:</p>
     <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm">
       <%= invoice.attention.presence || "—" %>
@@ -38,7 +38,7 @@
   </div>
 
   <%# Meta row: number / date / reference / client id %>
-  <div class="mt-6 rounded-lg border border-gray-300 grid grid-cols-2 sm:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-gray-200 text-center">
+  <div class="mt-6 grid grid-cols-2 divide-y divide-gray-200 rounded-lg border border-gray-300 text-center sm:grid-cols-4 sm:divide-x sm:divide-y-0">
     <% [
          [ "Invoice Number", invoice.number ],
          [ "Invoice Date", invoice.date&.strftime("%-d %b, %Y") ],
@@ -47,39 +47,39 @@
        ].each do |label, value| %>
       <div class="px-3 py-3">
         <p class="text-xs font-bold text-gray-600"><%= label %></p>
-        <p class="text-sm mt-1"><%= value.presence || " " %></p>
+        <p class="mt-1 text-sm"><%= value.presence || " " %></p>
       </div>
     <% end %>
   </div>
 
   <%# Line items %>
-  <table class="w-full mt-8 text-sm">
+  <table class="mt-8 w-full text-sm">
     <thead>
       <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
-        <th class="text-left py-2 pr-3">Date</th>
-        <th class="text-left py-2 pr-3">Job/Item Description</th>
-        <th class="text-right py-2 px-3 whitespace-nowrap">Quantity/Units</th>
-        <th class="text-right py-2 px-3 whitespace-nowrap">Unit Price</th>
-        <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+        <th class="py-2 pr-3 text-left">Date</th>
+        <th class="py-2 pr-3 text-left">Job/Item Description</th>
+        <th class="px-3 py-2 text-right whitespace-nowrap">Quantity/Units</th>
+        <th class="px-3 py-2 text-right whitespace-nowrap">Unit Price</th>
+        <th class="py-2 pl-3 text-right whitespace-nowrap">Amount</th>
       </tr>
     </thead>
     <tbody>
       <% invoice.line_items.each do |item| %>
         <tr class="border-b border-gray-100">
-          <td class="py-2 pr-3 whitespace-nowrap align-top"><%= item.date&.strftime("%m/%d/%y") %></td>
+          <td class="py-2 pr-3 align-top whitespace-nowrap"><%= item.date&.strftime("%m/%d/%y") %></td>
           <td class="py-2 pr-3 align-top">
             <%= item.description %>
             <% if item.details.any? %>
-              <ul class="mt-1 text-xs text-gray-500 leading-relaxed">
+              <ul class="mt-1 text-xs leading-relaxed text-gray-500">
                 <% item.details.each do |detail| %>
                   <li><%= detail %></li>
                 <% end %>
               </ul>
             <% end %>
           </td>
-          <td class="py-2 px-3 text-right tabular-nums align-top"><%= item.quantity %></td>
-          <td class="py-2 px-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.unit_price_cents) %></td>
-          <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.amount_cents) %></td>
+          <td class="px-3 py-2 text-right align-top tabular-nums"><%= item.quantity %></td>
+          <td class="px-3 py-2 text-right align-top whitespace-nowrap tabular-nums"><%= dollars_from_cents(item.unit_price_cents) %></td>
+          <td class="py-2 pl-3 text-right align-top whitespace-nowrap tabular-nums"><%= dollars_from_cents(item.amount_cents) %></td>
         </tr>
       <% end %>
     </tbody>
@@ -92,7 +92,7 @@
           <td colspan="3"></td>
           <td class="pt-4 text-right text-sm font-bold">Total</td>
           <td class="pt-4 text-right">
-            <span class="inline-block rounded-md border border-gray-400 px-3 py-1 text-sm font-bold tabular-nums whitespace-nowrap"><%= dollars_from_cents(invoice.total_cents) %></span>
+            <span class="inline-block rounded-md border border-gray-400 px-3 py-1 text-sm font-bold whitespace-nowrap tabular-nums"><%= dollars_from_cents(invoice.total_cents) %></span>
           </td>
         </tr>
       </tfoot>
@@ -102,19 +102,19 @@
   <%# Payments and credits already applied, and the balance the payer still owes. %>
   <% if invoice.amount_applied_cents.positive? %>
     <div class="mt-8">
-      <p class="text-xs font-bold text-gray-700 uppercase tracking-wide mb-2">Payments &amp; credits applied</p>
+      <p class="mb-2 text-xs font-bold tracking-wide text-gray-700 uppercase">Payments &amp; credits applied</p>
       <table class="w-full text-sm">
         <tbody>
           <% invoice.entries.each do |entry| %>
             <tr class="border-b border-gray-100">
-              <td class="py-2 pr-3 whitespace-nowrap align-top"><%= entry.date&.strftime("%m/%d/%y") %></td>
+              <td class="py-2 pr-3 align-top whitespace-nowrap"><%= entry.date&.strftime("%m/%d/%y") %></td>
               <td class="py-2 pr-3 align-top">
                 <%= entry.method %>
                 <% if entry.reference.present? %>
                   <span class="text-xs text-gray-500">· <%= entry.reference %></span>
                 <% end %>
               </td>
-              <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap">-<%= dollars_from_cents(entry.amount_cents) %></td>
+              <td class="py-2 pl-3 text-right align-top whitespace-nowrap tabular-nums">-<%= dollars_from_cents(entry.amount_cents) %></td>
             </tr>
           <% end %>
         </tbody>
@@ -134,7 +134,7 @@
         <div class="mt-1 flex items-center justify-between border-t border-gray-300 pt-2 font-bold">
           <dt>Balance due</dt>
           <dd>
-            <span class="inline-block rounded-md border px-3 py-1 tabular-nums whitespace-nowrap <%= invoice.balance_due_cents.positive? ? "border-amber-500 bg-amber-50 text-amber-800" : "border-green-500 bg-green-50 text-green-700" %>"><%= dollars_from_cents(invoice.balance_due_cents) %></span>
+            <span class="inline-block rounded-md border px-3 py-1 whitespace-nowrap tabular-nums <%= invoice.balance_due_cents.positive? ? "border-amber-500 bg-amber-50 text-amber-800" : "border-green-500 bg-green-50 text-green-700" %>"><%= dollars_from_cents(invoice.balance_due_cents) %></span>
           </dd>
         </div>
       </dl>
@@ -143,6 +143,6 @@
 
   <footer class="mt-12 text-sm">
     <p><%= invoice.payable_to_note %></p>
-    <p class="font-bold mt-1">Thank you.</p>
+    <p class="mt-1 font-bold">Thank you.</p>
   </footer>
 </article>

--- a/app/views/events/invoices/show.html.erb
+++ b/app/views/events/invoices/show.html.erb
@@ -16,6 +16,6 @@
     end
 %>
 <%= render "events/invoices/actions", back_path: back_path, back_label: back_label %>
-<div class="px-4 sm:px-8 py-6 print:p-0">
+<div class="px-4 py-6 sm:px-8 print:p-0">
   <%= render "events/invoices/invoice", invoice: @invoice %>
 </div>

--- a/app/views/events/onboarding/_results.html.erb
+++ b/app/views/events/onboarding/_results.html.erb
@@ -58,7 +58,7 @@
                     <%= column[:label] %>
                   <% end %>
                   <% if column[:note] %>
-                    <i class="fa-solid fa-circle-info text-gray-400 text-[0.65rem] ml-0.5" title="<%= column[:note] %>"></i>
+                    <i class="fa-solid fa-circle-info ml-0.5 text-[0.65rem] text-gray-400" title="<%= column[:note] %>"></i>
                   <% end %>
                 </th>
               <% end %>

--- a/app/views/events/public_registrations/_group_header.html.erb
+++ b/app/views/events/public_registrations/_group_header.html.erb
@@ -1,5 +1,5 @@
 <%# Renders a form section header inside the 12-column form grid. locals: field %>
-<div class="md:col-span-12 pt-7 pb-4">
+<div class="pt-7 pb-4 md:col-span-12">
   <h3 class="rich-label flex items-center gap-2.5 text-lg font-bold text-purple-900">
     <span class="<%= form_section_bar_class %>"></span><%= form_label_html(field.name) %>
   </h3>

--- a/app/views/events/receipts/_receipt.html.erb
+++ b/app/views/events/receipts/_receipt.html.erb
@@ -1,10 +1,10 @@
 <%# Renders one EventReceipt as a printable document. Mirrors the invoice layout
     but adds the payment ledger and a balance summary that reconciles to $0.
     `receipt` is an EventReceipt. %>
-<article class="mx-auto max-w-3xl bg-white text-gray-800 px-8 py-10 print:px-0 print:py-0 print:max-w-none">
+<article class="mx-auto max-w-3xl bg-white px-8 py-10 text-gray-800 print:max-w-none print:px-0 print:py-0">
   <%# Header: issuer details (left) + brand logo (right) %>
   <header class="flex items-start justify-between gap-6">
-    <address class="not-italic text-sm leading-snug">
+    <address class="text-sm leading-snug not-italic">
       <p class="font-medium"><%= receipt.issuer_name %></p>
       <% receipt.issuer_address_lines.each do |line| %>
         <p><%= line %></p>
@@ -16,7 +16,7 @@
 
   <div class="my-8 flex flex-col items-center gap-3">
     <h1 class="text-center text-3xl font-semibold tracking-wide">RECEIPT</h1>
-    <span class="inline-flex items-center gap-1.5 rounded-full border border-green-600 bg-green-50 px-3 py-1 text-sm font-semibold uppercase tracking-wide text-green-700">
+    <span class="inline-flex items-center gap-1.5 rounded-full border border-green-600 bg-green-50 px-3 py-1 text-sm font-semibold tracking-wide text-green-700 uppercase">
       <i class="fa-solid fa-circle-check"></i> Paid in full
     </span>
   </div>
@@ -36,7 +36,7 @@
   </div>
 
   <%# Attention %>
-  <div class="space-y-1 mt-5">
+  <div class="mt-5 space-y-1">
     <p class="text-sm font-bold">Attention:</p>
     <div class="rounded-lg border border-gray-300 px-4 py-3 text-sm">
       <%= receipt.attention.presence || "—" %>
@@ -44,7 +44,7 @@
   </div>
 
   <%# Meta row: number / date / client id %>
-  <div class="mt-6 rounded-lg border border-gray-300 grid grid-cols-3 divide-x divide-gray-200 text-center">
+  <div class="mt-6 grid grid-cols-3 divide-x divide-gray-200 rounded-lg border border-gray-300 text-center">
     <% [
          [ "Receipt Number", receipt.number ],
          [ "Date Paid", receipt.date&.strftime("%-d %b, %Y") ],
@@ -52,30 +52,30 @@
        ].each do |label, value| %>
       <div class="px-3 py-3">
         <p class="text-xs font-bold text-gray-600"><%= label %></p>
-        <p class="text-sm mt-1"><%= value.presence || " " %></p>
+        <p class="mt-1 text-sm"><%= value.presence || " " %></p>
       </div>
     <% end %>
   </div>
 
   <%# Charges %>
-  <table class="w-full mt-8 text-sm">
+  <table class="mt-8 w-full text-sm">
     <thead>
       <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
-        <th class="text-left py-2 pr-3">Date</th>
-        <th class="text-left py-2 pr-3">Description</th>
-        <th class="text-right py-2 px-3 whitespace-nowrap">Quantity/Units</th>
-        <th class="text-right py-2 px-3 whitespace-nowrap">Unit Price</th>
-        <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+        <th class="py-2 pr-3 text-left">Date</th>
+        <th class="py-2 pr-3 text-left">Description</th>
+        <th class="px-3 py-2 text-right whitespace-nowrap">Quantity/Units</th>
+        <th class="px-3 py-2 text-right whitespace-nowrap">Unit Price</th>
+        <th class="py-2 pl-3 text-right whitespace-nowrap">Amount</th>
       </tr>
     </thead>
     <tbody>
       <% receipt.line_items.each do |item| %>
         <tr class="border-b border-gray-100">
-          <td class="py-2 pr-3 whitespace-nowrap align-top"><%= item.date&.strftime("%m/%d/%y") %></td>
+          <td class="py-2 pr-3 align-top whitespace-nowrap"><%= item.date&.strftime("%m/%d/%y") %></td>
           <td class="py-2 pr-3 align-top"><%= item.description %></td>
-          <td class="py-2 px-3 text-right tabular-nums align-top"><%= item.quantity %></td>
-          <td class="py-2 px-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.unit_price_cents) %></td>
-          <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(item.amount_cents) %></td>
+          <td class="px-3 py-2 text-right align-top tabular-nums"><%= item.quantity %></td>
+          <td class="px-3 py-2 text-right align-top whitespace-nowrap tabular-nums"><%= dollars_from_cents(item.unit_price_cents) %></td>
+          <td class="py-2 pl-3 text-right align-top whitespace-nowrap tabular-nums"><%= dollars_from_cents(item.amount_cents) %></td>
         </tr>
       <% end %>
     </tbody>
@@ -83,27 +83,27 @@
 
   <%# Payment ledger: every allocation that settled the balance %>
   <div class="mt-8">
-    <p class="text-xs font-bold text-gray-700 uppercase tracking-wide mb-2">Payments &amp; credits</p>
+    <p class="mb-2 text-xs font-bold tracking-wide text-gray-700 uppercase">Payments &amp; credits</p>
     <table class="w-full text-sm">
       <thead>
         <tr class="border-b border-gray-300 text-xs font-bold text-gray-700">
-          <th class="text-left py-2 pr-3">Date</th>
-          <th class="text-left py-2 pr-3">Method</th>
-          <th class="text-right py-2 pl-3 whitespace-nowrap">Amount</th>
+          <th class="py-2 pr-3 text-left">Date</th>
+          <th class="py-2 pr-3 text-left">Method</th>
+          <th class="py-2 pl-3 text-right whitespace-nowrap">Amount</th>
         </tr>
       </thead>
       <tbody>
         <% if receipt.entries.any? %>
           <% receipt.entries.each do |entry| %>
             <tr class="border-b border-gray-100">
-              <td class="py-2 pr-3 whitespace-nowrap align-top"><%= entry.date&.strftime("%m/%d/%y") %></td>
+              <td class="py-2 pr-3 align-top whitespace-nowrap"><%= entry.date&.strftime("%m/%d/%y") %></td>
               <td class="py-2 pr-3 align-top">
                 <%= entry.method %>
                 <% if entry.reference.present? %>
                   <span class="text-xs text-gray-500">· <%= entry.reference %></span>
                 <% end %>
               </td>
-              <td class="py-2 pl-3 text-right tabular-nums align-top whitespace-nowrap"><%= dollars_from_cents(entry.amount_cents) %></td>
+              <td class="py-2 pl-3 text-right align-top whitespace-nowrap tabular-nums"><%= dollars_from_cents(entry.amount_cents) %></td>
             </tr>
           <% end %>
         <% else %>
@@ -129,7 +129,7 @@
       <div class="mt-1 flex items-center justify-between border-t border-gray-300 pt-2 font-bold">
         <dt>Balance due</dt>
         <dd>
-          <span class="inline-block rounded-md border border-green-500 bg-green-50 px-3 py-1 text-green-700 tabular-nums whitespace-nowrap"><%= dollars_from_cents(receipt.balance_cents) %></span>
+          <span class="inline-block rounded-md border border-green-500 bg-green-50 px-3 py-1 whitespace-nowrap text-green-700 tabular-nums"><%= dollars_from_cents(receipt.balance_cents) %></span>
         </dd>
       </div>
     </dl>

--- a/app/views/events/reconcile_affiliations/_attendance_day_ticks.html.erb
+++ b/app/views/events/reconcile_affiliations/_attendance_day_ticks.html.erb
@@ -6,7 +6,7 @@
     cell answers with a turbo_stream that repaints the tick and the status chip. %>
 <div class="flex shrink-0 items-center gap-2">
   <% EventRegistration::DAY_FIELDS.first(event.day_count).each_with_index do |field, index| %>
-    <label class="inline-flex cursor-pointer items-center gap-1 whitespace-nowrap text-xs text-gray-500"
+    <label class="inline-flex cursor-pointer items-center gap-1 text-xs whitespace-nowrap text-gray-500"
            title="Mark day <%= index + 1 %> attended">
       <%= render "events/onboarding/cell", registration: registration, field: field %>
       Day <%= index + 1 %>

--- a/app/views/events/registrations/invoice.html.erb
+++ b/app/views/events/registrations/invoice.html.erb
@@ -9,7 +9,7 @@
      [ registration_ticket_path(@event_registration.slug), "Back to ticket" ]
    end %>
 <%= render "events/invoices/actions", back_path: back_path, back_label: back_label %>
-<div class="px-4 sm:px-8 py-6 print:p-0">
+<div class="px-4 py-6 sm:px-8 print:p-0">
   <div class="print:hidden"><%= render "event_registrations/transfer_notice", event_registration: @event_registration %></div>
   <%= render "events/invoices/invoice", invoice: @invoice %>
 </div>

--- a/app/views/events/registrations/receipt.html.erb
+++ b/app/views/events/registrations/receipt.html.erb
@@ -9,7 +9,7 @@
      [ registration_ticket_path(@event_registration.slug), "Back to ticket" ]
    end %>
 <%= render "events/invoices/actions", back_path: back_path, back_label: back_label %>
-<div class="px-4 sm:px-8 py-6 print:p-0">
+<div class="px-4 py-6 sm:px-8 print:p-0">
   <div class="print:hidden"><%= render "event_registrations/transfer_notice", event_registration: @event_registration %></div>
   <%= render "events/receipts/receipt", receipt: @receipt %>
 </div>

--- a/app/views/events/registrations/show.html.erb
+++ b/app/views/events/registrations/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "public") %>
-<div class="max-w-3xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
+<div class="mx-auto flex max-w-3xl flex-wrap items-center gap-2 px-4 pt-4">
   <%= link_to event_path(@event_registration.event, reg: @event_registration.slug), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Back to event
   <% end %>

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -13,21 +13,21 @@
   <% back_label = "← Dashboard" %>
   <% back_path = dashboard_event_path(@event) %>
 <% end %>
-<div class="max-w-2xl mx-auto flex flex-wrap items-center gap-2 px-4 pt-4">
+<div class="mx-auto flex max-w-2xl flex-wrap items-center gap-2 px-4 pt-4">
   <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <div class="ml-auto flex gap-2">
     <%= link_to "Edit event", edit_event_path(@event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 </div>
-<div class="max-w-2xl mx-auto px-4">
+<div class="mx-auto max-w-2xl px-4">
 
   <%# Preview box: the description on the left, the admin-only options toggle in
       the top right. The toggle reloads this same preview with (or without)
       ?options=all, preserving the origin so the eyebrow still points home. %>
   <div class="mt-4 flex items-start gap-3 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3">
-    <i class="fa-solid fa-eye text-amber-500 text-xl shrink-0 mt-0.5"></i>
-    <div class="flex-1 min-w-0 text-sm text-amber-800">
+    <i class="fa-solid fa-eye mt-0.5 shrink-0 text-xl text-amber-500"></i>
+    <div class="min-w-0 flex-1 text-sm text-amber-800">
       <p class="font-semibold text-amber-900">Sample ticket preview</p>
       <% if @show_all_options %>
         <p>This is an example registration with every option turned on — including

--- a/app/views/faqs/_search_boxes.html.erb
+++ b/app/views/faqs/_search_boxes.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag(faqs_path, method: :get, class: "space-y-4", data: { controller: "collection" }) do |f| %>
-  <div class="flex flex-col md:flex-row md:items-end md:gap-4 mb-6">
+  <div class="mb-6 flex flex-col md:flex-row md:items-end md:gap-4">
     <!-- Search -->
-    <div class="w-full md:flex-1 mb-3 md:mb-0">
+    <div class="mb-3 w-full md:mb-0 md:flex-1">
       <%= label_tag :query, "Search", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :query, params[:query],
@@ -12,7 +12,7 @@
     </div>
 
     <!-- Visibility -->
-    <div class="w-full md:w-48 mb-3 md:mb-0">
+    <div class="mb-3 w-full md:mb-0 md:w-48">
       <%= render "shared/visibility_filter",
                  model_class: Faq,
                  admin: allowed_to?(:manage?, Faq),

--- a/app/views/features/_feature.html.erb
+++ b/app/views/features/_feature.html.erb
@@ -1,5 +1,5 @@
 <article
-  class="relative bg-white rounded-xl shadow-sm hover:shadow-md transition border border-gray-200 overflow-hidden"
+  class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition hover:shadow-md"
   data-controller="expandable-card"
   data-expandable-card-expanded-value="false"
   data-action="expandable-cards:expandAll@window->expandable-card#expand expandable-cards:collapseAll@window->expandable-card#collapse">
@@ -9,11 +9,11 @@
   <div class="p-4 pl-6">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0 flex-1 lg:flex lg:items-center lg:gap-2">
-        <h3 class="text-lg font-semibold text-gray-900 leading-tight truncate lg:flex-1 lg:min-w-0"
+        <h3 class="truncate text-lg leading-tight font-semibold text-gray-900 lg:min-w-0 lg:flex-1"
             title="<%= feature.name %>">
           <%= link_to feature.name, feature_path(feature), class: "hover:text-primary", data: { turbo_frame: "_top" } %>
         </h3>
-        <div class="mt-1.5 lg:mt-0 flex flex-wrap items-center gap-2 shrink-0">
+        <div class="mt-1.5 flex shrink-0 flex-wrap items-center gap-2 lg:mt-0">
           <%= feature.area_badge %>
           <%= feature.status_badge %>
           <% unless feature.published? %>
@@ -23,8 +23,8 @@
           <% end %>
         </div>
       </div>
-      <div class="flex items-center gap-3 shrink-0">
-        <span class="text-xs font-medium text-gray-500 whitespace-nowrap">
+      <div class="flex shrink-0 items-center gap-3">
+        <span class="text-xs font-medium whitespace-nowrap text-gray-500">
           <i class="fa-regular fa-calendar"></i> <%= feature.released_label %>
         </span>
         <button type="button" data-action="expandable-card#toggle" aria-label="Expand feature"
@@ -34,10 +34,10 @@
       </div>
     </div>
 
-    <div class="hidden mt-2" data-expandable-card-target="body">
+    <div class="mt-2 hidden" data-expandable-card-target="body">
       <div class="md:flex md:items-start md:gap-6">
-        <div class="md:flex-1 min-w-0">
-          <p class="text-gray-600 text-sm"><%= feature.summary %></p>
+        <div class="min-w-0 md:flex-1">
+          <p class="text-sm text-gray-600"><%= feature.summary %></p>
 
           <div class="mt-3 flex items-center gap-4 text-sm">
             <%= link_to feature_path(feature), class: "text-primary font-medium hover:underline",
@@ -54,11 +54,11 @@
         </div>
 
         <% if feature.pro_tips_list.any? %>
-          <div class="mt-3 md:mt-0 md:w-80 md:shrink-0 rounded-lg bg-amber-50 border border-amber-200 p-3">
-            <p class="text-xs font-semibold text-amber-800 uppercase tracking-wide mb-1">
+          <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 md:mt-0 md:w-80 md:shrink-0">
+            <p class="mb-1 text-xs font-semibold tracking-wide text-amber-800 uppercase">
               <i class="fa-solid fa-lightbulb"></i> <%= "Pro tip".pluralize(feature.pro_tips_list.size) %>
             </p>
-            <div class="text-sm text-amber-900 line-clamp-2">
+            <div class="line-clamp-2 text-sm text-amber-900">
               <% feature.pro_tips_list.each do |tip| %>
                 <p><span class="text-amber-500">•</span> <%= tip %></p>
               <% end %>

--- a/app/views/features/_results_skeleton.html.erb
+++ b/app/views/features/_results_skeleton.html.erb
@@ -1,9 +1,9 @@
 <div class="animate-pulse space-y-4">
   <% 4.times do %>
-    <div class="bg-white rounded-xl border border-gray-200 p-4 pl-6">
-      <div class="h-5 w-2/3 bg-gray-200 rounded mb-3"></div>
-      <div class="h-3 w-full bg-gray-100 rounded mb-1.5"></div>
-      <div class="h-3 w-5/6 bg-gray-100 rounded"></div>
+    <div class="rounded-xl border border-gray-200 bg-white p-4 pl-6">
+      <div class="mb-3 h-5 w-2/3 rounded bg-gray-200"></div>
+      <div class="mb-1.5 h-3 w-full rounded bg-gray-100"></div>
+      <div class="h-3 w-5/6 rounded bg-gray-100"></div>
     </div>
   <% end %>
 </div>

--- a/app/views/features/features_results.html.erb
+++ b/app/views/features/features_results.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag :features_results do %>
   <div data-controller="expandable-cards" data-expandable-cards-expanded-value="false">
-    <div class="flex items-center justify-between gap-3 mb-3">
+    <div class="mb-3 flex items-center justify-between gap-3">
       <p class="text-sm text-gray-500">
         Showing <%= @features.size %> of <%= @total %> <%= "feature".pluralize(@total) %>
       </p>
@@ -19,9 +19,9 @@
     </div>
 
     <% if @features.empty? %>
-      <div class="bg-white border border-dashed border-gray-300 rounded-xl p-10 text-center">
+      <div class="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center">
         <i class="fa-solid fa-magnifying-glass text-3xl text-gray-300"></i>
-        <p class="text-gray-500 mt-3">
+        <p class="mt-3 text-gray-500">
           <%= @total.zero? ? "No features yet." : "No features match your filters." %>
         </p>
       </div>

--- a/app/views/forms/_field_list.html.erb
+++ b/app/views/forms/_field_list.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (names:, indent: "ml-6") %>
-<ul class="hidden mt-2 <%= indent %> list-disc list-inside space-y-0.5 text-xs text-gray-600 marker:text-gray-300"
+<ul class="mt-2 hidden <%= indent %> list-inside list-disc space-y-0.5 text-xs text-gray-600 marker:text-gray-300"
     data-expandable-card-target="body">
   <% names.each do |name| %>
     <li><%= name %></li>

--- a/app/views/forms/_results_skeleton.html.erb
+++ b/app/views/forms/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
 <div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="w-full border-collapse">
-    <thead class="bg-gray-100 animate-pulse">
+    <thead class="animate-pulse bg-gray-100">
       <tr>
         <% 5.times do %>
           <th class="px-4 py-2 text-left">
@@ -8,11 +8,11 @@
           </th>
         <% end %>
         <th class="px-4 py-2">
-          <div class="h-4 w-6 ml-auto rounded bg-gray-200"></div>
+          <div class="ml-auto h-4 w-6 rounded bg-gray-200"></div>
         </th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-200">
       <% 3.times do %>
         <tr>
           <% 5.times do %>
@@ -21,7 +21,7 @@
             </td>
           <% end %>
           <td class="px-4 py-3 text-right">
-            <div class="h-6 w-6 ml-auto rounded bg-gray-200"></div>
+            <div class="ml-auto h-6 w-6 rounded bg-gray-200"></div>
           </td>
         </tr>
       <% end %>

--- a/app/views/grants/_results_skeleton.html.erb
+++ b/app/views/grants/_results_skeleton.html.erb
@@ -1,8 +1,8 @@
 <%# Placeholder shown while the grants_results frame loads its filtered rows. %>
-<div class="overflow-x-auto bg-white rounded-xl border border-gray-200 shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="w-full border-collapse">
     <thead>
-      <tr class="border-b border-gray-200 bg-gray-50 animate-pulse">
+      <tr class="animate-pulse border-b border-gray-200 bg-gray-50">
         <% 8.times do %>
           <th class="px-4 py-3"><div class="h-3 w-16 rounded bg-gray-200"></div></th>
         <% end %>
@@ -21,7 +21,7 @@
 </div>
 
 <%# Pagination skeleton, mirroring the bar placeholders on the other lazy indexes. %>
-<div class="flex justify-center space-x-2 mt-12 animate-pulse">
+<div class="mt-12 flex animate-pulse justify-center space-x-2">
   <% 3.times do %>
     <div class="h-8 w-10 rounded bg-gray-200"></div>
   <% end %>

--- a/app/views/home/_community_news_cards_skeleton.html.erb
+++ b/app/views/home/_community_news_cards_skeleton.html.erb
@@ -1,17 +1,17 @@
 <% 3.times do %>
-  <div class="bg-white shadow-sm rounded-xl p-4 animate-pulse mt-4">
+  <div class="mt-4 animate-pulse rounded-xl bg-white p-4 shadow-sm">
     <!-- Skeleton bookmark -->
     <div class="absolute top-3 right-3">
-      <div class="w-5 h-5 bg-gray-200 rounded"></div>
+      <div class="h-5 w-5 rounded bg-gray-200"></div>
     </div>
 
     <div class="flex flex-row items-start gap-4">
       <!-- LEFT: Title + body -->
-      <div class="flex-1 pr-10 space-y-1">
+      <div class="flex-1 space-y-1 pr-10">
         <!-- Title -->
-        <div class="h-5 w-1/5 bg-gray-200 rounded"></div>
+        <div class="h-5 w-1/5 rounded bg-gray-200"></div>
 
-        <div class="h-3 w-full bg-gray-200 rounded"></div>
+        <div class="h-3 w-full rounded bg-gray-200"></div>
       </div>
     </div>
   </div>

--- a/app/views/home/_resources_cards_skeleton.html.erb
+++ b/app/views/home/_resources_cards_skeleton.html.erb
@@ -1,43 +1,33 @@
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
   <% 3.times do %>
     <div
-      class="
-        flex flex-row flex-wrap
-        bg-white border border-gray-200 rounded-xl shadow-sm
-        overflow-hidden animate-pulse
-      "
+      class="flex animate-pulse flex-row flex-wrap overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
     >
       <!-- LEFT SIDE -->
       <div
-        class="
-          flex-shrink-0
-          w-40 md:w-40
-          flex flex-col items-center text-center justify-center
-          py-4 pb-3 px-3
-          border-b md:border-b-0 md:border-r border-gray-200
-        "
+        class="flex w-40 flex-shrink-0 flex-col items-center justify-center border-b border-gray-200 px-3 py-4 pb-3 text-center md:w-40 md:border-r md:border-b-0"
       >
         <!-- IMAGE SKELETON -->
-        <div class="w-32 h-32 bg-gray-200 rounded border border-gray-300"></div>
+        <div class="h-32 w-32 rounded border border-gray-300 bg-gray-200"></div>
 
         <!-- TYPE -->
-        <div class="mt-2 h-3 w-16 bg-gray-200 rounded"></div>
+        <div class="mt-2 h-3 w-16 rounded bg-gray-200"></div>
       </div>
 
       <!-- RIGHT SIDE -->
-      <div class="flex-1 min-w-0 pl-4 pr-10 pb-12 mt-2 relative">
+      <div class="relative mt-2 min-w-0 flex-1 pr-10 pb-12 pl-4">
         <!-- TITLE -->
         <div class="mt-3 mb-2">
-          <div class="h-5 w-3/4 bg-gray-200 rounded"></div>
+          <div class="h-5 w-3/4 rounded bg-gray-200"></div>
         </div>
 
         <!-- OPTIONAL SUB LINE -->
-        <div class="h-3 w-1/2 bg-gray-200 rounded mt-2"></div>
+        <div class="mt-2 h-3 w-1/2 rounded bg-gray-200"></div>
 
         <!-- ACTION BUTTONS SKELETON -->
-        <div class="absolute bottom-3 right-3 flex items-center space-x-2">
-          <div class="w-8 h-8 bg-gray-200 rounded-full"></div>
-          <div class="w-8 h-8 bg-gray-200 rounded-full"></div>
+        <div class="absolute right-3 bottom-3 flex items-center space-x-2">
+          <div class="h-8 w-8 rounded-full bg-gray-200"></div>
+          <div class="h-8 w-8 rounded-full bg-gray-200"></div>
         </div>
       </div>
     </div>

--- a/app/views/home/_stories_cards_skeleton.html.erb
+++ b/app/views/home/_stories_cards_skeleton.html.erb
@@ -1,25 +1,25 @@
 <% 3.times do %>
-  <div class="relative bg-white rounded-xl shadow-sm p-2 animate-pulse my-3">
+  <div class="relative my-3 animate-pulse rounded-xl bg-white p-2 shadow-sm">
     <!-- Bookmark placeholder -->
     <div class="absolute top-4 right-4">
-      <div class="w-5 h-5 bg-gray-200 rounded"></div>
+      <div class="h-5 w-5 rounded bg-gray-200"></div>
     </div>
 
     <!-- Card body -->
-    <div class="flex flex-col md:flex-row md:items-center gap-4">
+    <div class="flex flex-col gap-4 md:flex-row md:items-center">
       <!-- LEFT: Text -->
       <div class="flex-1 pr-12">
         <!-- Title -->
-        <div class="h-5 w-1/4 bg-gray-200 rounded"></div>
+        <div class="h-5 w-1/4 rounded bg-gray-200"></div>
 
         <!-- Body -->
         <div class="mt-2 space-y-2">
-          <div class="h-3 w-full bg-gray-200 rounded"></div>
+          <div class="h-3 w-full rounded bg-gray-200"></div>
         </div>
       </div>
 
       <!-- RIGHT: Image -->
-      <div class="w-24 h-14 bg-gray-200 rounded mr-9"></div>
+      <div class="mr-9 h-14 w-24 rounded bg-gray-200"></div>
     </div>
   </div>
 <% end %>

--- a/app/views/home/_video_gallery_skeleton.html.erb
+++ b/app/views/home/_video_gallery_skeleton.html.erb
@@ -1,10 +1,10 @@
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
   <% 3.times do %>
-    <div class="bg-white rounded-xl shadow-sm overflow-hidden animate-pulse">
+    <div class="animate-pulse overflow-hidden rounded-xl bg-white shadow-sm">
       <div class="aspect-video bg-gray-200"></div>
-      <div class="p-4 space-y-2">
-        <div class="h-4 w-3/4 bg-gray-200 rounded"></div>
-        <div class="h-3 w-1/2 bg-gray-200 rounded"></div>
+      <div class="space-y-2 p-4">
+        <div class="h-4 w-3/4 rounded bg-gray-200"></div>
+        <div class="h-3 w-1/2 rounded bg-gray-200"></div>
       </div>
     </div>
   <% end %>

--- a/app/views/home/_workshops_cards_skeleton.html.erb
+++ b/app/views/home/_workshops_cards_skeleton.html.erb
@@ -3,30 +3,27 @@
   <div class="swiper-wrapper flex items-stretch">
     <% 6.times do %>
       <div
-        class="
-          swiper-slide relative overflow-hidden block  rounded-xl border border-gray-200 shadow-sm bg-white p-4
-          cursor-pointer animate-pulse
-        "
+        class="swiper-slide relative block animate-pulse cursor-pointer overflow-hidden rounded-xl border border-gray-200 bg-white p-4 shadow-sm"
         style="width: 257.5px; margin-right: 30px;"
       >
         <!-- Bookmark Icon Placeholder -->
-        <div class="absolute bottom-3 right-3 w-5 h-5 bg-gray-300 rounded-full"></div>
+        <div class="absolute right-3 bottom-3 h-5 w-5 rounded-full bg-gray-300"></div>
 
         <!-- Media Placeholder -->
-        <div class="w-full h-24 bg-gray-300 rounded border border-gray-200 mb-4"></div>
+        <div class="mb-4 h-24 w-full rounded border border-gray-200 bg-gray-300"></div>
 
         <!-- Content Placeholder -->
-        <div class="p-4 space-y-6">
+        <div class="space-y-6 p-4">
           <div class="flex justify-between text-xs text-gray-400">
-            <span class="w-16 h-3 bg-gray-300 rounded"></span>
-            <span class="w-12 h-3 bg-gray-300 rounded"></span>
+            <span class="h-3 w-16 rounded bg-gray-300"></span>
+            <span class="h-3 w-12 rounded bg-gray-300"></span>
           </div>
 
           <div class="space-y-2">
-            <div class="w-3/4 h-5 bg-gray-300 rounded"></div>
-            <div class="w-full h-3 bg-gray-300 rounded"></div>
-            <div class="w-full h-3 bg-gray-300 rounded"></div>
-            <div class="w-5/6 h-3 bg-gray-300 rounded"></div>
+            <div class="h-5 w-3/4 rounded bg-gray-300"></div>
+            <div class="h-3 w-full rounded bg-gray-300"></div>
+            <div class="h-3 w-full rounded bg-gray-300"></div>
+            <div class="h-3 w-5/6 rounded bg-gray-300"></div>
           </div>
         </div>
       </div>

--- a/app/views/home/resources/index.html.erb
+++ b/app/views/home/resources/index.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "home_resources" do %>
   <% if @resources&.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <% @resources.each do |resource| %>
         <%= render "resources/resource_card", resource: resource.decorate %>
       <% end %>

--- a/app/views/home/video_recordings/index.html.erb
+++ b/app/views/home/video_recordings/index.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "home_video_gallery" do %>
   <% if @video_recordings&.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <% @video_recordings.each do |video_recording| %>
         <%= render "video_recordings/video_card", video_recording: video_recording %>
       <% end %>

--- a/app/views/home/workshops/_workshops_carousel.html.erb
+++ b/app/views/home/workshops/_workshops_carousel.html.erb
@@ -8,14 +8,9 @@
 
   <button
     class="
-      swiper-button-next-custom
-      absolute top-36 sm:top-36 right-2
-      w-12 h-12 rounded-full
-      bg-white border <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
+      swiper-button-next-custom absolute top-36 right-2 h-12 w-12 rounded-full border bg-white sm:top-36 <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
       <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>
-      shadow-md hover:shadow-lg
-      flex items-center justify-center
-      transition hover:<%= DomainTheme.bg_class_for(:workshops) %>
+      flex items-center justify-center shadow-md transition hover:shadow-lg hover:<%= DomainTheme.bg_class_for(:workshops) %>
       z-40
     "
   >
@@ -25,7 +20,7 @@
       fill="none"
       stroke="currentColor"
       stroke-width="2"
-      class="w-7 h-7"
+      class="h-7 w-7"
     >
       <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M13 6l6 6-6 6" />
     </svg>
@@ -33,14 +28,9 @@
 
   <button
     class="
-      swiper-button-prev-custom
-      absolute top-36 sm:top-36 left-2
-      w-12 h-12 rounded-full
-      bg-white border <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
+      swiper-button-prev-custom absolute top-36 left-2 h-12 w-12 rounded-full border bg-white sm:top-36 <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>
       <%= DomainTheme.text_class_for(:workshops, intensity: 700) %>
-      shadow-md hover:shadow-lg
-      flex items-center justify-center
-      transition hover:<%= DomainTheme.bg_class_for(:workshops) %>
+      flex items-center justify-center shadow-md transition hover:shadow-lg hover:<%= DomainTheme.bg_class_for(:workshops) %>
       z-40
     "
   >
@@ -50,7 +40,7 @@
       fill="none"
       stroke="currentColor"
       stroke-width="2"
-      class="w-7 h-7"
+      class="h-7 w-7"
     >
       <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5m6 6l-6 -6 6 -6" />
     </svg>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,10 +1,7 @@
 <%# flow-root to prevent table overflow %>
 <%# Override prose table text alignment %>
 <div
-  class="
-    prose max-w-none prose-strong:text-inherit prose-em:text-inherit flow-root
-    [&_td]:align-top [&_th]:align-top
-  "
+  class="flow-root max-w-none prose prose-em:text-inherit prose-strong:text-inherit [&_td]:align-top [&_th]:align-top"
   data-controller="print-options"
   data-print-options-images-value="true"
 >

--- a/app/views/membership_invoices/_results_skeleton.html.erb
+++ b/app/views/membership_invoices/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left">
           <div class="h-4 w-28 rounded bg-gray-200"></div>
@@ -24,7 +24,7 @@
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 10.times do %>
         <tr>
           <!-- Person -->

--- a/app/views/monthly_reports/_combined_workshop_log_summary.html.erb
+++ b/app/views/monthly_reports/_combined_workshop_log_summary.html.erb
@@ -6,7 +6,7 @@
       <div class="col-md-12 label-plus-comment">Adult and Children's Combined (Family) Log Summary</div>
       <div class="custom-smaller">Please note: If you submitted Combined/Family numbers, they will not automatically populate into your Monthly Report total. However, they will still count towards your monthly numbers. An AWBW staff member will input them separately once the Monthly Report is submitted.</div>
     </div>
-    <table class='table table-striped'>
+    <table class='table-striped table'>
       <th class='bold small'>Date</th>
       <th class='bold small'>Person/Workshop</th>
       <th class='bold small'># on-going adults</th>

--- a/app/views/monthly_reports/_monthly_reports_count.html.erb
+++ b/app/views/monthly_reports/_monthly_reports_count.html.erb
@@ -1,7 +1,7 @@
 <div id="monthly_reports_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Monthly reports (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Monthly reports (<%= @count_display %>)</h3>
   </div>
-  <hr class="border-gray-300 my-6">
+  <hr class="my-6 border-gray-300">
 </div>

--- a/app/views/monthly_reports/_results_skeleton.html.erb
+++ b/app/views/monthly_reports/_results_skeleton.html.erb
@@ -1,28 +1,28 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left"><div class="h-4 w-20 rounded bg-gray-200"></div></th>
         <th class="px-6 py-3 text-left"><div class="h-4 w-28 rounded bg-gray-200"></div></th>
         <th class="px-6 py-3 text-left"><div class="h-4 w-32 rounded bg-gray-200"></div></th>
         <th class="px-6 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
-        <th class="px-6 py-3 text-right"><div class="h-4 w-16 ml-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></th>
+        <th class="px-6 py-3 text-right"><div class="ml-auto h-4 w-16 rounded bg-gray-200"></div></th>
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 3.times do %>
         <tr>
           <td class="px-6 py-4"><div class="h-4 w-20 rounded bg-gray-200"></div></td>
           <td class="px-6 py-4"><div class="h-4 w-32 rounded bg-gray-200"></div></td>
           <td class="px-6 py-4"><div class="h-4 w-48 rounded bg-gray-200"></div></td>
           <td class="px-6 py-4"><div class="h-4 w-24 rounded bg-gray-200"></div></td>
-          <td class="px-4 py-4 text-center"><div class="h-4 w-10 mx-auto rounded bg-gray-200"></div></td>
-          <td class="px-4 py-4 text-center"><div class="h-4 w-10 mx-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-4 text-center"><div class="mx-auto h-4 w-10 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-4 text-center"><div class="mx-auto h-4 w-10 rounded bg-gray-200"></div></td>
           <td class="px-6 py-4 text-right">
-            <div class="inline-flex gap-2 justify-end">
+            <div class="inline-flex justify-end gap-2">
               <div class="h-8 w-14 rounded bg-gray-200"></div>
               <div class="h-8 w-14 rounded bg-gray-200"></div>
             </div>

--- a/app/views/monthly_reports/_search_boxes.html.erb
+++ b/app/views/monthly_reports/_search_boxes.html.erb
@@ -3,9 +3,9 @@
              id: "filter-form",
              class: "w-full",
              data: { controller: "collection", turbo_frame: "monthly_reports_results" } do %>
-  <div class="flex flex-wrap items-end gap-4 mb-4">
+  <div class="mb-4 flex flex-wrap items-end gap-4">
     <!-- Month -->
-    <div class="flex flex-col w-full sm:w-auto min-w-[10rem]">
+    <div class="flex w-full min-w-[10rem] flex-col sm:w-auto">
       <%= label_tag :month_and_year, "Month", class: search_label_class %>
       <%= select_tag :month_and_year,
                      options_for_select(@month_year_options, params[:month_and_year]),
@@ -15,7 +15,7 @@
     </div>
 
     <!-- Year -->
-    <div class="flex flex-col w-full sm:w-auto min-w-[9rem]">
+    <div class="flex w-full min-w-[9rem] flex-col sm:w-auto">
       <%= label_tag :year, "Year", class: search_label_class %>
       <%= select_tag :year,
                      options_for_select(@year_options, params[:year]),
@@ -25,7 +25,7 @@
     </div>
 
     <!-- Workshop -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5">
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
       <%= label_tag :workshop_id, "Workshop", class: search_label_class %>
       <%= select_tag :workshop_id,
                      options_from_collection_for_select(@workshops, :id, :type_name, params[:workshop_id]),
@@ -35,7 +35,7 @@
     </div>
 
     <!-- Submitted by -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5" data-controller="searchable-select" data-searchable-select-mode-value="person">
       <%= label_tag :created_by_id, "Submitted by", class: search_label_class %>
       <%= select_tag :created_by_id,
                      options_from_collection_for_select(@users, :id, :full_name_with_email, params[:created_by_id]),
@@ -45,7 +45,7 @@
     </div>
 
     <!-- Author name -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5">
+    <div class="flex w-full flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
       <%= label_tag :author_name, "Author name", class: search_label_class %>
       <div class="relative">
         <%= text_field_tag :author_name, params[:author_name],
@@ -57,7 +57,7 @@
     </div>
 
     <!-- Organization -->
-    <div class="flex flex-col w-full sm:w-1/2 md:w-1/4 lg:w-1/5 min-w-[14rem]">
+    <div class="flex w-full min-w-[14rem] flex-col sm:w-1/2 md:w-1/4 lg:w-1/5">
       <%= label_tag :organization_id, "Organization", class: search_label_class %>
       <%= select_tag :organization_id,
                      options_from_collection_for_select(@organizations, :id, :name, params[:organization_id]),

--- a/app/views/notifications/_results_skeleton.html.erb
+++ b/app/views/notifications/_results_skeleton.html.erb
@@ -1,22 +1,22 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200 text-sm">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-4 py-3 text-left"><div class="h-4 w-16 rounded bg-gray-200"></div></th>
         <th class="px-4 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
         <th class="px-4 py-3 text-left"><div class="h-4 w-32 rounded bg-gray-200"></div></th>
         <th class="px-4 py-3 text-left"><div class="h-4 w-20 rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-right"><div class="h-4 w-12 ml-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-right"><div class="ml-auto h-4 w-12 rounded bg-gray-200"></div></th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 5.times do %>
         <tr>
           <td class="px-4 py-3"><div class="h-4 w-24 rounded bg-gray-200"></div></td>
           <td class="px-4 py-3"><div class="h-4 w-40 rounded bg-gray-200"></div></td>
           <td class="px-4 py-3"><div class="h-4 w-48 rounded bg-gray-200"></div></td>
           <td class="px-4 py-3"><div class="h-4 w-28 rounded bg-gray-200"></div></td>
-          <td class="px-4 py-3 text-right"><div class="h-4 w-12 ml-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-right"><div class="ml-auto h-4 w-12 rounded bg-gray-200"></div></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/notifications/notifications_results.html.erb
+++ b/app/views/notifications/notifications_results.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "notifications_results" do %>
-  <div class="overflow-x-auto animate-fade blur-on-submit">
+  <div class="animate-fade overflow-x-auto blur-on-submit">
     <%= render "index" %>
   </div>
 
   <!-- Pagination -->
-  <div class="pagination flex justify-center mt-12">
+  <div class="pagination mt-12 flex justify-center">
     <%= tailwind_paginate @notifications %>
   </div>
 <% end %>

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -1,8 +1,8 @@
 <%# Persisted addresses start collapsed to a single-line header; new/blank ones
     stay expanded so their fields are ready to fill in. Native <details>/<summary>
     toggles the editable fields on click — no JavaScript needed. %>
-<details class="nested-fields group rounded-lg bg-white border border-gray-200 p-6 mb-4"<%= " open".html_safe unless f.object.persisted? %>>
-  <summary class="flex items-center justify-between gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+<details class="nested-fields group mb-4 rounded-lg border border-gray-200 bg-white p-6"<%= " open".html_safe unless f.object.persisted? %>>
+  <summary class="flex cursor-pointer list-none items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
     <div class="text-lg font-semibold text-gray-800">
       Address <%= "#" + (f.index.to_i + 1).to_s if f.object.persisted? %><%= ": " + f.object.name if f.object.persisted? %>
     </div>
@@ -15,7 +15,7 @@
   <%# Organization addresses are always "work" — the type designation only matters
       for Person addresses — so persist it with a hidden field rather than a selector. %>
   <%= f.hidden_field :address_type, value: "work" %>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-3">
     <div class="flex items-center gap-6">
       <%= f.input :primary,
                   as: :boolean,
@@ -35,7 +35,7 @@
 
 
   <!-- LA-SPECIFIC FIELDS -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :locality,
                 label: "Locality",
                 as: :select,
@@ -79,7 +79,7 @@
   </div>
 
   <!-- ADDRESS BLOCK -->
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :street_address,
                 label: "Street Address",
                 input_html: {
@@ -111,7 +111,7 @@
 
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+  <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :district,
                 label: "District",
                 input_html: {

--- a/app/views/organizations/_associated_records.html.erb
+++ b/app/views/organizations/_associated_records.html.erb
@@ -1,7 +1,7 @@
 <% return unless organization.persisted? %>
 <% org_filter = { organization_id: organization.id } %>
 <% monthly_reports = MonthlyReport.where(org_filter) %>
-<ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
+<ul class="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2 md:grid-cols-3">
   <li><%= index_button CommunityNews.where(org_filter), params: org_filter %></li>
   <li><%= index_button Story.where(org_filter), params: org_filter %></li>
   <li><%= index_button organization.workshop_logs, params: org_filter %></li>

--- a/app/views/organizations/sections/_events.html.erb
+++ b/app/views/organizations/sections/_events.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "organization_events_section" do %>
   <% if events.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% events.each do |event| %>
         <% decorated = event.decorate %>
         <%= render "people/show_card",

--- a/app/views/payments/_results_skeleton.html.erb
+++ b/app/views/payments/_results_skeleton.html.erb
@@ -1,7 +1,7 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
     <!-- Header skeleton -->
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left">
           <div class="h-4 w-12 rounded bg-gray-200"></div>
@@ -24,12 +24,12 @@
         </th>
 
         <th class="px-6 py-3 text-right">
-          <div class="h-4 w-14 ml-auto rounded bg-gray-200"></div>
+          <div class="ml-auto h-4 w-14 rounded bg-gray-200"></div>
         </th>
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 10.times do %>
         <tr>
           <!-- Type -->
@@ -59,7 +59,7 @@
 
           <!-- Actions -->
           <td class="px-6 py-4 text-right">
-            <div class="h-4 w-10 ml-auto rounded bg-gray-200"></div>
+            <div class="ml-auto h-4 w-10 rounded bg-gray-200"></div>
           </td>
         </tr>
       <% end %>

--- a/app/views/payments/payments_results.html.erb
+++ b/app/views/payments/payments_results.html.erb
@@ -1,33 +1,33 @@
 <%= turbo_frame_tag :payments_results do %>
   <% if @payments.any? %>
-    <div class="overflow-x-auto animate-fade blur-on-submit">
+    <div class="animate-fade overflow-x-auto blur-on-submit">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Payer</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Unallocated</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
-            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Type</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Payer</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Amount</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Unallocated</th>
+            <th class="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Created</th>
+            <th class="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">Actions</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="divide-y divide-gray-200 bg-white">
           <% @payments.each do |payment| %>
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.type.underscore.titleize.gsub(" Payment", "").gsub("External Processor", "Stripe") %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= payment.payer&.name || "Unknown" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents) %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= dollars_from_cents(payment.amount_cents_remaining) %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= payment.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"><%= link_to "View", payment_path(payment), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top"} %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= payment.type.underscore.titleize.gsub(" Payment", "").gsub("External Processor", "Stripe") %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= payment.payer&.name || "Unknown" %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= dollars_from_cents(payment.amount_cents) %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-900"><%= dollars_from_cents(payment.amount_cents_remaining) %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap text-gray-500"><%= payment.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>
+              <td class="px-6 py-4 text-right text-sm font-medium whitespace-nowrap"><%= link_to "View", payment_path(payment), class: "text-primary hover:text-primary-dark", data: { turbo_frame: "_top"} %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
     </div>
   <% else %>
-    <p class="text-gray-500 text-center py-6">There are no payments that match your search. Please try again.</p>
+    <p class="py-6 text-center text-gray-500">There are no payments that match your search. Please try again.</p>
   <% end %>
-  <div class="pagination flex justify-center mt-6"><%= tailwind_paginate @payments %></div>
+  <div class="pagination mt-6 flex justify-center"><%= tailwind_paginate @payments %></div>
 <% end %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -5,41 +5,41 @@
     or submitted. Keep the cards alphabetical by label within each cluster. %>
 
 <div class="mb-5">
-  <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Administrative</h3>
-  <ul class="columns-1 sm:columns-2 md:columns-3 gap-x-6">
-    <li class="break-inside-avoid mb-2"><%= index_button notifications, params: { email: email }, label: "#{t("communications.title")} (universal)" %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button ContinuingEducationRegistration.for_registrant(person.id), params: { person_id: person.id }, label: "CE registrations" %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
+  <h3 class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase">Administrative</h3>
+  <ul class="columns-1 gap-x-6 sm:columns-2 md:columns-3">
+    <li class="mb-2 break-inside-avoid"><%= index_button notifications, params: { email: email }, label: "#{t("communications.title")} (universal)" %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.event_registrations, params: { registrant_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button ContinuingEducationRegistration.for_registrant(person.id), params: { person_id: person.id }, label: "CE registrations" %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.form_submissions, params: { person_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.grants, params: { funder_id: person.id, funder_type: "Person" }, label: "Grants (as funder)" %></li>
     <% if Membership.enabled? %>
-      <li class="break-inside-avoid mb-2"><%= index_button person.memberships, path: person_memberships_path(person) %></li>
+      <li class="mb-2 break-inside-avoid"><%= index_button person.memberships, path: person_memberships_path(person) %></li>
     <% end %>
-    <li class="break-inside-avoid mb-2"><%= index_button Payment.where(person_id: person.id), params: { person_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Topic subscriptions" %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button(person.user&.workshop_logs || WorkshopLog.none, path: workshop_logs_person_path(person)) %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button Payment.where(person_id: person.id), params: { person_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.scholarships, params: { recipient_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.topic_subscriptions, params: { person_id: person.id }, label: "Topic subscriptions" %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button(person.user&.workshop_logs || WorkshopLog.none, path: workshop_logs_person_path(person)) %></li>
     <% if person.user %>
-      <li class="break-inside-avoid mb-2">
+      <li class="mb-2 break-inside-avoid">
         <%= link_to user_path(person.user),
                     data: { turbo_prefetch: false },
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
-          <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-user"></i></span>
-          <span class="font-medium text-gray-700 truncate">User</span>
-          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><%= number_with_delimiter(User.where(person_id: person.id).count) %></span>
+          <span class="w-5 text-center text-gray-500"><i class="fa-solid fa-user"></i></span>
+          <span class="truncate font-medium text-gray-700">User</span>
+          <span class="ml-auto inline-flex min-w-[2.25rem] items-center justify-center rounded-full border border-gray-200 bg-white px-2 py-0.5 text-sm font-semibold text-gray-700"><%= number_with_delimiter(User.where(person_id: person.id).count) %></span>
         <% end %>
       </li>
     <% end %>
     <%# Aggregate Ahoy history (person + user + all associated data). Placed last
         so the column flow lands it in the otherwise-empty bottom-right cell. %>
     <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
-      <li class="break-inside-avoid mb-2">
+      <li class="mb-2 break-inside-avoid">
         <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
                     data: { turbo_prefetch: false },
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
-          <span class="text-gray-500 w-5 text-center"><i class="fa-solid fa-clock-rotate-left"></i></span>
-          <span class="font-medium text-gray-700 truncate">History</span>
-          <span class="ml-auto inline-flex items-center justify-center min-w-[2.25rem] px-2 py-0.5 text-sm font-semibold rounded-full bg-white text-gray-700 border border-gray-200"><i class="fa-solid fa-magnifying-glass text-xs"></i></span>
+          <span class="w-5 text-center text-gray-500"><i class="fa-solid fa-clock-rotate-left"></i></span>
+          <span class="truncate font-medium text-gray-700">History</span>
+          <span class="ml-auto inline-flex min-w-[2.25rem] items-center justify-center rounded-full border border-gray-200 bg-white px-2 py-0.5 text-sm font-semibold text-gray-700"><i class="fa-solid fa-magnifying-glass text-xs"></i></span>
         <% end %>
       </li>
     <% end %>
@@ -47,23 +47,23 @@
 </div>
 
 <div>
-  <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Contributed content</h3>
+  <h3 class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase">Contributed content</h3>
   <%# Column-flow (top-to-bottom) pairs each record type with its related idea:
       community news / resources · stories / story ideas · workshops / workshop
       ideas · workshop variations / workshop variation ideas. %>
-  <ul class="columns-1 sm:columns-2 md:columns-4 gap-x-6">
+  <ul class="columns-1 gap-x-6 sm:columns-2 md:columns-4">
     <%# Ideas carry no author_id of their own — the credited person is the
         creating user's person, so they match through `created_by_person`. Keyed
         on the person rather than person.user&.id: a person with no user account
         authored nothing, and a nil user id would drop out of the path helper and
         land the card on everyone's ideas. %>
-    <li class="break-inside-avoid mb-2"><%= index_button person.community_news_as_author, params: { author_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.resources_as_author, params: { author_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.stories_as_author, params: { author_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button StoryIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.workshops_as_author, params: { author_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button WorkshopIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button person.workshop_variations_as_author, params: { author_id: person.id } %></li>
-    <li class="break-inside-avoid mb-2"><%= index_button WorkshopVariationIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.community_news_as_author, params: { author_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.resources_as_author, params: { author_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.stories_as_author, params: { author_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button StoryIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.workshops_as_author, params: { author_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button WorkshopIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button person.workshop_variations_as_author, params: { author_id: person.id } %></li>
+    <li class="mb-2 break-inside-avoid"><%= index_button WorkshopVariationIdea.created_by_person(person.id), params: { created_by_person_id: person.id } %></li>
   </ul>
 </div>

--- a/app/views/people/_membership.html.erb
+++ b/app/views/people/_membership.html.erb
@@ -1,15 +1,15 @@
-<div class="admin-only bg-blue-100 border border-blue-200 rounded-lg shadow-sm">
-  <div class="section-header flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-6 sm:px-7 py-3 border-b border-blue-200">
+<div class="admin-only rounded-lg border border-blue-200 bg-blue-100 shadow-sm">
+  <div class="section-header flex flex-col justify-between gap-2 border-b border-blue-200 px-6 py-3 sm:flex-row sm:items-center sm:px-7">
     <h2 class="text-xl font-semibold text-gray-800">Membership</h2>
     <%= link_to "Manage membership", person_memberships_path(person), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>
 
-  <div class="section-content px-3 sm:px-4 py-4">
+  <div class="section-content px-3 py-4 sm:px-4">
     <% if membership.blank? %>
-      <p class="text-gray-500 italic px-3">No membership yet.</p>
+      <p class="px-3 text-gray-500 italic">No membership yet.</p>
     <% else %>
       <div class="px-3">
-        <div class="flex flex-wrap gap-x-6 gap-y-1 mb-3 text-sm">
+        <div class="mb-3 flex flex-wrap gap-x-6 gap-y-1 text-sm">
           <span class="text-gray-600">Cost: <span class="font-medium text-gray-800"><%= membership.cost_label %></span></span>
           <span class="text-gray-600">Status: <span class="font-medium text-gray-800"><%= membership.status_label %></span></span>
         </div>

--- a/app/views/people/_other_responses.html.erb
+++ b/app/views/people/_other_responses.html.erb
@@ -5,7 +5,7 @@
     relevant section (sectors box, workshop-settings card, etc.). %>
 <% responses ||= [] %>
 <% responses.each do |text| %>
-  <span class="inline-flex items-center rounded-md border border-gray-300 bg-white text-gray-600 px-3 py-1 text-sm font-medium"
+  <span class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-600"
         title="Other response entered during registration">
     <%= text %>
     <span class="ml-1 text-xs text-gray-400">(other)</span>

--- a/app/views/people/_other_sector_responses.html.erb
+++ b/app/views/people/_other_sector_responses.html.erb
@@ -9,7 +9,7 @@
 <% curatable = local_assigns.fetch(:curatable, false) %>
 <% return_to = local_assigns.fetch(:return_to, nil) %>
 <% responses.each do |response| %>
-  <span class="inline-flex items-center rounded-md border border-gray-300 bg-white text-gray-600 px-3 py-1 text-sm font-medium"
+  <span class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-600"
         title="Other response entered during registration">
     <% if curatable %>
       <%= link_to response.text,

--- a/app/views/people/_show_card.html.erb
+++ b/app/views/people/_show_card.html.erb
@@ -12,18 +12,13 @@
 
   <!-- CARD -->
   <div class="
-    flex flex-row flex-wrap h-full
-    <%= bg_color %> border border-gray-200 rounded-xl shadow-sm hover:shadow-md
-    transition-all overflow-hidden cursor-pointer">
+    flex h-full flex-row flex-wrap
+    <%= bg_color %> cursor-pointer overflow-hidden rounded-xl border border-gray-200 shadow-sm transition-all hover:shadow-md">
 
     <!-- LEFT SIDE -->
-    <div class="
-      flex-shrink-0
-      w-18 md:w-24
-      flex flex-col items-center text-center justify-start py-4 pb-3 px-3
-      border-b md:border-b-0 md:border-r border-gray-200">
+    <div class="flex w-18 flex-shrink-0 flex-col items-center justify-start border-b border-gray-200 px-3 py-4 pb-3 text-center md:w-24 md:border-r md:border-b-0">
       <!-- IMAGE -->
-      <div class="relative w-12 h-12 md:w-16 md:h-16">
+      <div class="relative h-12 w-12 md:h-16 md:w-16">
         <%= link_to record.link_target, data: { turbo_frame: "_top"}, class: "block w-full h-full" do %>
           <%= render "assets/display_image",
                      resource: record.object,
@@ -37,13 +32,13 @@
     </div>
 
     <!-- RIGHT SIDE -->
-    <div class="flex-1 min-w-0 pl-4 pr-10 py-1 flex flex-col justify-between">
+    <div class="flex min-w-0 flex-1 flex-col justify-between py-1 pr-10 pl-4">
       <% if anonymous %>
         <%# Admin/owner-only marker: this credit renders "Anonymous" publicly, so
             the item is hidden from everyone else. %>
-        <span class="inline-flex items-center pl-2 pr-3 py-0.5 mt-2 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap"
+        <span class="mt-2 inline-flex items-center rounded-full bg-blue-100 py-0.5 pr-3 pl-2 text-xs font-medium whitespace-nowrap text-gray-600"
               title="Credited as Anonymous — hidden from public author credit">
-          <span class="inline-flex justify-center w-5"><i class="fa-solid fa-eye-slash"></i></span>
+          <span class="inline-flex w-5 justify-center"><i class="fa-solid fa-eye-slash"></i></span>
           <span class="ml-1">Anonymous</span>
         </span>
       <% end %>
@@ -56,7 +51,7 @@
                                 record_title: record_title).html_safe %>
         <% end %>
       </div>
-      <div class="text-gray-400 text-sm mb-2">
+      <div class="mb-2 text-sm text-gray-400">
         <%= record.created_at.strftime("%b %d, %Y") %>
       </div>
     </div>

--- a/app/views/people/person_comments_results.html.erb
+++ b/app/views/people/person_comments_results.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "person_comments_results" do %>
-  <div class="border-t border-gray-100 pt-4 mb-3">
+  <div class="mb-3 border-t border-gray-100 pt-4">
     <h2 class="text-sm font-semibold text-gray-700">Comments <span class="font-normal text-gray-400">· <%= @count_display %> shown</span></h2>
   </div>
   <%= render "comments/feed",

--- a/app/views/people/sections/_affiliations.html.erb
+++ b/app/views/people/sections/_affiliations.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "person_affiliations_section" do %>
   <% grouped = affiliations.select { |a| a.organization.present? }.group_by(&:organization) %>
   <% if grouped.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 blur-on-submit">
+    <div class="grid grid-cols-1 gap-2 blur-on-submit sm:grid-cols-2">
       <% grouped.each do |organization, org_affiliations| %>
         <% titles = org_affiliations.filter_map { |a| a.title.presence }.uniq %>
         <% titles = titles.sort_by { |t| [t.downcase.include?("facilitator") ? 0 : 1, t.downcase] } %>

--- a/app/views/people/sections/_events.html.erb
+++ b/app/views/people/sections/_events.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_events_section" do %>
   <% if event_registrations.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% event_registrations.each do |event_registration| %>
         <%= render "show_card",
                    bookmarkable: event_registration.event,

--- a/app/views/people/sections/_resources.html.erb
+++ b/app/views/people/sections/_resources.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_resources_section" do %>
   <% if resources.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-1 lg:grid-cols-2">
       <% resources.each do |resource| %>
         <%= render "show_card", record: resource.decorate, title_font_size: "text-sm",
                    anonymous: resource.credit_anonymous?(person) %>

--- a/app/views/people/sections/_story_ideas.html.erb
+++ b/app/views/people/sections/_story_ideas.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_story_ideas_section" do %>
   <% if story_ideas.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-1 lg:grid-cols-2">
       <% story_ideas.each do |story_idea| %>
         <%= render "show_card",
                    record_title: story_idea.workshop_title,

--- a/app/views/people/sections/_workshop_ideas.html.erb
+++ b/app/views/people/sections/_workshop_ideas.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_workshop_ideas_section" do %>
   <% if workshop_ideas.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% workshop_ideas.each do |idea| %>
         <%= render "show_card",
                    record: idea.decorate, title_font_size: "text-sm" %>

--- a/app/views/people/sections/_workshop_log_card.html.erb
+++ b/app/views/people/sections/_workshop_log_card.html.erb
@@ -13,20 +13,20 @@
                       hover:shadow-md transition-all overflow-hidden cursor-pointer" do %>
     <div class="px-4 pt-4 pb-3">
       <!-- TITLE -->
-      <div class="text-sm font-semibold text-gray-900 leading-tight pr-6 mb-1">
+      <div class="mb-1 pr-6 text-sm leading-tight font-semibold text-gray-900">
         <%= workshop_log.workshop_title.presence || "Workshop Log ##{workshop_log.id}" %>
         <%= render "workshop_logs/content_icons", workshop_log: workshop_log %>
       </div>
 
       <!-- WINDOWS TYPE -->
       <% if workshop_log.windows_type_name.present? %>
-        <div class="text-xs text-gray-500 mb-3"><%= workshop_log.windows_type_name %></div>
+        <div class="mb-3 text-xs text-gray-500"><%= workshop_log.windows_type_name %></div>
       <% end %>
 
       <!-- PARTICIPANT COUNTS + DATE -->
       <% display_date = workshop_log.workshop_held_on || workshop_log.created_at %>
       <div class="grid grid-cols-5 gap-2">
-        <div class="rounded-lg py-2 px-2.5 text-center">
+        <div class="rounded-lg px-2.5 py-2 text-center">
           <div class="text-sm font-bold text-gray-800"><%= display_date.strftime("%b %-d") %></div>
           <div class="text-xs text-gray-500"><%= display_date.strftime("%Y") %></div>
         </div>
@@ -34,7 +34,7 @@
              "Adults" => workshop_log.adults_first_time + workshop_log.adults_ongoing,
              "Teens" => workshop_log.teens_first_time + workshop_log.teens_ongoing,
              "Children" => workshop_log.children_first_time + workshop_log.children_ongoing }.each do |label, count| %>
-          <div class="<%= label == "Total" ? "bg-purple-100" : "bg-purple-50" %> rounded-lg py-2 px-2.5 text-center">
+          <div class="<%= label == "Total" ? "bg-purple-100" : "bg-purple-50" %> rounded-lg px-2.5 py-2 text-center">
             <div class="text-xs text-gray-500"><%= label %></div>
             <div class="text-sm font-bold text-gray-800"><%= count %></div>
           </div>

--- a/app/views/people/sections/_workshop_log_grouped_card.html.erb
+++ b/app/views/people/sections/_workshop_log_grouped_card.html.erb
@@ -1,7 +1,6 @@
 <% first_log = logs.first %>
 <% link_params = first_log.workshop_id? ? { workshop_id: first_log.workshop_id } : { external_title: first_log.external_workshop_title } %>
-<div class="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md
-            transition-all overflow-hidden">
+<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all hover:shadow-md">
   <div class="px-4 pt-4 pb-3">
     <!-- TITLE (links to grouped page) -->
     <%= link_to workshop_logs_person_path(person, **link_params),

--- a/app/views/people/sections/_workshop_log_totals_row.html.erb
+++ b/app/views/people/sections/_workshop_log_totals_row.html.erb
@@ -1,20 +1,20 @@
 <% show_actions = local_assigns.fetch(:show_actions, false) %>
-<div class="flex items-center gap-2 mb-1">
-  <div class="grid grid-cols-5 gap-2 flex-1 min-w-0">
-    <div class="rounded-lg py-2 px-2.5 <%= show_actions ? "text-right pr-4" : "text-center" %>">
+<div class="mb-1 flex items-center gap-2">
+  <div class="grid min-w-0 flex-1 grid-cols-5 gap-2">
+    <div class="rounded-lg px-2.5 py-2 <%= show_actions ? "text-right pr-4" : "text-center" %>">
       <div class="text-xs font-medium text-gray-500">Grand totals</div>
     </div>
     <% { "Total" => logs.sum(&:total_attendance),
          "Adults" => logs.sum { |l| l.adults_first_time + l.adults_ongoing },
          "Teens" => logs.sum { |l| l.teens_first_time + l.teens_ongoing },
          "Children" => logs.sum { |l| l.children_first_time + l.children_ongoing } }.each do |label, count| %>
-      <div class="<%= label == "Total" ? "bg-purple-200" : "bg-purple-100" %> rounded-lg py-2 px-1.5 text-center">
+      <div class="<%= label == "Total" ? "bg-purple-200" : "bg-purple-100" %> rounded-lg px-1.5 py-2 text-center">
         <% unless show_actions %><div class="text-xs text-gray-500"><%= label %></div><% end %>
         <div class="text-sm font-bold text-gray-800"><%= count %></div>
       </div>
     <% end %>
   </div>
   <% if show_actions %>
-    <div class="shrink-0 w-20 ml-4"></div>
+    <div class="ml-4 w-20 shrink-0"></div>
   <% end %>
 </div>

--- a/app/views/people/sections/_workshop_logs.html.erb
+++ b/app/views/people/sections/_workshop_logs.html.erb
@@ -2,7 +2,7 @@
   <% if workshop_logs.any? %>
     <% all_logs = person.user&.workshop_logs || WorkshopLog.none %>
     <% grouped = workshop_logs.group_by { |log| log.workshop_id || log.external_workshop_title } %>
-    <div class="flex flex-wrap items-center gap-3 mb-4 text-sm text-gray-600">
+    <div class="mb-4 flex flex-wrap items-center gap-3 text-sm text-gray-600">
       <span class="font-semibold text-gray-800">
         Total participants: <%= all_logs.sum(:children_first_time) + all_logs.sum(:children_ongoing) +
                    all_logs.sum(:teens_first_time) + all_logs.sum(:teens_ongoing) +
@@ -17,7 +17,7 @@
      dates = logs.first(10).map { |l| -(l.workshop_held_on || l.created_at.to_date).to_time.to_i }
      dates.fill(0, dates.size...10)
    }.to_h %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% sorted_grouped.each do |key, logs| %>
         <%= render "people/sections/workshop_log_grouped_card",
                    person: person, logs: logs %>

--- a/app/views/people/sections/_workshop_variation_ideas.html.erb
+++ b/app/views/people/sections/_workshop_variation_ideas.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_workshop_variation_ideas_section" do %>
   <% if workshop_variation_ideas.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% workshop_variation_ideas.each do |idea| %>
         <%= render "show_card",
                    record_title: "#{idea.name}<br>" +

--- a/app/views/people/sections/_workshop_variations.html.erb
+++ b/app/views/people/sections/_workshop_variations.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_workshop_variations_section" do %>
   <% if workshop_variations.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% workshop_variations.each do |workshop_variation| %>
         <%= render "show_card",
                    record_title: "#{workshop_variation.name}<br>" +

--- a/app/views/people/sections/_workshops.html.erb
+++ b/app/views/people/sections/_workshops.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "person_workshops_section" do %>
   <% if workshops.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% workshops.each do |workshop| %>
         <%= render "show_card", record: workshop.decorate, title_font_size: "text-sm",
                    anonymous: workshop.credit_anonymous?(person) %>

--- a/app/views/professional_licenses/_results_skeleton.html.erb
+++ b/app/views/professional_licenses/_results_skeleton.html.erb
@@ -1,6 +1,6 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <% [ "w-28", "w-16", "w-20", "w-12", "w-24", "w-20", "w-8" ].each_with_index do |w, i| %>
           <th class="px-4 py-3 <%= i == 6 ? "text-right" : "text-left" %>">
@@ -10,7 +10,7 @@
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 10.times do %>
         <tr>
           <% [ "w-32", "w-16", "w-20", "w-10", "w-28", "w-20", "w-6" ].each_with_index do |w, i| %>

--- a/app/views/resources/_resources_count.html.erb
+++ b/app/views/resources/_resources_count.html.erb
@@ -1,7 +1,7 @@
 <div id="resources_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Resources (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Resources (<%= @count_display %>)</h3>
     <%= render "shared/copy_url" %>
   </div>
 </div>

--- a/app/views/resources/_results_skeleton.html.erb
+++ b/app/views/resources/_results_skeleton.html.erb
@@ -1,29 +1,29 @@
 <div class="min-h-screen">
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 animate-pulse">
+  <div class="grid animate-pulse grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
     <% 9.times do %>
       <div class="relative">
-        <div class="flex flex-row flex-wrap bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div class="flex flex-row flex-wrap overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
           <!-- LEFT SIDE -->
-          <div class="flex-shrink-0 w-40 flex flex-col items-center justify-center py-4 px-3 border-b md:border-b-0 md:border-r border-gray-200">
+          <div class="flex w-40 flex-shrink-0 flex-col items-center justify-center border-b border-gray-200 px-3 py-4 md:border-r md:border-b-0">
             <!-- Asset placeholder -->
-            <div class="w-32 h-32 bg-gray-200 rounded-lg"></div>
+            <div class="h-32 w-32 rounded-lg bg-gray-200"></div>
 
             <!-- Type -->
-            <div class="mt-3 h-3 w-16 bg-gray-200 rounded"></div>
+            <div class="mt-3 h-3 w-16 rounded bg-gray-200"></div>
           </div>
 
           <!-- RIGHT SIDE -->
-          <div class="flex-1 min-w-0 pl-4 pr-6 pb-12 mt-2 relative">
+          <div class="relative mt-2 min-w-0 flex-1 pr-6 pb-12 pl-4">
             <!-- Title lines -->
             <div class="mt-3 space-y-2">
-              <div class="h-5 w-3/4 bg-gray-200 rounded"></div>
-              <div class="h-5 w-1/2 bg-gray-200 rounded"></div>
+              <div class="h-5 w-3/4 rounded bg-gray-200"></div>
+              <div class="h-5 w-1/2 rounded bg-gray-200"></div>
             </div>
 
             <!-- Action buttons -->
-            <div class="absolute bottom-3 right-3 flex space-x-2">
-              <div class="h-8 w-8 bg-gray-200 rounded-md"></div>
-              <div class="h-8 w-8 bg-gray-200 rounded-md"></div>
+            <div class="absolute right-3 bottom-3 flex space-x-2">
+              <div class="h-8 w-8 rounded-md bg-gray-200"></div>
+              <div class="h-8 w-8 rounded-md bg-gray-200"></div>
             </div>
           </div>
         </div>
@@ -32,11 +32,11 @@
   </div>
 
   <!-- Pagination skeleton -->
-  <div class="flex justify-center mt-8 space-x-2 animate-pulse">
-    <div class="h-8 w-10 bg-gray-200 rounded"></div>
+  <div class="mt-8 flex animate-pulse justify-center space-x-2">
+    <div class="h-8 w-10 rounded bg-gray-200"></div>
 
-    <div class="h-8 w-10 bg-gray-200 rounded"></div>
+    <div class="h-8 w-10 rounded bg-gray-200"></div>
 
-    <div class="h-8 w-10 bg-gray-200 rounded"></div>
+    <div class="h-8 w-10 rounded bg-gray-200"></div>
   </div>
 </div>

--- a/app/views/resources/_search_boxes.html.erb
+++ b/app/views/resources/_search_boxes.html.erb
@@ -12,9 +12,9 @@
          autocomplete: "off",
   class: "space-y-2" do %>
   <!-- Search Fields -->
-  <div class="flex flex-wrap md:flex-nowrap items-end gap-6">
+  <div class="flex flex-wrap items-end gap-6 md:flex-nowrap">
     <!-- KEYWORDS -->
-    <div class="flex-1 min-w-[200px] pb-2">
+    <div class="min-w-[200px] flex-1 pb-2">
       <label for="query" class="<%= search_label_class %>">
         Keywords
       </label>

--- a/app/views/resources/_search_boxes_kinds.html.erb
+++ b/app/views/resources/_search_boxes_kinds.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-3">
-  <h3 class="text-xs font-semibold text-gray-500 tracking-wide mb-1 uppercase">
+  <h3 class="mb-1 text-xs font-semibold tracking-wide text-gray-500 uppercase">
     Kinds (click to filter)
   </h3>
 
@@ -10,9 +10,7 @@
       <label
         for="kind_<%= name %>"
         class="
-          inline-flex items-center cursor-pointer
-          px-4 py-2 rounded-lg font-medium text-sm
-          transition-all duration-150
+          inline-flex cursor-pointer items-center rounded-lg px-4 py-2 text-sm font-medium transition-all duration-150
           <%= default_btn %>
         "
       >

--- a/app/views/resources/resources_results.html.erb
+++ b/app/views/resources/resources_results.html.erb
@@ -3,14 +3,14 @@
   <%= turbo_stream.replace("copy_url", partial: "shared/copy_url") %>
 
   <% if @resources.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 animate-fade blur-on-submit">
+    <div class="grid animate-fade grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% @resources.each do |resource| %>
         <%= render "resource_card", resource: resource.decorate %>
       <% end %>
     </div>
   <% else %>
-    <p class="text-gray-500 text-center py-6">There are no resources that match your search. Please try again.</p>
+    <p class="py-6 text-center text-gray-500">There are no resources that match your search. Please try again.</p>
   <% end %>
 
-  <div class="pagination flex justify-center mt-6 w-full"><%= tailwind_paginate @resources %></div>
+  <div class="pagination mt-6 flex w-full justify-center"><%= tailwind_paginate @resources %></div>
 <% end %>

--- a/app/views/scholarships/_grant_criteria_tasks.html.erb
+++ b/app/views/scholarships/_grant_criteria_tasks.html.erb
@@ -3,7 +3,7 @@
     (toggled by grant_details_controller) when an optional grant is picked. %>
 <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
   <div>
-    <h3 class="text-xs font-medium uppercase tracking-wide text-gray-400">Eligibility criteria</h3>
+    <h3 class="text-xs font-medium tracking-wide text-gray-400 uppercase">Eligibility criteria</h3>
     <% if grant.eligibility_criteria_list.any? %>
       <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-800">
         <% grant.eligibility_criteria_list.each do |criterion| %>
@@ -15,7 +15,7 @@
     <% end %>
   </div>
   <div>
-    <h3 class="text-xs font-medium uppercase tracking-wide text-gray-400">Tasks to complete</h3>
+    <h3 class="text-xs font-medium tracking-wide text-gray-400 uppercase">Tasks to complete</h3>
     <% if grant.task_list.any? %>
       <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-gray-800">
         <% grant.task_list.each do |task| %>

--- a/app/views/scholarships/_grant_group.html.erb
+++ b/app/views/scholarships/_grant_group.html.erb
@@ -3,16 +3,16 @@
     label and no grant budget figures. %>
 <% grant = grant_group.grant&.decorate %>
 <details class="group/card rounded-lg border border-gray-200 bg-white" open>
-  <summary class="cursor-pointer select-none list-none [&::-webkit-details-marker]:hidden px-4 py-3 hover:bg-gray-50 rounded-lg">
+  <summary class="cursor-pointer list-none rounded-lg px-4 py-3 select-none hover:bg-gray-50 [&::-webkit-details-marker]:hidden">
     <div class="flex items-center justify-between gap-4">
-      <div class="flex items-center gap-2.5 min-w-0">
-        <i class="fa-solid fa-chevron-down text-gray-400 text-xs transition-transform group-open/card:rotate-180"></i>
+      <div class="flex min-w-0 items-center gap-2.5">
+        <i class="fa-solid fa-chevron-down text-xs text-gray-400 transition-transform group-open/card:rotate-180"></i>
         <% if grant %>
           <%= link_to grant.name, grant_path(grant, from_scholarships: true), class: "font-medium text-gray-900 hover:underline truncate" %>
         <% else %>
           <span class="font-medium text-gray-500 italic">No grant</span>
         <% end %>
-        <span class="inline-flex items-center rounded-full bg-gray-100 text-gray-600 px-2 py-0.5 text-xs font-semibold tabular-nums"><%= grant_group.count %></span>
+        <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600 tabular-nums"><%= grant_group.count %></span>
       </div>
       <div class="shrink-0 text-xs text-gray-500 tabular-nums">
         <% if grant %>
@@ -24,7 +24,7 @@
       </div>
     </div>
     <% if grant && grant.eligibility_criteria_list.any? %>
-      <p class="mt-1.5 ml-6 text-xs text-gray-500 truncate"><%= grant.eligibility_criteria_list.join(" · ") %></p>
+      <p class="mt-1.5 ml-6 truncate text-xs text-gray-500"><%= grant.eligibility_criteria_list.join(" · ") %></p>
     <% end %>
   </summary>
 
@@ -32,16 +32,16 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Recipient</th>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Program</th>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
-          <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Training</th>
-          <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
-          <th class="px-4 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Tasks</th>
+          <th class="px-4 py-2 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Recipient</th>
+          <th class="px-4 py-2 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Program</th>
+          <th class="px-4 py-2 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Location</th>
+          <th class="px-4 py-2 text-center text-xs font-medium tracking-wider text-gray-500 uppercase">Status</th>
+          <th class="px-4 py-2 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Training</th>
+          <th class="px-4 py-2 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">Amount</th>
+          <th class="px-4 py-2 text-center text-xs font-medium tracking-wider text-gray-500 uppercase">Tasks</th>
         </tr>
       </thead>
-      <tbody class="bg-white divide-y divide-gray-100">
+      <tbody class="divide-y divide-gray-100 bg-white">
         <%= render partial: "recipient_row", collection: grant_group.scholarships, as: :scholarship %>
       </tbody>
     </table>

--- a/app/views/sectors/_search_boxes.html.erb
+++ b/app/views/sectors/_search_boxes.html.erb
@@ -1,5 +1,5 @@
 <!-- Filters -->
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
+<div class="mb-6 rounded-lg border border-gray-200 bg-white p-4">
   <%= form_with url: sectors_path,
                 method: :get,
                 local: true,

--- a/app/views/shared/_age_range_item_fields.html.erb
+++ b/app/views/shared/_age_range_item_fields.html.erb
@@ -5,9 +5,8 @@
     There is no leader/crown flag for age ranges. %>
 <% collection ||= @age_ranges_collection || Category.age_ranges.published.order(:position, :name).map { |c| [ c.decorate.age_group_label, c.id ] } %>
 <% is_primary = f.object&.is_primary? %>
-<div class="nested-fields inline-flex items-center gap-2
-            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
-            text-gray-700 px-3 py-1 text-sm font-medium transition"
+<div class="nested-fields inline-flex items-center gap-2 rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
+            px-3 py-1 text-sm font-medium text-gray-700 transition"
      data-primary-tag-target="chip">
   <% if f.object&.category_id.present? %>
     <%= f.hidden_field :category_id %>
@@ -28,7 +27,7 @@
     <%= f.check_box :is_primary,
                     class: "peer sr-only",
                     data: { primary_tag_target: "primary", action: "primary-tag#selectPrimary" } %>
-    <i class="fa-solid fa-star text-base text-gray-300 peer-checked:text-amber-400 transition-colors" aria-hidden="true"></i>
+    <i class="fa-solid fa-star text-base text-gray-300 transition-colors peer-checked:text-amber-400" aria-hidden="true"></i>
     <span class="sr-only">Primary</span>
   </label>
   <%= link_to_remove_association "✖",

--- a/app/views/shared/_audit_info.html.erb
+++ b/app/views/shared/_audit_info.html.erb
@@ -8,8 +8,8 @@
   updated_by_user = resource.try(:updated_by)
 %>
 
-<div class="flex justify-end mt-6 pt-4 border-t border-gray-200">
-  <div class="text-xs text-gray-500 text-right space-y-1">
+<div class="mt-6 flex justify-end border-t border-gray-200 pt-4">
+  <div class="space-y-1 text-right text-xs text-gray-500">
     <% if resource.created_at.present? %>
       <div>
         <span class="font-medium">Created:</span>

--- a/app/views/shared/_category_checkbox.html.erb
+++ b/app/views/shared/_category_checkbox.html.erb
@@ -5,20 +5,20 @@
     primary vs additional age groups served. The primary toggle sits outside the
     membership label so the two checkboxes never toggle each other. %>
 <% id = "#{param_key}_category_ids_#{category.id}" %>
-<div class="flex items-center gap-2 p-3 w-auto min-w-[180px] bg-white border border-gray-200 rounded-lg shadow-sm hover:bg-gray-100 transition">
-  <label for="<%= id %>" class="flex items-center gap-2 cursor-pointer">
+<div class="flex w-auto min-w-[180px] items-center gap-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm transition hover:bg-gray-100">
+  <label for="<%= id %>" class="flex cursor-pointer items-center gap-2">
     <%= hidden_field_tag "#{param_key}[category_ids][]", "" %>
     <%= check_box_tag "#{param_key}[category_ids][]",
                       category.id,
                       checked,
                       id: id,
                       class: "h-4 w-4 text-blue-600 rounded" %>
-    <span class="text-sm text-gray-700 whitespace-nowrap"><%= is_age ? category.decorate.age_group_label : category.name %></span>
+    <span class="text-sm whitespace-nowrap text-gray-700"><%= is_age ? category.decorate.age_group_label : category.name %></span>
   </label>
   <% if is_age %>
     <% primary_id = "#{param_key}_primary_age_#{category.id}" %>
     <label for="<%= primary_id %>"
-           class="ml-auto flex items-center gap-1 text-xs text-gray-500 cursor-pointer"
+           class="ml-auto flex cursor-pointer items-center gap-1 text-xs text-gray-500"
            title="Mark as a primary age group served">
       <%= check_box_tag "#{param_key}[primary_age_category_ids][]",
                         category.id,

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,13 +1,13 @@
 <% if resource.errors.any? %>
   <div class="errors">
     <% classes = status_classes(:danger) %>
-    <div class="rounded-lg border <%= classes[:border] %> <%= classes[:surface] %> p-4 mb-6">
-      <h2 class="<%= classes[:text] %> font-semibold mb-2">
+    <div class="rounded-lg border <%= classes[:border] %> <%= classes[:surface] %> mb-6 p-4">
+      <h2 class="<%= classes[:text] %> mb-2 font-semibold">
         <%= pluralize(resource.errors.count, "error") %> prevented this <%= resource.model_name.human.downcase %> from being saved
       </h2>
 
       <% if resource.errors.any? %>
-        <ul class="list-disc pl-5 space-y-1 text-sm <%= classes[:text] %> mb-5">
+        <ul class="list-disc space-y-1 pl-5 text-sm <%= classes[:text] %> mb-5">
           <% resource.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>
           <% end %>

--- a/app/views/shared/_event_page_header.html.erb
+++ b/app/views/shared/_event_page_header.html.erb
@@ -13,8 +13,8 @@
 %>
 <% event = local_assigns[:event] %>
 <% person = local_assigns[:person] %>
-<div class="text-center mb-8">
-  <h1 class="flex items-center justify-center gap-3 text-3xl sm:text-4xl font-extrabold text-black">
+<div class="mb-8 text-center">
+  <h1 class="flex items-center justify-center gap-3 text-3xl font-extrabold text-black sm:text-4xl">
     <i class="<%= icon %> <%= DomainTheme.text_class_for(color, intensity: 600) %>"></i>
     <%= title %>
   </h1>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,4 +1,4 @@
-<div id="flash_now" class="fixed top-4 right-0 left-0 flex justify-center z-50 print:hidden">
+<div id="flash_now" class="fixed top-4 right-0 left-0 z-50 flex justify-center print:hidden">
   <%# === Collect manual messages from params === %>
   <% manual_messages = [] %>
   <% { notice: params[:notice], alert: params[:alert], info: params[:info], warning: params[:warning], error: params[:error] }.each do |type, msg| %>
@@ -26,11 +26,11 @@
     <% disable_outside_click = ["alert", "error"].include?(type.to_s) %>
 
     <div
-      class="max-w-3xl my-2"
+      class="my-2 max-w-3xl"
       data-controller="dismiss"
       data-dismiss-timeout-value="<%= timeout %>"
       data-dismiss-disable-outside-click-value="<%= disable_outside_click %>">
-      <div class="flex items-center justify-between px-4 py-3 rounded shadow-md <%= classes[:surface] %> <%= classes[:text] %>">
+      <div class="flex items-center justify-between rounded px-4 py-3 shadow-md <%= classes[:surface] %> <%= classes[:text] %>">
         <div class="flex-1 text-center font-medium">
           <p class="<%= type %>">
             <%= msg.html_safe %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-primary text-white py-4">
+<footer class="bg-primary py-4 text-white">
   <div class="container mx-auto text-center">
     <p class="py-4 text-sm text-white">
       2026 A Window Between Worlds ® ™ • Registered 501(c)(3) EIN: 95-448606

--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -1,10 +1,10 @@
 <!-- Floating Help Button -->
 <div id="fab-container"
-     class="fixed bottom-6 right-6 z-50 flex flex-col items-end print:hidden">
+     class="fixed right-6 bottom-6 z-50 flex flex-col items-end print:hidden">
 
   <!-- Hidden menu items -->
   <div id="fab-menu"
-     class="hidden flex flex-col items-start space-y-2 mb-2 p-4 bg-white border border-gray-300 rounded-lg shadow-md transition-all duration-300">
+     class="mb-2 flex hidden flex-col items-start space-y-2 rounded-lg border border-gray-300 bg-white p-4 shadow-md transition-all duration-300">
  
   <%= link_to faqs_path, class: "flex items-center space-x-2 text-gray-800 px-3 py-2 rounded hover:bg-gray-100 w-max" do %>
     <i class="fas fa-question-circle"></i> 
@@ -33,8 +33,7 @@
   <!-- Main round button -->
   <button id="fab-button"
           type="button"
-          class="bg-primary text-white w-10 h-10 rounded-full shadow-lg flex items-center
-                 justify-center text-lg font-bold hover:bg-primary/90 transition">
+          class="bg-primary hover:bg-primary/90 flex h-10 w-10 items-center justify-center rounded-full text-lg font-bold text-white shadow-lg transition">
     ?
   </button>
 </div>

--- a/app/views/shared/_form_dropdown.html.erb
+++ b/app/views/shared/_form_dropdown.html.erb
@@ -22,13 +22,10 @@
     type="button"
     data-action="dropdown#toggle"
     data-dropdown-payload-param='[{"<%= field %>-dropdown":"hidden"},{"<%= field %>-arrow":"rotate-180"},{"<%= field %>-button":"rounded-md rounded-t-md"}]'
-    class="
-      flex items-center justify-between cursor-pointer w-full
-      bg-gray-500 text-white hover:bg-gray-300 px-3 py-2 rounded-md
-    "
+    class="flex w-full cursor-pointer items-center justify-between rounded-md bg-gray-500 px-3 py-2 text-white hover:bg-gray-300"
   >
     <%= label_tag %>
-    <i id="<%= field %>-arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
+    <i id="<%= field %>-arrow" class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300"></i>
   </button>
 
   <div id="<%= field %>-dropdown" class="<%= class_names(hidden: hidden) %>"><%= yield %></div>

--- a/app/views/shared/_form_image_field.html.erb
+++ b/app/views/shared/_form_image_field.html.erb
@@ -39,7 +39,7 @@
   <%= f.label label, class: "block font-medium gap-1 text-gray-700 string required" %>
 
   <% if hint %>
-    <p class="text-gray-500 text-sm"><%= hint.html_safe %></p>
+    <p class="text-sm text-gray-500"><%= hint.html_safe %></p>
   <% end %>
 
   <div class="flex flex-col items-center gap-2">
@@ -70,21 +70,20 @@
 
         <%# ---------- PLACEHOLDER ---------- %>
       <% else %>
-        <div class="relative w-32 h-32">
+        <div class="relative h-32 w-32">
           <img id="<%= image_dom_id %>"
                data-file-preview-target="preview"
-               class="hidden w-32 h-32 object-cover border border-gray-300 shadow-sm">
+               class="hidden h-32 w-32 border border-gray-300 object-cover shadow-sm">
 
           <div data-file-preview-target="placeholder"
-               class="absolute inset-0 flex items-center justify-center
-                      border border-gray-300 shadow-sm bg-gray-50 text-gray-400 text-6xl">
+               class="absolute inset-0 flex items-center justify-center border border-gray-300 bg-gray-50 text-6xl text-gray-400 shadow-sm">
             <i class="fa-regular fa-image"></i>
           </div>
         </div>
       <% end %>
 
       <div data-file-preview-target="filename"
-           class="text-center text-sm text-gray-500 break-all max-w-[8rem]">
+           class="max-w-[8rem] text-center text-sm break-all text-gray-500">
         <%= if blob.present? && blob.respond_to?(:persisted?) && blob.persisted?
               link_to(blob.filename.to_s, url_for(file), class: "underline cursor-zoom-in", target: "_blank", rel: "noopener noreferrer", title: "Open image in a new tab")
             else
@@ -110,7 +109,7 @@
                            class: "absolute inset-0 w-full h-full opacity-0 cursor-pointer" %>
 
           <button type="button"
-                  class="w-full py-2 px-3 border border-gray-300 rounded-lg bg-white text-sm text-gray-700 hover:bg-gray-50">
+                  class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-50">
             Choose file
           </button>
         </div>
@@ -129,7 +128,7 @@
       </div>
 
       <% if accepted_label.present? %>
-        <p class="text-gray-400 text-xs mt-1">Accepts: <%= accepted_label %></p>
+        <p class="mt-1 text-xs text-gray-400">Accepts: <%= accepted_label %></p>
       <% end %>
     <% end %>
 
@@ -137,8 +136,8 @@
 </div>
 
 <% if asset.errors[:file].any? %>
-  <div class="mt-2 mx-auto w-fit rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center">
-    <p class="text-red-600 text-sm">
+  <div class="mx-auto mt-2 w-fit rounded-md border border-red-200 bg-red-50 px-3 py-2 text-center">
+    <p class="text-sm text-red-600">
       <i class="fa-solid fa-circle-exclamation mr-1"></i>
       File type not accepted
     </p>

--- a/app/views/shared/_form_image_field_insert.html.erb
+++ b/app/views/shared/_form_image_field_insert.html.erb
@@ -1,6 +1,6 @@
 <% label ||= "Gallery media" %>
 
-<div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
+<div class="items-left mb-6 flex w-full flex-col gap-1 text-left md:w-1/3 lg:w-1/4">
   <%= render "shared/form_image_field",
              f: f,
              label: label %>

--- a/app/views/shared/_form_image_fields.html.erb
+++ b/app/views/shared/_form_image_fields.html.erb
@@ -20,11 +20,11 @@
 <% gallery_title       ||= "Upload" %>
 
 <div class="image-fields my-3">
-  <h2 class="text-lg font-semibold text-gray-800 mb-2">
+  <h2 class="mb-2 text-lg font-semibold text-gray-800">
     <%= section_title %>
   </h2>
 
-  <div class="images bg-gray-50 border border-gray-200 rounded-md p-4 pb-0">
+  <div class="images rounded-md border border-gray-200 bg-gray-50 p-4 pb-0">
 
     <% if section_subtitle.present? %>
       <div class="mb-6"><%= section_subtitle %></div>
@@ -32,7 +32,7 @@
 
     <!-- MAIN + GALLERY images all share this same flex row -->
     <div
-      class="flex flex-wrap items-start content-start gap-6 image-fields-row"
+      class="image-fields-row flex flex-wrap content-start items-start gap-6"
       data-association-insertion-node="this"
       data-association-insertion-method="append">
 
@@ -40,7 +40,7 @@
       <%# ---- MAIN IMAGE ---- %>
       <% if include_primary_asset %>
         <%= f.fields_for :primary_asset do |img| %>
-          <div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
+          <div class="items-left mb-6 flex w-full flex-col gap-1 text-left md:w-1/3 lg:w-1/4">
             <%= render "shared/form_image_field",
                        f: img, label: primary_title %>
           </div>
@@ -50,7 +50,7 @@
       <%# ---- DOWNLOADABLE ---- %>
       <% if include_downloadable_asset %>
         <%= f.fields_for :downloadable_asset do |img| %>
-          <div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
+          <div class="items-left mb-6 flex w-full flex-col gap-1 text-left md:w-1/3 lg:w-1/4">
             <%= render "shared/form_image_field",
                        f: img, label: downloadable_title %>
           </div>
@@ -61,7 +61,7 @@
       <% if include_gallery_assets %>
         <% counter = 1 %>
         <%= f.fields_for :gallery_assets do |img| %>
-          <div class="flex flex-col text-left items-left gap-1 w-full md:w-1/3 lg:w-1/4 mb-6">
+          <div class="items-left mb-6 flex w-full flex-col gap-1 text-left md:w-1/3 lg:w-1/4">
             <%= render "shared/form_image_field",
                        f: img,
                        label: "#{gallery_title} #{counter}" %>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,3 +1,3 @@
-<div class="flex justify-center border p-2 border-gray-200 rounded-md bg-white">
+<div class="flex justify-center rounded-md border border-gray-200 bg-white p-2">
   <i class="fa-solid fa-spinner animate-spin text-gray-600"></i>
 </div>

--- a/app/views/shared/_navbar_menu.html.erb
+++ b/app/views/shared/_navbar_menu.html.erb
@@ -9,8 +9,7 @@
     <button
       type="button"
       id="facilitate_button"
-      class="flex items-center gap-1 rounded-md px-3 py-2 text-lg font-medium cursor-pointer
-             text-gray-300 hover:bg-white/5 hover:text-white"
+      class="flex cursor-pointer items-center gap-1 rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5 hover:text-white"
       data-action="dropdown#toggle"
       data-dropdown-payload-param='[{"curriculum_menu":"hidden"}]'>
 <!--      <i class="fas fa-handshake-simple text-base"></i>-->
@@ -20,7 +19,7 @@
 
     <div
       id="curriculum_menu"
-      class="hidden absolute left-0 mt-2 w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
+      class="absolute left-0 mt-2 hidden w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
       data-dropdown-target="content">
 
       <%= link_to workshops_path,
@@ -48,8 +47,7 @@
     <button
       type="button"
       id="community_button"
-      class="flex items-center gap-1 rounded-md px-3 py-2 text-lg font-medium cursor-pointer
-             text-gray-300 hover:bg-white/5 hover:text-white"
+      class="flex cursor-pointer items-center gap-1 rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5 hover:text-white"
       data-action="dropdown#toggle"
       data-dropdown-payload-param='[{"community_menu":"hidden"}]'>
 <!--      <i class="fas fa-users text-base"></i>-->
@@ -59,7 +57,7 @@
 
     <div
       id="community_menu"
-      class="hidden absolute left-0 mt-2 w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
+      class="absolute left-0 mt-2 hidden w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
       data-dropdown-target="content">
 
       <%= link_to community_news_index_path,
@@ -116,8 +114,7 @@
       <button
         type="button"
         id="create_button"
-        class="flex items-center gap-1 rounded-md px-3 py-2 text-lg font-medium cursor-pointer
-               text-gray-300 hover:bg-white/5 hover:text-white"
+        class="flex cursor-pointer items-center gap-1 rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5 hover:text-white"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"create_menu":"hidden"}]'>
         Create
@@ -125,7 +122,7 @@
 
       <div
         id="create_menu"
-        class="hidden absolute left-0 mt-2 w-60 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
+        class="absolute left-0 mt-2 hidden w-60 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
         data-dropdown-target="content">
 
         <%= link_to new_workshop_variation_idea_path,
@@ -194,8 +191,7 @@
     <button
       type="button"
       id="help_button"
-      class="flex items-center gap-2 rounded-md px-3 py-2 text-lg font-medium cursor-pointer
-             text-gray-300 hover:bg-white/5 hover:text-white"
+      class="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-lg font-medium text-gray-300 hover:bg-white/5 hover:text-white"
       data-action="dropdown#toggle"
       data-dropdown-payload-param='[{"help_menu":"hidden"}]'>
 <!--      <i class="fas fa-circle-info text-base"></i>-->
@@ -205,7 +201,7 @@
 
     <div
       id="help_menu"
-      class="hidden absolute left-0 mt-2 w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
+      class="absolute left-0 mt-2 hidden w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
       data-dropdown-target="content">
 
       <%= link_to faqs_path,

--- a/app/views/shared/_navbar_menu_mobile.html.erb
+++ b/app/views/shared/_navbar_menu_mobile.html.erb
@@ -4,7 +4,7 @@
     <!-- CURRICULUM -->
     <div data-controller="dropdown">
       <button
-        class="mobile-section flex justify-between w-full"
+        class="mobile-section flex w-full justify-between"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"mobile-curriculum":"hidden"}]'>
         Curriculum
@@ -12,7 +12,7 @@
       </button>
 
       <div id="mobile-curriculum"
-           class="hidden flex flex-col pl-4 mt-1 mb-3 space-y-2"
+           class="mt-1 mb-3 flex hidden flex-col space-y-2 pl-4"
            data-dropdown-target="content">
         <%= link_to workshops_path, class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
@@ -35,7 +35,7 @@
     <!-- Community -->
     <div data-controller="dropdown">
       <button
-        class="mobile-section flex justify-between w-full"
+        class="mobile-section flex w-full justify-between"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"mobile-community":"hidden"}]'
       >
@@ -44,7 +44,7 @@
       </button>
 
       <div id="mobile-community"
-           class="hidden flex flex-col pl-4 mt-1 mb-3 space-y-2"
+           class="mt-1 mb-3 flex hidden flex-col space-y-2 pl-4"
            data-dropdown-target="content">
         <%= link_to community_news_index_path, class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>
@@ -88,7 +88,7 @@
     <!-- Help -->
     <div data-controller="dropdown">
       <button
-        class="mobile-section flex justify-between w-full"
+        class="mobile-section flex w-full justify-between"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"mobile-help":"hidden"}]'>
         Help
@@ -96,7 +96,7 @@
       </button>
 
       <div id="mobile-help"
-           class="hidden flex flex-col pl-4 mt-1 mb-3 space-y-2"
+           class="mt-1 mb-3 flex hidden flex-col space-y-2 pl-4"
            data-dropdown-target="content">
         <%= link_to faqs_path, class: "flex items-center px-4 py-2 text-sm text-white
                     hover:text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>

--- a/app/views/shared/_navbar_new_button.html.erb
+++ b/app/views/shared/_navbar_new_button.html.erb
@@ -3,11 +3,7 @@
   <div class="relative flex items-center">
     <button
       type="button"
-      class="
-        flex items-center gap-2 rounded-md bg-white px-4 py-1 mt-1 text-sm font-semibold text-gray-900
-        shadow-sm border border-gray-200 hover:bg-gray-50 active:bg-gray-100
-        focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-        transition cursor-pointer"
+      class="mt-1 flex cursor-pointer items-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-1 text-sm font-semibold text-gray-900 shadow-sm transition hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none active:bg-gray-100"
       data-action="dropdown#toggle"
       data-dropdown-payload-param='[{"workshop-dropdown":"hidden"}]'
     >
@@ -17,7 +13,7 @@
     <!-- Dropdown menu -->
    <div
   id="workshop-dropdown"
-  class="absolute right-0 top-11 mt-2 w-60 rounded-md bg-white py-1 shadow-lg outline outline-black/5 transition transition-discrete hidden"
+  class="absolute top-11 right-0 mt-2 hidden w-60 rounded-md bg-white py-1 shadow-lg outline outline-black/5 transition transition-discrete"
   data-dropdown-target="content">
   <%= link_to new_workshop_variation_idea_path,
               class: "flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full space-x-2" do %>

--- a/app/views/shared/_navbar_user.html.erb
+++ b/app/views/shared/_navbar_user.html.erb
@@ -5,8 +5,7 @@
 
   <button
     type="button"
-    class="relative flex rounded-full focus-visible:outline-2
-           focus-visible:outline-offset-2 focus-visible:outline-indigo-500 cursor-pointer"
+    class="relative flex cursor-pointer rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
     data-action="dropdown#toggle"
     data-dropdown-payload-param='[{"avatar-dropdown":"hidden"}]'>
     <span class="sr-only">Open user menu</span>
@@ -18,8 +17,7 @@
                     class: "size-10 rounded-full bg-gray-800 outline -outline-offset-1 outline-white/10" %>
     <% else %>
       <span id="avatar-image"
-            class="size-10 rounded-full bg-sky-200 text-sky-700 font-bold text-lg
-                   flex items-center justify-center border border-sky-300 shadow-sm">
+            class="flex size-10 items-center justify-center rounded-full border border-sky-300 bg-sky-200 text-lg font-bold text-sky-700 shadow-sm">
         <%= (person&.first_name.presence || user.first_name.presence || user.email).to_s.first.upcase %>
       </span>
     <% end %>
@@ -27,7 +25,7 @@
 
   <!-- Dropdown menu -->
   <div
-    class="absolute right-0 mt-2 w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5 hidden"
+    class="absolute right-0 mt-2 hidden w-56 rounded-md bg-white py-1 shadow-lg outline outline-black/5"
     id="avatar-dropdown"
     data-dropdown-target="content">
 

--- a/app/views/shared/_sectorable_item_fields.html.erb
+++ b/app/views/shared/_sectorable_item_fields.html.erb
@@ -2,9 +2,8 @@
 <% show_admin_flags = local_assigns.fetch(:show_admin_flags, false) %>
 <% is_primary = f.object&.is_primary? %>
 
-<div class="nested-fields inline-flex items-center gap-2
-            rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
-            text-gray-700 px-3 py-1 text-sm font-medium transition"
+<div class="nested-fields inline-flex items-center gap-2 rounded-md border border-lime-300 <%= is_primary ? "bg-lime-100" : "bg-lime-50" %>
+            px-3 py-1 text-sm font-medium text-gray-700 transition"
      data-primary-tag-target="chip">
   <% if f.object&.sector_id.present? %>
     <%= f.hidden_field :sector_id %>
@@ -26,12 +25,12 @@
       <%= f.check_box :is_primary,
                       class: "peer sr-only",
                       data: { primary_tag_target: "primary", action: "primary-tag#selectPrimary" } %>
-      <i class="fa-solid fa-star text-base text-gray-300 peer-checked:text-amber-400 transition-colors" aria-hidden="true"></i>
+      <i class="fa-solid fa-star text-base text-gray-300 transition-colors peer-checked:text-amber-400" aria-hidden="true"></i>
       <span class="sr-only">Primary</span>
     </label>
     <label class="admin-only cursor-pointer leading-none" title="Mark as sector leader">
       <%= f.check_box :is_leader, class: "peer sr-only" %>
-      <i class="fa-solid fa-crown text-base text-gray-300 peer-checked:text-lime-700 transition-colors" aria-hidden="true"></i>
+      <i class="fa-solid fa-crown text-base text-gray-300 transition-colors peer-checked:text-lime-700" aria-hidden="true"></i>
       <span class="sr-only">Leader</span>
     </label>
   <% end %>

--- a/app/views/shared/_sortable_header.html.erb
+++ b/app/views/shared/_sortable_header.html.erb
@@ -10,7 +10,7 @@
 <% key = local_assigns.fetch(:key, nil) %>
 <% button_class = local_assigns.fetch(:class, "hover:text-gray-900") %>
 <button type="button"
-        class="inline-flex items-center gap-1.5 cursor-pointer select-none <%= button_class %>"
+        class="inline-flex cursor-pointer items-center gap-1.5 select-none <%= button_class %>"
         data-table-sort-target="header"
         data-sort-index="<%= index %>"
         <%= "data-sort-key=#{key}".html_safe if key %>

--- a/app/views/shared/_visibility_filter.html.erb
+++ b/app/views/shared/_visibility_filter.html.erb
@@ -20,21 +20,16 @@
         type="button"
         data-action="dropdown#toggle"
         data-dropdown-payload-param='[{"visibility-filter-dropdown":"hidden"},{"visibility-filter-arrow":"rotate-180"},{"visibility-filter-button":"rounded-md rounded-t-md"}]'
-        class="
-          relative z-10 w-full bg-white text-gray-800 py-2 px-4 shadow-sm
-          rounded-md border border-gray-300 cursor-pointer flex justify-between
-          items-center">
+        class="relative z-10 flex w-full cursor-pointer items-center justify-between rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-800 shadow-sm">
         <label class="mb-0 font-medium text-gray-700"><%= button_text %></label>
-        <i id="visibility-filter-arrow" class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"></i>
+        <i id="visibility-filter-arrow" class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300"></i>
       </button>
 
       <div
         id="visibility-filter-dropdown"
-        class="
-          absolute left-0 top-full w-full shadow-sm bg-white border border-t-0
-          border-gray-300 rounded-b-md hidden z-40">
+        class="absolute top-full left-0 z-40 hidden w-full rounded-b-md border border-t-0 border-gray-300 bg-white shadow-sm">
         <% options.each do |label, param_name, admin_only| %>
-          <div class="flex items-center gap-2 mb-1 px-4 <%= 'admin-only bg-blue-100' if admin_only %>">
+          <div class="mb-1 flex items-center gap-2 px-4 <%= 'admin-only bg-blue-100' if admin_only %>">
             <%= check_box_tag param_name,
                 true,
                 params[param_name].present?,

--- a/app/views/shared/_visibility_info.html.erb
+++ b/app/views/shared/_visibility_info.html.erb
@@ -4,20 +4,20 @@
 <% flags = local_assigns.fetch(:flags) %>
 <% heading = local_assigns.fetch(:heading, "Visibility") %>
 <% definitions = flags.filter_map { |flag| VisibilityFlagsHelper::FLAG_DEFINITIONS[flag] } %>
-<div class="flex items-center gap-2 mb-2">
+<div class="mb-2 flex items-center gap-2">
   <span class="text-sm font-medium text-gray-700"><%= heading %></span>
   <% if definitions.any? %>
     <div class="group relative inline-flex">
       <button type="button"
               aria-label="What these checkboxes mean"
-              class="text-gray-400 group-hover:text-blue-600 focus:text-blue-600 focus:outline-none cursor-help">
+              class="cursor-help text-gray-400 group-hover:text-blue-600 focus:text-blue-600 focus:outline-none">
         <i class="fa-solid fa-circle-info"></i>
       </button>
 
       <%# pt-2 (not margin) keeps the hover area continuous across the visual gap %>
-      <div class="hidden group-hover:block group-focus-within:block absolute left-0 top-full z-40 pt-2">
+      <div class="absolute top-full left-0 z-40 hidden pt-2 group-focus-within:block group-hover:block">
         <div class="w-72 rounded-lg border border-gray-200 bg-white p-3 text-left shadow-lg">
-          <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">What these mean</p>
+          <p class="mb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase">What these mean</p>
           <dl class="space-y-2">
             <% definitions.each do |definition| %>
               <div>

--- a/app/views/stories/_results_skeleton.html.erb
+++ b/app/views/stories/_results_skeleton.html.erb
@@ -1,7 +1,7 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
     <!-- Header skeleton -->
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
         <th class="px-6 py-3 text-left">
           <div class="h-4 w-24 rounded bg-gray-200"></div>
@@ -16,29 +16,29 @@
         </th>
 
         <th class="px-6 py-3 text-center">
-          <div class="h-4 w-16 mx-auto rounded bg-gray-200"></div>
+          <div class="mx-auto h-4 w-16 rounded bg-gray-200"></div>
         </th>
 
         <th class="px-6 py-3 text-right">
-          <div class="h-4 w-20 ml-auto rounded bg-gray-200"></div>
+          <div class="ml-auto h-4 w-20 rounded bg-gray-200"></div>
         </th>
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 3.times do %>
         <tr>
           <!-- Title -->
           <td class="px-4 py-3">
             <div class="flex items-center gap-3">
               <!-- Bookmark -->
-              <div class="w-5 h-5 rounded bg-gray-200"></div>
+              <div class="h-5 w-5 rounded bg-gray-200"></div>
 
               <!-- Image -->
-              <div class="w-24 h-14 rounded border border-gray-200 bg-gray-200"></div>
+              <div class="h-14 w-24 rounded border border-gray-200 bg-gray-200"></div>
 
               <!-- Title + badge -->
-              <div class="flex flex-col gap-2 flex-1">
+              <div class="flex flex-1 flex-col gap-2">
                 <div class="h-5 w-40 rounded bg-gray-200"></div>
                 <div class="h-4 w-24 rounded-full bg-gray-200"></div>
               </div>
@@ -57,12 +57,12 @@
 
           <!-- Updated -->
           <td class="px-6 py-4 text-center">
-            <div class="h-4 w-20 mx-auto rounded bg-gray-200"></div>
+            <div class="mx-auto h-4 w-20 rounded bg-gray-200"></div>
           </td>
 
           <!-- Actions -->
           <td class="px-6 py-4 text-right">
-            <div class="inline-flex gap-2 justify-end">
+            <div class="inline-flex justify-end gap-2">
               <div class="h-8 w-14 rounded bg-gray-200"></div>
               <div class="h-8 w-14 rounded bg-gray-200"></div>
             </div>

--- a/app/views/stories/_stories_count.html.erb
+++ b/app/views/stories/_stories_count.html.erb
@@ -1,7 +1,7 @@
 <div id="stories_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Stories (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Stories (<%= @count_display %>)</h3>
   </div>
-  <hr class="border-gray-300 my-6">
+  <hr class="my-6 border-gray-300">
 </div>

--- a/app/views/stories/_story_card.html.erb
+++ b/app/views/stories/_story_card.html.erb
@@ -1,6 +1,6 @@
-<div class="relative bg-white rounded-xl shadow-sm hover:shadow-md transition p-4">
+<div class="relative rounded-xl bg-white p-4 shadow-sm transition hover:shadow-md">
   <!-- BOOKMARK COLUMN (not inside link) -->
-  <div class="absolute top-4 right-4 z-20 pointer-events-auto">
+  <div class="pointer-events-auto absolute top-4 right-4 z-20">
     <%= render "bookmarks/editable_bookmark_icon", resource: story.object %>
   </div>
   <!-- CLICKABLE CARD -->
@@ -11,11 +11,11 @@
     <!-- LEFT: TEXT (leave right padding equal to bookmark width) -->
     <div class="flex-1 pr-12">
       <!-- <-- This prevents text going under bookmark -->
-      <h3 class="text-lg font-semibold text-gray-900 leading-tight"><%= story.title %></h3>
-      <p class="text-gray-600 text-sm mt-1 line-clamp-3"><%= story.rhino_body&.plain_text_body&.truncate(250) %></p>
+      <h3 class="text-lg leading-tight font-semibold text-gray-900"><%= story.title %></h3>
+      <p class="line-clamp-3 mt-1 text-sm text-gray-600"><%= story.rhino_body&.plain_text_body&.truncate(250) %></p>
     </div>
     <!-- RIGHT: IMAGE -->
-    <div class="w-24 h-14 rounded bg-gray-200 mr-9">
+    <div class="mr-9 h-14 w-24 rounded bg-gray-200">
       <%= render "assets/display_image",
                  resource: story,
                  width: 24, height: 14,

--- a/app/views/taggings/_explore_by_sector.html.erb
+++ b/app/views/taggings/_explore_by_sector.html.erb
@@ -1,4 +1,4 @@
-<h3 class="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4 text-center">
+<h3 class="mb-4 text-center text-sm font-semibold tracking-wide text-gray-500 uppercase">
   <% if @sector_names.present? %>
     Explore other sectors
   <% else %>
@@ -6,7 +6,7 @@
   <% end %>
 </h3>
 
-<div class="flex flex-wrap justify-center gap-2 mb-6">
+<div class="mb-6 flex flex-wrap justify-center gap-2">
   <% @sectors.each do |sector| %>
     <% next if sector.name == @sector_names %>
     <%= render "sectors/tagging_label", sector: sector %>

--- a/app/views/taggings/_index_footer.html.erb
+++ b/app/views/taggings/_index_footer.html.erb
@@ -1,5 +1,5 @@
-<section class="other-categories mt-24 pt-6 border-t border-gray-100">
-  <div class="max-w-7xl mx-auto">
+<section class="other-categories mt-24 border-t border-gray-100 pt-6">
+  <div class="mx-auto max-w-7xl">
     <%= render "explore_by_sector" %>
     <%= render "explore_by_combination" %>
   </div>

--- a/app/views/taggings/_tagged_item_card.html.erb
+++ b/app/views/taggings/_tagged_item_card.html.erb
@@ -8,28 +8,19 @@
   <%# end %>
 
   <!-- CARD -->
-  <div class="
-    flex flex-row flex-wrap min-h-[160px]
-    bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md
-    transition-all overflow-hidden cursor-pointer
-  ">
+  <div class="flex min-h-[160px] cursor-pointer flex-row flex-wrap overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all hover:shadow-md">
 
     <!-- LEFT SIDE -->
-    <div class="
-      flex-shrink-0
-      w-24
-      flex flex-col items-center text-center justify-center py-4 pb-3 px-3
-      border-b md:border-b-0 md:border-r border-gray-200
-    ">
+    <div class="flex w-24 flex-shrink-0 flex-col items-center justify-center border-b border-gray-200 px-3 py-4 pb-3 text-center md:border-r md:border-b-0">
 
       <!-- IMAGE / ICON -->
-      <div class="relative w-18 h-18">
+      <div class="relative h-18 w-18">
         <%= link_to polymorphic_path(item),
                     target: item.external_link? ? "_blank" : "", rel: "noopener noreferrer",
                     class: "block w-full h-full" do %>
 
           <% if item.class == ResourceDecorator %>
-            <div class="absolute inset-0 flex items-center justify-center text-gray-700 resource-icon">
+            <div class="resource-icon absolute inset-0 flex items-center justify-center text-gray-700">
               <%= render "resources/resource_icon", kind: item.kind %>
             </div>
           <% end %>
@@ -47,18 +38,18 @@
 
       <!-- TYPE LABEL -->
       <% if item.class == ResourceDecorator %>
-        <span class="mt-2 text-xs font-medium text-gray-500 uppercase tracking-wide">
+        <span class="mt-2 text-xs font-medium tracking-wide text-gray-500 uppercase">
           <%= item.kind == "Scholarship" ? "Scholar-ship" : (item.kind || "Resource") %>
         </span>
       <% end %>
     </div>
 
     <!-- RIGHT SIDE -->
-    <div class="flex-1 min-w-0 pl-4 pr-8 pb-4 mt-2 relative">
+    <div class="relative mt-2 min-w-0 flex-1 pr-8 pb-4 pl-4">
 
       <!-- STANDOUT BADGE (admin-only) -->
       <% if item.class == QuoteDecorator && item.standout? && allowed_to?(:manage?, Quote) %>
-        <span class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-yellow-800 mt-3">
+        <span class="mt-3 inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-yellow-800">
           <i class="fa-solid fa-star mr-1"></i>
           Standout
         </span>
@@ -76,7 +67,7 @@
 
       <!-- OPTIONAL DESCRIPTION -->
       <% if item.detail.present? %>
-        <p class="text-sm text-gray-600 leading-snug line-clamp-3">
+        <p class="line-clamp-3 text-sm leading-snug text-gray-600">
           <span title="<%= item.class == WorkshopDecorator ? item.detail : item.detail(length: 999) %>">
             <%= item.detail(length: 100) %>
           </span>

--- a/app/views/taggings/_tagged_items_carousel.html.erb
+++ b/app/views/taggings/_tagged_items_carousel.html.erb
@@ -1,6 +1,6 @@
 <div
   data-controller="carousel"
-  class="relative swiper"
+  class="swiper relative"
   data-carousel-options-value='{
     "slidesPerView": "auto",
     "spaceBetween": 16
@@ -9,12 +9,7 @@
   <div class="swiper-wrapper">
     <% items.each do |item| %>
       <div
-        class="
-    swiper-slide
-    shrink-0
-basis-[360px]
-    max-w-[360px]
-  "
+        class="swiper-slide max-w-[360px] shrink-0 basis-[360px]"
       >
         <%= render "tagged_item_card", item: item %>
       </div>
@@ -23,32 +18,14 @@ basis-[360px]
 
   <!-- NEXT BUTTON -->
   <button
-    class="
-      swiper-button-next-custom
-      absolute top-1/2 -translate-y-1/2 right-2
-      w-12 h-12 rounded-full
-      bg-white border border-gray-300
-      text-gray-700
-      shadow-md hover:shadow-lg
-      flex items-center justify-center
-      transition hover:bg-gray-50
-      z-40"
+    class="swiper-button-next-custom absolute top-1/2 right-2 z-40 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-700 shadow-md transition hover:bg-gray-50 hover:shadow-lg"
     aria-label="Next">
     <i class="fa-solid fa-chevron-right text-xl"></i>
   </button>
 
   <!-- PREV BUTTON -->
   <button
-    class="
-      swiper-button-prev-custom
-      absolute top-1/2 -translate-y-1/2 left-2
-      w-12 h-12 rounded-full
-      bg-white border border-gray-300
-      text-gray-700
-      shadow-md hover:shadow-lg
-      flex items-center justify-center
-      transition hover:bg-gray-50
-      z-40"
+    class="swiper-button-prev-custom absolute top-1/2 left-2 z-40 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-700 shadow-md transition hover:bg-gray-50 hover:shadow-lg"
     aria-label="Previous">
     <i class="fa-solid fa-chevron-left text-xl"></i>
   </button>

--- a/app/views/tags/_categories.html.erb
+++ b/app/views/tags/_categories.html.erb
@@ -2,7 +2,7 @@
   <div class="space-y-8">
     <% @categories_by_type.each do |type, categories| %>
       <div>
-        <div class="text-sm font-semibold text-stone-800 mb-3 uppercase tracking-wide"><%= type.titleize %></div>
+        <div class="mb-3 text-sm font-semibold tracking-wide text-stone-800 uppercase"><%= type.titleize %></div>
 
         <div class="flex flex-wrap gap-2">
           <% categories.each do |category| %>

--- a/app/views/tags/_loading.html.erb
+++ b/app/views/tags/_loading.html.erb
@@ -1,3 +1,3 @@
-<div class="flex justify-center border p-2 border-gray-200 rounded-md bg-white">
+<div class="flex justify-center rounded-md border border-gray-200 bg-white p-2">
   <i class="fa-solid fa-spinner animate-spin text-gray-600"></i>
 </div>

--- a/app/views/topic_subscriptions/_results_skeleton.html.erb
+++ b/app/views/topic_subscriptions/_results_skeleton.html.erb
@@ -1,7 +1,7 @@
-<div class="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
   <div class="overflow-x-auto">
     <table class="w-full border-collapse border border-gray-200">
-      <thead class="bg-gray-100 animate-pulse">
+      <thead class="animate-pulse bg-gray-100">
         <tr>
           <th class="px-4 py-2 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
           <th class="px-4 py-2 text-left"><div class="h-4 w-16 rounded bg-gray-200"></div></th>
@@ -14,7 +14,7 @@
         </tr>
       </thead>
 
-      <tbody class="divide-y divide-gray-200 animate-pulse">
+      <tbody class="animate-pulse divide-y divide-gray-200">
         <% 10.times do %>
           <tr>
             <td class="px-4 py-2"><div class="h-4 w-24 rounded bg-gray-200"></div></td>
@@ -32,8 +32,8 @@
   </div>
 </div>
 
-<div class="flex justify-center mt-6 space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/users/_password_errors.html.erb
+++ b/app/views/users/_password_errors.html.erb
@@ -1,13 +1,13 @@
 <% password_errors = user.errors.select { |e| e.attribute.to_s =~ /^password/ || e.attribute == :current_password } %>
 <% if password_errors.any? %>
-  <div id="password-errors" class="mb-4 p-4 bg-red-50 border border-red-200 rounded-md" role="alert">
+  <div id="password-errors" class="mb-4 rounded-md border border-red-200 bg-red-50 p-4" role="alert">
     <div class="flex items-start">
       <div class="flex-shrink-0">
         <i class="fa-solid fa-circle-xmark text-red-400" aria-hidden="true"></i>
       </div>
       <div class="ml-3">
-        <h3 class="text-sm font-medium text-red-800 mb-2">There was a problem with your password:</h3>
-        <ul class="list-disc list-inside text-sm text-red-700 space-y-1">
+        <h3 class="mb-2 text-sm font-medium text-red-800">There was a problem with your password:</h3>
+        <ul class="list-inside list-disc space-y-1 text-sm text-red-700">
           <% password_errors.each do |error| %>
             <li><%= error.full_message %></li>
           <% end %>

--- a/app/views/users/_results_skeleton.html.erb
+++ b/app/views/users/_results_skeleton.html.erb
@@ -1,24 +1,24 @@
-<div class="bg-white rounded overflow-x-auto">
-  <table class="w-full border-collapse border border-gray-200 animate-pulse">
+<div class="overflow-x-auto rounded bg-white">
+  <table class="w-full border-collapse animate-pulse border border-gray-200">
     <thead class="bg-gray-100">
     <tr>
-      <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/3">Email</th>
-      <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700 w-1/6">Person</th>
-      <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Confirmed</th>
-      <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Access</th>
-      <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[60px]">Admin</th>
-      <th class="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-[80px]"></th>
+      <th class="w-1/3 px-4 py-2 text-left text-sm font-semibold text-gray-700">Email</th>
+      <th class="w-1/6 px-4 py-2 text-left text-sm font-semibold text-gray-700">Person</th>
+      <th class="w-[60px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Confirmed</th>
+      <th class="w-[60px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Access</th>
+      <th class="w-[60px] px-4 py-2 text-center text-sm font-semibold text-gray-700">Admin</th>
+      <th class="w-[80px] px-4 py-2 text-center text-sm font-semibold text-gray-700"></th>
     </tr>
     </thead>
     <tbody class="divide-y divide-gray-200">
       <% 8.times do %>
         <tr>
-          <td class="px-4 py-3"><div class="h-4 w-48 bg-gray-200 rounded"></div></td>
-          <td class="px-4 py-3"><div class="h-4 w-32 bg-gray-200 rounded"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-6 bg-gray-200 rounded mx-auto"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-6 bg-gray-200 rounded mx-auto"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-6 bg-gray-200 rounded mx-auto"></div></td>
-          <td class="px-4 py-3"><div class="h-4 w-20 bg-gray-200 rounded mx-auto"></div></td>
+          <td class="px-4 py-3"><div class="h-4 w-48 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3"><div class="h-4 w-32 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-6 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-6 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-6 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3"><div class="mx-auto h-4 w-20 rounded bg-gray-200"></div></td>
         </tr>
       <% end %>
     </tbody>
@@ -26,8 +26,8 @@
 </div>
 
 <!-- Pagination skeleton -->
-<div class="mt-6 flex justify-center space-x-2 animate-pulse">
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
-  <div class="h-8 w-10 bg-gray-200 rounded"></div>
+<div class="mt-6 flex animate-pulse justify-center space-x-2">
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
+  <div class="h-8 w-10 rounded bg-gray-200"></div>
 </div>

--- a/app/views/users/_search_boxes.html.erb
+++ b/app/views/users/_search_boxes.html.erb
@@ -2,7 +2,7 @@
   data: { controller: "collection", turbo_frame: "users_results" },
   autocomplete: "off",
   class: "w-full") do %>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6 items-end">
+  <div class="mb-6 grid grid-cols-1 items-end gap-4 sm:grid-cols-2 lg:grid-cols-4">
     <!-- Search -->
     <div>
       <%= label_tag :search, "Search", class: search_label_class %>
@@ -37,7 +37,7 @@
     </div>
 
     <!-- Clear filters -->
-    <div class="flex sm:justify-end items-end">
+    <div class="flex items-end sm:justify-end">
       <%= render "shared/search_clear", url: users_path %>
     </div>
   </div>

--- a/app/views/video_recordings/_results_skeleton.html.erb
+++ b/app/views/video_recordings/_results_skeleton.html.erb
@@ -1,11 +1,11 @@
 <div class="mt-4">
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-pulse">
+  <div class="grid animate-pulse grid-cols-1 gap-6 lg:grid-cols-2">
     <% 4.times do %>
-      <div class="bg-white rounded-xl shadow-sm overflow-hidden">
+      <div class="overflow-hidden rounded-xl bg-white shadow-sm">
         <!-- Video thumbnail -->
         <div class="w-full bg-gray-200" style="padding-top: 56.25%;"></div>
 
-        <div class="p-4 flex gap-2">
+        <div class="flex gap-2 p-4">
           <!-- Title -->
           <div class="flex-1 space-y-2">
             <div class="h-5 w-3/4 rounded bg-gray-200"></div>
@@ -13,7 +13,7 @@
           </div>
 
           <!-- Actions -->
-          <div class="flex flex-col gap-2 flex-shrink-0 items-end">
+          <div class="flex flex-shrink-0 flex-col items-end gap-2">
             <div class="flex gap-2">
               <div class="h-6 w-12 rounded bg-gray-200"></div>
               <div class="h-6 w-6 rounded bg-gray-200"></div>

--- a/app/views/video_recordings/_search_boxes.html.erb
+++ b/app/views/video_recordings/_search_boxes.html.erb
@@ -1,13 +1,13 @@
 <!-- Filters -->
-<div class="mb-6 p-4 bg-white border border-gray-200 rounded-lg">
+<div class="mb-6 rounded-lg border border-gray-200 bg-white p-4">
   <%= form_with url: video_recordings_path,
                 method: :get,
                 data: { turbo_frame: "video_recordings_results", controller: "collection searchable-checkbox" },
                 autocomplete: "off",
                 local: false,
                 class: "space-y-4" do |f| %>
-    <div class="flex flex-wrap gap-4 items-end">
-      <div class="flex-1 min-w-[200px]">
+    <div class="flex flex-wrap items-end gap-4">
+      <div class="min-w-[200px] flex-1">
         <%= f.label :search, "Title or body contains",
                     class: search_label_class %>
 
@@ -18,7 +18,7 @@
       </div>
 
       <% if @video_type != "instructional" %>
-        <div class="flex-0 min-w-[180px]">
+        <div class="min-w-[180px] flex-0">
           <label for="video_type" class="<%= search_label_class %>">
             Video type
           </label>
@@ -44,7 +44,7 @@
                   action: "searchable-checkbox#clear collection#clearAndSubmit" %></div>
     </div>
 
-    <div class="flex flex-col sm:flex-row gap-4">
+    <div class="flex flex-col gap-4 sm:flex-row">
       <%# Categories dropdown %>
       <div class="w-full">
         <label class="<%= search_label_class %>" for="categories">Categories</label>

--- a/app/views/video_recordings/_video_card.html.erb
+++ b/app/views/video_recordings/_video_card.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow-sm overflow-hidden hover:shadow-md transition-shadow">
+<div class="overflow-hidden rounded-xl bg-white shadow-sm transition-shadow hover:shadow-md">
   <% if video_recording.youtube_url.present? %>
     <div class="relative w-full overflow-hidden" style="padding-top: 56.25%;">
       <iframe
@@ -12,13 +12,13 @@
     </div>
   <% end %>
 
-  <div class="p-4 flex gap-2">
+  <div class="flex gap-2 p-4">
     <div class="flex-1">
       <%= link_to title_with_badges(video_recording), video_recording_path(video_recording),
                   class: "hover:text-primary",
                   data: { turbo_frame: "_top" } %>
     </div>
-    <div class="flex flex-col gap-2 flex-shrink-0">
+    <div class="flex flex-shrink-0 flex-col gap-2">
       <div class="flex gap-2">
         <%= link_to "View", video_recording_path(video_recording),
                     data: { turbo_frame: "_top" },

--- a/app/views/video_recordings/video_recordings_results.html.erb
+++ b/app/views/video_recordings/video_recordings_results.html.erb
@@ -8,7 +8,7 @@
       <% end %>
 
       <!-- Pagination -->
-      <div class="pagination flex justify-center mt-12">
+      <div class="pagination mt-12 flex justify-center">
         <%= tailwind_paginate @video_recordings %>
       </div>
     <% else %>

--- a/app/views/workshop_ideas/_workshop_series_child_fields.html.erb
+++ b/app/views/workshop_ideas/_workshop_series_child_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields display-flex gap-2 items-center" style="display: flex">
+<div class="nested-fields display-flex items-center gap-2" style="display: flex">
   <%= f.input :workshop_parent_id, as: :hidden,
               input_html: { value: f.object.workshop_parent_id } %>
   <%= f.input :workshop_child_id,

--- a/app/views/workshop_logs/_index_per_page.html.erb
+++ b/app/views/workshop_logs/_index_per_page.html.erb
@@ -11,8 +11,7 @@
 
   <select name="number_of_items_per_page"
           id="number_of_items_per_page"
-          class="rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm
-                   focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none">
+          class="rounded-md border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none">
     <% [10, 25, 50, 100, 250].each do |n| %>
       <option value="<%= n %>" <%= 'selected' if @per_page.to_i == n %>>
         <%= n %>

--- a/app/views/workshop_variations/_results_skeleton.html.erb
+++ b/app/views/workshop_variations/_results_skeleton.html.erb
@@ -1,21 +1,21 @@
-<div class="overflow-x-auto bg-white border border-gray-200 rounded-xl shadow-sm">
+<div class="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
   <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50 animate-pulse">
+    <thead class="animate-pulse bg-gray-50">
       <tr>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-6 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-6 rounded bg-gray-200"></div></th>
         <th class="px-4 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
         <th class="px-4 py-3 text-left"><div class="h-4 w-24 rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></th>
-        <th class="px-4 py-3 text-center"><div class="h-4 w-10 mx-auto rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></th>
+        <th class="px-4 py-3 text-center"><div class="mx-auto h-4 w-10 rounded bg-gray-200"></div></th>
       </tr>
     </thead>
 
-    <tbody class="divide-y divide-gray-100 animate-pulse">
+    <tbody class="animate-pulse divide-y divide-gray-100">
       <% 3.times do %>
         <tr>
-          <td class="px-4 py-3"><div class="w-12 h-9 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3"><div class="h-9 w-12 rounded bg-gray-200"></div></td>
           <td class="px-4 py-3">
             <div class="flex flex-col gap-2">
               <div class="h-5 w-48 rounded bg-gray-200"></div>
@@ -23,10 +23,10 @@
             </div>
           </td>
           <td class="px-4 py-3"><div class="h-4 w-6 rounded bg-gray-200"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-24 mx-auto rounded bg-gray-200"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-4 w-16 mx-auto rounded bg-gray-200"></div></td>
-          <td class="px-4 py-3 text-center"><div class="h-8 w-14 mx-auto rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-24 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-4 w-16 rounded bg-gray-200"></div></td>
+          <td class="px-4 py-3 text-center"><div class="mx-auto h-8 w-14 rounded bg-gray-200"></div></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/workshop_variations/_workshop_variations_count.html.erb
+++ b/app/views/workshop_variations/_workshop_variations_count.html.erb
@@ -1,7 +1,7 @@
 <div id="workshop_variations_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide"><%= WorkshopVariation.model_name.human.pluralize %> (<%= @count_display %>)</h3>
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase"><%= WorkshopVariation.model_name.human.pluralize %> (<%= @count_display %>)</h3>
   </div>
-  <hr class="border-gray-300 my-6">
+  <hr class="my-6 border-gray-300">
 </div>

--- a/app/views/workshops/_categories_fields.html.erb
+++ b/app/views/workshops/_categories_fields.html.erb
@@ -9,8 +9,7 @@
         data-dropdown-payload-param='[{"<%= category_type.name %>-dropdown":"hidden"},
                                      {"<%= category_type.name %>-arrow":"rotate-180"},
                                      {"<%= category_type.name %>-button":"rounded-md rounded-t-md"}]'
-        class="relative z-10 w-full bg-white text-gray-800 py-2 px-4 shadow-sm rounded-md
-               border border-gray-300 cursor-pointer flex justify-between items-center"
+        class="relative z-10 flex w-full cursor-pointer items-center justify-between rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-800 shadow-sm"
       >
         <label class="mb-0 font-medium text-gray-700">
           <%= category_type.title %>
@@ -18,19 +17,18 @@
 
         <i
           id="<%= category_type.name %>-arrow"
-          class="fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300"
+          class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300"
         ></i>
       </button>
 
       <div
         id="<%= category_type.name %>-dropdown"
-        class="absolute left-0 top-full w-full shadow-sm bg-white border border-t-0
-               border-gray-300 rounded-b-md hidden z-40"
+        class="absolute top-full left-0 z-40 hidden w-full rounded-b-md border border-t-0 border-gray-300 bg-white shadow-sm"
       >
 
         <%# Class "category-checkbox" is used to submit on change %>
         <% category_type.categories.ordered_by_position_and_name.each do |category| %>
-          <div class="flex items-center gap-2 mb-1 px-4">
+          <div class="mb-1 flex items-center gap-2 px-4">
             <%= check_box_tag "categories[#{category.id}]",
                               category.id,
                               params.dig(:categories, category.id.to_s).to_s == category.id.to_s,

--- a/app/views/workshops/_combined_workshop_log_summary.html.erb
+++ b/app/views/workshops/_combined_workshop_log_summary.html.erb
@@ -10,7 +10,7 @@
   </div>
       </div>
     </div>
-    <table class='table table-striped'>
+    <table class='table-striped table'>
       <th class='bold small'>Date</th>
       <th class='bold small'>Person/Workshop</th>
       <th class='bold small'># on-going adults</th>

--- a/app/views/workshops/_dropdown_filter.html.erb
+++ b/app/views/workshops/_dropdown_filter.html.erb
@@ -11,30 +11,22 @@
       type="button"
       data-action="dropdown#toggle"
       data-dropdown-payload-param='[{"<%= dom_id_prefix %>-dropdown":"hidden"},{"<%= dom_id_prefix %>-arrow":"rotate-180"},{"<%= dom_id_prefix %>-button":"rounded-md rounded-t-md"}]'
-      class="
-        relative z-10 w-full bg-white text-gray-800 py-2 px-4 shadow-sm rounded-md
-        border border-gray-300 cursor-pointer flex justify-between items-center
-      "
+      class="relative z-10 flex w-full cursor-pointer items-center justify-between rounded-md border border-gray-300 bg-white px-4 py-2 text-gray-800 shadow-sm"
     >
       <label class="mb-0 font-medium text-gray-700"><%= label_text %></label>
       <i
         id="<%= dom_id_prefix %>-arrow"
-        class="
-          fa-solid fa-chevron-down w-4 h-4 transition-transform duration-300
-        "
+        class="fa-solid fa-chevron-down h-4 w-4 transition-transform duration-300"
       ></i>
     </button>
 
     <div
       id="<%= dom_id_prefix %>-dropdown"
-      class="
-        absolute left-0 top-full w-full shadow-sm bg-white border border-t-0
-        border-gray-300 rounded-b-md hidden z-40
-      "
+      class="absolute top-full left-0 z-40 hidden w-full rounded-b-md border border-t-0 border-gray-300 bg-white shadow-sm"
     >
       <%# Class "category-checkbox" is used to submit on change %>
       <% items.each do |item| %>
-        <div class="flex items-center gap-2 mb-1 px-4">
+        <div class="mb-1 flex items-center gap-2 px-4">
           <%= check_box_tag "#{param_name}[#{item.id}]",
           item.id,
           params.dig(param_name, item.id.to_s).to_s == item.id.to_s,

--- a/app/views/workshops/_filters.html.erb
+++ b/app/views/workshops/_filters.html.erb
@@ -1,12 +1,12 @@
 <!-- Filters Header -->
 
 <div>
-  <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">Keyword search filters</h3>
+  <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Keyword search filters</h3>
 </div>
 
 <!-- Search Fields -->
 
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4 px-4 py-0 mb-0">
+<div class="mb-0 grid grid-cols-1 gap-4 px-4 py-0 md:grid-cols-3">
   <% [[:title, "Title contains"], [:author_name, "Author name contains"], [:query, "Full-text contains"]].each do |field, placeholder| %>
     <div class="relative">
       <%= text_field_tag field,
@@ -20,7 +20,7 @@
 
 <!-- Checkboxes -->
 
-<div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 overflow-visible p-4">
+<div class="grid grid-cols-1 gap-4 overflow-visible p-4 sm:grid-cols-2 xl:grid-cols-4">
 
   <%= render "dropdown_filter",
              dom_id_prefix: "windows-types",

--- a/app/views/workshops/_flex.html.erb
+++ b/app/views/workshops/_flex.html.erb
@@ -4,11 +4,11 @@
   <div class='row'>
     <div class='col-xs-4 fixed-width'>
       <div
-        class='portrait-img content-img-popular popular-img'
+        class='portrait-img popular-img content-img-popular'
         style="background-image: url(<%= thumbnail_image %>)"
       ></div>
     </div>
-    <div class='col-xs-8 col-xs-6-custom content-heading span'>
+    <div class='col-xs-8 col-xs-6-custom span content-heading'>
       <h3><%= link_to workshop.title, link_route, data: { turbo_prefetch: false } %></h3>
       <small><%= "#{workshop.windows_type.short_name unless workshop.windows_type.nil?} - #{workshop.date}" %></small><br/>
       <small>Author:

--- a/app/views/workshops/_index_row.html.erb
+++ b/app/views/workshops/_index_row.html.erb
@@ -15,8 +15,7 @@
   class="
     flex flex-col sm:flex-row
     <%= "admin-only bg-blue-100" unless workshop.published? %>
-    border-b border-gray-200 bg-white py-4 gap-4
-    px-4 sm:px-0">
+    gap-4 border-b border-gray-200 bg-white px-4 py-4 sm:px-0">
   <div id="workshop-<%= workshop.id %>-anchor" style="position: relative; top: -200px;"></div>
 
   <!-- 1️⃣ Media -->
@@ -29,18 +28,18 @@
 
 
   <!-- Content (bookmark + title+ + description) -->
-  <div class="flex flex-col sm:flex-row gap-4 flex-1">
+  <div class="flex flex-1 flex-col gap-4 sm:flex-row">
 
     <!-- 2️⃣ Title / author / metadata -->
     <div class="flex flex-1 gap-4">
 
       <!-- Bookmark column (always visible, always left of title badges) -->
-      <div class="flex-shrink-0 pt-1 w-6">
+      <div class="w-6 flex-shrink-0 pt-1">
         <%= render "bookmarks/editable_bookmark_icon", resource: workshop.object %>
       </div>
 
       <!-- Title + badges + metadata -->
-      <div class="flex flex-col gap-1 flex-1 min-w-0">
+      <div class="flex min-w-0 flex-1 flex-col gap-1">
 
         <!-- Title with badges (single column, bookmark stays separate) -->
         <%= link_to link_route,
@@ -51,7 +50,7 @@
         <% end %>
 
         <!-- Author + date -->
-        <div class="text-sm text-gray-600 leading-tight">
+        <div class="text-sm leading-tight text-gray-600">
           By:
           <%= credited_author_link(workshop, class: "hover:underline", data: { turbo: false }) %>
           | <%= workshop.date %>
@@ -59,8 +58,8 @@
 
         <!-- Bookmarked count + Tags count -->
         <% tag_list = hide_tags ? [] : collect_all_tags(workshop) %>
-        <div class="text-sm text-gray-600 leading-tight">
-          <span id="<%= dom_id(workshop, :bookmark_count) %>">Bookmarked: <%= workshop.bookmarks_count %> <%= "time".pluralize(workshop.bookmarks_count.to_i) %></span><% if tag_list.any? %>, <span class="group relative inline-block"><span class="cursor-help">Tags: <%= tag_list.count %></span><div class="hidden group-hover:block absolute left-0 top-full mt-1 bg-white border border-gray-300 rounded-lg shadow-lg p-3 z-10 min-w-[300px] max-w-[500px]"><div class="text-sm text-gray-800"><%= tag_list.join(", ") %></div></div></span><% end %>
+        <div class="text-sm leading-tight text-gray-600">
+          <span id="<%= dom_id(workshop, :bookmark_count) %>">Bookmarked: <%= workshop.bookmarks_count %> <%= "time".pluralize(workshop.bookmarks_count.to_i) %></span><% if tag_list.any? %>, <span class="group relative inline-block"><span class="cursor-help">Tags: <%= tag_list.count %></span><div class="absolute top-full left-0 z-10 mt-1 hidden max-w-[500px] min-w-[300px] rounded-lg border border-gray-300 bg-white p-3 shadow-lg group-hover:block"><div class="text-sm text-gray-800"><%= tag_list.join(", ") %></div></div></span><% end %>
         </div>
 
         <!-- Led count -->

--- a/app/views/workshops/_results_skeleton.html.erb
+++ b/app/views/workshops/_results_skeleton.html.erb
@@ -1,35 +1,35 @@
 <div class="mt-6">
-  <div class="space-y-4 animate-pulse">
+  <div class="animate-pulse space-y-4">
     <% 3.times do %>
-      <div class="flex flex-col sm:flex-row border-b border-gray-200 bg-white gap-4 p-4">
+      <div class="flex flex-col gap-4 border-b border-gray-200 bg-white p-4 sm:flex-row">
         <!-- Skeleton -->
-        <div class="flex-shrink-0 w-full sm:w-32 h-32 sm:h-24 bg-gray-200 rounded"></div>
+        <div class="h-32 w-full flex-shrink-0 rounded bg-gray-200 sm:h-24 sm:w-32"></div>
 
         <!-- Content -->
-        <div class="flex flex-col sm:flex-row gap-4 flex-1">
+        <div class="flex flex-1 flex-col gap-4 sm:flex-row">
           <!-- Title / metadata -->
           <div class="flex flex-1 gap-4">
             <!-- Bookmark placeholder -->
-            <div class="flex-shrink-0 pt-1 w-6">
-              <div class="w-5 h-5 bg-gray-200 rounded"></div>
+            <div class="w-6 flex-shrink-0 pt-1">
+              <div class="h-5 w-5 rounded bg-gray-200"></div>
             </div>
 
             <!-- Title + metadata -->
-            <div class="flex flex-col gap-2 flex-1 min-w-0">
+            <div class="flex min-w-0 flex-1 flex-col gap-2">
               <!-- Badge -->
-              <div class="h-5 w-32 bg-gray-200 rounded-full"></div>
+              <div class="h-5 w-32 rounded-full bg-gray-200"></div>
 
               <!-- Title -->
-              <div class="h-6 w-3/4 bg-gray-300 rounded"></div>
+              <div class="h-6 w-3/4 rounded bg-gray-300"></div>
 
               <!-- Author + date -->
-              <div class="h-4 w-1/2 bg-gray-200 rounded"></div>
+              <div class="h-4 w-1/2 rounded bg-gray-200"></div>
 
               <!-- Bookmark count -->
-              <div class="h-4 w-40 bg-gray-200 rounded"></div>
+              <div class="h-4 w-40 rounded bg-gray-200"></div>
 
               <!-- Age ranges -->
-              <div class="h-4 w-48 bg-gray-200 rounded"></div>
+              <div class="h-4 w-48 rounded bg-gray-200"></div>
             </div>
           </div>
 
@@ -40,14 +40,14 @@
 
             <!-- Description text -->
             <div class="flex-1 space-y-2">
-              <div class="h-4 w-full bg-gray-200 rounded"></div>
+              <div class="h-4 w-full rounded bg-gray-200"></div>
 
-              <div class="h-4 w-5/6 bg-gray-200 rounded"></div>
+              <div class="h-4 w-5/6 rounded bg-gray-200"></div>
 
-              <div class="h-4 w-2/3 bg-gray-200 rounded"></div>
+              <div class="h-4 w-2/3 rounded bg-gray-200"></div>
 
               <!-- Tags -->
-              <div class="mt-3 h-4 w-1/2 bg-gray-200 rounded"></div>
+              <div class="mt-3 h-4 w-1/2 rounded bg-gray-200"></div>
             </div>
           </div>
         </div>

--- a/app/views/workshops/_show_actions_row.html.erb
+++ b/app/views/workshops/_show_actions_row.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap items-center justify-between gap-6 mt-4 print:hidden p-2">
+<div class="mt-4 flex flex-wrap items-center justify-between gap-6 p-2 print:hidden">
   <!-- Left: Bookmark -->
   <div class="flex items-center gap-2">
     <%= render "bookmarks/editable_bookmark_button", resource: workshop.object %>

--- a/app/views/workshops/_show_body.html.erb
+++ b/app/views/workshops/_show_body.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white border border-gray-200 rounded-xl shadow p-6 print:border-none print:shadow-none">
+<div class="rounded-xl border border-gray-200 bg-white p-6 shadow print:border-none print:shadow-none">
   <div id="workshop-top" class="mt-6"></div>
 
   <!-- Tabs / Accordion -->
@@ -6,16 +6,10 @@
   <div data-controller="tabs" class="my-4">
     <!-- Tabs -->
     <ul class="flex border-b border-gray-300 pb-4 print:hidden">
-      <li class="-mb-px mr-1">
+      <li class="mr-1 -mb-px">
         <a
           href="#"
-          class="
-            tab-link px-4 py-2 font-medium text-gray-700
-            border-b-2 border-transparent
-            hover:text-gray-900 hover:border-gray-300
-            transition-colors duration-200
-            data-[active=true]:border-primary data-[active=true]:text-primary
-          "
+          class="tab-link data-[active=true]:border-primary data-[active=true]:text-primary border-b-2 border-transparent px-4 py-2 font-medium text-gray-700 transition-colors duration-200 hover:border-gray-300 hover:text-gray-900"
           data-action="click->tabs#switch"
           data-tabs-target="tabLink"
           data-tab-content-id="english-content"
@@ -25,16 +19,10 @@
       </li>
 
       <% if workshop.has_spanish_fields? %>
-        <li class="-mb-px mr-1">
+        <li class="mr-1 -mb-px">
           <a
             href="#"
-            class="
-              tab-link px-4 py-2 font-medium text-gray-700
-              border-b-2 border-transparent
-              hover:text-gray-900 hover:border-gray-300
-              transition-colors duration-200
-              data-[active=true]:border-primary data-[active=true]:text-primary
-            "
+            class="tab-link data-[active=true]:border-primary data-[active=true]:text-primary border-b-2 border-transparent px-4 py-2 font-medium text-gray-700 transition-colors duration-200 hover:border-gray-300 hover:text-gray-900"
             data-action="click->tabs#switch"
             data-tabs-target="tabLink"
             data-tab-content-id="spanish-content"
@@ -44,27 +32,21 @@
         </li>
       <% end %>
 
-      <li class="-mb-px mr-1 ml-auto">
+      <li class="mr-1 -mb-px ml-auto">
         <a
           href="#workshopVariations"
           data-turbo="false"
-          class="
-            px-3 py-1 rounded bg-gray-200 text-gray-500 text-sm
-            hover:bg-gray-300 hover:text-gray-700 transition-colors duration-200
-          "
+          class="rounded bg-gray-200 px-3 py-1 text-sm text-gray-500 transition-colors duration-200 hover:bg-gray-300 hover:text-gray-700"
         >
           Workshop variations
         </a>
       </li>
 
       <% if @quotes.any? %>
-        <li class="-mb-px mr-1">
+        <li class="mr-1 -mb-px">
           <a
             href="#workshopQuotes"
-            class="
-              px-3 py-1 rounded bg-gray-200 text-gray-500 text-sm
-              hover:bg-gray-300 hover:text-gray-700 transition-colors duration-200
-            "
+            class="rounded bg-gray-200 px-3 py-1 text-sm text-gray-500 transition-colors duration-200 hover:bg-gray-300 hover:text-gray-700"
           >
             Related quotes
           </a>
@@ -72,13 +54,10 @@
       <% end %>
 
       <% if @leader_spotlights.any? %>
-        <li class="-mb-px mr-1">
+        <li class="mr-1 -mb-px">
           <a
             href="#workshopLeaderSpotlights"
-            class="
-              px-3 py-1 rounded bg-gray-200 text-gray-500 text-sm
-              hover:bg-gray-300 hover:text-gray-700 transition-colors duration-200
-            "
+            class="rounded bg-gray-200 px-3 py-1 text-sm text-gray-500 transition-colors duration-200 hover:bg-gray-300 hover:text-gray-700"
           >
             Related stories
           </a>
@@ -87,11 +66,11 @@
     </ul>
 
     <!-- Tab contents -->
-    <div class="mt-4 ml-2 default-link">
+    <div class="default-link mt-4 ml-2">
       <!-- English / Details -->
       <div id="english-content" data-tabs-target="tabContent">
         <% if content_has_value?(workshop.rhino_extra_field) %>
-          <div class="text-sm mb-4"><%= workshop.rhino_extra_field %></div>
+          <div class="mb-4 text-sm"><%= workshop.rhino_extra_field %></div>
         <% end %>
 
         <% workshop_sections = { "Objective" => workshop.rhino_objective,
@@ -115,13 +94,13 @@
           <% next unless content_has_value?(content, title: title) %>
 
           <div class="workshop-<%= title %> single-workshop-detail mb-4">
-            <h3 class="text-lg font-semibold mb-1"><%= title %></h3>
+            <h3 class="mb-1 text-lg font-semibold"><%= title %></h3>
 
             <% if title == "Suggested time frame" %>
               <%= render "show_time_frame", workshop: workshop,
                            title: title, content: content, language: "english" %>
             <% else %>
-              <hr class="border-gray-300 mb-2">
+              <hr class="mb-2 border-gray-300">
               <div class="text-sm after:clear-both after:block after:content-['']"><%= content %></div>
             <% end %>
           </div>
@@ -129,8 +108,8 @@
 
         <% if workshop.gallery_assets.any? { |img| img.persisted? && img.file.attached? } %>
           <div class="workshop-gallery single-workshop-detail mb-4">
-            <h3 class="text-lg font-semibold mb-1">Gallery</h3>
-            <hr class="border-gray-300 mb-2">
+            <h3 class="mb-1 text-lg font-semibold">Gallery</h3>
+            <hr class="mb-2 border-gray-300">
 
             <div class="flex flex-wrap gap-4">
                 <% workshop.gallery_assets.each_with_index do |gallery_assets, idx| %>
@@ -172,13 +151,13 @@
               (title == "Tiempo sugerido" && content == "00:00") %>
 
             <div class="workshop-<%= title %> single-workshop-detail mb-4">
-              <h3 class="text-lg font-semibold mb-1"><%= title %></h3>
+              <h3 class="mb-1 text-lg font-semibold"><%= title %></h3>
 
               <% if title == "Tiempo sugerido" && content != "00:00" %>
                 <%= render "show_time_frame", workshop: workshop,
                            title: title, content: content, language: "spanish" %>
               <% else %>
-                <hr class="border-gray-300 mb-2">
+                <hr class="mb-2 border-gray-300">
                 <div class="text-sm after:clear-both after:block after:content-['']"><%= content %></div>
               <% end %>
             </div>

--- a/app/views/workshops/_show_header.html.erb
+++ b/app/views/workshops/_show_header.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full aspect-[3/2] sm:aspect-[21/9] lg:aspect-[24/9] overflow-hidden rounded-xl print:hidden">
+<div class="aspect-[3/2] w-full overflow-hidden rounded-xl sm:aspect-[21/9] lg:aspect-[24/9] print:hidden">
   <!-- Background image -->
   <div id="hero-image"><%= render "assets/display_image",
                 resource: workshop,
@@ -8,19 +8,19 @@
                 file: workshop.display_image,
                 variant: :hero %></div>
 </div>
-<div id="upload-progress" class="mt-2 h-1 w-full bg-gray-200 rounded overflow-hidden hidden">
+<div id="upload-progress" class="mt-2 hidden h-1 w-full overflow-hidden rounded bg-gray-200">
   <div id="upload-progress-bar" class="h-full w-0 bg-blue-500 transition-[width] duration-200 ease-out"></div>
 </div>
 <!-- Title + meta -->
-<div class="flex justify-between px-8 py-4 my-2 border-md bg-primary rounded-xl">
+<div class="border-md bg-primary my-2 flex justify-between rounded-xl px-8 py-4">
   <div>
-    <h1 class="text-3xl md:text-4xl font-bold text-white">
+    <h1 class="text-3xl font-bold text-white md:text-4xl">
       <%= workshop.title %>
       <% unless workshop.published %>
-        <span class="text-red-300 text-lg">(Unpublished)</span>
+        <span class="text-lg text-red-300">(Unpublished)</span>
       <% end %>
     </h1>
-    <div class="flex flex-wrap gap-4 text-sm text-gray-200 mt-3"><span>Author: <%= credited_author_link(workshop, class: "hover:underline") %></span><span>Category: <%= workshop.windows_type&.short_name %></span><span>Added: <%= workshop.date %></span></div>
+    <div class="mt-3 flex flex-wrap gap-4 text-sm text-gray-200"><span>Author: <%= credited_author_link(workshop, class: "hover:underline") %></span><span>Category: <%= workshop.windows_type&.short_name %></span><span>Added: <%= workshop.date %></span></div>
   </div>
   <%= render "assets/primary_image_picker", owner: workshop %>
 </div>

--- a/app/views/workshops/_show_series_membership_children.html.erb
+++ b/app/views/workshops/_show_series_membership_children.html.erb
@@ -7,12 +7,12 @@
   .group_by(&:theme_name) %>
 
 <div class="workshop-series-children single-workshop-detail mb-4">
-  <h3 class="text-lg font-semibold mb-1">Series workshops</h3>
-  <hr class="border-gray-300 mb-2">
+  <h3 class="mb-1 text-lg font-semibold">Series workshops</h3>
+  <hr class="mb-2 border-gray-300">
   <div class="prose text-sm after:clear-both after:block after:content-['']">
     <% grouped_series_memberships.each do |theme_name, series_memberships| %>
       <% if theme_name.present? %>
-        <h3 class="font-semibold mt-4 mb-2"><%= theme_name %></h3>
+        <h3 class="mt-4 mb-2 font-semibold"><%= theme_name %></h3>
       <% end %>
       <% series_memberships.each do |series_membership| %>
         <% child_workshop = series_membership.workshop_child %>

--- a/app/views/workshops/_show_series_membership_parents.html.erb
+++ b/app/views/workshops/_show_series_membership_parents.html.erb
@@ -1,6 +1,6 @@
 <div class="workshop-series-parents single-workshop-detail m-4 ml-2">
-  <h3 class="text-lg font-semibold mb-1">Associated series</h3>
-  <hr class="border-gray-300 mb-2">
+  <h3 class="mb-1 text-lg font-semibold">Associated series</h3>
+  <hr class="mb-2 border-gray-300">
   <div class="prose text-sm after:clear-both after:block after:content-['']">
     This workshop is part of the following series.
     <ul style="list-style: disc; margin-left: 2rem;"><!-- # Not sure why this is needed -->

--- a/app/views/workshops/_show_skeleton.html.erb
+++ b/app/views/workshops/_show_skeleton.html.erb
@@ -1,16 +1,16 @@
-<div class="bg-white border border-gray-200 rounded-xl shadow p-6 animate-pulse mt-6">
+<div class="mt-6 animate-pulse rounded-xl border border-gray-200 bg-white p-6 shadow">
   <!-- Top spacer -->
-  <div class="mt-6 h-4 w-1/3 bg-gray-200 rounded"></div>
+  <div class="mt-6 h-4 w-1/3 rounded bg-gray-200"></div>
 
   <!-- Tabs -->
   <div class="my-4">
-    <ul class="flex border-b border-gray-300 pb-4 gap-2">
+    <ul class="flex gap-2 border-b border-gray-300 pb-4">
       <li>
-        <div class="h-8 w-24 bg-gray-200 rounded"></div>
+        <div class="h-8 w-24 rounded bg-gray-200"></div>
       </li>
 
       <li class="ml-auto">
-        <div class="h-7 w-40 bg-gray-200 rounded"></div>
+        <div class="h-7 w-40 rounded bg-gray-200"></div>
       </li>
     </ul>
 
@@ -18,49 +18,49 @@
     <div class="mt-6 ml-2 space-y-8">
       <!-- Section: Objective -->
       <div>
-        <div class="h-5 w-32 bg-gray-300 rounded mb-2"></div>
-        <div class="border-t border-gray-200 mb-3"></div>
+        <div class="mb-2 h-5 w-32 rounded bg-gray-300"></div>
+        <div class="mb-3 border-t border-gray-200"></div>
 
         <div class="space-y-2">
-          <div class="h-3 w-full bg-gray-200 rounded"></div>
-          <div class="h-3 w-11/12 bg-gray-200 rounded"></div>
-          <div class="h-3 w-10/12 bg-gray-200 rounded"></div>
+          <div class="h-3 w-full rounded bg-gray-200"></div>
+          <div class="h-3 w-11/12 rounded bg-gray-200"></div>
+          <div class="h-3 w-10/12 rounded bg-gray-200"></div>
         </div>
       </div>
 
       <!-- Section: Materials -->
       <div>
-        <div class="h-5 w-32 bg-gray-300 rounded mb-2"></div>
-        <div class="border-t border-gray-200 mb-3"></div>
+        <div class="mb-2 h-5 w-32 rounded bg-gray-300"></div>
+        <div class="mb-3 border-t border-gray-200"></div>
 
         <div class="space-y-2">
-          <div class="h-3 w-1/2 bg-gray-200 rounded"></div>
-          <div class="h-3 w-1/3 bg-gray-200 rounded"></div>
-          <div class="h-3 w-2/5 bg-gray-200 rounded"></div>
+          <div class="h-3 w-1/2 rounded bg-gray-200"></div>
+          <div class="h-3 w-1/3 rounded bg-gray-200"></div>
+          <div class="h-3 w-2/5 rounded bg-gray-200"></div>
         </div>
       </div>
 
       <!-- Section: Introduction -->
       <div>
-        <div class="h-5 w-40 bg-gray-300 rounded mb-2"></div>
-        <div class="border-t border-gray-200 mb-3"></div>
+        <div class="mb-2 h-5 w-40 rounded bg-gray-300"></div>
+        <div class="mb-3 border-t border-gray-200"></div>
 
         <div class="space-y-2">
-          <div class="h-3 w-full bg-gray-200 rounded"></div>
-          <div class="h-3 w-full bg-gray-200 rounded"></div>
-          <div class="h-3 w-5/6 bg-gray-200 rounded"></div>
-          <div class="h-3 w-4/6 bg-gray-200 rounded"></div>
+          <div class="h-3 w-full rounded bg-gray-200"></div>
+          <div class="h-3 w-full rounded bg-gray-200"></div>
+          <div class="h-3 w-5/6 rounded bg-gray-200"></div>
+          <div class="h-3 w-4/6 rounded bg-gray-200"></div>
         </div>
       </div>
 
       <!-- Section: Gallery -->
       <div>
-        <div class="h-5 w-28 bg-gray-300 rounded mb-2"></div>
-        <div class="border-t border-gray-200 mb-4"></div>
+        <div class="mb-2 h-5 w-28 rounded bg-gray-300"></div>
+        <div class="mb-4 border-t border-gray-200"></div>
 
         <div class="flex flex-wrap gap-4">
           <% 3.times do %>
-            <div class="w-32 h-32 bg-gray-200 rounded border border-gray-300"></div>
+            <div class="h-32 w-32 rounded border border-gray-300 bg-gray-200"></div>
           <% end %>
         </div>
       </div>

--- a/app/views/workshops/_show_tags.html.erb
+++ b/app/views/workshops/_show_tags.html.erb
@@ -1,11 +1,11 @@
 <% tag_count = workshop.sectors.published.count + workshop.categories.published.count %>
-<div class="tags-section print:hidden p-2 mb-4" data-controller="dropdown">
+<div class="tags-section mb-4 p-2 print:hidden" data-controller="dropdown">
   <button
     type="button"
     class="inline-flex items-center gap-1 text-sm <%= eyebrow_link_class %> cursor-pointer transition"
     data-action="dropdown#toggle"
     data-dropdown-payload-param='[{"workshop_tags_content":"hidden"}, {"workshop_tags_show_label":"hidden"}, {"workshop_tags_hide_label":"hidden"}, {"workshop_tags_chevron":"rotate-180"}]'>
-    <i id="workshop_tags_chevron" class="fa-solid fa-chevron-down text-xs transition-transform duration-200 rotate-180"></i>
+    <i id="workshop_tags_chevron" class="fa-solid fa-chevron-down rotate-180 text-xs transition-transform duration-200"></i>
     <span id="workshop_tags_show_label" class="hidden">Show tags (<%= tag_count %>)</span>
     <span id="workshop_tags_hide_label">Hide tags (<%= tag_count %>)</span>
   </button>

--- a/app/views/workshops/_show_time_frame.html.erb
+++ b/app/views/workshops/_show_time_frame.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-wrap divide-x divide-gray-300 border border-gray-300 rounded-lg overflow-hidden">
+<div class="flex flex-wrap divide-x divide-gray-300 overflow-hidden rounded-lg border border-gray-300">
   <% unless workshop.time_intro.to_i == 0 %>
     <div class="flex-1 p-4 text-center">
       <h3 class="text-sm font-semibold text-gray-700">
@@ -76,7 +76,7 @@
     </div>
   <% end %>
 
-  <div class="flex-1 p-4 text-center bg-gray-50">
+  <div class="flex-1 bg-gray-50 p-4 text-center">
     <h3 class="text-sm font-semibold text-gray-700">
       <%= language == "english" ? "Total" : "Total" %>
     </h3>

--- a/app/views/workshops/_sort_by_options.html.erb
+++ b/app/views/workshops/_sort_by_options.html.erb
@@ -1,5 +1,5 @@
 <div class="flex items-center gap-1">
-  <label class="flex items-center gap-1 cursor-pointer">
+  <label class="flex cursor-pointer items-center gap-1">
     <%= radio_button_tag :sort, "created",
                          @sort == "created" %>
     <span class="text-sm">Newest</span>
@@ -7,7 +7,7 @@
 </div>
 
 <div class="flex items-center gap-1">
-  <label class="flex items-center gap-1 cursor-pointer">
+  <label class="flex cursor-pointer items-center gap-1">
     <%= radio_button_tag :sort, "title",
                          @sort == "title" %>
     <span class="text-sm">Title</span>
@@ -15,7 +15,7 @@
 </div>
 
 <div class="flex items-center gap-1">
-  <label class="flex items-center gap-1 cursor-pointer">
+  <label class="flex cursor-pointer items-center gap-1">
     <%= radio_button_tag :sort, "popularity",
                          @sort == "popularity" %>
     <span class="text-sm">Most bookmarked</span>
@@ -23,7 +23,7 @@
 </div>
 
 <div class="flex items-center gap-1">
-  <label class="flex items-center gap-1 cursor-pointer">
+  <label class="flex cursor-pointer items-center gap-1">
     <%= radio_button_tag :sort, "author",
                          @sort == "author" %>
     <span class="text-sm">Author</span>

--- a/app/views/workshops/_workshop_card.html.erb
+++ b/app/views/workshops/_workshop_card.html.erb
@@ -1,8 +1,6 @@
-<div class="swiper-slide relative overflow-visible block rounded-xl border border-gray-200 shadow-sm
-            bg-white hover:shadow-md hover:bg-gray-50
-            transition p-4 cursor-pointer">
+<div class="swiper-slide relative block cursor-pointer overflow-visible rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:bg-gray-50 hover:shadow-md">
   <!-- BOOKMARK ICON (clickable, bottom-right) -->
-  <div class="absolute bottom-3 right-3 z-30">
+  <div class="absolute right-3 bottom-3 z-30">
     <%= render "bookmarks/editable_bookmark_icon", resource: workshop.object %>
   </div>
   <% cache workshop do %>
@@ -19,10 +17,10 @@
       <!-- Content section -->
       <div class="p-4">
         <!-- add bottom padding so text never overlaps the bookmark -->
-        <div class="text-xs text-gray-500 mb-2 flex justify-between"><span><%= workshop.windows_type&.short_name %></span><span><%= workshop.date %></span></div>
+        <div class="mb-2 flex justify-between text-xs text-gray-500"><span><%= workshop.windows_type&.short_name %></span><span><%= workshop.date %></span></div>
         <div class="flex flex-col gap-2">
           <span class="text-lg font-semibold text-gray-800"><%= workshop.title %></span>
-          <p class="text-gray-600 text-sm"><%= workshop.title.length > 25 ?
+          <p class="text-sm text-gray-600"><%= workshop.title.length > 25 ?
                 workshop.formatted_objective.truncate(75) :
                 workshop.formatted_objective %></p>
         </div>

--- a/app/views/workshops/_workshop_log_summary.html.erb
+++ b/app/views/workshops/_workshop_log_summary.html.erb
@@ -2,22 +2,22 @@
 <div>
   <h4 class="normal light mb-3" data-workshop-logs="<%= workshop_logs %>">Workshop Log Summary</h4>
   <h4>
-    <table class='table normal light table-striped js-workshop-logs'>
+    <table class='normal light table-striped js-workshop-logs table'>
       <thead>
         <th colspan="3"></th>
-        <th colspan="3" class="bold small text-center blue-200"># Ongoing</th>
-        <th colspan="3" class="bold small text-center green-200"># First-time</th>
+        <th colspan="3" class="bold small blue-200 text-center"># Ongoing</th>
+        <th colspan="3" class="bold small green-200 text-center"># First-time</th>
       </thead>
       <thead>
         <th class='bold small'>Date</th>
         <th class='bold small'>Workshop</th>
         <th class='bold small'>Person</th>
-        <th class="bold small text-center blue-200">children</th>
-        <th class="bold small text-center blue-200">teens</th>
-        <th class="bold small text-center blue-200">adults</th>
-        <th class="bold small text-center green-200">children</th>
-        <th class="bold small text-center green-200">teens</th>
-        <th class="bold small text-center green-200">adults</th>
+        <th class="bold small blue-200 text-center">children</th>
+        <th class="bold small blue-200 text-center">teens</th>
+        <th class="bold small blue-200 text-center">adults</th>
+        <th class="bold small green-200 text-center">children</th>
+        <th class="bold small green-200 text-center">teens</th>
+        <th class="bold small green-200 text-center">adults</th>
       </thead>
 
       <% if workshop_logs && workshop_logs.any? %>
@@ -30,12 +30,12 @@
             <td class='small'><%= link_to log.date_label, edit_workshop_log_path(log.id) , target: :blank %></td>
             <td class='small'><%= log.workshop_title %></td>
             <td class='small'><%= log.name %></td>
-            <td class='small text-center blue-100'><%= log.children_ongoing %></td>
-            <td class='small text-center blue-100'><%= log.teens_ongoing %></td>
-            <td class='small text-center blue-100'><%= log.adults_ongoing %></td>
-            <td class='small text-center green-100'><%= log.children_first_time %></td>
-            <td class='small text-center green-100'><%= log.teens_first_time %></td>
-            <td class='small text-center green-100'><%= log.adults_first_time %></td>
+            <td class='small blue-100 text-center'><%= log.children_ongoing %></td>
+            <td class='small blue-100 text-center'><%= log.teens_ongoing %></td>
+            <td class='small blue-100 text-center'><%= log.adults_ongoing %></td>
+            <td class='small green-100 text-center'><%= log.children_first_time %></td>
+            <td class='small green-100 text-center'><%= log.teens_first_time %></td>
+            <td class='small green-100 text-center'><%= log.adults_first_time %></td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/workshops/_workshop_series_child_fields.html.erb
+++ b/app/views/workshops/_workshop_series_child_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="nested-fields display-flex gap-2 items-center" style="display: flex">
+<div class="nested-fields display-flex items-center gap-2" style="display: flex">
   <%= f.input :workshop_parent_id, as: :hidden, input_html: { value: f.object.workshop_parent_id } %>
   <%= f.input :workshop_child_id,
               as: :select,

--- a/app/views/workshops/_workshops_count.html.erb
+++ b/app/views/workshops/_workshops_count.html.erb
@@ -1,7 +1,7 @@
 <div id="workshops_count">
-  <hr class="border-gray-300 my-6">
-  <div class="filters-applied w-full flex gap-3 items-center">
-    <h3 class="text-sm font-semibold uppercase text-gray-500 tracking-wide">
+  <hr class="my-6 border-gray-300">
+  <div class="filters-applied flex w-full items-center gap-3">
+    <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">
       Workshops (<%= @workshops&.total_entries || "" %>)
     </h3>
     <%= render "shared/copy_url" %>

--- a/app/views/workshops/workshops_results.html.erb
+++ b/app/views/workshops/workshops_results.html.erb
@@ -7,13 +7,13 @@
 
   <div id="workshops-list" class="mt-6">
     <% if @workshops.any? %>
-      <div class="space-y-4 animate-fade blur-on-submit">
+      <div class="animate-fade space-y-4 blur-on-submit">
         <% @workshops.each do |workshop| %>
           <%= render "workshops/index_row", workshop: workshop.decorate,
                    breadcrumb: "Workshops", link_route: workshop_path(workshop) %>
         <% end %>
       </div>
-      <div class="pagination flex justify-center mt-12"><%= tailwind_paginate @workshops %></div>
+      <div class="pagination mt-12 flex justify-center"><%= tailwind_paginate @workshops %></div>
     <% else %>
       <p class="text-gray-600">
         Your search returned no results. Please try again.


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 formatting-only Tailwind class reordering, no logic or copy changes

Runs `bin/tw-sort --all` once over the whole tree so canonical Tailwind class order stops arriving one file at a time and future PRs don't mix reordering noise into their real diffs.

- 197 files (`app/views` + `app/frontend/javascript`) — the ones still unsorted; ~830 were already canonical.
- Class order inside an attribute has no CSS effect. Nothing else changed: every added/removed line is inside a `class` attribute.
- rustywind also collapses the multi-line class attributes it rewrites, which is why the line count drops. Attributes containing an ERB or JS interpolation keep their shape, sorted around the interpolation.
- `bin/tw-sort --all --check` is now clean, so `ai/tw-sort` on a feature branch only ever flags classes that branch actually wrote.

Not included: the ~40 helpers/decorators that build class strings in Ruby. rustywind doesn't scan `.rb`, and those need a custom regex — worth a separate look if we want them canonical too.
