### PR TITLE
Document the FileMaker fields each Fm* archive model carries

### DIFF
--- a/app/models/fm_activity.rb
+++ b/app/models/fm_activity.rb
@@ -1,3 +1,35 @@
+# Contact log — calls, letters and mailings against a rolodex record.
+#
+# FileMaker source: Activity (Activity.csv).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   ActivityLogID    PK
+#   ID               FK → FmRolodex
+#   LinkID           FK → FmPayment
+#   Date
+#   Time
+#   Type
+#   Origin
+#   Category
+#   Pages
+#   ListBy
+#   Subject
+#   Message
+#   Message2
+#   MessageForFrom
+#   Comments
+#   Addressee
+#   Greeting
+#   FirstName        denormalized from ID
+#   LastName         denormalized
+#   FullName         denormalized
+#   TitleDept        denormalized
+#   Organization     denormalized
+#   TakenEntered By  field name contains a space
+#   ModifiedBy
+#   DateModifed      spelled this way in FileMaker
 class FmActivity < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "ActivityLogID"

--- a/app/models/fm_address.rb
+++ b/app/models/fm_address.rb
@@ -1,3 +1,27 @@
+# Addresses for rolodex records and organizations.
+#
+# FileMaker source: prj_org_ADR__Addresses (Addresses.csv, 28,398 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   AddrsID               PK
+#   RolodexID             FK → FmRolodex
+#   OrgID                 FK → FmOrganization
+#   PostalCodeLookup      FK → FmPostalCode.Zipcode
+#   AddrsType
+#   Primacy               primary address flag
+#   AddrsFormat
+#   StreetNo
+#   AddrsLine1
+#   AddrsLine2
+#   AddrsCity
+#   AddrsState
+#   AddrsPostalCode       stored value, mirrors PostalCodeLookup
+#   AddrsCountry
+#   Note
+#   DateEntered
+#   ModificationDateTime
 class FmAddress < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "AddrsID"

--- a/app/models/fm_allocation.rb
+++ b/app/models/fm_allocation.rb
@@ -1,3 +1,24 @@
+# Slices of a grant assigned to a project.
+#
+# FileMaker source: prj_ALC__Allocations (Allocations.csv, 3,099 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   AllocRecID      PK
+#   FundingRecID    FK → FmFunding
+#   ProjectID       FK → FmProject
+#   Year
+#   Status
+#   Active
+#   AmountGeneral
+#   AmountSupplies
+#   AmountExhibit
+#   Trainings       training seats granted
+#   Attended
+#   Paid
+#   Notes
+#   DateEntered
 class FmAllocation < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "AllocRecID"

--- a/app/models/fm_event.rb
+++ b/app/models/fm_event.rb
@@ -1,3 +1,39 @@
+# Trainings, fundraisers and other events.
+#
+# FileMaker source: prj_EVT__Events (Events.csv, 3,468 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   EventID                PK, e.g. E4037
+#   LinkID                 unlinked in the UI
+#   Title
+#   Category
+#   Type
+#   Group
+#   Description
+#   Notes
+#   Comments
+#   ItemDescription
+#   Available              open for registration
+#   EventDate
+#   EndDate
+#   StartTime
+#   EndTime
+#   Year
+#   Location
+#   Organizer
+#   Fee
+#   MinParticipants
+#   MaxParticipants
+#   EstimatedParticipants
+#   EventCostItems
+#   EventCosts
+#   EventCostsInKind
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   DateTimeModified
 class FmEvent < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "EventID"

--- a/app/models/fm_expenditure.rb
+++ b/app/models/fm_expenditure.rb
@@ -1,3 +1,21 @@
+# Spending charged against a project.
+#
+# FileMaker source: prj_EXP__Expenditure (Expenditure.csv, 5,314 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   ExpendRecID  PK, e.g. X5510
+#   ProjectID    FK → FmProject
+#   Type
+#   Category
+#   Name
+#   Description
+#   Notes
+#   Amount
+#   CheckNo
+#   DatePaid
+#   DateEntered
 class FmExpenditure < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "ExpendRecID"

