### PR TITLE
Add back arrows to CE index eyebrows; inline New license button

### DIFF
--- a/app/views/continuing_education_registrations/index.html.erb
+++ b/app/views/continuing_education_registrations/index.html.erb
@@ -4,7 +4,7 @@
   <%# Top-left menu: jump to the cross-event CE timesheets. %>
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to signins_events_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
-      <i class="fa-solid fa-clipboard-check text-xs"></i> CE timesheets
+      <i class="fa-solid fa-arrow-left text-xs"></i> CE timesheets
     <% end %>
     <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>

--- a/app/views/professional_licenses/index.html.erb
+++ b/app/views/professional_licenses/index.html.erb
@@ -3,15 +3,14 @@
 <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6 flex flex-wrap items-center justify-between gap-2">
     <%= link_to continuing_education_registrations_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
-      <i class="fa-solid fa-certificate text-xs"></i> CE registrations
+      <i class="fa-solid fa-arrow-left text-xs"></i> CE registrations
     <% end %>
-    <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-  </div>
-
-  <div class="mb-6 flex justify-end">
-    <%= link_to new_professional_license_path, class: button_classes(:primary) do %>
-      <i class="fa-solid fa-plus text-xs"></i> New license
-    <% end %>
+    <div class="flex flex-wrap items-center gap-3">
+      <%= link_to "Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <%= link_to new_professional_license_path, class: button_classes(:primary) do %>
+        <i class="fa-solid fa-plus text-xs"></i> New license
+      <% end %>
+    </div>
   </div>
 
   <div class="mb-6 flex items-center gap-3">


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup on two CE index headers, no logic changes

Makes the CE registrations and Licenses page headers read as real navigation: the eyebrow back-links now lead with a `←` arrow instead of a decorative domain icon, so it's obvious they go back.

### What is the goal of this PR and why is this important?
The top-of-page eyebrow links on the two CE index pages looked like static labels, not back navigation. Swapping their icons for a left arrow matches the site's back-link convention so users can tell they're clickable ways back.

### How did you approach the change?
- CE registrations index: "CE timesheets" eyebrow icon → `fa-arrow-left`.
- Licenses index: "CE registrations" eyebrow icon → `fa-arrow-left`, and moved the "New license" button up into the top bar next to "Home" instead of its own row.

### Anything else to add?
Markup-only, no logic or data changes.
