### PR TITLE
Exclude no-show trainings from program status; red attendance chip on org edit

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -179,16 +179,25 @@ class OrganizationsController < ApplicationController
     end
 
     # Drives the edit form's per-event program-status chips. Trainings only —
-    # program status is meaningless for other events (ADR-0001 D6).
+    # program status is meaningless for other events (ADR-0001 D6). Includes
+    # trainings the org only registered for inactively (no-show / cancelled /
+    # transferred out): those get a red attendance-status chip and stay out of the
+    # program-status reporting.
     @organization_events = if @organization.persisted?
       authorized_scope(
-        Event.where(id: @organization.event_registrations.active.select(:event_id))
+        Event.where(id: @organization.event_registrations.select(:event_id))
              .where(facilitator_training: true)
              .order(start_date: :desc)
       )
     else
       Event.none
     end
+
+    # event_id => the inactive attendance status to show as a red chip, only for
+    # trainings where the org has no active registration (so it's absent from the
+    # program-status counts). Trainings with an active registration are left out and
+    # keep their New / Ongoing / Reinstated chip.
+    @organization_event_attendance = organization_event_attendance_statuses
 
     @org_categories_grouped = Category
       .includes(:category_type)
@@ -197,6 +206,22 @@ class OrganizationsController < ApplicationController
       .group_by(&:category_type)
       .select { |type, _| type&.profile_specific? }
       .sort_by { |type, _| type&.name.to_s.downcase }
+  end
+
+  # For the edit form's chips: the inactive attendance status to show per training
+  # where the org has no active registration. Active-registration trainings are
+  # excluded so they keep their program-status chip; among the inactive ones the
+  # lowest status alphabetically ("cancelled" < "no_show" < "transferred_out") wins
+  # when several people from the org were inactively registered at the same one.
+  def organization_event_attendance_statuses
+    return {} unless @organization.persisted?
+
+    active_event_ids = @organization.event_registrations.active.distinct.pluck(:event_id)
+    @organization.event_registrations.inactive
+      .where.not(event_id: active_event_ids)
+      .order(:event_id, :status)
+      .pluck(:event_id, :status)
+      .each_with_object({}) { |(event_id, status), map| map[event_id] ||= status }
   end
 
   def set_index_variables

--- a/app/services/facilitator_program_status.rb
+++ b/app/services/facilitator_program_status.rb
@@ -16,7 +16,9 @@ class FacilitatorProgramStatus
   def initialize(affiliations, as_of: nil)
     @as_of = (as_of || Date.current.beginning_of_year).to_date
     @year_anchored = as_of.nil?
-    @facilitators = affiliations.select { |affiliation| affiliation.facilitator? && affiliation.start_date }
+    @facilitators = affiliations.select do |affiliation|
+      affiliation.facilitator? && affiliation.start_date && !same_day?(affiliation)
+    end
   end
 
   # Views that show a year-anchored figure add a caveat saying so.
@@ -82,9 +84,17 @@ class FacilitatorProgramStatus
 
   def month(date) = date&.strftime("%b %Y")
 
+  # A same-day span (start == end) records a training the person was signed up for
+  # but never completed — a no-show, cancellation, or transfer out — so it confers
+  # no facilitator standing and is dropped from @facilitators before any verdict.
+  # An open-ended affiliation the training mints (end nil) is unaffected. (ADR-0001
+  # D8a, refining D8.)
+  def same_day?(affiliation)
+    affiliation.end_date.present? && affiliation.end_date == affiliation.start_date
+  end
+
   # Strictly before: an affiliation starting ON the anchor is the one this event
-  # minted (ADR-0001 D8), so a first-time org still reads New at its own training —
-  # including a same-day (start == end) affiliation dated to the event.
+  # minted (ADR-0001 D8), so a first-time org still reads New at its own training.
   def earlier
     @earlier ||= @facilitators.select { |affiliation| affiliation.start_date < as_of }
   end

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -327,7 +327,8 @@
             <div class="pt-1 flex flex-wrap items-center gap-2">
               <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }) %>
               <%= render "organizations/program_status_event_chips",
