### PR TITLE
Stop a double-submit from creating duplicate registrations and people

### DIFF
--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -118,12 +118,14 @@ module Events
       end
 
       # Scope submissions to this event so a person registered for multiple
-      # events that share the same form sees only the answers for this one.
+      # events that share the same form sees only the answers for this one. A
+      # returning registrant appends a new submission each time, so default to the
+      # most recent — their freshest answers — when none is named.
       submissions = @registration_form.form_submissions.where(person: person, event: @event)
       @form_submission = if params[:form_submission_id].present?
         submissions.find_by(id: params[:form_submission_id])
       else
-        submissions.first
+        submissions.order(:created_at).last
       end
       unless @form_submission
         redirect_to event_path(@event), alert: "No registration form submission found."

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,10 +2,6 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
-    # How long a concurrent submission waits for the in-flight one to finish before
-    # giving up on the identity lock and proceeding anyway (see #acquire_identity_lock).
-    LOCK_TIMEOUT_SECONDS = 10
-
     # Well-known field_identifier of the "magic" CE question seeded onto the
     # registration form. Answering it "Yes" creates a ContinuingEducationRegistration
     # (hours come from the event). Kept here so the seed, service, and specs agree.
@@ -70,7 +66,6 @@ module EventRegistrationServices
     end
 
     def call
-      lock_name = acquire_identity_lock
       ActiveRecord::Base.transaction do
         person = find_or_create_person
         sync_person_profile(person)
@@ -143,52 +138,9 @@ module EventRegistrationServices
       else
         Result.new(success?: false, event_registration: nil, errors: [ e.message ])
       end
-    ensure
-      release_identity_lock(lock_name)
     end
 
     private
-
-    # Serialize concurrent submissions for the same identity so a double-submit (two
-    # POSTs racing before either commits) can't slip past find_or_create_person and
-    # mint duplicate people and registrations. A MySQL named lock — no schema change,
-    # released the moment this submission commits — makes the second request wait,
-    # then match the first's now-committed person. The lock name is namespaced by
-    # database so parallel test suites (separate databases, one shared server) don't
-    # contend. Best-effort: a blank identity has nothing to dedupe, and a lock we
-    # couldn't get within the timeout falls through rather than failing a real
-    # registration.
-    def acquire_identity_lock
-      key = identity_lock_key
-      return if key.blank?
-
-      connection = ActiveRecord::Base.connection
-      namespaced = "#{connection.current_database}|#{key}"
-      lock_name = "awbw-reg-#{Digest::SHA256.hexdigest(namespaced)[0, 40]}"
-      connection.select_value("SELECT GET_LOCK(#{connection.quote(lock_name)}, #{LOCK_TIMEOUT_SECONDS})")
-      lock_name
-    end
-
-    def release_identity_lock(lock_name)
-      return if lock_name.blank?
-
-      connection = ActiveRecord::Base.connection
-      connection.select_value("SELECT RELEASE_LOCK(#{connection.quote(lock_name)})")
-    end
-
-    # The identity two concurrent submissions would collide on: a signed-in person is
-    # already resolved (no matching needed), so lock on them; an incognito submission
-    # locks on the strong, stable identifiers find_matching_person keys on — email and
-    # last name — for this event. Blank when we can't dedupe (missing email/last name).
-    def identity_lock_key
-      return "#{@event.id}|person|#{@person.id}" if @person
-
-      last_name = field_value("last_name")&.strip&.downcase
-      email = field_value("primary_email")&.strip&.downcase
-      return if email.blank? || last_name.blank?
-
-      "#{@event.id}|#{email}|#{last_name}"
-    end
 
     # Turn a database "Data too long for column 'city'" failure into a friendly,
     # form-level message. We can't always map the column back to a single form

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -2,6 +2,10 @@ module EventRegistrationServices
   class PublicRegistration
     Result = Struct.new(:success?, :event_registration, :form_submission, :errors, keyword_init: true)
 
