### PR TITLE
Count a no-show training as no facilitation: program status, Facilitators since, and a red chip

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -187,6 +187,13 @@ class OrganizationsController < ApplicationController
       Event.none
     end
 
+    # Trainings the org only ever registered for inactively — a no-show,
+    # cancellation, or transfer out with no active registration there. These earn a
+    # red attendance chip on the edit form instead of a program-status one, since a
+    # no-show confers no facilitation (ADR-0001 D8a). One representative
+    # registration per training, newest first.
+    @organization_inactive_training_registrations = inactive_only_training_registrations
+
     @org_categories_grouped = Category
       .includes(:category_type)
       .published
@@ -304,6 +311,22 @@ class OrganizationsController < ApplicationController
         [ org.filemaker_code.presence && "FileMaker #{org.filemaker_code}", org.program_location ].compact.join(" · ").presence
       }
     }
+  end
+
+  # One inactive registration per training the org never actively attended, newest
+  # first — the source for the edit form's red attendance chips (ADR-0001 D8a).
+  def inactive_only_training_registrations
+    return [] unless @organization.persisted?
+
+    active_event_ids = @organization.event_registrations.active.select(:event_id)
+    @organization.event_registrations.inactive
+                 .joins(:event)
+                 .where(events: { facilitator_training: true })
+                 .where.not(event_id: active_event_ids)
+                 .includes(:event)
+                 .sort_by { |registration| registration.event.start_date || Date.new(1900, 1, 1) }
+                 .reverse
+                 .uniq(&:event_id)
   end
 
   def find_duplicate_organizations(name)

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -99,11 +99,11 @@ class OrganizationDecorator < ApplicationDecorator
   # "Facilitators since" — facilitators only, at month precision, since the exact
   # start/lapse month is the point. Blank when the org has never facilitated.
   def program_since_display(affiliations = object.affiliations)
-    AffiliationPeriods.label(affiliations.select(&:facilitator?), precision: :month) || ""
+    AffiliationPeriods.label(facilitations(affiliations), precision: :month) || ""
   end
 
   def program_since_date
-    @program_since_date ||= object.affiliations.select(&:facilitator?).filter_map(&:start_date).min
+    @program_since_date ||= facilitations.filter_map(&:start_date).min
   end
 
   # A grey secondary line under "Facilitators since", shown only when the earliest
@@ -127,7 +127,7 @@ class OrganizationDecorator < ApplicationDecorator
   # never feeds into this (ADR-0001 D3). Upcoming (a facilitator scheduled but not
   # started) is distinct from Active and from a lapsed Formerly active.
   def organization_status_bucket
-    facilitators = object.affiliations.select(&:facilitator?)
+    facilitators = facilitations
     return :never_active if facilitators.none?
     return :active if facilitators.any?(&:active?)
     return :upcoming if facilitators.any?(&:upcoming?)
@@ -222,6 +222,15 @@ class OrganizationDecorator < ApplicationDecorator
   end
 
   private