-                         organization: f.object, events: org_events, return_to: "organization_edit" %>
+                         organization: f.object, events: org_events, return_to: "organization_edit",
+                         attendance_statuses: @organization_event_attendance || {} %>
             </div>
           </div>
         <% end %>

--- a/app/views/organizations/_program_status_event_chips.html.erb
+++ b/app/views/organizations/_program_status_event_chips.html.erb
@@ -1,13 +1,25 @@
-<%# Per-event program status, on both the org profile and the edit form. The chips
-    open in a new tab, where the back button is no help, so return_to names which of
-    the two the participation report should return to. %>
+<%# Per-event program status, on the org edit form. The chips open in a new tab,
+    where the back button is no help, so return_to names where the participation
+    report should return to. Trainings the org only registered for inactively
+    (no-show / cancelled / transferred out) get a red attendance-status chip
+    instead — they're left out of the New/Ongoing/Reinstated reporting. %>
+<% attendance_statuses = local_assigns.fetch(:attendance_statuses, {}) %>
 <% decorated = organization.decorate %>
 <% events.sort_by { |event| event.start_date || Date.new(1900, 1, 1) }.reverse.each do |event| %>
-  <% status = decorated.facilitator_status_as_of(event.start_date) %>
-  <%= link_to participation_events_path(event_id: event.id, return_organization_id: organization.id, return_to: return_to),
-              target: "_blank", rel: "noopener noreferrer",
-              title: "#{event.title} — #{status.explanation}",
-              class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{OrganizationDecorator.program_status_classes(status.status)}" do %>
-    <%= status.label %><%= " · #{event.start_date.strftime('%b %Y')}" if event.start_date %> · <%= event.decorate.compact_label.truncate(40) %>
+  <% date_suffix = " · #{event.start_date.strftime('%b %Y')}" if event.start_date %>
+  <% if (attendance_status = attendance_statuses[event.id]) %>
+    <% attendance_label = EventRegistration::ATTENDANCE_STATUS_LABELS.fetch(attendance_status, attendance_status.humanize) %>
+    <span class="inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 bg-red-50 text-red-700 border-red-200"
+          title="<%= event.title %> — not counted in program status (<%= attendance_label.downcase %>)">
+      <%= attendance_label %><%= date_suffix %> · <%= event.decorate.compact_label.truncate(40) %>
+    </span>
+  <% else %>
+    <% status = decorated.facilitator_status_as_of(event.start_date) %>
+    <%= link_to participation_events_path(event_id: event.id, return_organization_id: organization.id, return_to: return_to),
+                target: "_blank", rel: "noopener noreferrer",
+                title: "#{event.title} — #{status.explanation}",
+                class: "inline-flex items-center rounded-full text-xs font-medium border px-2.5 py-0.5 #{OrganizationDecorator.program_status_classes(status.status)}" do %>
+      <%= status.label %><%= date_suffix %> · <%= event.decorate.compact_label.truncate(40) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -94,8 +94,9 @@ facilitator affiliations by a single class, `FacilitatorProgramStatus`:
 
 - **New** — no facilitator affiliation started **before** the anchor (strict `<`).
   An affiliation dated **on** the anchor is the one this event mints (D8), so a
-  first-time org reads New at its own training — including a **same-day**
-  (`start == end`) affiliation dated to the event.
+  first-time org reads New at its own training. A **same-day** (`start == end`)
+  affiliation is a no-show / cancellation / transfer out and confers no standing at
+  all (D8a) — it is dropped before the verdict, wherever it falls.
 - **Ongoing** — an earlier facilitator affiliation is **still active** on the
   anchor (no end date, or it ends on/after it).
 - **Reinstated** — earlier facilitator affiliation(s) existed but **all ended**
@@ -177,6 +178,28 @@ history" for its own training. An event with no start date is the one gap — th
 affiliation then falls back to the creation date. That event has no anchor either,
 so both its dashboard and the annual report read it as year-anchored (D7) rather
 than one of them silently using "today".
