### PR TITLE
Brand values from tokens: CTA shadow + both rainbow strips

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -219,6 +219,12 @@
   --text-2xs: 0.625rem; /* 10px */
   --text-3xs: 0.5rem;   /* 8px */
   --text-4xs: 0.375rem; /* 6px */
+
+  /* The brand CTA's raised bottom edge (see ButtonHelper::BRAND_CTA), pressed
+     on :active. Named here so the edge tracks the gold it sits under instead of
+     freezing a copy of it. */
+  --shadow-brand-cta: 0 4px 0 var(--color-brand-yellow-600);
+  --shadow-brand-cta-pressed: 0 2px 0 var(--color-brand-yellow-600);
 }
 
 /* Font face declarations */

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -63,9 +63,10 @@ module ButtonHelper
   end
 
   # The AWBW brand CTA button (marketing "Donate" / "Explore" style): gold fill,
-  # navy label, with a raised darker-gold bottom edge that presses on click.
+  # navy label, with a raised darker-gold bottom edge that presses on click. The
+  # edge comes from the --shadow-brand-cta theme token so it tracks the gold.
   # Register buttons layer on `font-display uppercase` — see BRAND_CTA_REGISTER.
-  BRAND_CTA = "inline-flex items-center justify-center gap-2 rounded-lg bg-brand-yellow-400 font-bold text-brand-navy-900 shadow-[0_4px_0_#bd9500] transition hover:bg-brand-yellow-300 active:translate-y-0.5 active:shadow-[0_2px_0_#bd9500]".freeze
+  BRAND_CTA = "inline-flex items-center justify-center gap-2 rounded-lg bg-brand-yellow-400 font-bold text-brand-navy-900 shadow-brand-cta transition hover:bg-brand-yellow-300 active:translate-y-0.5 active:shadow-brand-cta-pressed".freeze
   BRAND_CTA_REGISTER = "font-display tracking-wide uppercase".freeze
 
   def brand_cta_classes(register: false, extra: nil)

--- a/app/views/events/show/_rainbow.html.erb
+++ b/app/views/events/show/_rainbow.html.erb
@@ -1,2 +1,0 @@
-<%# The AWBW brand rainbow accent strip (matches the marketing site + story-share footer). %>
-<div class="h-1.5 w-full" style="background:linear-gradient(to right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)"></div>

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -1,7 +1,7 @@
 <%# Centered — brand-polished centered layout: a cream card holds the header
     image, and a second cream card below holds the title, details and body. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "events/show/rainbow" %>
+<%= render "shared/brand_accent_strip_alt" %>
 
 <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -1,7 +1,7 @@
 <%# Editorial — warm cream page, centred masthead with a hairline meta line, the
     description on a white paper card. Best for text-heavy events. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "events/show/rainbow" %>
+<%= render "shared/brand_accent_strip_alt" %>
 
 <div class="bg-brand-cream w-full">
   <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -1,7 +1,7 @@
 <%# Navy hero — bold navy gradient band with the title, details and register beside
     the framed header image; the description sits below on a light page. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "events/show/rainbow" %>
+<%= render "shared/brand_accent_strip_alt" %>
 
 <section class="from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 w-full bg-gradient-to-br text-white">
   <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%# Details sidebar — description flows left; a sticky card on the right holds the
     details and register actions. Best for long, info-dense events. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "events/show/rainbow" %>
+<%= render "shared/brand_accent_strip_alt" %>
 
 <div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>

--- a/app/views/shared/_brand_accent_strip.html.erb
+++ b/app/views/shared/_brand_accent_strip.html.erb
@@ -3,4 +3,4 @@
     rule still follows the card's rounded top corners.
     A second stop set lives in shared/_brand_accent_strip_alt — check which one a
     surface already uses before adding a strip to it. %>
-<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,#4e8324,#d56027,#ffcb05,#992a5b,#41006c,#24479e)]"></div>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-green-700),var(--color-brand-orange-600),var(--color-brand-yellow-400),var(--color-brand-magenta-800),var(--color-brand-purple-950),var(--color-brand-navy-800))]"></div>

--- a/app/views/shared/_brand_accent_strip.html.erb
+++ b/app/views/shared/_brand_accent_strip.html.erb
@@ -1,4 +1,6 @@
 <%# The AWBW rainbow rule that tops a branded page card (matches awbw.org).
     Pass rounded: true when the card is not clipping its own overflow, so the
-    rule still follows the card's rounded top corners. %>
+    rule still follows the card's rounded top corners.
+    A second stop set lives in shared/_brand_accent_strip_alt — check which one a
+    surface already uses before adding a strip to it. %>
 <div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,#4e8324,#d56027,#ffcb05,#992a5b,#41006c,#24479e)]"></div>

--- a/app/views/shared/_brand_accent_strip_alt.html.erb
+++ b/app/views/shared/_brand_accent_strip_alt.html.erb
@@ -1,0 +1,6 @@
+<%# The second AWBW rainbow rule — gold and teal where shared/_brand_accent_strip
+    runs yellow and purple. Used by the branded event templates and the
+    story-shares footer. Same locals as that partial: pass rounded: true when the
+    container is not clipping its own overflow, so the rule still follows the
+    container's rounded top corners. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>

