### PR TITLE
Shrink title badge chips so visibility flags fit on one line

### DIFF
--- a/app/helpers/title_display_helper.rb
+++ b/app/helpers/title_display_helper.rb
@@ -9,12 +9,12 @@ module TitleDisplayHelper
 
     # --- Hidden badge ---
     if show_hidden_badge && !home_page && record.respond_to?(:published?) && !record.published?
-      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-eye-slash"), class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-eye-slash"), class: "inline-flex justify-center w-4")
       fragments << content_tag(
         :span,
         icon + content_tag(:span, "Unpublished", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-blue-100 text-gray-600 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap"
       )
     end
 
@@ -23,72 +23,72 @@ module TitleDisplayHelper
 
     if user_signed_in? && !home_page &&
        record.respond_to?(:publicly_visible?) && record.publicly_visible?
-      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-globe"), class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-globe"), class: "inline-flex justify-center w-4")
       visibility_badges << content_tag(
         :span,
         icon + content_tag(:span, "Public", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-violet-100 text-violet-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-violet-100 text-violet-800 whitespace-nowrap"
       )
     end
 
     if user_signed_in? && !home_page && record.respond_to?(:featured?) && record.featured?
-      icon = content_tag(:span, "🌟", class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, "🌟", class: "inline-flex justify-center w-4")
       visibility_badges << content_tag(
         :span,
         icon + content_tag(:span, "Featured", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-yellow-100 text-yellow-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-yellow-100 text-yellow-800 whitespace-nowrap"
       )
     end
 
     if visibility_badges.any?
-      fragments << content_tag(:span, safe_join(visibility_badges, " "), class: "inline-flex items-center gap-2 flex-nowrap")
+      fragments << content_tag(:span, safe_join(visibility_badges, " "), class: "inline-flex items-center gap-1.5 flex-nowrap")
     end
 
     # --- Hidden from search badge (publicly accessible, but excluded from portal searches) ---
     if current_user&.super_user? && !home_page &&
        record.respond_to?(:hidden_from_search?) && record.hidden_from_search?
-      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-filter-circle-xmark"), class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-filter-circle-xmark"), class: "inline-flex justify-center w-4")
       fragments << content_tag(
         :span,
         icon + content_tag(:span, "Hidden from search", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-amber-100 text-amber-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-amber-100 text-amber-800 whitespace-nowrap"
       )
     end
 
     # --- Publicly Featured badge ---
     if !home_page && record.respond_to?(:publicly_featured?) && record.publicly_featured?
       label = user_signed_in? ? "Public Featured" : "Featured"
-      icon = content_tag(:span, purple_star_svg, class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, purple_star_svg, class: "inline-flex justify-center w-4")
       fragments << content_tag(
         :span,
         icon + content_tag(:span, label, class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-purple-100 text-purple-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-purple-100 text-purple-800 whitespace-nowrap"
       )
     end
 
     # --- Instructional badge ---
     if record.respond_to?(:is_instructional) && record.is_instructional?
-      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-graduation-cap"), class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-graduation-cap"), class: "inline-flex justify-center w-4")
       fragments << content_tag(
         :span,
         icon + content_tag(:span, "Instructional", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-teal-100 text-teal-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-teal-100 text-teal-800 whitespace-nowrap"
       )
     end
 
     # --- Promoted from story idea badge ---
     if record.respond_to?(:story_idea) && record.story_idea.present?
-      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-arrow-up-from-bracket"), class: "inline-flex justify-center w-5")
+      icon = content_tag(:span, content_tag(:i, "", class: "fa-solid fa-arrow-up-from-bracket"), class: "inline-flex justify-center w-4")
       fragments << content_tag(
         :span,
         icon + content_tag(:span, "Promoted", class: "ml-1"),
-        class: "inline-flex items-center pl-2 pr-3 py-0.5 rounded-full
-              text-sm font-medium bg-green-100 text-green-800 whitespace-nowrap"
+        class: "inline-flex items-center pl-1.5 pr-2.5 py-0.5 rounded-full
+              text-xs font-medium bg-green-100 text-green-800 whitespace-nowrap"
       )
     end
 
@@ -108,7 +108,7 @@ module TitleDisplayHelper
     if fragments.any?
       content_tag :div, class: "flex flex-col" do
         safe_join([
-                    content_tag(:div, safe_join(fragments), class: "flex flex-wrap items-center gap-2 mb-1"),
+                    content_tag(:div, safe_join(fragments), class: "flex flex-wrap items-center gap-1.5 mb-1"),
                     title_row
                   ])
       end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only class-string tweaks in one helper, no logic change

Shrinks the title visibility chips (Public / Featured / Public Featured, and the sibling Unpublished / Hidden from search / Instructional / Promoted badges) so all three visibility flags fit on one line instead of wrapping in narrower cards.

### What is the goal of this PR and why is this important?
The Public / Featured / Public Featured chips were wrapping to a second line in narrower cards, pushing the title down. This keeps them on one row.

### How did you approach the change?
Trimmed each chip a small, uniform amount in `title_display_helper.rb`: font `text-sm` → `text-xs`, padding `pl-2 pr-3` → `pl-1.5 pr-2.5`, icon slot `w-5` → `w-4`, and both gaps `gap-2` → `gap-1.5`. The row still uses `flex-wrap`, so it degrades gracefully on very narrow viewports.

### Anything else to add?
Applied to every chip the helper renders so they stay visually matched, not just the three shown.