+    # How long a concurrent submission waits for the in-flight one to finish before
+    # giving up on the identity lock and proceeding anyway (see #acquire_identity_lock).
+    LOCK_TIMEOUT_SECONDS = 10
+
     # Well-known field_identifier of the "magic" CE question seeded onto the
     # registration form. Answering it "Yes" creates a ContinuingEducationRegistration
     # (hours come from the event). Kept here so the seed, service, and specs agree.
@@ -66,6 +70,7 @@ module EventRegistrationServices
     end
 
     def call
+      lock_name = acquire_identity_lock
       ActiveRecord::Base.transaction do
         person = find_or_create_person
         sync_person_profile(person)
@@ -138,9 +143,52 @@ module EventRegistrationServices
       else
         Result.new(success?: false, event_registration: nil, errors: [ e.message ])
       end
+    ensure
+      release_identity_lock(lock_name)
     end
 
     private
+
+    # Serialize concurrent submissions for the same identity so a double-submit (two
+    # POSTs racing before either commits) can't slip past find_or_create_person and
+    # mint duplicate people and registrations. A MySQL named lock — no schema change,
+    # released the moment this submission commits — makes the second request wait,
+    # then match the first's now-committed person. The lock name is namespaced by
+    # database so parallel test suites (separate databases, one shared server) don't
+    # contend. Best-effort: a blank identity has nothing to dedupe, and a lock we
+    # couldn't get within the timeout falls through rather than failing a real
+    # registration.
+    def acquire_identity_lock
+      key = identity_lock_key
+      return if key.blank?
+
+      connection = ActiveRecord::Base.connection
+      namespaced = "#{connection.current_database}|#{key}"
+      lock_name = "awbw-reg-#{Digest::SHA256.hexdigest(namespaced)[0, 40]}"
+      connection.select_value("SELECT GET_LOCK(#{connection.quote(lock_name)}, #{LOCK_TIMEOUT_SECONDS})")
+      lock_name
+    end
+
+    def release_identity_lock(lock_name)
+      return if lock_name.blank?
+
+      connection = ActiveRecord::Base.connection
+      connection.select_value("SELECT RELEASE_LOCK(#{connection.quote(lock_name)})")
+    end
+
+    # The identity two concurrent submissions would collide on: a signed-in person is
+    # already resolved (no matching needed), so lock on them; an incognito submission
+    # locks on the strong, stable identifiers find_matching_person keys on — email and
+    # last name — for this event. Blank when we can't dedupe (missing email/last name).
+    def identity_lock_key
+      return "#{@event.id}|person|#{@person.id}" if @person
+
+      last_name = field_value("last_name")&.strip&.downcase
+      email = field_value("primary_email")&.strip&.downcase
+      return if email.blank? || last_name.blank?
+
+      "#{@event.id}|#{email}|#{last_name}"
+    end
 
     # Turn a database "Data too long for column 'city'" failure into a friendly,
     # form-level message. We can't always map the column back to a single form

--- a/app/services/event_registration_services/public_registration.rb
+++ b/app/services/event_registration_services/public_registration.rb
@@ -107,7 +107,7 @@ module EventRegistrationServices
             send_notifications(existing)
           end
           organization_link = connect_organization(existing, organization)
-          submission = update_form_submission(person)
+          submission = create_form_submission(person)
           organization_link&.record_form_submission(submission)
           save_scholarship_submission(person)
           save_continuing_education_submission(person)
@@ -488,16 +488,6 @@ module EventRegistrationServices
 
     def create_form_submission(person)
       submission = FormSubmission.create!(person: person, form: @registration_form, event: @event, role: "registration")
-      save_form_answers(submission)
-      OtherResponses::CaptureFromSubmission.call(submission)
-      Quotes::CaptureFromSubmission.call(submission)
-      submission
-    end
-
-    def update_form_submission(person)
-      submission = FormSubmission.find_or_create_by!(person: person, form: @registration_form, role: "registration", event: @event) do |record|
-        record.event = @event
-      end
       save_form_answers(submission)
       OtherResponses::CaptureFromSubmission.call(submission)
       Quotes::CaptureFromSubmission.call(submission)

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -94,7 +94,7 @@
         </div>
       <% end %>
 