+
+  # The facilitator rows that record real facilitation. A zero-length (start ==
+  # end) row is a no-show's deactivated stub, not a term served, so it feeds
+  # neither "Facilitators since" nor the Active / Formerly active bucket —
+  # matching FacilitatorProgramStatus (ADR-0001 D8a). Reads already-loaded
+  # affiliations, so list pages can pass their preloaded ones.
+  def facilitations(affiliations = object.affiliations)
+    affiliations.select { |affiliation| affiliation.facilitator? && !affiliation.zero_length? }
+  end
 
   def badge(label, key)
     {

--- a/app/frontend/javascript/controllers/affiliation_dates_controller.js
+++ b/app/frontend/javascript/controllers/affiliation_dates_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { isFacilitatorTitle } from "../lib/affiliation"
+import { isFacilitatorTitle, isZeroLength } from "../lib/affiliation"
 
 export default class extends Controller {
   static targets = ["facilitatorSince", "affiliatedNote", "affiliatedNoteText", "memberSinceFlag", "affiliationsContainer", "programStatus"]
@@ -52,7 +52,11 @@ export default class extends Controller {
     const now = new Date()
     const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()))
 
-    const facilitatorAffiliations = affiliations.filter(a => isFacilitatorTitle(a.title))
+    const titled = affiliations.filter(a => isFacilitatorTitle(a.title))
+    // The org form (mergedPeriods) reads the organization's program, which zero-length
+    // rows play no part in (ADR-0001 D8a) — matching OrganizationDecorator. The person
+    // form reports that person's own dates, so it keeps them.
+    const facilitatorAffiliations = this.mergedPeriodsValue ? titled.filter(a => !isZeroLength(a)) : titled
     const facStartDates = facilitatorAffiliations.map(a => a.startDate).filter(Boolean)
     const facilitatorSince = facStartDates.length
       ? new Date(Math.min(...facStartDates.map(d => new Date(d))))

--- a/app/frontend/javascript/lib/affiliation.js
+++ b/app/frontend/javascript/lib/affiliation.js
@@ -4,3 +4,10 @@
 export const facilitatorTitle = "Facilitator"
 
 export const isFacilitatorTitle = (title) => (title ?? "").trim() === facilitatorTitle
+
+// Mirrors Affiliation#zero_length? / .zero_length: a row that starts and ends on the
+// same day is a no-show's deactivated stub, not facilitation (ADR-0001 D8a). The org
+// form's readings drop these; a person's own facilitator dates keep them.
+export const isZeroLength = (affiliation) =>
+  Boolean(affiliation.startDate) && Boolean(affiliation.endDate) &&
+  new Date(affiliation.endDate).getTime() === new Date(affiliation.startDate).getTime()

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -78,6 +78,16 @@ class Affiliation < ApplicationRecord
   # title index usable). Titles are normalized on write, so no TRIM is needed.
   scope :facilitators, -> { where("affiliations.title = BINARY ?", FACILITATOR_TITLE) }
 
+  # SQL twin of #zero_length? — a row that starts and ends on the same day, and so
+  # records no facilitation (ADR-0001 D8a). `with_duration` is its complement: an
+  # unstarted or genuinely-spanning row. Kept in lock-step with the predicate by an
+  # executable agreement spec.
+  scope :zero_length, -> { where("affiliations.end_date = affiliations.start_date") }
+  scope :with_duration, -> {
+    where("affiliations.end_date IS NULL OR affiliations.start_date IS NULL
+           OR affiliations.end_date <> affiliations.start_date")
+  }
+
   # Affiliations whose #status_on(date) equals the given status, expressed in SQL
   # so it composes as a subquery (e.g. person-id narrowing). Kept in lock-step with
   # #status_on by an executable agreement spec.
@@ -121,8 +131,8 @@ class Affiliation < ApplicationRecord
 
   # Starts and ends on the same day — the shape a no-show / cancelled /
   # transferred-out training leaves once its minted facilitator row is deactivated
-  # (ADR-0001 D8a). It represents no facilitation, so program-status classification
-  # drops it.
+  # (ADR-0001 D8a). It represents no facilitation, so no organization-level reading
+  # of the facilitator program counts it. In-memory twin of the .zero_length scope.
   def zero_length?
     end_date.present? && end_date == start_date
   end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -119,6 +119,14 @@ class Affiliation < ApplicationRecord
     title.to_s.strip == FACILITATOR_TITLE
   end
 
+  # Starts and ends on the same day — the shape a no-show / cancelled /
+  # transferred-out training leaves once its minted facilitator row is deactivated
+  # (ADR-0001 D8a). It represents no facilitation, so program-status classification
+  # drops it.
+  def zero_length?
+    end_date.present? && end_date == start_date
+  end
+
   # Genuinely active now — the in-memory twin of the `active` scope and of
   # status_on == "Active", so already-loaded affiliations can be filtered in Ruby
   # without another query (e.g. on list pages that preload affiliations). A

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -129,10 +129,10 @@ class Affiliation < ApplicationRecord
     title.to_s.strip == FACILITATOR_TITLE
   end
 
-  # Starts and ends on the same day — the shape a no-show / cancelled /
-  # transferred-out training leaves once its minted facilitator row is deactivated
-  # (ADR-0001 D8a). It represents no facilitation, so no organization-level reading
-  # of the facilitator program counts it. In-memory twin of the .zero_length scope.
+  # Starts and ends on the same day — the shape a training leaves when nobody
+  # completed it: a no-show, a cancellation, a transfer out, or a partial attendance
+  # (only an attended training confers facilitation, ADR-0001 D8a). No organization-level
+  # reading of the program counts it. In-memory twin of the .zero_length scope.
   def zero_length?
     end_date.present? && end_date == start_date
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -118,9 +118,12 @@ class Organization < ApplicationRecord
   # Off facilitator affiliations only, never the legacy organization_status, so the
   # filter and the status chip can't disagree (ADR-0001 D3).
   scope :program_status, ->(bucket) {
-    fac_ids = Affiliation.facilitators.select(:organization_id)
-    active_fac_ids = Affiliation.facilitators.active.select(:organization_id)
-    upcoming_fac_ids = Affiliation.facilitators.with_status("Upcoming").select(:organization_id)
+    # with_duration for the same reason the chip drops zero-length rows: a no-show's
+    # deactivated stub is not facilitation (ADR-0001 D8a).
+    facilitations = Affiliation.facilitators.with_duration
+    fac_ids = facilitations.select(:organization_id)
+    active_fac_ids = facilitations.active.select(:organization_id)
+    upcoming_fac_ids = facilitations.with_status("Upcoming").select(:organization_id)
     case bucket.to_s
     when "active"            then where(id: active_fac_ids)
     when "upcoming"          then where(id: upcoming_fac_ids).where.not(id: active_fac_ids)

--- a/app/services/affiliation_services/reconcile_person.rb
+++ b/app/services/affiliation_services/reconcile_person.rb
@@ -272,8 +272,9 @@ module AffiliationServices
     end
 
     # Only the row this training minted, and only when the person didn't turn up at
-    # all. Partial attendance is something that happened: they were here for part of
-    # it, and deleting the row would erase that rather than record it as brief.
+    # all. A partial attendance is kept as an auditable record that they were here —
+    # it confers no facilitation either way (ADR-0001 D8a), but the row and its
+    # comments survive.
     def discardable?(affiliation)
       minted_here?(affiliation) && !partially_attended?
     end

--- a/app/services/facilitator_program_status.rb
+++ b/app/services/facilitator_program_status.rb
@@ -16,7 +16,9 @@ class FacilitatorProgramStatus
   def initialize(affiliations, as_of: nil)
     @as_of = (as_of || Date.current.beginning_of_year).to_date
     @year_anchored = as_of.nil?
-    @facilitators = affiliations.select { |affiliation| affiliation.facilitator? && affiliation.start_date }
+    @facilitators = affiliations.select do |affiliation|
+      affiliation.facilitator? && affiliation.start_date && !affiliation.zero_length?
+    end
   end
 
   # Views that show a year-anchored figure add a caveat saying so.
@@ -83,8 +85,9 @@ class FacilitatorProgramStatus
   def month(date) = date&.strftime("%b %Y")
 
   # Strictly before: an affiliation starting ON the anchor is the one this event
-  # minted (ADR-0001 D8), so a first-time org still reads New at its own training —
-  # including a same-day (start == end) affiliation dated to the event.
+  # minted (ADR-0001 D8), so a first-time org still reads New at its own training.
+  # Zero-length (start == end) rows are already dropped in the initializer (D8a), so
+  # a no-show at an earlier training can't count as prior history here.
   def earlier
     @earlier ||= @facilitators.select { |affiliation| affiliation.start_date < as_of }
   end

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -329,12 +329,15 @@
               <p>Overall status first (Active / Formerly active / Never active), then the facilitator-program status as of each event's date:<br>
                 • <span class="font-medium">New</span> — no facilitator affiliations yet<br>
                 • <span class="font-medium">Ongoing</span> — has an active facilitator<br>
-                • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).</p>
+                • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).<br>
+                A <span class="font-medium text-red-700">red chip</span> marks a training the org only registered for inactively (no show / cancelled / transferred out), which confers no program status.</p>
             </div>
             <div class="flex flex-wrap items-center gap-2 pt-1">
               <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }, admin: allowed_to?(:manage?, Organization)) %>
               <%= render "organizations/program_status_event_chips",
                          organization: f.object, events: org_events, return_to: "organization_edit" %>
+              <%= render "organizations/inactive_training_chips",
+                         registrations: @organization_inactive_training_registrations || [] %>
             </div>
           </div>
         <% end %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -330,7 +330,7 @@
                 • <span class="font-medium">New</span> — no facilitator affiliations yet<br>
                 • <span class="font-medium">Ongoing</span> — has an active facilitator<br>
                 • <span class="font-medium">Reinstated</span> — new again, but formerly active (all prior facilitations had ended).<br>