+
+### D8a — A same-day (`start == end`) affiliation is a no-show, and confers nothing
+
+When a registrant is marked **no-show / cancelled / transferred out**, the training
+they signed up for never made them a facilitator. That shows up as a Facilitator
+affiliation whose span collapses to a single day (`start_date == end_date`).
+`FacilitatorProgramStatus` drops every such affiliation before it judges anything,
+so it never reads as prior history (no spurious Reinstated at a later training) and
+never as the minted row at its own (no spurious New from a training nobody
+attended). An **open-ended** affiliation the training mints (`end_date` nil) is
+untouched — this only removes zero-length spans.
+
+Two surfaces reflect the same fact from the registration side, so a no-show org
+stays out of the program-status figures entirely:
+
+- **Reporting & the event dashboard** already scope their "represented"
+  organizations to `EventRegistration.active`, so an org whose only registration at
+  a training is inactive is absent from the counts.
+- **The org edit form's per-event chips** still list those trainings, but render a
+  **red attendance-status chip** ("No show", "Cancelled", "Transferred out") in
+  place of a New/Ongoing/Reinstated one — a visible marker that the training
+  happened for the org but doesn't count.
 
 ### D9 — Annual reporting counts organizations two ways
 

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -205,6 +205,39 @@ RSpec.describe "/organizations", type: :request do
       expect(response.body).to include("Qwultz Training")
       expect(response.body).not_to include("Zibberpicnic Social")
     end
+
+    it "renders a red attendance-status chip for a training the org only no-showed" do
+      organization = Organization.create!(valid_attributes)
+      training = create(:event, title: "Noshow Training", facilitator_training: true,
+                                start_date: Date.new(2026, 8, 1))
+      registration = create(:event_registration, registrant: create(:person), event: training, status: "no_show")
+      registration.event_registration_organizations.create!(organization: organization)
+
+      get edit_organization_url(organization)
+
+      expect(response.body).to include("Noshow Training")
+      expect(response.body).to include("No show")
+      expect(response.body).to include("bg-red-50 text-red-700 border-red-200")
+      # It is a no-show, so it never reads as a program status.
+      expect(response.body).not_to match(/No show[^<]*·[^<]*·[^<]*(New|Ongoing|Reinstated)/)
+    end
+
+    it "keeps the program-status chip when the org also has an active registration at the training" do
+      organization = Organization.create!(valid_attributes)
+      create(:affiliation, organization: organization, person: create(:person),
+                           title: "Facilitator", start_date: Date.new(2020, 1, 1))
+      training = create(:event, title: "Mixed Training", facilitator_training: true,
+                                start_date: Date.new(2026, 8, 1))
+      create(:event_registration, registrant: create(:person), event: training, status: "no_show")
+        .event_registration_organizations.create!(organization: organization)
+      create(:event_registration, registrant: create(:person), event: training, status: "registered")
+        .event_registration_organizations.create!(organization: organization)
+
+      get edit_organization_url(organization)
+
+      expect(response.body).to include("Mixed Training")
+      expect(response.body).not_to include("bg-red-50 text-red-700 border-red-200")
+    end
   end
 
   describe "POST /create" do

--- a/spec/services/event_program_status_report_spec.rb
+++ b/spec/services/event_program_status_report_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe EventProgramStatusReport do
     end
 
     it "counts a same-day (start == end) facilitation dated to the training as New" do
-      # The minted affiliation with a same-day span is still the training's own,
-      # not prior history (ADR-0001 D8) — so it must not read Ongoing.
+      # A same-day span records a no-show/cancelled training — it confers no
+      # standing (ADR-0001 D8a), so with no other history the org reads New.
       one_day = create(:organization, name: "One Day")
       facilitator_since(one_day, spring.start_date, spring.start_date)
       represent(one_day, spring)
@@ -56,6 +56,19 @@ RSpec.describe EventProgramStatusReport do
 
       expect(column.statuses[one_day.id].status).to eq(:new)
       expect(column.new_count).to eq(2)
+    end
+
+    it "reads New (not Reinstated) at a later training when the only prior history is a no-show" do
+      # A same-day span at the spring training is a no-show, so the org is not a
+      # returning program at the fall training — it reads New both times.
+      returning = create(:organization, name: "No-show then real")
+      facilitator_since(returning, spring.start_date, spring.start_date)  # no-show in spring
+      represent(returning, fall)
+
+      fall_column = report.columns.find { |column| column.event == fall }
+
+      expect(fall_column.statuses[returning.id].status).to eq(:new)
+      expect(fall_column.reinstated_count).to eq(0)
     end
 
     it "reads Ongoing for an org with a prior active facilitator plus one minted at the training" do
