### PR TITLE
Show weekday in registrants date-registered hover tooltip

### DIFF
--- a/app/views/events/_registrants_results.html.erb
+++ b/app/views/events/_registrants_results.html.erb
@@ -540,7 +540,7 @@
                 </td>
 
                 <td class="px-4 py-2 text-center text-sm text-nowrap" data-column-toggle-col="attendance" data-sort-value="<%= registration.status %>"><%= render "event_registrations/attendance_status_badge", registration: registration, return_to: "registrants" %></td>
-                <td class="hidden px-4 py-2 text-center text-sm text-nowrap text-gray-600" data-column-toggle-col="date" data-sort-value="<%= registration.created_at.to_i %>" title="<%= registration.created_at.strftime("%B %-d, %Y at %l:%M %P") %>"><%= registration.created_at.strftime("%b %-d, %Y") %></td>
+                <td class="hidden px-4 py-2 text-center text-sm text-nowrap text-gray-600" data-column-toggle-col="date" data-sort-value="<%= registration.created_at.to_i %>" title="<%= registration.created_at.strftime("%A, %B %-d, %Y at %-l:%M %P") %>"><%= registration.created_at.strftime("%b %-d, %Y") %></td>
                 <% readiness = @readiness[registration.id] %>
                 <td class="px-4 py-2 text-center text-sm" data-sort-value="<%= readiness.status_sort_key %>">
                   <%= render "event_registrations/readiness_badge",


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only tooltip copy change, no logic or data changes

Adds the day of the week to the "Date registered" column's hover tooltip on the event registrants index, so admins can see which weekday a registration landed on.

### What is the goal of this PR and why is this important?
The registrants table already revealed the full date and time when hovering the "Date registered" cell. Admins also want the weekday at a glance without doing the math.

### How did you approach the change?
Extended the cell's `title` strftime format to include `%A` (weekday) and switched `%l` → `%-l` to drop the stray leading space in the hour. The visible short date is unchanged.

### Anything else to add?
View-only change to `app/views/events/_registrants_results.html.erb`; hover now reads e.g. "Monday, August 31, 2026 at 9:05 pm".