--- a/app/models/fm_funding.rb
+++ b/app/models/fm_funding.rb
@@ -1,3 +1,51 @@
+# Grants and other funding sources.
+#
+# FileMaker source: prj_FND__FundingviaTempID (Funding.csv, 1,391 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   RecordID           PK, e.g. F1581
+#   FunderID           FK → FmRolodex
+#   ProgramScope
+#   GeographicScope
+#   ScopeGranted
+#   Status
+#   Category
+#   GrantType
+#   Source
+#   Active
+#   NonAllocated
+#   Purpose
+#   Notes
+#   NameTemp
+#   Submission
+#   RequestAmount
+#   AmountGranted
+#   GeneralBudget
+#   SupplyBudget
+#   ExhibitBudget
+#   TrainingsBudgeted
+#   CostPerTraining
+#   StartDate
+#   EndDate
+#   Month
+#   KeyYearOverride
+#   DateReq
+#   SubmissionDate
+#   FirmDeadline
+#   TargetDeadline
+#   NotificationDate
+#   NotifyDateEst
+#   ReportDueDate
+#   ReportDescription
+#   ReportIn
+#   DateReportSent
+#   ReconciliationDue
+#   EnteredBy
+#   ModifiedBy
+#   Date Entered       field name contains a space
+#   DateModified
 class FmFunding < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "RecordID"

--- a/app/models/fm_note.rb
+++ b/app/models/fm_note.rb
@@ -1,3 +1,26 @@
+# Polymorphic note log — Context names the table, LinkID the record.
+#
+# FileMaker source: prj_NTS__Notes (Notes.csv, 616 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   NoteID            PK, e.g. N00643
+#   Context           discriminator: Project, Organizations or Rolodex
+#   LinkID            FK → the table named by Context
+#   ProjectID         FK → FmProject, redundant with LinkID
+#   OrgID             FK → FmOrganization, redundant with LinkID
+#   RolodexID         FK → FmRolodex, redundant with LinkID
+#   EventID           FK → FmEvent, never populated
+#   Date
+#   Subject
+#   Note
+#   Category
+#   Classification
+#   Status
+#   EnteredBy
+#   ModifiedBy
+#   DateTimeModified
 class FmNote < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "NoteID"

--- a/app/models/fm_organization.rb
+++ b/app/models/fm_organization.rb
@@ -1,3 +1,34 @@
+# Organizations and agencies.
+#
+# FileMaker source: prj_ORG__Organization (Organizations.csv, 7,191 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   OrgID                 PK, e.g. ORG07206
+#   ParentID              FK → FmOrganization
+#   MainID                unlinked in the UI
+#   OrgName
+#   OrgType
+#   Classification
+#   Status
+#   Hierarchy
+#   Website
+#   Description
+#   Mission
+#   Facilities
+#   Interests
+#   FundingPriorities
+#   Meetings
+#   Newsletter
+#   Keywords
+#   Comments
+#   OutreachStatus
+#   OutreachDate
+#   CreatedBy
+#   ModifiedBy
+#   CreationDate
+#   ModificationDateTime
 class FmOrganization < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "OrgID"

--- a/app/models/fm_participant.rb
+++ b/app/models/fm_participant.rb
@@ -1,3 +1,41 @@
+# Event registrations. ParticipantID doubles as the registrant's rolodex ID.
+#
+# FileMaker source: prj_PTC__Participants (Participants.csv, 68,497 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   ParticipantID     PK, also the FmRolodex ID of the registrant
+#   EventID           FK → FmEvent
+#   ProjectID         FK → FmProject
+#   OrgID             FK → FmOrganization
+#   AllocRecID        FK → FmAllocation, scholarship funding the seat
+#   PaymentID         FK → FmPayment
+#   HostID            FK → FmRolodex, host who invited this guest
+#   PRecID            legacy participant ref, unlinked in the UI
+#   SubmissionID      external ref
+#   Name
+#   Organization      denormalized
+#   Phone
+#   Role
+#   Status
+#   Year
+#   Invited
+#   Replied
+#   Attended
+#   Paid
+#   Comp              comped seat
+#   NoOfPersons
+#   Fee
+#   AmountPaid
+#   BidderNumbers     silent auction
+#   CEHours           continuing education hours
+#   Notes
+#   Comments
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   DateTimeModified
 class FmParticipant < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "ParticipantID"