-                A <span class="font-medium text-red-700">red chip</span> marks a training the org only registered for inactively (no show / cancelled / transferred out), which confers no program status.</p>
+                A <span class="font-medium text-red-700">red chip</span> marks a training the org only registered for inactively (no show / cancelled / transferred out). It is not facilitation, so it counts toward neither the overall status nor the program status.</p>
             </div>
             <div class="flex flex-wrap items-center gap-2 pt-1">
               <%= org_decorated.organization_status_chip(data: { affiliation_dates_target: "programStatus" }, admin: allowed_to?(:manage?, Organization)) %>

--- a/app/views/organizations/_inactive_training_chips.html.erb
+++ b/app/views/organizations/_inactive_training_chips.html.erb
@@ -1,0 +1,11 @@
+<%# Trainings the org only registered for inactively (no-show / cancelled /
+    transferred out, never an active registration there). A no-show confers no
+    facilitation, so these read as a red attendance chip rather than a
+    program-status one (ADR-0001 D8a). %>
+<% registrations.each do |registration| %>
+  <% event = registration.event %>
+  <span class="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2.5 py-0.5 text-xs font-medium text-red-700"
+        title="<%= "#{event.title} — #{registration.attendance_status_label}: no active registration, so no program status." %>">
+    <%= registration.attendance_status_label %><%= " · #{event.start_date.strftime('%b %Y')}" if event.start_date %> · <%= event.decorate.compact_label.truncate(40) %>
+  </span>
+<% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,7 +38,7 @@
     attendance chip (No show / Cancelled / Transferred out) instead of a
     program-status one.
   action_path: /organizations
-  pr_number: 2454
+  pr_number: 2464
 
 - name: "Set who a workshop log is credited to"
   area: content

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,19 @@
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
+- name: "No-show trainings no longer count toward program status"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-31
+  summary: >-
+    A registrant who was a no-show, cancelled, or transferred out never became a
+    facilitator, so that training no longer counts an organization as New,
+    Ongoing, or Reinstated. On the org edit page those trainings now show a red
+    attendance chip (No show / Cancelled / Transferred out) instead of a
+    program-status one.
+  action_path: /organizations
+  pr_number: 2454
+
 - name: "Set who a workshop log is credited to"
   area: content
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -32,11 +32,9 @@
   display_status: admin_facing
   released_on: 2026-08-31
   summary: >-
-    A registrant who was a no-show, cancelled, or transferred out never became a
-    facilitator, so that training no longer counts an organization as New,
-    Ongoing, or Reinstated. On the org edit page those trainings now show a red
-    attendance chip (No show / Cancelled / Transferred out) instead of a
-    program-status one.
+    No-show, cancelled, and transferred-out trainings no longer count an
+    organization as New, Ongoing, or Reinstated. On the org edit page they now
+    show a red attendance chip instead of a program-status one.
   action_path: /organizations
   pr_number: 2464
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -32,9 +32,10 @@
   display_status: admin_facing
   released_on: 2026-08-31
   summary: >-
-    No-show, cancelled, and transferred-out trainings no longer count an
-    organization as New, Ongoing, or Reinstated. On the org edit page they now
-    show a red attendance chip instead of a program-status one.
+    No-show, cancelled, and transferred-out trainings no longer count as
+    facilitation: not toward New / Ongoing / Reinstated, not toward
+    "Facilitators since", and not toward Active / Formerly active. On the org
+    edit page they now show a red attendance chip instead.
   action_path: /organizations
   pr_number: 2464
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -148,8 +148,8 @@ facilitator affiliations by a single class, `FacilitatorProgramStatus`:
 
 - **New** — no facilitator affiliation started **before** the anchor (strict `<`).
   An affiliation dated **on** the anchor is the one this event mints (D8), so a
-  first-time org reads New at its own training — including a **same-day**
-  (`start == end`) affiliation dated to the event.
+  first-time org reads New at its own training. A **zero-length** (`start == end`)
+  row is dropped as non-facilitation before judging (D8a).
 - **Ongoing** — an earlier facilitator affiliation is **still active** on the
   anchor (no end date, or it ends on/after it).
 - **Reinstated** — earlier facilitator affiliation(s) existed but **all ended**
@@ -238,6 +238,32 @@ history" for its own training. An event with no start date is the one gap — th
 affiliation then falls back to the creation date. That event has no anchor either,
 so both its dashboard and the annual report read it as year-anchored (D7) rather
 than one of them silently using "today".
+
+### D8a — Zero-length facilitator affiliations don't count as facilitation
+
+A no-show / cancelled / transferred-out facilitator-training registration leaves a
+**zero-length** (`start_date == end_date`) Facilitator affiliation: D8 mints the row
+dated to the training, then reconciliation ends it — and it can't end before it
+starts, so `deactivation_end_date` clamps the end to the start date
+(`AffiliationServices::ReconcilePerson`). That row represents **no facilitation**, so
+`FacilitatorProgramStatus` **drops every zero-length facilitator affiliation** before
+judging (`Affiliation#zero_length?`).
+
+**This reverses D8's same-day handling.** D8 read a same-day (`start == end`)
+affiliation dated to the event as the training's own minted row, so a first-time org
+still read **New** at that training. That verdict is unchanged — a dropped row leaves
+no facilitator history, which is still New — but the *reason* is now "no facilitation
+here," not "minted here." What D8 got wrong is the **later** anchor: a zero-length row
+from an earlier no-show would count as prior-but-ended history and wrongly **Reinstate**
+the org at a later training, or let a no-show **invent a New** at an event nobody
+attended. Neither happens now. Open-ended minted rows (`end_date` nil) are untouched;
+only genuinely zero-length rows are dropped.
+
+The org **edit form** makes this legible: a training the org **only** registered for
+inactively (no active registration there) gets a **red attendance chip** — "No show" /
+"Cancelled" / "Transferred out" — instead of a program-status chip
+(`organizations/_inactive_training_chips`). A training keeps its program-status chip if
+the org has **any** active registration there.
 
 ### D9 — Annual reporting counts organizations two ways
 

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -261,6 +261,13 @@ anchored verdict, and not the "now" question of D3:
 - `Organization.program_status` — the index filter — drops it too, so the SQL filter
   and the chip it filters on still agree (D3).
 
