### PR TITLE
Remove edit-registration button from registrations index

### DIFF
--- a/app/views/event_registrations/index.html.erb
+++ b/app/views/event_registrations/index.html.erb
@@ -46,7 +46,6 @@
                     <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Event</th>
                   <% end %>
                   <th class="px-4 py-2 text-left text-sm font-semibold whitespace-nowrap text-gray-700">Date registered</th>
-                  <th class="w-px px-4 py-2 text-center text-sm font-semibold whitespace-nowrap text-gray-700">Actions</th>
                 </tr>
                 </thead>
 
@@ -79,15 +78,6 @@
                       <% end %>
                       <td class="px-3 py-1 align-middle text-sm whitespace-nowrap text-gray-800">
                         <%= event_registration.created_at.strftime("%B %d, %Y") %>
-                      </td>
-
-                      <!-- Actions -->
-                      <td class="px-3 py-1 align-middle">
-                        <%= link_to edit_event_registration_path(event_registration, return_to: "index"),
-                                    class: "group relative flex items-center gap-2 w-full px-2 py-1 border #{DomainTheme.border_class_for(:event_registrations)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100)} #{DomainTheme.bg_class_for(:event_registrations, intensity: 100, hover: true)} rounded-lg transition-colors duration-200 font-medium shadow-sm leading-none overflow-hidden" do %>
-                          <i class="fa-solid fa-user-pen shrink-0 text-sm <%= DomainTheme.text_class_for(:event_registrations) %>"></i>
-                          <span class="truncate text-xs font-semibold <%= DomainTheme.text_class_for(:event_registrations) %>">Edit registration</span>
-                        <% end %>
                       </td>
                     </tr>
                   <% end %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only markup change, one column removed from a table

Removes the "Edit registration" button from the event registrations index — and the now-empty "Actions" column with it — to declutter the list.

### What is the goal of this PR and why is this important?
The edit link was the only action in the table's Actions column, so the whole column read as clutter. Removing it simplifies the registrations list.

### How did you approach the change?
Deleted the edit `link_to` and its `<td>` in `app/views/event_registrations/index.html.erb`, plus the "Actions" `<th>` header since nothing else lived in that column. The edit page and route are untouched and still reachable from other flows.

### UI Testing Checklist
- [ ] Registrations index renders without the Actions column
- [ ] Table layout/alignment still looks correct

### Anything else to add?
No route or controller changes — markup only.