### PR TITLE
HOLD UNTIL AFTER FM IMPORT: Remove unused legacy DB columns

### DIFF
--- a/app/controllers/concerns/tag_assignable.rb
+++ b/app/controllers/concerns/tag_assignable.rb
@@ -15,7 +15,7 @@ module TagAssignable
       # The form only edits certain category types (e.g. age ranges + workshop
       # settings). Preserve taggings of every other type the form never shows so
       # saving can't silently drop them — and assign the union so the join rows
-      # for preserved categories stay intact (is_primary/legacy_id untouched).
+      # for preserved categories stay intact (is_primary untouched).
       managed_type_ids = Array(params[key][:managed_category_type_ids]).reject(&:blank?).map(&:to_i)
       preserved = record.categories.reject { |category| managed_type_ids.include?(category.category_type_id) }
       record.categories = (preserved + selected).uniq

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -418,7 +418,7 @@ class UsersController < ApplicationController
       :email, :comment, :person_id, :inactive, :locked, :primary_address, :time_zone, :super_user, :favorite_event_id,
 
       ##### legacy to remove later
-      :legacy, :legacy_id, :subscribecode, :first_name, :last_name, # legacy to remove later
+      :subscribecode, :first_name, :last_name, # legacy to remove later
       :address, :address2, :city, :city2, :state, :state2, :zip, :zip2, # legacy to remove later
       :phone, :phone2, :phone3, :birthday, :best_time_to_call, :notes, # legacy to remove later
       #####

--- a/db/migrate/20260831200133_remove_unused_legacy_columns.rb
+++ b/db/migrate/20260831200133_remove_unused_legacy_columns.rb
@@ -1,0 +1,36 @@
+class RemoveUnusedLegacyColumns < ActiveRecord::Migration[7.2]
+  # Dead + soft-referenced `legacy`/`legacy_id` columns left over from the pre-portal
+  # import (rubyforgood/awbw#400). HOLD UNTIL AFTER the FileMaker prod-data import:
+  # the `legacy_id` columns map old FileMaker records during import, so they must
+  # survive until that finishes. Load-bearing legacy columns are intentionally kept:
+  # resources.legacy_author_name, workshops.legacy, workshop_variations.legacy,
+  # windows_types.legacy_id.
+  COLUMNS = {
+    categories: [ [ :legacy_id, :integer ] ],
+    categorizable_items: [ [ :legacy_id, :integer ] ],
+    category_types: [ [ :legacy_id, :string ] ],
+    organizations: [ [ :legacy, :boolean, { default: false } ], [ :legacy_id, :integer ] ],
+    permissions: [ [ :legacy_id, :integer ] ],
+    quotable_item_quotes: [ [ :legacy_id, :integer ] ],
+    quotes: [ [ :legacy, :boolean, { default: false } ], [ :legacy_id, :integer ] ],
+    resources: [ [ :legacy, :boolean ], [ :legacy_id, :integer ] ],
+    users: [ [ :legacy, :boolean, { default: false } ], [ :legacy_id, :integer ] ],
+    workshops: [ [ :legacy_id, :integer ] ]
+  }.freeze
+
+  def up
+    COLUMNS.each do |table, columns|
+      columns.each do |name, _type, _opts|
+        remove_column table, name, if_exists: true
+      end
+    end
+  end
+
+  def down
+    COLUMNS.each do |table, columns|
+      columns.each do |name, type, opts|
+        add_column table, name, type, **(opts || {}) unless column_exists?(table, name)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_200133) do
   create_table "action_text_mentions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "action_text_rich_text_id", null: false
     t.datetime "created_at", null: false
@@ -347,7 +347,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.text "description"
-    t.integer "legacy_id"
     t.string "name"
     t.integer "position", null: false
     t.boolean "published", default: false
@@ -368,7 +367,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.boolean "is_primary", default: false, null: false
-    t.integer "legacy_id"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "updated_by_id"
     t.index ["categorizable_type", "categorizable_id"], name: "idx_on_categorizable_type_categorizable_id_ccce65d80c"
@@ -382,7 +380,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
     t.string "display_text"
-    t.string "legacy_id"
     t.string "name"
     t.boolean "profile_specific", default: false, null: false
     t.boolean "published", default: false
@@ -1175,8 +1172,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.string "filemaker_code"
     t.boolean "high_profile", default: false, null: false
     t.string "internal_id"