--- a/app/models/fm_payment.rb
+++ b/app/models/fm_payment.rb
@@ -1,3 +1,40 @@
+# Donations and payments received.
+#
+# FileMaker source: prj_PMT__Payment (Payments.csv, 27,146 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   RecordID              PK, e.g. D29186
+#   RolodexID             FK → FmRolodex, the payer
+#   OrgID                 FK → FmOrganization
+#   ProjectID             FK → FmProject
+#   ParticRecID           FK → FmParticipant.PRecID, redundant with FmParticipant.PaymentID
+#   PledgeID              FK → FmPayment, pledge this payment pays down
+#   FormSubmissionID      external ref, e.g. FSB03117
+#   InvoiceID             external ref
+#   RefID                 external ref
+#   FormLetterID          acknowledgment letter
+#   Name
+#   Description
+#   Note
+#   Type
+#   Category
+#   Account
+#   Year
+#   Amount
+#   Value                 in-kind value
+#   Quantity
+#   InKindValueAcknowl
+#   PledgeSchedule
+#   LetterStatus
+#   PaymentMethod
+#   PaymentDetails        card last 4 plus processor transaction ID
+#   DateReceived
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   ModificationDateTime
 class FmPayment < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "RecordID"

--- a/app/models/fm_personnel.rb
+++ b/app/models/fm_personnel.rb
@@ -1,3 +1,25 @@
+# People assigned to a project, with their role and agreement status.
+#
+# FileMaker source: prj_PRS__Personnel (Personnel.csv, 8,907 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   PrsnlRecID        PK, e.g. PS9999
+#   PersonID          FK → FmRolodex
+#   ProjectID         FK → FmProject
+#   AgmtID            agreement ref, e.g. FSB02561, unlinked in the UI
+#   Name              denormalized from PersonID
+#   Role
+#   ProjectType
+#   Status
+#   AgreementStatus
+#   Update            annual update status
+#   Notes
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   DateTimeModified
 class FmPersonnel < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "PrsnlRecID"

--- a/app/models/fm_phone_number.rb
+++ b/app/models/fm_phone_number.rb
@@ -1,3 +1,20 @@
+# Phone numbers for rolodex records and organizations.
+#
+# FileMaker source: prj_org_PHN__Phones (PhoneNumbers.csv, 33,915 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   PhoneID               PK
+#   RolodexID             FK → FmRolodex
+#   OrgID                 FK → FmOrganization
+#   PhoneType
+#   PhoneNumber
+#   Country
+#   Primacy               primary number flag
+#   Note
+#   DateEntered
+#   ModificationDateTime
 class FmPhoneNumber < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "PhoneID"

--- a/app/models/fm_postal_code.rb
+++ b/app/models/fm_postal_code.rb
@@ -1,3 +1,24 @@
+# ZIP code reference data.
+#
+# FileMaker source: prj_PZC__CityState (PostalCodes.csv, 80,134 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   Zipcode          PK
+#   City
+#   State
+#   County
+#   FIPS
+#   Type
+#   Preferred
+#   PrefSort
+#   AreaCode
+#   TimeZone
+#   DaylightSavings
+#   Latitude
+#   Longitude
+#   Population
 class FmPostalCode < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "Zipcode"