-      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2", data: { turbo: !@event.cost_cents.to_i.positive? } do |f| %>
+      <%= form_with url: event_public_registration_path(@event), method: :post, local: true, class: "space-y-2", data: { turbo: !@event.cost_cents.to_i.positive?, controller: "submit-once", "submit-once-submitting-text-value": "Registering…" } do |f| %>
 
         <% if @scholarship %>
           <input type="hidden" name="scholarship_requested" value="true">

--- a/config/features.yml
+++ b/config/features.yml
@@ -39,6 +39,20 @@
   action_path: /organizations
   pr_number: 2464
 
+- name: "Repeat registration submissions no longer create duplicates"
+  area: registration
+  display_status: user_facing
+  released_on: 2026-08-31
+  summary: >-
+    If someone submits an event registration more than once — two submissions in a
+    row, or coming back to register again later — they now stay a single person with
+    one registration for that event, instead of appearing as duplicates on your
+    roster. Every submission is still saved, so no answers are lost.
+  pr_number: 2465
+  pro_tips:
+    - "The registrant's confirmation page shows their most recent submission."
+    - "Each submission is kept in full, so you can see what changed between them."
+
 - name: "Set who a workshop log is credited to"
   area: content
   display_status: admin_facing

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -250,6 +250,24 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       expect(response.body).to include("Minimum of 5 words.")
     end
 
+    # A double-click used to fire two POSTs and create duplicate people and
+    # registrations — worst on paid events, which opt out of Turbo (turbo: false)
+    # and so lose even Turbo's own submitter disabling.
+    it "guards the form against double-submit on a free event" do
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include('data-controller="submit-once"')
+    end
+
+    it "guards the form against double-submit on a paid event that opts out of Turbo" do
+      event.update!(cost_cents: 5_000)
+
+      get new_event_public_registration_path(event)
+
+      expect(response.body).to include('data-controller="submit-once"')
+      expect(response.body).to include('data-turbo="false"')
+    end
+
     it "surfaces the CE deadlines on the continuing education section" do
       ce = FormBuilderService.new(name: "CE", sections: %i[continuing_education], role: "continuing_education").call
       event.event_forms.create!(form: ce, role: "continuing_education")

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -735,6 +735,21 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       end
     end
 
+    # A returning registrant appends a new submission each time, so the default
+    # view (no form_submission_id) must land on their freshest answers.
+    it "defaults to the most recently created submission when the registrant re-registered" do
+      older = FormSubmission.find_by(person: person, form: form)
+      older.form_answers.create!(form_field: essay_field, submitted_answer: "my older reasons")
+      newer = create(:form_submission, person: person, form: form, event: event)
+      newer.form_answers.create!(form_field: essay_field, submitted_answer: "my newer reasons")
+
+      get event_public_registration_path(event, person_id: person.id)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("my newer reasons")
+      expect(response.body).not_to include("my older reasons")
+    end
+
     it "renders header and field-label HTML unescaped on the response page" do
       create(:form_field, form: form, answer_type: :group_header, name: "<strong>Your details</strong>")
       create(:form_field, form: form, answer_type: :free_form_input_one_line, name: "<em>Name</em>", required: false)

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -631,26 +631,6 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(event.event_registrations.where(registrant: person).count).to eq(1)
       expect(person.form_submissions.where(form: form, role: "registration", event: event).count).to eq(2)
     end
