### PR TITLE
Remove dead variation_id column from workshop_variations

### DIFF
--- a/db/migrate/20260831220340_remove_variation_id_from_workshop_variations.rb
+++ b/db/migrate/20260831220340_remove_variation_id_from_workshop_variations.rb
@@ -1,0 +1,9 @@
+class RemoveVariationIdFromWorkshopVariations < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :workshop_variations, :variation_id, if_exists: true
+  end
+
+  def down
+    add_column :workshop_variations, :variation_id, :integer unless column_exists?(:workshop_variations, :variation_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2160,7 +2160,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_220445) do
     t.boolean "published", default: false, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "updated_by_id"
-    t.integer "variation_id"
     t.integer "windows_type_id"
     t.integer "workshop_id"
     t.bigint "workshop_variation_idea_id"


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 single-column drop migration, no code references

Removes the long-dead `variation_id` column from `workshop_variations`. It was nil across all rows in prod and referenced nowhere in the app.

Closes rubyforgood/awbw#402

- `up` drops the column (`if_exists: true`); `down` re-adds it as an integer, guarded by `column_exists?`.
- No index or FK on the column, so nothing else to clean up.