--- a/app/models/fm_program_sponsorship.rb
+++ b/app/models/fm_program_sponsorship.rb
@@ -1,3 +1,24 @@
+# A funder sponsoring a specific program.
+#
+# FileMaker source: prj_PSP__ProgramSponsorships (ProgramSponsorships.csv, 608 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   RecordID          PK, e.g. PSP0901
+#   FunderID          FK → FmRolodex
+#   FundingID         FK → FmFunding
+#   ProgramID         FK → FmProject
+#   QuotationID       unlinked in the UI
+#   Status
+#   StartDate
+#   EndDate
+#   Notes
+#   MessageText
+#   CreatedBy
+#   ModifiedBy
+#   DateCreated
+#   DateTimeModified
 class FmProgramSponsorship < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "RecordID"

--- a/app/models/fm_project.rb
+++ b/app/models/fm_project.rb
@@ -1,3 +1,49 @@
+# Programs run at an organization.
+#
+# FileMaker source: PRJ__Projects (Projects.csv, 1,976 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   ProjectID                PK, e.g. P2775
+#   OrgID                    FK → FmOrganization
+#   MergerWithID             FK → FmProject, set when a project was merged away
+#   FacilityID               rolodex ref, unlinked in the UI
+#   ProjectName
+#   ProjectType
+#   AgencyType
+#   Description
+#   Status
+#   ObligationStatus
+#   Primary
+#   PrimarySetting
+#   SecondarySetting
+#   PrimaryServiceArea
+#   SecondaryAreas
+#   LifeExperiences
+#   City
+#   County
+#   State
+#   Locality
+#   District
+#   LASupervisorialDistrict
+#   SPA                      LA service planning area
+#   International
+#   StartDate
+#   EndDate
+#   CloseDate
+#   FeePaidFor
+#   FundingPotential
+#   QuotationID
+#   MessageText
+#   Comments
+#   WebID                    external/legacy key
+#   SQLid                    external/legacy key
+#   CreatedBy
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   DateTimeModified
 class FmProject < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "ProjectID"

--- a/app/models/fm_rolodex.rb
+++ b/app/models/fm_rolodex.rb
@@ -1,3 +1,92 @@
+# Party table — every person and agency contact.
+#
+# FileMaker source: prj_RDX__Rolodex (Rolodex.csv, 39,608 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   ID                        PK, e.g. 00006
+#   OrgID                     FK → FmOrganization
+#   PrimaryContactID          FK → FmRolodex
+#   PrimaryAddrsID            FK → FmAddress
+#   WorksiteAddrsID           FK → FmAddress
+#   PrimaryPhoneID            FK → FmPhoneNumber
+#   NamePrefix
+#   FirstName
+#   MiddleName
+#   LastName
+#   Suffix
+#   Pronouns
+#   Gender
+#   Gender2ndPerson           second person on a shared record
+#   Title
+#   Department
+#   Dept2ndName
+#   Organization              denormalized org name
+#   Classification
+#   Status
+#   isAgency__c               agency rather than individual
+#   PrimaryContact
+#   IncludeTitle
+#   ListBy
+#   AddresseeGreetingStyles   drives the letter salutation
+#   SourceOfName
+#   FamilyCode
+#   Keywords
+#   Interest
+#   MailingList
+#   Private
+#   Delete                    soft-delete flag
+#   DuplicateStatus
+#   Comments
+#   NameNote
+#   Mission
+#   WebSite
+#   EMail
+#   EmailPrimary
+#   EmailType
+#   EmailNotes
+#   BestTimeToCall
+#   Ethnicity
+#   Languages
+#   DateOfBirth
+#   BirthDay
+#   BirthMonth
+#   BirthYear
+#   BirthdayFlag
+#   Anniversary
+#   Children
+#   FacilitatorSinceMonth
+#   FacilitatorSinceYear
+#   FacilitatorStatusPending
+#   HowTrained
+#   TrainingMotivation
+#   LifeExperiences
+#   PrimaryAgeGroup
+#   PrimaryServiceArea
+#   OtherServiceArea
+#   BBSLicense                board of behavioral sciences license
+#   VolEnrollDate
+#   DropDate
+#   AvailMon
+#   AvailTue
+#   AvailWed
+#   AvailThu
+#   AvailFri
+#   AvailSat
+#   Settings                  workshop settings the facilitator works in
+#   Amount
+#   CkNo                      check number
+#   DonationCount
+#   DonationTotal
+#   FunderPotential
+#   CallForArtRecord
+#   UserID                    legacy FileMaker login
+#   Password                  legacy FileMaker login
+#   EnteredBy
+#   ModifiedBy
+#   DateEntered
+#   DateTimeModified
 class FmRolodex < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "ID"