+**Only an attended training confers facilitation.** A *partial* attendance
+(`incomplete_attendance`) leaves the same zero-length shape — ADR-0003 D6 ends that row
+rather than deleting it, and an end date can't precede its own start — and it counts for
+nothing here either. Being present for part of a training is kept **on the record**
+(the row and its comments survive); it is not a facilitation period. ADR-0003 D6 is
+amended to match.
+
 The rule lives in one place at each end: `Affiliation#zero_length?` and its SQL twin
 `Affiliation.zero_length` / `.with_duration`, locked together by an agreement spec.
 Person-level facilitator surfaces (`PersonDecorator`) are unchanged — they answer a

--- a/docs/adr/0001-organization-affiliation-and-program-status.md
+++ b/docs/adr/0001-organization-affiliation-and-program-status.md
@@ -88,6 +88,10 @@ precedence order:
 - Facilitator affiliation(s), but **all ended** → **Formerly active**
 - **No** facilitator affiliation → **Never active**
 
+"Facilitator affiliation" here means one that records real facilitation: a
+zero-length (`start == end`) row is a no-show's deactivated stub and counts for
+nothing, on this question as on the anchored one (D8a).
+
 Upcoming is distinct from Formerly active: an org whose only facilitator is
 scheduled for a future training was never active, so it must not read as
 "Formerly active".
@@ -246,8 +250,21 @@ A no-show / cancelled / transferred-out facilitator-training registration leaves
 dated to the training, then reconciliation ends it — and it can't end before it
 starts, so `deactivation_end_date` clamps the end to the start date
 (`AffiliationServices::ReconcilePerson`). That row represents **no facilitation**, so
-`FacilitatorProgramStatus` **drops every zero-length facilitator affiliation** before
-judging (`Affiliation#zero_length?`).
+**no organization-level reading of the facilitator program counts it** — not the
+anchored verdict, and not the "now" question of D3:
+
+- `FacilitatorProgramStatus` drops it before judging New / Ongoing / Reinstated.
+- `OrganizationDecorator` drops it from **"Facilitators since"** (`program_since_display`
+  / `program_since_date`) and from the **Active / Formerly active / Never active**
+  bucket, so an org whose only Facilitator row is a no-show's stub reads **Never
+  active** with no facilitator period rather than "Formerly active · Aug 2026 – Aug 2026".
+- `Organization.program_status` — the index filter — drops it too, so the SQL filter
+  and the chip it filters on still agree (D3).
+
+The rule lives in one place at each end: `Affiliation#zero_length?` and its SQL twin
+`Affiliation.zero_length` / `.with_duration`, locked together by an agreement spec.
+Person-level facilitator surfaces (`PersonDecorator`) are unchanged — they answer a
+different question (ADR-0003) and no organization status is read from them.
 
 **This reverses D8's same-day handling.** D8 read a same-day (`start == end`)
 affiliation dated to the event as the training's own minted row, so a first-time org

--- a/docs/adr/0003-affiliations-as-the-record-of-two-relationships.md
+++ b/docs/adr/0003-affiliations-as-the-record-of-two-relationships.md
@@ -185,9 +185,19 @@ facilitator affiliation depends on what that row represents:
   (`incomplete_attendance`) — **ended**, not deleted. Provenance is not the whole
   test: the question is whether anything happened. A no-show or a cancellation means
   the assumption never came true and there is nothing to keep; a partial attendance
