### PR TITLE
Show only the author on workshop log, report, and idea show pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,22 @@ module ApplicationHelper
     end
   end
 
+  # The credited author as an admin edit-person card, for the workshop log /
+  # monthly report / variation idea show pages where an admin wants to jump
+  # straight to editing the person. Falls back to the plain byline for viewers
+  # who can't edit people, and honors the credit preference: an anonymous credit
+  # has no person, so it stays plain text.
+  def credited_author_edit_button(record)
+    person = record.author_credit_person
+    return credited_author_link(record) unless person && allowed_to?(:edit?, person)
+
+    person_edit_button(person,
+                       display_name: record.author_credit,
+                       compact: true,
+                       width_class: "inline-flex w-fit",
+                       data: { turbo_frame: "_top" })
+  end
+
   # The person an author picker should show. Only the record's own author counts —
   # falling back to the creator would present a person nobody chose as the selected
   # author, and saving the form would silently promote them over a legacy credit.

--- a/app/views/monthly_reports/show.html.erb
+++ b/app/views/monthly_reports/show.html.erb
@@ -21,18 +21,8 @@
     <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
       <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
-          <span class="font-semibold text-gray-700">Submitted by:</span>
-          <% if @monthly_report.created_by&.person %>
-            <%= person_edit_button(@monthly_report.created_by.person, compact: true, width_class: "inline-flex w-fit", data: { turbo_frame: "_top" }) %>
-          <% elsif @monthly_report.created_by %>
-            <%= user_button(@monthly_report.created_by, data: { turbo_frame: "_top" }) %>
-          <% else %>
-            —
-          <% end %>
-        </div>
-        <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= credited_author_link(@monthly_report) %>
+          <%= credited_author_edit_button(@monthly_report) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Organization:</span>
@@ -53,18 +43,6 @@
           <span class="font-semibold text-gray-700">Report date:</span>
           <%= @monthly_report.date&.strftime("%B %d, %Y") || "—" %>
         </div>
-        <div>
-          <span class="font-semibold text-gray-700">Created by:</span>
-          <%= user_button(@monthly_report.created_by) if @monthly_report.created_by %>
-          <br><span class="text-gray-400"><%= @monthly_report.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-        </div>
-        <% if @monthly_report.updated_at != @monthly_report.created_at %>
-          <div>
-            <span class="font-semibold text-gray-700">Updated by:</span>
-            <%= @monthly_report.updated_by ? user_button(@monthly_report.updated_by) : "—" %>
-            <br><span class="text-gray-400"><%= @monthly_report.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-          </div>
-        <% end %>
       </div>
     </div>
 

--- a/app/views/workshop_logs/show.html.erb
+++ b/app/views/workshop_logs/show.html.erb
@@ -22,16 +22,8 @@
     <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
       <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
-          <span class="font-semibold text-gray-700">Submitted by:</span>
-          <% if @workshop_log.created_by %>
-            <%= user_button(@workshop_log.created_by, data: { turbo_frame: "_top" }) %>
-          <% else %>
-            <%= @workshop_log.created_by&.name || "—" %>
-          <% end %>
-        </div>
-        <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= credited_author_link(@workshop_log) %>
+          <%= credited_author_edit_button(@workshop_log) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Organization:</span>
@@ -69,18 +61,6 @@
           <% end %>
           <br><span class="text-gray-400"><%= @workshop_log.workshop_held_on&.strftime("%B %d, %Y") || "—" %></span>
         </div>
-        <div>
-          <span class="font-semibold text-gray-700">Created by:</span>
-          <%= @workshop_log.created_by&.name %>
-          <br><span class="text-gray-400"><%= @workshop_log.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-        </div>
-        <% if @workshop_log.updated_at != @workshop_log.created_at %>
-          <div>
-            <span class="font-semibold text-gray-700">Updated by:</span>
-            <%= @workshop_log.updated_by&.name || "—" %>
-            <br><span class="text-gray-400"><%= @workshop_log.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-          </div>
-        <% end %>
       </div>
     </div>
 