--- a/app/models/fm_service.rb
+++ b/app/models/fm_service.rb
@@ -1,3 +1,26 @@
+# Monthly participant counts per project.
+#
+# FileMaker source: prj_SRV__Service (Service.csv, 69,590 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   RecordID          PK
+#   ProjectID         FK → FmProject
+#   Year
+#   Month
+#   NewAdult
+#   NewTeen
+#   NewChild
+#   OngoingAdult
+#   OngoingTeen
+#   OngoingChild
+#   Acknowledgment
+#   LateCard          report filed late
+#   CreatedBy
+#   ModifiedBy
+#   DateTimeCreated
+#   DateTimeModified
 class FmService < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "RecordID"

--- a/app/models/fm_workshop_log.rb
+++ b/app/models/fm_workshop_log.rb
@@ -1,3 +1,38 @@
+# One submitted workshop report.
+#
+# FileMaker source: WSL__WorkshopLog (WorkshopLogs.csv, 10,859 rows).
+# Fields below live in the `data` JSON column, except the primary key, which
+# the import lifts into `fm_id`. FileMaker's zc*/zg*/zs* calc, global and
+# summary fields are imported too but left out here — nothing reads them.
+#
+#   RecordID            PK
+#   ProjectID           FK → FmProject
+#   LeaderID            FK → FmRolodex
+#   AgencyID            FK → FmRolodex
+#   LeaderName          denormalized from LeaderID
+#   WorkshopID          e.g. W0421
+#   sqlWorkshopID       external/legacy key
+#   WebReportID         external/legacy key
+#   ReportSubmissionID  external/legacy key
+#   LinkIDs             unlinked in the UI
+#   WorkshopTitle
+#   WorkshopDate
+#   ReportDate
+#   Year__c
+#   MonthNumber__c
+#   TotalNew
+#   TotalNewTeen
+#   TotalNewChild
+#   TotalOngoing
+#   TotalOngoingTeen
+#   TotalOngoingChild
+#   AgesAdult
+#   AgesTeen
+#   AgesChild
+#   Materials
+#   Notes
+#   EnteredBy
+#   DateEntered
 class FmWorkshopLog < ApplicationRecord
   include FmArchive
   FM_KEY_COLUMN = "RecordID"


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 comments only, no code or behavior changes

Adds an annotate-style field list to the top of each of the 18 `Fm*` archive models, so you can see what's in a record without opening a CSV or querying one — groundwork for the FM → app importer.

- The archive tables are a single `data` JSON blob, so `schema.rb` documents nothing about their contents.
- Each header carries the FileMaker source table + CSV, the field list, and which fields are foreign keys (`FK → FmProject`).
- Fields come from `fm_data_structure.md`. FileMaker's `zc*`/`zg*`/`zs*` calc, global and summary columns are left out — they're imported but nothing reads them.
- Verified every `FM_KEY_COLUMN`, `FM_LINKS` FK and `HAS_MANY` backlink column appears in the annotations, and that no field was invented or dropped versus the source doc.

### Quirks called out in place

`FmActivity` is the one model with no entry in `fm_data_structure.md` — its fields come from the FileMaker record screen instead, so its list is the meaningful fields rather than a full column dump. `Date Entered` and `TakenEntered By` really do contain spaces, and `DateModifed` really is misspelled in FileMaker.