-
-    # Two POSTs racing before either commits used to each mint a person + registration.
-    # A MySQL named lock serializes them so the second waits and matches the first's
-    # person. A true concurrent race is not unit-testable without flaky threads, so we
-    # assert the guard is wired: the lock is taken and released around the flow.
-    it "serializes concurrent submissions behind a released identity lock" do
-      statements = []
-      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
-        statements << ActiveSupport::Notifications::Event.new(*args).payload[:sql]
-      end
-
-      begin
-        described_class.call(event: event, registration_form: form, form_params: params)
-      ensure
-        ActiveSupport::Notifications.unsubscribe(subscriber)
-      end
-
-      expect(statements).to include(a_string_matching(/GET_LOCK\('awbw-reg-/))
-      expect(statements).to include(a_string_matching(/RELEASE_LOCK\('awbw-reg-/))
-    end
   end
 
   describe "an answer longer than its database column" do

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -610,6 +610,29 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
     end
   end
 
+  describe "re-submitting the registration form with the same name and email" do
+    let(:params) { base_form_params(first_name: "Rae", last_name: "Fox", email: "rae@example.com") }
+
+    it "reuses the same person rather than creating a duplicate" do
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      expect {
+        described_class.call(event: event, registration_form: form, form_params: params)
+      }.not_to change(Person, :count)
+
+      expect(Person.where(email: "rae@example.com").count).to eq(1)
+    end
+
+    it "keeps a single event registration but appends a second form submission" do
+      described_class.call(event: event, registration_form: form, form_params: params)
+      described_class.call(event: event, registration_form: form, form_params: params)
+
+      person = Person.find_by!(email: "rae@example.com")
+      expect(event.event_registrations.where(registrant: person).count).to eq(1)
+      expect(person.form_submissions.where(form: form, role: "registration", event: event).count).to eq(2)
+    end
+  end
+
   describe "an answer longer than its database column" do
     # `city` (like the other mapped person/address columns) is a varchar(255).
     # A longer answer must surface as a form error, not an ActiveRecord::ValueTooLong
@@ -1135,48 +1158,55 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(Person.find_by(email: "badid@example.com")).to be_nil
     end
 
-    # submitted_answer is only a cache of the attachment's name. Pinned across
-    # every transition so a second writer that skips FormAnswer#sync_uploaded_filename!
-    # fails here rather than silently desyncing the two.
-    it "keeps submitted_answer equal to the attached filename through upload, replace, and blank re-submit" do
+    # submitted_answer is only a cache of the attachment's name. Each re-submission
+    # is its own FormSubmission, so its answer's submitted_answer must equal its own
+    # attachment — a writer that skips FormAnswer#sync_uploaded_filename! fails here
+    # rather than silently desyncing the two.
+    it "keeps each submission's submitted_answer equal to its own attached filename" do
       params = base_form_params(first_name: "Sync", last_name: "Check", email: "sync@example.com")
       in_sync = lambda do |result|
         answer = result.form_submission.form_answers.find_by(form_field: upload_field)
         expect(answer.submitted_answer).to eq(answer.uploaded_file&.filename.to_s)
-        answer
+        result.form_submission
       end
 
-      uploaded = in_sync.call(described_class.call(
+      png = in_sync.call(described_class.call(
         event: event, registration_form: form,
         form_params: params.merge(upload_field.id.to_s => signed_id_for("sample.png", "image/png"))
       ))
-      expect(uploaded.submitted_answer).to eq("sample.png")
-
-      replaced = in_sync.call(described_class.call(
+      pdf = in_sync.call(described_class.call(
         event: event, registration_form: form,
         form_params: params.merge(upload_field.id.to_s => signed_id_for("sample.pdf", "application/pdf"))
       ))
-      expect(replaced.submitted_answer).to eq("sample.pdf")
-
-      blanked = in_sync.call(described_class.call(
+      blank = in_sync.call(described_class.call(
         event: event, registration_form: form, form_params: params.merge(upload_field.id.to_s => "")
       ))
-      expect(blanked.submitted_answer).to eq("sample.pdf")
+
+      expect([ png, pdf, blank ].map(&:id).uniq.size).to eq(3)
+      expect(png.form_answers.find_by(form_field: upload_field).submitted_answer).to eq("sample.png")
+      expect(pdf.form_answers.find_by(form_field: upload_field).submitted_answer).to eq("sample.pdf")
+      expect(blank.form_answers.find_by(form_field: upload_field).submitted_answer).to eq("")
     end
 
-    it "keeps the file already on the answer when a re-submission leaves the field blank" do
+    it "leaves the earlier submission's file intact when a blank re-submission adds a fileless one" do
       params = base_form_params(first_name: "Re", last_name: "Sub", email: "resub@example.com").merge(
         upload_field.id.to_s => signed_id_for("sample.png", "image/png")
       )
-      described_class.call(event: event, registration_form: form, form_params: params)
+      first = described_class.call(event: event, registration_form: form, form_params: params)
 
       result = described_class.call(event: event, registration_form: form,
                                     form_params: params.merge(upload_field.id.to_s => ""))
 
       expect(result.success?).to be true
-      answer = result.form_submission.form_answers.find_by(form_field: upload_field)
-      expect(answer.uploaded_file).to be_attached
-      expect(answer.submitted_answer).to eq("sample.png")
+      expect(result.form_submission).not_to eq(first.form_submission)
+
+      original_answer = first.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(original_answer.uploaded_file).to be_attached
+      expect(original_answer.submitted_answer).to eq("sample.png")
+
+      blank_answer = result.form_submission.form_answers.find_by(form_field: upload_field)
+      expect(blank_answer.uploaded_file).to be_nil
+      expect(blank_answer.submitted_answer).to eq("")
     end
   end
 end

--- a/spec/services/event_registration_services/public_registration_spec.rb
+++ b/spec/services/event_registration_services/public_registration_spec.rb
@@ -631,6 +631,26 @@ RSpec.describe EventRegistrationServices::PublicRegistration do
       expect(event.event_registrations.where(registrant: person).count).to eq(1)
       expect(person.form_submissions.where(form: form, role: "registration", event: event).count).to eq(2)
     end
+
+    # Two POSTs racing before either commits used to each mint a person + registration.
+    # A MySQL named lock serializes them so the second waits and matches the first's
+    # person. A true concurrent race is not unit-testable without flaky threads, so we
+    # assert the guard is wired: the lock is taken and released around the flow.
+    it "serializes concurrent submissions behind a released identity lock" do
+      statements = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        statements << ActiveSupport::Notifications::Event.new(*args).payload[:sql]
+      end
+
+      begin
+        described_class.call(event: event, registration_form: form, form_params: params)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(statements).to include(a_string_matching(/GET_LOCK\('awbw-reg-/))
+      expect(statements).to include(a_string_matching(/RELEASE_LOCK\('awbw-reg-/))
+    end
   end
 
   describe "an answer longer than its database column" do


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 concurrency guard (MySQL named lock) + registration-flow change across the public registration path

A registrant who double-clicked Register (or came back and re-submitted) could end up with two people and two registrations for the same event — this closes both the accidental double-click and the underlying race, and stops re-submissions from silently losing earlier answers.

## Duplicate registrations from a double-submit
- **Client guard:** the public registration form now uses the existing `submit-once` Stimulus controller, so the button locks after the first click. This matters most on **paid events**, which opt out of Turbo (`turbo: false`) and so had *no* submitter disabling at all — the likely source of the "two registrations in the same minute" incident.
- **Server backstop:** a genuine concurrent submission (two tabs, a proxy retry) still raced `find_or_create_person`, so the flow now serializes same-identity submissions behind a **MySQL named lock** (email + last name + event, namespaced by database so parallel test suites don't contend). The second request waits, then matches the first's committed person. Best-effort: a blank identity or an un-acquirable lock falls through rather than failing a real registration.

## Re-registration no longer overwrites answers
- A returning registrant reuses their one Person and one event registration, but re-submitting used to overwrite their prior `FormSubmission` in place, silently dropping the earlier answers. Each submission is now recorded on its own, preserving the full history (the admin registrants view already iterated multiple submissions).
- The public confirmation view defaults to the **most recent** submission when none is named.

## Tests
- Same name + email → one person, one registration, two submissions.
- File-upload specs updated: each submission is independent; the earlier one keeps its file, a blank re-submit adds a fileless submission.
- Confirmation view defaults to the latest submission.
- `submit-once` renders on free and paid events.
- The identity lock is taken and released around the flow (a true thread race isn't unit-testable without flakiness).