--- a/app/views/workshop_variation_ideas/show.html.erb
+++ b/app/views/workshop_variation_ideas/show.html.erb
@@ -50,16 +50,8 @@
     <div class="border-primary/10 rounded-2xl border bg-gray-50 p-4 text-sm text-gray-600">
       <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
         <div>
-          <span class="font-semibold text-gray-700">Submitted by:</span>
-          <% if @workshop_variation_idea.created_by %>
-            <%= user_button(@workshop_variation_idea.created_by, data: { turbo_frame: "_top" }) %>
-          <% else %>
-            <%= @workshop_variation_idea.created_by&.name || "—" %>
-          <% end %>
-        </div>
-        <div>
           <span class="font-semibold text-gray-700">Author credit:</span>
-          <%= credited_author_link(@workshop_variation_idea) %>
+          <%= credited_author_edit_button(@workshop_variation_idea) %>
         </div>
         <div>
           <span class="font-semibold text-gray-700">Permission given:</span>
@@ -94,19 +86,6 @@
             <%= @workshop_variation_idea.organization&.name || "—" %>
           <% end %>
         </div>
-        <div class="hidden md:block"></div>
-        <div>
-          <span class="font-semibold text-gray-700">Created by:</span>
-          <%= @workshop_variation_idea.created_by&.name %>
-          <br><span class="text-gray-400"><%= @workshop_variation_idea.created_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-        </div>
-        <% if @workshop_variation_idea.updated_at != @workshop_variation_idea.created_at %>
-          <div>
-            <span class="font-semibold text-gray-700">Updated by:</span>
-            <%= @workshop_variation_idea.updated_by&.name || "—" %>
-            <br><span class="text-gray-400"><%= @workshop_variation_idea.updated_at.in_time_zone.strftime("%Y-%m-%d %I:%M %P") %></span>
-          </div>
-        <% end %>
       </div>
     </div>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,6 +53,38 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "#credited_author_edit_button" do
+    let(:person) { create(:person, first_name: "Ada", last_name: "Lovelace") }
+    let(:workshop) { create(:workshop, author_credit_preference: "full_name") }
+
+    before { allow(workshop).to receive(:author).and_return(person) }
+
+    it "links to the person edit page when the viewer can edit people" do
+      allow(helper).to receive(:allowed_to?).with(:edit?, person).and_return(true)
+
+      html = helper.credited_author_edit_button(workshop)
+      expect(html).to include("<a")
+      expect(html).to include(edit_person_path(person))
+      expect(html).to include("Ada Lovelace")
+    end
+
+    it "falls back to the profile byline when the viewer cannot edit people" do
+      allow(helper).to receive(:allowed_to?).with(:edit?, person).and_return(false)
+      allow(person).to receive(:profile_is_searchable).and_return(true)
+
+      html = helper.credited_author_edit_button(workshop)
+      expect(html).to include(person_path(person))
+      expect(html).not_to include(edit_person_path(person))
+    end
+
+    it "stays plain text for a suppressed (anonymous) credit" do
+      anonymous = create(:workshop, author_credit_preference: "anonymous")
+      allow(anonymous).to receive(:author).and_return(person)
+
+      expect(helper.credited_author_edit_button(anonymous)).to eq("AWBW Staff")
+    end
+  end
+
   describe "#timezone_visibility_hint" do
     let(:me) { create(:user) }
     let(:other) { create(:user) }

--- a/spec/requests/monthly_reports_spec.rb
+++ b/spec/requests/monthly_reports_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "/monthly_reports", type: :request do
 
     it "renders sections for associated data" do
       get monthly_report_url(report)
-      expect(response.body).to include("Submitted by")
+      expect(response.body).to include("Author credit")
       expect(response.body).to include("Organization")
       expect(response.body).to include("Workshop")
       expect(response.body).to include("Uploads")

--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -69,15 +69,15 @@ RSpec.describe "/workshop_logs", type: :request do
       expect(page).to have_link(user.name, href: person_path(person))
     end
 
-    it "renders the creator as plain text when they have no person record" do
+    it "shows the facilitator author credit, not the submitting account, when the creator has no person record" do
       workshop_log = create(:workshop_log, created_by: user, organization: organization,
                             workshop: workshop, windows_type: windows_type, workshop_held_on: 1.day.ago)
 
       get workshop_log_path(workshop_log)
 
       page = Capybara.string(response.body)
