### PR TITLE
Hide reconciled-away registrations on person profiles

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -85,7 +85,12 @@ class PeopleController < ApplicationController
         @resources = visible_authored_content(Resource.credited_to_person(@person)).order(created_at: :desc).paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/resources", locals: { person: @person, resources: @resources }
       when "events"
-        @event_registrations = @person.event_registrations.active.includes(:event).order("events.start_date DESC").references(:events).paginate(page: params[:page], per_page: per_page)
+        # Admins and the profile's own person also see reconciled-away registrations
+        # (cancelled, no-show, transferred-out), flagged with their status; everyone
+        # else sees only active ones.
+        registrations = @person.event_registrations.includes(:event).order("events.start_date DESC").references(:events)
+        registrations = registrations.active unless viewing_own_or_admin?
+        @event_registrations = registrations.paginate(page: params[:page], per_page: per_page)
         render partial: "people/sections/events", locals: { person: @person, event_registrations: @event_registrations }
       when "workshop_ideas"
         # Author, or the legacy fallback to their user's creations (author_person).
@@ -401,9 +406,15 @@ class PeopleController < ApplicationController
   # Showing anonymous content to anyone but the person and admins would tie an
   # "Anonymous" credit back to a name.
   def visible_authored_content(scope)
-    return scope if allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
+    return scope if viewing_own_or_admin?
     return scope.none if @person.anonymous_contributions?
     scope.credited_openly
+  end
+
+  # The profile's own person, or an admin — the audience allowed to see private/
+  # reconciled-away content that's hidden from other profile viewers.
+  def viewing_own_or_admin?
+    allowed_to?(:manage?, Person) || current_user&.person_id == @person.id
   end
 
   def set_person

--- a/app/decorators/event_registration_decorator.rb
+++ b/app/decorators/event_registration_decorator.rb
@@ -113,6 +113,12 @@ class EventRegistrationDecorator < ApplicationDecorator
     ATTENDANCE_STATUS_ICONS.fetch(status, "fa-question")
   end
 
+  # Pill bundle for the profile event card's status marker, reusing the shared
+  # status SSOT so label, icon, and colors stay in one place.
+  def attendance_status_badge
+    { label: attendance_status_label, icon: attendance_status_icon, classes: attendance_status_classes }
+  end
+
   def title
     name
   end

--- a/app/views/people/_show_card.html.erb
+++ b/app/views/people/_show_card.html.erb
@@ -3,6 +3,7 @@
 <% title_font_size ||= nil %>
 <% bookmarkable ||= record.object %>
 <% anonymous ||= false %>
+<% card_badge ||= nil %>
 
 <div class="relative h-full <%= "opacity-70" if anonymous %>">
   <!-- BOOKMARK ICON -->
@@ -12,18 +13,13 @@
 
   <!-- CARD -->
   <div class="
-    flex flex-row flex-wrap h-full
-    <%= bg_color %> border border-gray-200 rounded-xl shadow-sm hover:shadow-md
-    transition-all overflow-hidden cursor-pointer">
+    flex h-full flex-row flex-wrap
+    <%= bg_color %> cursor-pointer overflow-hidden rounded-xl border border-gray-200 shadow-sm transition-all hover:shadow-md">
 
     <!-- LEFT SIDE -->
-    <div class="
-      flex-shrink-0
-      w-18 md:w-24
-      flex flex-col items-center text-center justify-start py-4 pb-3 px-3
-      border-b md:border-b-0 md:border-r border-gray-200">
+    <div class="flex w-18 flex-shrink-0 flex-col items-center justify-start border-b border-gray-200 px-3 py-4 pb-3 text-center md:w-24 md:border-r md:border-b-0">
       <!-- IMAGE -->
-      <div class="relative w-12 h-12 md:w-16 md:h-16">
+      <div class="relative h-12 w-12 md:h-16 md:w-16">
         <%= link_to record.link_target, data: { turbo_frame: "_top"}, class: "block w-full h-full" do %>
           <%= render "assets/display_image",
                      resource: record.object,
@@ -37,14 +33,20 @@
     </div>
 
     <!-- RIGHT SIDE -->
-    <div class="flex-1 min-w-0 pl-4 pr-10 py-1 flex flex-col justify-between">
+    <div class="flex min-w-0 flex-1 flex-col justify-between py-1 pr-10 pl-4">
       <% if anonymous %>
         <%# Admin/owner-only marker: this credit renders "Anonymous" publicly, so
             the item is hidden from everyone else. %>
-        <span class="inline-flex items-center pl-2 pr-3 py-0.5 mt-2 rounded-full text-xs font-medium bg-blue-100 text-gray-600 whitespace-nowrap"
+        <span class="mt-2 inline-flex items-center rounded-full bg-blue-100 py-0.5 pr-3 pl-2 text-xs font-medium whitespace-nowrap text-gray-600"
               title="Credited as Anonymous — hidden from public author credit">