-    t.boolean "legacy", default: false
-    t.integer "legacy_id"
     t.integer "location_id"
     t.text "mission_vision_values"
     t.string "name"
@@ -1416,7 +1411,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
 
   create_table "permissions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.integer "legacy_id"
     t.string "security_cat"
     t.datetime "updated_at", precision: nil, null: false
   end
@@ -1440,7 +1434,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
   create_table "quotable_item_quotes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "created_by_id"
-    t.integer "legacy_id"
     t.integer "quotable_id"
     t.string "quotable_type"
     t.integer "quote_id"
@@ -1460,8 +1453,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.integer "created_by_id"
     t.string "gender", limit: 1
     t.boolean "inactive", default: true
-    t.boolean "legacy", default: false
-    t.integer "legacy_id"
     t.text "original_body", size: :long
     t.boolean "published", default: false, null: false
     t.string "speaker_name"
@@ -1610,9 +1601,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.boolean "hidden_from_search", default: false, null: false
     t.boolean "inactive", default: true
     t.string "kind"
-    t.boolean "legacy"
     t.string "legacy_author_name"
-    t.integer "legacy_id"
     t.boolean "male", default: false
     t.integer "organization_id"
     t.integer "position"
@@ -1886,8 +1875,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.string "last_name", default: ""
     t.datetime "last_sign_in_at", precision: nil
     t.string "last_sign_in_ip"
-    t.boolean "legacy", default: false
-    t.integer "legacy_id"
     t.datetime "locked_at"
     t.text "notes", size: :long
     t.bigint "person_id"
@@ -2190,7 +2177,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_011834) do
     t.text "introduction_spanish", size: :long
     t.integer "led_count", default: 0
     t.boolean "legacy", default: false
-    t.integer "legacy_id"
     t.text "materials", size: :long
     t.text "materials_spanish", size: :long
     t.string "misc1"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -317,7 +317,7 @@ category_type_categories = [
   # ["Service Population", "Substance Abuse"], # now a Sector
   # ["Service Population", "Veterans & Military"], # now a Sector
 ]
-category_type_categories.each do |category_type_name, category_name, _legacy_id|
+category_type_categories.each do |category_type_name, category_name|
   next if category_type_name.nil?
 
   ct = find_or_create_by_name!(CategoryType, category_type_name, published: true)

--- a/db/seeds/dev/resources.rb
+++ b/db/seeds/dev/resources.rb
@@ -29,8 +29,6 @@ puts "Creating Resources…"
     kind: kind,
     url: [ "https://example.com/resource/#{SecureRandom.hex(4)}", nil ].sample,
     inactive: false,
-    legacy: [ true, false, false ].sample,
-    legacy_id: rand(1000..9999),
     position: rand(1..50),
     windows_type_id: WindowsType.all.sample&.id,
     workshop_id: Workshop.all.sample&.id,


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 mechanical column drops; verified none are referenced by logic/UI, but confirm the kept-vs-dropped split

Drops the dead and soft-referenced `legacy`/`legacy_id` columns left over from the pre-portal system so the schema stops carrying columns nothing reads.

**Held until after the FileMaker prod-data import** — the `legacy_id` columns map old FileMaker records during import, so this must not merge until that import is done.

Closes #400

## What's dropped (14 columns)
- **No references at all:** `organizations.legacy` + `legacy_id`, `quotes.legacy` + `legacy_id`, `resources.legacy` (bool), `quotable_item_quotes.legacy_id`, `workshops.legacy_id`, `permissions.legacy_id`.
- **Only soft references (permitted params / seeds):** `users.legacy` + `legacy_id`, `resources.legacy_id`, `categories.legacy_id`, `category_types.legacy_id`, `categorizable_items.legacy_id` — their references are removed in the same PR.

## Deliberately kept (still load-bearing)
- `resources.legacy_author_name` — active author-credit display/search.
- `workshops.legacy` — backs `scope :legacy`.
- `workshop_variations.legacy` — used in its decorator.
- `windows_types.legacy_id` — shown in the UI, permitted, seeded.

## Notes
- Migration is reversible (`up`/`down`, guarded); `down` re-adds every column with its original type/default.
- `permissions` has no model — its rake task reads `security_cat`/`id`, not `legacy_id`.