-  means they were here, and deleting the row would erase that instead of recording a
-  facilitator term that was brief. It same-days (the end date can't precede its own
-  start), so it reads as a term that began and ended on the training's day.
+  means they were here, so the row and its comments stay **on the record**. It
+  same-days (the end date can't precede its own start).
+
+  **Kept on the record is not the same as counted.** This bullet originally read that
+  same-day row as "a facilitator term that was brief"; it is not one.
+  [ADR-0001](0001-organization-affiliation-and-program-status.md) **D8a** drops every
+  zero-length row from every organization-level figure, and **only an attended training
+  confers facilitation** — so a partial attendance leaves an auditable row that counts
+  toward nothing. Two consequences to know: the bulk reconcile page **disables
+  Deactivate for a row this training minted** and preselects Delete, so in practice
+  these rows are usually deleted by an admin rather than same-dayed; and the org still
+  appears normally *at that training* either way, because `incomplete_attendance` is an
+  active registration status.
 
 **Everything ends the day BEFORE the training. One rule, no exceptions**, matching
 `AffiliationServices::ApplyScenarioEndDating`

--- a/docs/affiliations-and-program-status.md
+++ b/docs/affiliations-and-program-status.md
@@ -1,0 +1,259 @@
+# How affiliations and organization status work
+
+The Portal shows several figures about an organization that are easy to mix up:
+**Affiliated since**, **Facilitators since**, the org's **status chip** (Active /
+Formerly active / …), and the per-training **program status** chips (New / Ongoing /
+Reinstated). They come from the same place — the people linked to the org — but they
+answer different questions.
+
+This doc explains what each one means, what creates them, and what changes them.
+
+---
+
+## The big idea
+
+An **affiliation** is a link between one person and one organization. It has a
+**title**, a **start date**, and an **end date**.
+
+There are two kinds, and they are not interchangeable:
+
+| Kind | Title | What it says | Dates |
+|---|---|---|---|
+| **Job affiliation** | Anything else — "Counselor", "Program Director", even "Lead Facilitator" | Who this person *is* to the org | Usually none — we rarely know when they took the job |
+| **Facilitator affiliation** | Exactly **"Facilitator"** | This org was **running an art program**, staffed by this person, over this period | Dated to the training that conferred it |
+
+**Only facilitator affiliations decide anything about the organization's program.** A
+job affiliation never makes an org active and is never touched by reconciliation. One
+person usually has both at the same org — a "Lead Facilitator" job affiliation *and* a
+plain "Facilitator" one.
+
+> The title must be **exactly** "Facilitator". "Lead Facilitator" and "facilitator"
+> are job titles, not facilitator affiliations. If an org looks wrong, this is the
+> first thing to check.
+
+Everything else in this doc is the Portal answering **two separate questions** off
+those facilitator affiliations:
+
+1. **Is this organization running a program now?** → the status chip.
+2. **What was this organization at this training?** → the program status chip.
+
+They can legitimately disagree. An org can read **Ongoing** at a training in 2022 and
+**Formerly active** today — that's not a bug, it's two questions about two moments.
+
+---
+
+## Where facilitator affiliations come from
+
+- **Registering someone for a facilitator training** and linking them to an
+  organization creates their facilitator affiliation, **dated to the training's start
+  date** — not to the day they registered.
+- **Registering for anything that isn't a facilitator training** creates the job
+  affiliation only. Attending an event does not make anyone a facilitator.
+- **By hand** — you can add, edit, and end affiliations on the person's edit page, the
+  organization's edit page, or the affiliation's own edit page.
+- **Reconcile affiliations** (after the training) trues them up against who actually
+  turned up. See below.
+
+---
+
+## Question 1 — Is this organization running a program now?
+
+The status chip on the org index, profile, and edit page. Checked in this order:
+
+| Chip | Means |
+|---|---|
+| **Active** | Someone's facilitator affiliation is current |
+| **Upcoming** | A facilitator is scheduled (future start date) but none is current yet |
+| **Formerly active** | There were facilitators, but every one of them has ended |
+| **Never active** | No facilitator affiliation at all |
+
+- **Upcoming is admin-only.** Non-admins see a not-yet-started program as plain
+  "Inactive", coloured like Never active — the public view reflects today, not a
+  scheduled future.
+- **The filter has one more option than the chip.** The org index and people directory
+  offer **Active / Inactive / Upcoming / Formerly active / Never active**. "Inactive"
+  is the umbrella: everything that isn't currently active, including Upcoming.
+- **On the edit page the chip updates live** as you type dates into the affiliation
+  rows, so you can see what a change will do before saving.
+
+**The old stored "Organization status" field is not used for any of this.** It is
+legacy data that drifted. It survives only to raise the mismatch warning on the edit
+page when it contradicts the affiliations — expect that warning on a fair number of
+orgs.
+
+---
+
+## Question 2 — What was this organization at this training?
+
+The program status chip, judged **as of one date** — normally the training's start
+date:
+
+| Chip | Means |
+|---|---|
+| **New** | No facilitator affiliation started **before** that date |
+| **Ongoing** | An earlier facilitator affiliation was **still running** on that date |
+| **Reinstated** | There were earlier facilitator affiliations, but all had **ended** before that date — a lapse, now returning |
+
+Two things follow from "before":
+
+- **A first-time org reads New at its own training.** The affiliation that training
+  creates starts *on* the training date, which isn't "before" it.
+- **Revisiting an old event always reports what was true then.** These figures back
+  grant applications, so the same question about the same past date must give the same
+  answer forever.
+
+**Where there's no event in view** — the cross-event attendees index and its charts —
+the status reads **as of January 1 of the current year** ("where each program stands
+this reporting year"). Those pages say so.
+
+Every chip has a **hover explanation**: the date it was judged on, when the program
+went (or last was) active, and the full facilitator history.
+
+---
+
+## "Affiliated since" vs "Facilitators since"
+
+| Figure | Counts | Shown as | Where |
+|---|---|---|---|
+| **Affiliated since** | **All** affiliations, any title | Merged year periods, e.g. `2010-2012, 2026`; falls back to the org's own start date | Org profile, org edit page |
+| **Facilitators since** | **Facilitator** affiliations only | Merged **month** periods, e.g. `Aug 2015 – Jun 2018, Feb 2024`; blank if the org never facilitated | Org index column, org profile, org edit page |
+
+Both merge overlapping periods and show a real gap as a gap — a lapse and return reads
+as two periods, not one unbroken range.
+
+---
+
+## What does not count as facilitation
+
+- **A title that isn't exactly "Facilitator."**
+- **A non-training event.** Attendance alone confers nothing.
+- **A training the person didn't complete.** A no-show, a cancellation, or a transfer
+  out never made anyone a facilitator, so it counts toward nothing: not New / Ongoing /
+  Reinstated, not "Facilitators since", not Active / Formerly active.
+- **A facilitator affiliation that starts and ends on the same day**, which is the
+  trace a not-completed training leaves behind.
+
+On the org edit page, a training the org **only** registered for inactively gets a
+**red attendance chip** — "No show", "Cancelled", "Transferred out" — instead of a
+program status chip. If **anyone** from the org had an active registration at that
+training, it keeps its normal program status chip.
+
+---
+
+## After a training: reconciling affiliations
+
+Open the event → **Bulk actions → Reconcile affiliations**. Every facilitator
+affiliation for a linked org is compared against attendance, a suggested outcome is
+preselected, and every row also has a leave-it-alone option. **Preview changes** shows
+what will happen before anything is written.
+
+| Outcome | When it's offered | What it does |
+|---|---|---|
+| **Create new FA** | They attended but have no facilitator affiliation | Adds one, dated to the training |
+| **Keep active** | Anything | Leaves the row alone |
+| **Delete affiliation** | The row **this** training created, and they never turned up | Removes it — it recorded an assumption that never came true |
+| **Deactivate affiliation** | An **older** row (hand-entered, or from an earlier training) | Ends it — never deletes it, because it records facilitation that really happened |
+| **Reactivate** | A row this reconciliation previously ended, now that attendance says otherwise | Reopens it, with no lapse recorded |
+| **Move to the new event** | They transferred to another training | Re-dates the affiliation to the new training instead of ending it |
+
+Two rules worth knowing:
+
+- **Endings land the day *before* the training.** A row that ended the same day
+  another starts would count on both and double the person in any date total — and the
+  row is being ended precisely because we have no record they completed a training
+  there, so it must not still count as active on that date.
+- **A transfer is not a failure.** The affiliation follows the person to the
+  destination training rather than being ended.
+
+Whatever reconciliation does, it leaves a **comment on the affiliation** saying why.
+
+---
+
+## Editing affiliations by hand — what moves what
+
+| What you change | What it moves |
+|---|---|
+| **Start date** | History. It changes what the org reads at **every** training after that date |
+| **End date** | History, the same way — and today's status once the date is past |
+| **The Inactive flag** | Today's status only. Past verdicts don't move |
+| **Deleting the row** | Both — the org reads as if that facilitation never happened |
+| **The title** | Everything, if you're moving a row into or out of exactly "Facilitator" |
+
+The **Inactive** flag exists so you can end someone effective *now* without inventing a
+false end date — for example a one-day training that starts and ends today, where the
+dates alone would still read as active for the rest of the day.
+
+> Anything that changes a date is a change to the historical record that grant
+> reporting rests on. Prefer the Inactive flag when you mean "they're done as of now,"
+> and change dates only when the dates were wrong.
+
+---
+
+## Reading the reports
+
+- **Event dashboard** — the New / Ongoing / Reinstated breakdown for that training,
+  one count per organization, judged at that training's date. Only orgs with an
+  **active** registration are counted.
+- **Reports → Program status** — per training, grouped by year, with **two** counts,
+  always labelled because they answer different questions:
+  - **Organization-trainings** — one count per org per training. An org at three
+    trainings in a year counts three times.
+  - **Distinct organizations** — each org once for the period, classified at the
+    **earliest** training it appeared at.
+- **Attendees index** — spans events, so it is anchored on January 1 of the current
+  year and says so.
+- **Scholarships** — each award is judged at the training it paid for, so two awards
+  side by side are read at their own events rather than at one page-wide "today".
+
+---
+
+## Quick answers
+
+| "Why does this org…" | Because |
+|---|---|
+| …say **Never active** when someone's clearly linked? | Their title isn't exactly "Facilitator", or their only training was a no-show |
+| …say **New** at a training it has attended before? | The earlier training didn't leave a facilitator affiliation — check for a red attendance chip on its edit page |
+| …say **Reinstated** rather than Ongoing at a training? | Every earlier facilitator affiliation had ended before that date. Reconciliation ends rows the day before a training nobody completed, which produces exactly this |
+| …read **Ongoing** in 2022 but **Formerly active** today? | Those are the two different questions. Both are correct |
+| …show a **status mismatch warning**? | The legacy stored status field disagrees with the affiliations. The affiliations win; the warning is there to surface the drift |
+| …have a **red chip** on a training? | Nobody from the org had an active registration there — no show, cancelled, or transferred out |
+
+---
+
+## Glossary
+
+- **Affiliation** — a person ↔ organization link with a title and dates.
+- **Facilitator affiliation** — an affiliation titled exactly "Facilitator"; the only
+  kind that affects the organization's program status.
+- **Job affiliation** — any other title; records the person's role, nothing more.
+- **Anchor date** — the date a program status is judged on, normally a training's start
+  date, otherwise January 1 of the current year.
+- **Reconciliation** — comparing an event's facilitator affiliations against who
+  actually attended, and creating / ending / deleting / moving them accordingly.
+- **Inactive flag** — ends an affiliation as of now without changing its dates.
+
+---
+
+## Known gaps
+
+- **Partial attendance.** Someone marked *incomplete attendance* has their affiliation
+  ended on the training day itself, which is the same shape a no-show leaves — so it
+  currently drops out of the program figures alongside the no-shows. Whether a partial
+  attendance should count as a brief facilitation is under review.
+- **A person's own page still shows the training.** The organization's figures ignore a
+  not-completed training; the person's own facilitator dates are a separate question
+  and are unchanged.
+- **Old affiliation dates.** Rows created before mid-2026 may be dated to the 1st of
+  the month rather than to the training, which can make an org read Ongoing at a
+  same-month training where it should read New. Worth checking before trusting a
+  historical year's "New" figures.
+
+---
+
+## For developers
+
+The rules and the reasoning behind them are pinned in
+[ADR-0001](adr/0001-organization-affiliation-and-program-status.md) (the figures, the
+anchor date, the boundaries) and
+[ADR-0003](adr/0003-affiliations-as-the-record-of-two-relationships.md) (what an
+affiliation records, and what reconciliation may do to it).

--- a/docs/affiliations-and-program-status.md
+++ b/docs/affiliations-and-program-status.md
@@ -127,11 +127,17 @@ as two periods, not one unbroken range.
 
 - **A title that isn't exactly "Facilitator."**
 - **A non-training event.** Attendance alone confers nothing.
-- **A training the person didn't complete.** A no-show, a cancellation, or a transfer
-  out never made anyone a facilitator, so it counts toward nothing: not New / Ongoing /
-  Reinstated, not "Facilitators since", not Active / Formerly active.
+- **A training the person didn't complete.** Only an **Attended** training confers
+  facilitation. A no-show, a cancellation, a transfer out, or a **partial attendance**
+  counts toward nothing: not New / Ongoing / Reinstated, not "Facilitators since", not
+  Active / Formerly active.
 - **A facilitator affiliation that starts and ends on the same day**, which is the
   trace a not-completed training leaves behind.
+
+A partial attendance is still **kept on the record** — the affiliation and its
+comments stay, and the organization still appears normally in that training's own
+dashboard and report figures, because it was an active registration. What it doesn't
+do is give the organization a facilitation period going forward.
 
 On the org edit page, a training the org **only** registered for inactively gets a
 **red attendance chip** — "No show", "Cancelled", "Transferred out" — instead of a
@@ -236,10 +242,6 @@ dates alone would still read as active for the rest of the day.
 
 ## Known gaps
 
-- **Partial attendance.** Someone marked *incomplete attendance* has their affiliation
-  ended on the training day itself, which is the same shape a no-show leaves — so it
-  currently drops out of the program figures alongside the no-shows. Whether a partial
-  attendance should count as a brief facilitation is under review.
 - **A person's own page still shows the training.** The organization's figures ignore a
   not-completed training; the person's own facilitator dates are a separate question
   and are unchanged.

--- a/spec/decorators/organization_decorator_spec.rb
+++ b/spec/decorators/organization_decorator_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe OrganizationDecorator do
       create(:affiliation, organization: organization, person: create(:person), title: "Facilitator", start_date: Date.new(2024, 2, 1), end_date: nil)
       expect(organization.reload.decorate.program_since_display).to eq("Jan 2015 – Jun 2018, Feb 2024")
     end
+
+    it "ignores a zero-length row, which records no facilitation (ADR-0001 D8a)" do
+      create(:affiliation, organization: organization, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2026, 8, 1), end_date: Date.new(2026, 8, 1), inactive: true)
+      expect(organization.reload.decorate.program_since_display).to eq("")
+    end
   end
 
   describe "#affiliated_since_note" do