-      expect(page).to have_text(user.name)
-      expect(page).not_to have_link(user.name)
+      expect(page).not_to have_text(user.name)
+      expect(page).to have_text(AuthorCreditable::FACILITATOR_AUTHOR_LABEL)
     end
 
     it "shows the external title in the heading and beside the Workshop label when there is no workshop" do
@@ -112,7 +112,7 @@ RSpec.describe "/workshop_logs", type: :request do
       let(:admin) { create(:user, :admin) }
       before { sign_in admin }
 
-      it "renders the organization and creator as links" do
+      it "renders the organization as a link and the author credit as an edit-person link" do
         person = create(:person, user: user)
         create(:affiliation, person: person, organization: organization)
         workshop_log = create(:workshop_log, created_by: user, organization: organization,
@@ -122,7 +122,7 @@ RSpec.describe "/workshop_logs", type: :request do
 
         page = Capybara.string(response.body)
         expect(page).to have_link(organization.name, href: organization_path(organization))
-        expect(page).to have_link(user.name, href: person_path(person))
+        expect(page).to have_link(user.name, href: edit_person_path(person))
       end
     end
   end

--- a/spec/requests/workshop_variation_ideas_spec.rb
+++ b/spec/requests/workshop_variation_ideas_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "/workshop_variation_ideas", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "renders the organization and creator as links" do
+      it "renders the organization as a link and the author credit as an edit-person link" do
         creator_person = create(:person, user: regular_user)
         org = create(:organization, name: "Community Arts Project")
         idea = create(:workshop_variation_idea, valid_attributes.merge(organization_id: org.id))
@@ -65,7 +65,7 @@ RSpec.describe "/workshop_variation_ideas", type: :request do
 
         page = Capybara.string(response.body)
         expect(page).to have_link(org.name, href: organization_path(org))
-        expect(page).to have_link(regular_user.name, href: person_path(creator_person))
+        expect(page).to have_link(regular_user.name, href: edit_person_path(creator_person))
       end
     end
 
@@ -209,14 +209,14 @@ RSpec.describe "/workshop_variation_ideas", type: :request do
         expect(page).to have_link(regular_user.name, href: person_path(person))
       end
 
-      it "renders the creator as plain text when they have no person record" do
+      it "shows the facilitator author credit, not the submitting account, when the creator has no person record" do
         idea = create(:workshop_variation_idea, valid_attributes)
 
         get workshop_variation_idea_path(idea)
 
         page = Capybara.string(response.body)
-        expect(page).to have_text(regular_user.name)
-        expect(page).not_to have_link(regular_user.name)
+        expect(page).not_to have_text(regular_user.name)
+        expect(page).to have_text(AuthorCreditable::FACILITATOR_AUTHOR_LABEL)
       end
 
       it "redirects from another's workshop_variation_idea to root" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view removal plus a small permission-gated author-credit helper

On the workshop log, monthly report, and workshop variation idea show pages, only the author credit is shown now — the submitter/creator identity was redundant and is account-level info that belongs on the admin-only edit pages, not these owner/member-visible pages. For admins, the author credit itself is now a clickable card that jumps straight to editing the credited person.

### What is the goal of this PR and why is this important?
Facilitators and members viewing one of these records should see who is credited as the author — not the login account that entered it. The account was shown twice ("Submitted by" duplicated "Created by") and exposed submitter identity on pages that aren't admin-only. Admins also wanted to click the author and land on that person's edit page.

### How did you approach the change?
Removed the "Submitted by", "Created by", and "Updated by" rows, leaving the anonymity-aware "Author credit". A new `credited_author_edit_button` helper renders that credit as the `person_edit_button` card (from #2453) when the viewer can edit people (admins); everyone else keeps the profile byline, and an anonymous credit stays plain text. The index-page "Submitted by" filters and the edit-page audit info are unchanged.

### Anything else to add?
Rebased on main to pick up the new `person_edit_button`. Request specs assert admins get the edit-person link and non-admins the profile byline; a helper spec covers the edit / fallback / anonymous branches.