-          <span class="inline-flex justify-center w-5"><i class="fa-solid fa-eye-slash"></i></span>
+          <span class="inline-flex w-5 justify-center"><i class="fa-solid fa-eye-slash"></i></span>
           <span class="ml-1">Anonymous</span>
+        </span>
+      <% end %>
+      <% if card_badge %>
+        <span class="mt-2 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap <%= card_badge[:classes] %>">
+          <i class="fa-solid <%= card_badge[:icon] %>"></i>
+          <%= card_badge[:label] %>
         </span>
       <% end %>
       <div class="my-2">
@@ -56,7 +58,7 @@
                                 record_title: record_title).html_safe %>
         <% end %>
       </div>
-      <div class="text-gray-400 text-sm mb-2">
+      <div class="mb-2 text-sm text-gray-400">
         <%= record.created_at.strftime("%b %d, %Y") %>
       </div>
     </div>

--- a/app/views/people/sections/_events.html.erb
+++ b/app/views/people/sections/_events.html.erb
@@ -1,13 +1,16 @@
 <%= turbo_frame_tag "person_events_section" do %>
   <% if event_registrations.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 blur-on-submit">
+    <div class="grid grid-cols-1 gap-6 blur-on-submit sm:grid-cols-2 lg:grid-cols-3">
       <% event_registrations.each do |event_registration| %>
+        <% registration = event_registration.decorate %>
         <%= render "show_card",
                    bookmarkable: event_registration.event,
                    record_title: "#{event_registration.event.title}<br>" +
                      "<span class='text-xs text-gray-500'>TIME: " +
                      "#{event_registration.event.decorate.times}<span>",
-                   record: event_registration.decorate, title_font_size: "text-sm" %>
+                   record: registration, title_font_size: "text-sm",
+                   bg_color: (registration.active? ? "bg-white" : "bg-blue-50"),
+                   card_badge: (registration.active? ? nil : registration.attendance_status_badge) %>
       <% end %>
     </div>
     <div class="mt-6 flex justify-center">

--- a/config/features.yml
+++ b/config/features.yml
@@ -2969,3 +2969,15 @@
   pro_tips:
     - "Change your answers any time by reopening the survey, or from your profile directly."
     - "Admins: on a registration form the change shows up on the submission's \"What this submission changed\" page, like any other profile edit."
+
+- name: "Reconciled-away registrations hidden on profiles, flagged for staff"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-08-31
+  summary: >-
+    A person's profile no longer shows event cards for registrations that were
+    reconciled away — cancelled, no-show, or transferred out. Admins and the
+    person themselves still see those cards, tinted blue and marked with the
+    attendance status, so the history isn't lost.
+  pro_tips:
+    - "Everyone else sees only active registrations (registered, attended, incomplete)."

--- a/spec/requests/people_events_section_spec.rb
+++ b/spec/requests/people_events_section_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Person profile events section", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before { sign_in admin }
+
+  # The section lazy-loads via a Turbo Frame, so request it the way the frame does.
+  def get_events_section
+    get person_path(person, section: "events"),
+        headers: { "Turbo-Frame" => "person_events_section" }
+  end
+
+  def registration_for(event_title, status:)
+    event = create(:event, title: event_title)
+    create(:event_registration, registrant: person, event: event, status: status)
+  end
+
+  it "shows an active registration without a status badge" do
+    registration_for("Active Event", status: "registered")
+
+    get_events_section
+
+    expect(response).to be_successful
+    expect(response.body).to include("Active Event")
+    expect(response.body).not_to include("No show")
+  end
+
+  it "shows a reconciled-away registration to an admin, flagged with its status" do
+    registration_for("Missed Event", status: "no_show")
+
+    get_events_section
+
+    expect(response.body).to include("Missed Event")
+    expect(response.body).to include("No show")
+    expect(response.body).to include("bg-blue-50")
+  end
+
+  it "flags a cancelled registration with its status for an admin" do
+    registration_for("Dropped Event", status: "cancelled")
+
+    get_events_section
+
+    expect(response.body).to include("Dropped Event")
+    expect(response.body).to include("Cancelled")
+  end
+
+  it "still shows the reconciled-away registration, flagged, to the owner viewing their own profile" do
+    sign_in owner_user
+    registration_for("Missed Event", status: "no_show")
+
+    get_events_section
+
+    expect(response.body).to include("Missed Event")
+    expect(response.body).to include("No show")
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic + view change on the profile events section, covered by a request spec

Person profiles no longer show event cards for registrations that were reconciled away (cancelled, no-show, transferred out) to general viewers — those cards tied a name to an event outcome. Admins and the person themselves still see them, so the history isn't lost.

- Non-admin/non-owner viewers see only active registrations (registered, attended, incomplete) — unchanged from today's `.active` scope.
- Admins + the profile owner now also see reconciled-away registrations, tinted blue with an attendance-status pill (label + icon + color) reusing the existing status SSOT on `EventRegistrationDecorator`.
- Viewer check extracted to `viewing_own_or_admin?` and shared with the anonymous-content gate.
- `_show_card` gains an optional generic `card_badge` pill (other callers unaffected).