@@ -73,8 +86,11 @@ RSpec.describe EventProgramStatusReport do
     end
 
     it "counts only organizations on active registrations" do
-      cancelled_org = create(:organization, name: "Cancelled")
-      represent(cancelled_org, spring, status: "cancelled")
+      # Cancelled / no-show / transferred-out registrations never became a
+      # facilitation, so their orgs stay out of the program-status counts entirely.
+      EventRegistration::INACTIVE_STATUSES.each do |status|
+        represent(create(:organization, name: "Inactive #{status}"), spring, status: status)
+      end
 
       expect(report.years.first.columns.first.organization_count).to eq(3)
     end

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe FacilitatorProgramStatus do
     end
 
     it "is :new for a same-day (start == end) facilitation dated to the anchor" do
-      # start == end == the event date is the affiliation this training mints (D8),
-      # so a first-time org still reads New — not Ongoing.
+      # A same-day span records a training the person never completed (no-show), so
+      # it confers no standing and is dropped — leaving no facilitator history at all.
       facilitator(start_date: anchor, end_date: anchor)
       expect(status_on.status).to eq(:new)
     end
@@ -47,9 +47,11 @@ RSpec.describe FacilitatorProgramStatus do
       expect(status_on.status).to eq(:new)
     end
 
-    it "is :reinstated for a same-day facilitation that ran before the anchor" do
+    it "is :new (not :reinstated) for a same-day facilitation that ran before the anchor" do
+      # A no-show/cancelled training minted a zero-length affiliation; it must not
+      # read as prior facilitator history that reinstates the org.
       facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))
-      expect(status_on.status).to eq(:reinstated)
+      expect(status_on.status).to eq(:new)
     end
 
     it "is :reinstated when every earlier facilitator affiliation has ended" do
@@ -90,6 +92,29 @@ RSpec.describe FacilitatorProgramStatus do
       facilitator(start_date: anchor, end_date: anchor)   # minted, same-day
       facilitator(start_date: anchor + 5)                 # starts after the event
       expect(status_on.status).to eq(:new)
+    end
+  end
+
+  # A same-day span (start == end) is how a no-show / cancelled / transferred-out
+  # training shows up: the person was signed up but never became a facilitator, so
+  # it confers no standing and is left out of the verdict entirely.
+  describe "same-day (no-show) facilitations" do
+    it "does not upgrade a New org to Reinstated when it's the only prior history" do
+      facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))  # no-show
+      facilitator(start_date: anchor)                                                # minted here
+      expect(status_on.status).to eq(:new)
+    end
+
+    it "still reads Ongoing when a genuine active affiliation coexists with a no-show" do
+      facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))  # no-show
+      facilitator(start_date: Date.new(2019, 3, 1))                                  # genuine, active
+      expect(status_on.status).to eq(:ongoing)
+    end
+
+    it "leaves a same-day span out of the facilitator periods and active_since" do
+      facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))
+      expect(status_on.active_since).to be_nil
+      expect(status_on.periods_label).to be_blank
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 focused rule change in one service + one chip view, with tests

## Why
A registrant marked **no-show / cancelled / transferred out** never became a facilitator, yet the training was still counting toward the org's New / Ongoing / Reinstated program status.

## Change
### Classification (`FacilitatorProgramStatus`)
- Drops **zero-length (`start == end`) facilitator affiliations** — the shape a no-show/cancelled/transferred-out training leaves — before judging.
- A no-show no longer reinstates an org at a later training, nor invents a New at one nobody attended. Open-ended minted affiliations (end nil) are untouched.

### Org edit chips
- Now lists trainings the org **only registered for inactively**, rendering a **red attendance-status chip** ("No show" / "Cancelled" / "Transferred out") instead of a program-status one.
- A training keeps its program-status chip if the org has *any* active registration there.

### Reporting & dashboard
- Already scope to `EventRegistration.active`, so no-show-only orgs stay out of the counts — locked in with a test covering all three inactive statuses.

Reverses ADR-0001 D8's same-day handling; documented as **D8a**.