### PR TITLE
Remove project/project_spanish columns from workshops (#404)

### DIFF
--- a/db/migrate/20260831220429_remove_project_fields_from_workshops.rb
+++ b/db/migrate/20260831220429_remove_project_fields_from_workshops.rb
@@ -1,0 +1,11 @@
+class RemoveProjectFieldsFromWorkshops < ActiveRecord::Migration[8.0]
+  def up
+    remove_column :workshops, :project, if_exists: true
+    remove_column :workshops, :project_spanish, if_exists: true
+  end
+
+  def down
+    add_column :workshops, :project, :text, size: :long unless column_exists?(:workshops, :project)
+    add_column :workshops, :project_spanish, :text, size: :long unless column_exists?(:workshops, :project_spanish)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2226,8 +2226,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_220445) do
     t.text "optional_materials", size: :long
     t.text "optional_materials_spanish", size: :long
     t.string "photo_caption"
-    t.text "project", size: :long
-    t.text "project_spanish", size: :long
     t.string "pub_issue"
     t.boolean "publicly_featured", default: false, null: false
     t.boolean "publicly_visible", default: false, null: false


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 single migration dropping two empty, unreferenced columns

Drops the empty `project` and `project_spanish` text columns from `workshops` — they're empty in prod and unused in the app, since a workshop's organization link is the `organization_id` association.

- Reversible `up`/`down` migration, guarded with `if_exists:` / `column_exists?`.
- No app code, factory, or spec referenced either column (grep-verified).

Closes #404