@@ -119,6 +125,18 @@ RSpec.describe OrganizationDecorator do
       create(:affiliation, organization: org, person: person, title: "Facilitator", start_date: 3.years.ago, end_date: 1.year.ago)
       create(:affiliation, organization: org, person: create(:person), title: "Facilitator", start_date: 1.month.from_now, end_date: nil)
       expect(org.reload.decorate.organization_status_bucket).to eq(:upcoming)
+    end
+
+    it "is :never_active when the only facilitator row is a no-show's zero-length stub" do
+      # Same rule as the anchored verdict: start == end is no facilitation, so the
+      # org never became active (ADR-0001 D8a).
+      org = create(:organization)
+      create(:affiliation, organization: org, person: create(:person), title: "Facilitator",
+                           start_date: Date.new(2026, 8, 1), end_date: Date.new(2026, 8, 1), inactive: true)
+
+      expect(org.reload.decorate.organization_status_bucket).to eq(:never_active)
+      expect(Organization.program_status(:never_active)).to include(org)
+      expect(Organization.program_status(:formerly_active)).not_to include(org)
     end
   end
 

--- a/spec/models/affiliation_spec.rb
+++ b/spec/models/affiliation_spec.rb
@@ -187,6 +187,34 @@ RSpec.describe Affiliation, type: :model do
     end
   end
 