--- a/app/views/shared/_brand_accent_strip_alt.html.erb
+++ b/app/views/shared/_brand_accent_strip_alt.html.erb
@@ -1,6 +1,6 @@
-<%# The second AWBW rainbow rule — gold and teal where shared/_brand_accent_strip
-    runs yellow and purple. Used by the branded event templates and the
-    story-shares footer. Same locals as that partial: pass rounded: true when the
-    container is not clipping its own overflow, so the rule still follows the
-    container's rounded top corners. %>
-<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+<%# The second AWBW rainbow rule — gold, navy and teal where
+    shared/_brand_accent_strip runs yellow, purple and navy. Used by the branded
+    event templates and the story-shares footer. Same locals as that partial:
+    pass rounded: true when the container is not clipping its own overflow, so
+    the rule still follows the container's rounded top corners. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-green-700),var(--color-brand-orange-600),var(--color-brand-yellow-500),var(--color-brand-magenta-800),var(--color-brand-navy-800),var(--color-brand-teal-600))]"></div>

--- a/app/views/story_shares/_portal_footer.html.erb
+++ b/app/views/story_shares/_portal_footer.html.erb
@@ -1,6 +1,5 @@
 <footer class="bg-brand-navy-950 text-white print:hidden">
-  <!-- Rainbow accent strip (AWBW brand) -->
-  <div class="h-1.5 w-full bg-[linear-gradient(to_right,#4e8324,#d56027,#e0b528,#9b2c5e,#24479e,#3aa0a0)]"></div>
+  <%= render "shared/brand_accent_strip_alt" %>
 
   <div class="mx-auto max-w-6xl px-4 py-14 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-4">

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -75,4 +75,26 @@ RSpec.describe ButtonHelper, type: :helper do
       expect { helper.button_classes(:nope) }.to raise_error(KeyError)
     end
   end
+
+  describe "#brand_cta_classes" do
+    it "renders the gold fill with the raised and pressed edge tokens" do
+      result = helper.brand_cta_classes
+
+      expect(result).to include("bg-brand-yellow-400", "text-brand-navy-900")
+      expect(result).to include("shadow-brand-cta", "active:shadow-brand-cta-pressed")
+    end
+
+    it "takes the edge from the theme token rather than a hard-coded hex" do
+      expect(helper.brand_cta_classes).not_to match(/#[0-9a-f]{6}/i)
+    end
+
+    it "layers the display face on register buttons only" do
+      expect(helper.brand_cta_classes(register: true)).to include("font-display", "uppercase")
+      expect(helper.brand_cta_classes).not_to include("font-display")
+    end
+
+    it "appends extra classes" do
+      expect(helper.brand_cta_classes(extra: "px-10 py-3")).to include("px-10", "py-3")
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small refactors, but one shifts a rainbow stop on 5 pages

Three brand values were living as literal hexes instead of coming from the palette. Two of the three changes are pixel-identical; one shifts a single gradient stop.

## CTA shadow token

The gold CTA drew its raised bottom edge from a literal `#bd9500` — exactly what `--color-brand-yellow-600` already holds. Retune the brand gold and the fill and hover would move (both tokens) while the edge stayed put.

- Now `--shadow-brand-cta` / `--shadow-brand-cta-pressed`, following how `--text-2xs` replaced the scattered arbitrary font sizes.
- Drops the helper's last arbitrary value; the class list is plain static utilities.
- Adds the first specs for `#brand_cta_classes`, which had none.
- No visual change.

## One home per rainbow

The app ships two different AWBW rainbow rules, previously spread across three copies: `shared/_brand_accent_strip` (24 sites), `events/show/_rainbow` (4), and a hand-rolled `<div>` in the story-shares footer (1). The last two carry an identical second stop set.

- Second set gets `shared/_brand_accent_strip_alt`, set up the same way as the first (same locals, same markup); all 5 sites point at it.
- `events/show/_rainbow.html.erb` deleted — it was also the only copy using an inline `style=` instead of a Tailwind class.
- No visual change from the move; verified by an unchanged Tailwind bundle hash.

## Both rainbows now come from the palette

Three stops in the second set were colors the brand palette does not contain. Each moves to its nearest real token:

| Stop | Was | Now | Shift |
|---|---|---|---|
| 3 | `#e0b528` *(no token)* | `brand-yellow-500` `#e6b704` | ΔE 7.7 — slightly richer gold |
| 4 | `#9b2c5e` *(no token)* | `brand-magenta-800` `#992a5b` | ΔE 1.1 — imperceptible |
| 6 | `#3aa0a0` *(no token)* | `brand-teal-600` `#008d80` | **ΔE 12.0 — the one visible change** |

**Stop 6 is the thing to look at.** A greyed teal becomes the true brand teal, most noticeable where it meets the navy story-shares footer.

The first rainbow is pixel-identical — its six stops were already exact token values; it just names them now.

Verified in the compiled CSS that both gradients build and every referenced var is emitted, including `--color-brand-teal-600`, which is reachable only from inside the arbitrary value.