### PR TITLE
Make branded event header images actually cover their frame

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -439,11 +439,18 @@ class EventDecorator < ApplicationDecorator
     "#{bookmarks_link} >> #{bookmarkable_link}".html_safe
   end
 
+  # The template key the show page renders, which it interpolates into a partial
+  # path. #preview renders unsaved, unvalidated attributes, so an unknown value
+  # falls back to the legacy frame instead of raising MissingTemplate.
+  def display_template
+    Event::TEMPLATE_KEYS.include?(template) ? template : Event::TEMPLATE_NONE
+  end
+
   # Whether the show page is wearing a branded frame. "none" is the frozen legacy
   # layout, so it keeps the orange/green buttons it shipped with; every other
   # template gets the gold brand CTA.
   def branded_page?
-    template != Event::TEMPLATE_NONE
+    display_template != Event::TEMPLATE_NONE
   end
 
   # Classes for the show page's calls to action (register, view ticket). Read off

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,12 +14,12 @@
 <% end %>
 
 <div class="mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">
-  <% if params[:template].present? && allowed_to?(:edit?, @event) %>
+  <% if Event::TEMPLATE_KEYS.include?(params[:template]) && allowed_to?(:edit?, @event) %>
     <div class="border-brand-navy-200 bg-brand-navy-50 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
       <span class="text-brand-navy-800 text-sm">
-        Previewing the <span class="font-semibold"><%= Event::TEMPLATES.dig(@event.template, :label) %></span> template — not yet saved.
+        Previewing the <span class="font-semibold"><%= Event::TEMPLATES.dig(@event.display_template, :label) %></span> template — not yet saved.
       </span>
-      <%= link_to "Apply & edit", edit_event_path(@event, template: @event.template, section: "page_content", anchor: "page_content_button"),
+      <%= link_to "Apply & edit", edit_event_path(@event, template: @event.display_template, section: "page_content", anchor: "page_content_button"),
                   class: "rounded-md bg-brand-navy-800 px-3 py-1.5 text-sm font-semibold text-white hover:bg-brand-navy-900" %>
     </div>
   <% end %>
@@ -54,7 +54,7 @@
 </div>
 
 <%# ---- DISPLAY TEMPLATE ---- (frames the admin-curated content; honors autoshow_*) %>
-<%= render "events/templates/#{@event.template}", event: @event, sample: false %>
+<%= render "events/templates/#{@event.display_template}", event: @event, sample: false %>
 
 <% if @preview %>
   <div class="mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">

--- a/app/views/events/show/_header_media.html.erb
+++ b/app/views/events/show/_header_media.html.erb
@@ -5,10 +5,11 @@
 <% fill = local_assigns.fetch(:fill, false) %>
 <% if event.rhino_header.present? %>
   <% if fill == "cover" %>
-    <%# Round the <img> itself, not just an overflow-hidden frame: overflow
-        clipping can fail to round the top corners, so the image carries its own
-        radius. %>
-    <div class="h-full [&_img]:h-full [&_img]:w-full [&_img]:rounded-2xl [&_img]:object-cover">
+    <%# Pin the image to the frame rather than sizing it in flow: rich text nests
+        it in auto-height wrappers, so a percentage height resolves to auto and
+        object-cover would have no box to cover. Rounding rides on the <img>
+        because overflow clipping can fail to round the top corners. %>
+    <div class="relative h-full [&_img]:absolute [&_img]:inset-0 [&_img]:m-0 [&_img]:h-full [&_img]:w-full [&_img]:rounded-2xl [&_img]:object-cover">
       <%= event.rhino_header %>
     </div>
   <% else %>

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe EventDecorator do
     end
   end
 
+  describe "#display_template" do
+    it "returns the event's own template when it is a known key" do
+      expect(build(:event, template: "editorial").decorate.display_template).to eq("editorial")
+    end
+
+    it "falls back to none for an unknown template" do
+      event = build(:event, template: "bogus").decorate
+      expect(event.display_template).to eq(Event::TEMPLATE_NONE)
+      expect(event).not_to be_branded_page
+    end
+  end
+
   describe "#videoconference_domain" do
     it "extracts domain name from URL" do
       event = build(:event, videoconference_url: "https://www.zoom.us/j/123").decorate

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -220,6 +220,13 @@ RSpec.describe "Events", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).not_to include("Apply &amp; edit")
       end
+
+      it "shows no preview banner for an unknown ?template" do
+        sign_in admin
+        get event_path(templated_event, template: "bogus")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Apply &amp; edit")
+      end
     end
   end
 
@@ -1379,6 +1386,18 @@ RSpec.describe "Events", type: :request do
       it "logs an Ahoy page-view event" do
         expect(Analytics::AhoyTracker).to receive(:track_event).with(anything, "view.events.preview", { event_id: event.id })
         patch preview_event_path(event), params: { event: { title: "Preview Title" } }
+      end
+
+      it "previews the submitted display template" do
+        patch preview_event_path(event), params: { event: { template: "hero" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("from-brand-navy-950")
+      end
+
+      it "falls back to the none template when the submitted one is unknown" do
+        patch preview_event_path(event), params: { event: { template: "bogus" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("from-brand-navy-950")
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small CSS + one guard on the show page's template lookup

Header images on the four branded event templates were never filling their frame — they letterboxed or got cropped at the bottom instead of covering.

- Rich text nests the image in auto-height wrappers (`div.prose…flow-root` → authored `div` → `figure.attachment`), so `height: 100%` on the `<img>` resolved to `auto` and `object-cover` had no box to cover.
- Fix pins the image to the frame instead, so cover no longer depends on that wrapper chain.
- Follow-up to #2442; only the `fill: "cover"` branch changes, so the `none` template is untouched.

Separately, the show page now falls back to the `none` frame when the template key isn't a known one. `#preview` renders unsaved, unvalidated attributes with CSRF verification skipped, so a crafted `PATCH` could reach the view with any string and 500 on a missing partial.

**Please eyeball the header image** on a hero/centered/editorial/sidebar event — the cover behavior is CSS, so the specs can't confirm it.