### PR TITLE
Add an author picker to workshop log edit; stop edits overwriting the submitter

### DIFF
--- a/app/controllers/workshop_logs_controller.rb
+++ b/app/controllers/workshop_logs_controller.rb
@@ -40,7 +40,7 @@ class WorkshopLogsController < ApplicationController
     set_default_values
     @workshop_log = WorkshopLog.new(workshop_log_params)
     authorize! @workshop_log
-    @workshop_log.author ||= @workshop_log.created_by&.person
+    @workshop_log.author ||= current_user&.person
 
     if @workshop_log.save
       NotificationServices::CreateNotification.call(
@@ -198,8 +198,9 @@ class WorkshopLogsController < ApplicationController
   def workshop_log_params
     params.require(:workshop_log).permit(
       :children_ongoing, :children_first_time, :teens_ongoing, :teens_first_time,
-      :adults_ongoing, :adults_first_time, :created_by_id, :organization_id, :workshop_held_on,
+      :adults_ongoing, :adults_first_time, :organization_id, :workshop_held_on,
       :workshop_id, :windows_type_id, :external_workshop_title,
+      :author_id, :author_credit_preference,
       quotable_item_quotes_attributes: [
         :id, :quotable_type, :quotable_id, :_destroy,
         quote_attributes: [ :id, :body, :age, :workshop_id, :_destroy ] ],

--- a/app/views/workshop_logs/_form.html.erb
+++ b/app/views/workshop_logs/_form.html.erb
@@ -1,6 +1,5 @@
 <div class="rounded-xl bg-white p-6">
   <%= simple_form_for(@workshop_log) do |f| %>
-    <%= f.input :created_by_id, as: :hidden, input_html: { value: params[:created_by_id] || current_user.id } %>
     <%= f.input :windows_type_id, as: :hidden, input_html: { value: @windows_type_id } %>
 
     <!-- Error messages -->
@@ -66,6 +65,27 @@
                   label_html: { class: "block text-sm font-medium text-gray-700 mb-1" } %>
       </div>
     </div>
+
+    <% if allowed_to?(:manage?, WorkshopLog) %>
+      <div class="admin-only mb-6 space-y-4 rounded-md bg-blue-100 p-4">
+        <h2 class="text-lg font-semibold text-gray-800">Author credit</h2>
+        <%= f.input :author_id,
+                    as: :select,
+                    label: (f.object.author ? (
+                      link_to "Author",
+                              person_path(f.object.author),
+                              class: "hover:underline") : "Author").html_safe,
+                    collection: author_picker_person(f.object).present? ? [[ author_picker_person(f.object).remote_search_label[:label], author_picker_person(f.object).id ]] : [],
+                    selected: author_picker_person(f.object)&.id,
+                    hint: "Credited author — any person, not just active users. Defaults to the submitter; change to credit someone else.",
+                    input_html: {
+                      class: "block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
+                      data: { controller: "remote-select", remote_select_model_value: "person" } } %>
+        <%= render "shared/author_credit_note", record: f.object %>
+        <%= render "shared/author_credit_field", f: f %>
+        <%= render "shared/author_credit_warning", record: f.object %>
+      </div>
+    <% end %>
 
     <!-- Participants Section -->
     <hr class="my-6 border-gray-200">

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "Set who a workshop log is credited to"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-08-31
+  summary: >-
+    Admins can now credit a workshop log to a specific person on its edit page,
+    separate from the account that entered it. Editing a log also no longer
+    changes who is recorded as having submitted it.
+  action_path: /workshop_logs
+  pr_number: 2460
+
 - name: "Pick a layout template for each event page"
   area: events
   display_status: user_facing

--- a/spec/requests/people_notifications_spec.rb
+++ b/spec/requests/people_notifications_spec.rb
@@ -139,11 +139,13 @@ RSpec.describe "Person notifications", type: :request do
       get edit_person_path(person)
 
       doc = Nokogiri::HTML(response.body)
-      # Only admins reach the profile, so nothing inside the section carries the blue
-      # admin-only wash — buttons and cards alike render on the plain white card.
+      # Only admins reach the profile, so nothing inside the section carries the
+      # `admin-only` wash — buttons and cards alike render on the plain white card.
+      # (Per-author identity chips may independently be blue: chip_color hashes the
+      # author id onto a palette that includes bg-blue-100, so don't ban that class
+      # outright — the wash is signalled by the admin-only marker.)
       section = doc.at_css("#comments-section").to_s
       expect(section).not_to include("admin-only")
-      expect(section).not_to include("bg-blue-100")
       expect(response.body).to include("Internal staff note")
     end
   end

--- a/spec/requests/workshop_logs_spec.rb
+++ b/spec/requests/workshop_logs_spec.rb
@@ -420,6 +420,60 @@ RSpec.describe "/workshop_logs", type: :request do
     end
   end
 
+  describe "PATCH /update" do
+    let!(:combined_windows_type) { create(:windows_type, :combined) }
+    let!(:form_builder) do
+      fb = FormBuilder.create!(windows_type_id: combined_windows_type.id, name: "Combined form")
+      fb.forms.create!
+      fb
+    end
+    let(:submitter) { create(:user, person: create(:person)) }
+    let(:workshop_log) do
+      create(:workshop_log, created_by: submitter, organization: organization,
+                            workshop: workshop, windows_type: combined_windows_type, workshop_held_on: 1.day.ago)
+    end
+
+    context "as an admin" do
+      let(:admin) { create(:user, :admin) }
+      before { sign_in admin }
+
+      it "does not overwrite the original submitter when an admin edits the log" do
+        patch workshop_log_path(workshop_log), params: {
+          workshop_log: valid_attributes.merge(adults_ongoing: 9)
+        }
+
+        expect(workshop_log.reload.created_by).to eq(submitter)
+        expect(workshop_log.adults_ongoing).to eq(9)
+      end
+
+      it "reassigns the credited author to the chosen person" do
+        new_author = create(:person)
+
+        patch workshop_log_path(workshop_log), params: {
+          workshop_log: valid_attributes.merge(author_id: new_author.id)
+        }
+
+        expect(workshop_log.reload.author).to eq(new_author)
+      end
+
+      it "renders the author picker on the edit form" do
+        get edit_workshop_log_path(workshop_log)
+
+        expect(response.body).to include("workshop_log[author_id]")
+      end
+    end
+
+    context "as the owner" do
+      before { sign_in submitter }
+
+      it "does not render the author picker on the edit form" do
+        get edit_workshop_log_path(workshop_log)
+
+        expect(response.body).not_to include("workshop_log[author_id]")
+      end
+    end
+  end
+
   describe "DELETE /destroy" do
     it "destroys the workshop log and redirects to index" do
       workshop_log = create(:workshop_log, valid_attributes)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small controller/params change plus an audit-integrity fix, gated by policy

Admins can now credit a workshop log to a different person, and editing a log no longer silently steals the "submitted by" attribution.

### What is the goal of this PR and why is this important?
Admins needed to credit a log to someone other than the account that entered it (e.g. logging on a facilitator's behalf). Separately, editing a log used to overwrite `created_by` with whoever saved it — so the audit trail lied about who submitted it.

### How did you approach the change?
- Added an **admin-only** author section to the workshop-log form: an `author_id` person picker plus the credit-preference field/note/warning, mirroring the `workshops` form (`allowed_to?(:manage?, WorkshopLog)`).
- Removed the form's hidden `created_by_id` field and dropped `:created_by_id` from permitted params, so an edit can't reassign the submitter — `UserStampable` already stamps `created_by` on create.
- New-log author now defaults to the submitter's person directly (`current_user.person`), since the controller no longer reads a posted `created_by_id`.

### Anything else to add?
- Non-admins (owners) see no author picker. Request specs cover: an admin edit not overwriting `created_by`, admin reassigning the author, and the picker showing for admins but not owners. Independent of the "show only the author" PR (#2458); branched off main.
- **Rode along to unblock CI:** fixed a pre-existing flaky spec (`people_notifications_spec`) that banned any `bg-blue-100` inside the comments section — the per-author identity chips hash onto a palette that includes blue, so it failed whenever the author's id landed on the blue chip. Happy to split this into its own PR if preferred.
- Pre-existing latent 500 noted for awareness: `set_form_variables` (`FormBuilder…first&.forms.first` doesn't guard the second `.first`) surfaces only for a windows_type with no form builder. Left as out of scope.