+  describe '.zero_length / .with_duration' do
+    let!(:zero_length) { create(:affiliation, start_date: Date.new(2026, 8, 1), end_date: Date.new(2026, 8, 1)) }
+    let!(:spanning) { create(:affiliation, start_date: Date.new(2026, 8, 1), end_date: Date.new(2026, 8, 2)) }
+    let!(:open_ended) { create(:affiliation, start_date: Date.new(2026, 8, 1), end_date: nil) }
+    let!(:no_start) { create(:affiliation, start_date: nil, end_date: Date.new(2026, 8, 1)) }
+    let!(:no_dates) { create(:affiliation, start_date: nil, end_date: nil) }
+
+    it 'matches only rows that start and end on the same day' do
+      expect(described_class.zero_length).to contain_exactly(zero_length)
+    end
+
+    it 'is partitioned by .with_duration, which keeps rows missing either date' do
+      expect(described_class.with_duration).to contain_exactly(spanning, open_ended, no_start, no_dates)
+    end
+  end
+
+  describe 'zero-length seam (#zero_length? <-> .zero_length agree)' do
+    it '.zero_length returns exactly the saved rows whose #zero_length? is true' do
+      day = Date.new(2026, 8, 1)
+      [ [ day, day ], [ day, day + 1 ], [ day, nil ], [ nil, day ], [ nil, nil ] ]
+        .each { |start_date, end_date| create(:affiliation, start_date: start_date, end_date: end_date) }
+
+      in_ruby = described_class.all.select(&:zero_length?).map(&:id).sort
+      expect(described_class.zero_length.ids.sort).to eq(in_ruby)
+      expect(described_class.with_duration.ids.sort).to eq(described_class.all.reject(&:zero_length?).map(&:id).sort)
+    end
+  end
+
   describe 'title normalization on write' do
     it 'stores the title trimmed' do
       affiliation = create(:affiliation, title: "  Facilitator ")

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -205,6 +205,38 @@ RSpec.describe "/organizations", type: :request do
       expect(response.body).to include("Qwultz Training")
       expect(response.body).not_to include("Zibberpicnic Social")
     end
+
+    it "renders a red attendance chip for a training the org only registered for inactively" do
+      organization = Organization.create!(valid_attributes)
+      no_show_training = create(:event, title: "Skipped Training", abbreviation: "SKP101",
+                                        facilitator_training: true, start_date: Date.new(2026, 8, 1))
+      registration = create(:event_registration, registrant: create(:person),
+                                                 event: no_show_training, status: "no_show")
+      registration.event_registration_organizations.create!(organization: organization)
+
+      get edit_organization_url(organization)
+
+      chip = Capybara.string(response.body).all("span", text: /SKP101/).first
+      expect(chip.native.text).to match(/No show .* SKP101/)
+      expect(chip[:class]).to include("text-red-700")
+    end
+
+    it "keeps a training's program-status chip when the org has any active registration there" do
+      organization = Organization.create!(valid_attributes)
+      create(:affiliation, organization: organization, person: create(:person),
+                           title: "Facilitator", start_date: Date.new(2020, 1, 1))
+      training = create(:event, title: "Half Skipped", abbreviation: "HLF101",
+                                facilitator_training: true, start_date: Date.new(2026, 8, 1))
+      [ "registered", "no_show" ].each do |status|
+        registration = create(:event_registration, registrant: create(:person), event: training, status: status)
+        registration.event_registration_organizations.create!(organization: organization)
+      end
+
+      get edit_organization_url(organization)
+
+      expect(response.body).to match(/Ongoing .* HLF101/)
+      expect(response.body).not_to match(/No show .* HLF101/)
+    end
   end
 
   describe "POST /create" do

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -219,6 +219,22 @@ RSpec.describe EventDashboard do
         expect(dashboard.program_status_counts).to eq(new: 3, ongoing: 0, reinstated: 0)
       end
 
+      it "excludes organizations that only registered inactively, for every inactive status" do
+        # A no-show / cancelled / transferred-out registration confers no
+        # facilitation, so an org that only registered inactively stays out of the
+        # breakdown (ADR-0001 D8a).
+        EventRegistration::INACTIVE_STATUSES.each do |status|
+          person = create(:person)
+          organization = create(:organization, name: "Only #{status}")
+          create(:affiliation, person: person, organization: organization)
+          registration = create(:event_registration, event: event, registrant: person, status: status)
+          registration.event_registration_organizations.create!(organization: organization)
+        end
+
+        expect(dashboard.organizations).to contain_exactly(org_a, org_b, org_c)
+        expect(dashboard.program_status_counts.values.sum).to eq(3)
+      end
+
       it "totals the program-status breakdown to the organization count" do
         expect(dashboard.program_status_counts.values.sum).to eq(dashboard.organization_count)
       end

--- a/spec/services/event_program_status_report_spec.rb
+++ b/spec/services/event_program_status_report_spec.rb
@@ -72,11 +72,18 @@ RSpec.describe EventProgramStatusReport do
       expect(column.ongoing_count).to eq(2)
     end
 
-    it "counts only organizations on active registrations" do
-      cancelled_org = create(:organization, name: "Cancelled")
-      represent(cancelled_org, spring, status: "cancelled")
+    it "counts only organizations on active registrations, whatever the inactive status" do
+      # A no-show / cancelled / transferred-out registration never became
+      # facilitation, so an org that only ever registered inactively stays out of
+      # the counts (ADR-0001 D8a).
+      EventRegistration::INACTIVE_STATUSES.each do |status|
+        inactive_org = create(:organization, name: "Inactive #{status}")
+        represent(inactive_org, spring, status: status)
+      end
 
-      expect(report.years.first.columns.first.organization_count).to eq(3)
+      column = report.years.first.columns.first
+      expect(column.organization_count).to eq(3)
+      expect(column.statuses.keys).to match_array([ brand_new.id, established.id, lapsed.id ])
     end
 
     it "reads each organization as of the training it attended, not as of today" do

--- a/spec/services/facilitator_program_status_math_spec.rb
+++ b/spec/services/facilitator_program_status_math_spec.rb
@@ -205,5 +205,31 @@ RSpec.describe "facilitator affiliation math" do
       expect(Affiliation.exists?(minted.id)).to be(false)
       expect(bucket).to eq(:never_active)
     end
+
+    # Deactivating (rather than deleting) the row the training minted clamps its end
+    # to its own start, leaving a zero-length row. Both questions must read that as
+    # no facilitation, or the org edit form shows "Formerly active" beside a red
+    # no-show chip (ADR-0001 D8a).
+    it "leaves a deactivated no-show reading New and Never active, with no facilitator period" do
+      person = create(:person)
+      event = create(:event, :ended, facilitator_training: true)
+      anchor = event.start_date.to_date
+      registration = create(:event_registration, event: event, registrant: person, status: "no_show")
+      create(:event_registration_organization, event_registration: registration, organization: organization)
+      minted = create(:affiliation, organization: organization, person: person, title: "Facilitator",
+                                    start_date: anchor, event_registration: registration)
+
+      AffiliationServices::ReconcilePerson.new(
+        person: person, organization: organization, event: event,
+        registration: registration, include_unowned: true
+      ).perform(:deactivate, affiliation: minted)
+
+      expect(minted.reload.end_date).to eq(minted.start_date)
+      expect(status_on(anchor)).to eq(:new)
+      expect(status_on(anchor + 1.year)).to eq(:new)
+      expect(bucket).to eq(:never_active)
+      expect(organization.reload.decorate.program_since_display).to eq("")
+      expect(Organization.program_status(:never_active)).to include(organization)
+    end
   end
 end

--- a/spec/services/facilitator_program_status_spec.rb
+++ b/spec/services/facilitator_program_status_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe FacilitatorProgramStatus do
     end
 
     it "is :new for a same-day (start == end) facilitation dated to the anchor" do
-      # start == end == the event date is the affiliation this training mints (D8),
-      # so a first-time org still reads New — not Ongoing.
+      # A zero-length row is what a no-show / cancelled training leaves (ADR-0001
+      # D8a); it represents no facilitation and is dropped, so a first-time org
+      # still reads New.
       facilitator(start_date: anchor, end_date: anchor)
       expect(status_on.status).to eq(:new)
     end
@@ -47,9 +48,11 @@ RSpec.describe FacilitatorProgramStatus do
       expect(status_on.status).to eq(:new)
     end
 
-    it "is :reinstated for a same-day facilitation that ran before the anchor" do
+    it "is :new for a zero-length facilitation that ran before the anchor" do
+      # A no-show at an earlier training leaves a same-day row (ADR-0001 D8a). It is
+      # not prior facilitation, so it must not reinstate the org at a later date.
       facilitator(start_date: Date.new(2020, 1, 1), end_date: Date.new(2020, 1, 1))
-      expect(status_on.status).to eq(:reinstated)
+      expect(status_on.status).to eq(:new)
     end
 
     it "is :reinstated when every earlier facilitator affiliation has ended" do

--- a/spec/system/affiliation_dates_spec.rb
+++ b/spec/system/affiliation_dates_spec.rb
@@ -172,5 +172,19 @@ RSpec.describe "Affiliation dates auto-update", type: :system do
 
       expect(program).to have_text("Jan 2018 – Dec 2019, May 2021", wait: 5)
     end
+
+    # The live preview reads the same rule as the server: a zero-length row is a
+    # no-show's deactivated stub, not facilitation (ADR-0001 D8a). If the JS twin
+    # kept it, the chip would flip to "Formerly active" on load.
+    it "ignores a zero-length facilitator row, matching the server render" do
+      no_show_org = create(:organization)
+      create(:affiliation, person: org_person, organization: no_show_org, title: "Facilitator",
+             start_date: "2026-08-01", end_date: "2026-08-01", inactive: true)
+
+      visit_and_wait edit_organization_path(no_show_org)
+
+      expect(find("[data-affiliation-dates-target='facilitatorSince']")).to have_text("—")
+      expect(find("[data-affiliation-dates-target='programStatus']")).to have_text("Never active")
+    end
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one rule applied across the org-level status surfaces (Ruby + SQL + JS twin), with tests

Registrants who no-showed, cancelled, or transferred out never became facilitators, yet their training was still counting toward the org's program status and "Facilitators since" — this stops that everywhere and makes it visible on the org edit page.

## The rule
- A **zero-length (`start == end`) facilitator affiliation** is the stub reconciliation leaves when it ends a no-show / cancelled / transferred-out training's minted row. It records no facilitation, so no org-level reading counts it.
- Applied in `FacilitatorProgramStatus` (New / Ongoing / Reinstated), `OrganizationDecorator` ("Facilitators since" + the Active / Formerly active / Never active bucket), `Organization.program_status` (the index filter, so SQL and chip still agree), and the org form's live-preview JS.
- Expressed once at each end: `Affiliation#zero_length?` and its SQL twin `Affiliation.zero_length` / `.with_duration`, locked together by an agreement spec.
- Person-level facilitator surfaces are deliberately unchanged — a person's own dates are a different question (ADR-0003).

## Org edit chips
- Trainings the org **only registered for inactively** render a **red attendance chip** ("No show" / "Cancelled" / "Transferred out") instead of a program-status one.
- A training keeps its program-status chip if the org has **any** active registration there.

## Reporting & dashboard
- Already scope to `EventRegistration.active`, so no-show-only orgs stay out of the counts — locked in with tests covering all three inactive statuses.

Documented as ADR-0001 **D8a** (and a pointer from D3). Adds a `/features` entry.
