### PR TITLE
Reduce dev seed volume for workshop logs and monthly reports

### DIFF
--- a/db/seeds/dev/monthly_reports.rb
+++ b/db/seeds/dev/monthly_reports.rb
@@ -119,8 +119,8 @@ if MonthlyReport.none?
   }
 
   if aisha_user
-    # 30 monthly reports for Aisha (30 months of history)
-    30.times do |i|
+    # A handful of monthly reports for Aisha (recent months of history)
+    8.times do |i|
       create_monthly_report.call(
         organization: aisha_org,
         created_by: aisha_user,
@@ -128,8 +128,8 @@ if MonthlyReport.none?
       )
     end
 
-    # Additional batches under varying older dates to mimic prod's long tail
-    report_counts = [ 15, 12, 9, 7, 5, 4, 3, 2, 1, 1 ]
+    # A few older batches to mimic prod's long tail
+    report_counts = [ 4, 3, 2, 1 ]
     report_counts.each_with_index do |count, batch|
       count.times do |i|
         create_monthly_report.call(
@@ -144,7 +144,7 @@ if MonthlyReport.none?
   # A few monthly reports for the admin user as well
   admin_user = User.first
   if admin_user && admin_user != aisha_user
-    5.times do
+    3.times do
       create_monthly_report.call(
         organization: Organization.all.sample || aisha_org,
         created_by: admin_user,

--- a/db/seeds/dev/workshop_logs.rb
+++ b/db/seeds/dev/workshop_logs.rb
@@ -8,9 +8,9 @@ aisha_org = aisha_user&.person&.affiliations&.first&.organization || Organizatio
 all_workshops = Workshop.all.to_a.shuffle
 
 if aisha_user && all_workshops.any? && WorkshopLog.where(created_by_id: aisha_user.id).none?
-  # 30 logs for Aisha's primary workshop
+  # A handful of logs for Aisha's primary workshop
   primary_workshop = all_workshops.shift
-  30.times do |i|
+  8.times do |i|
     WorkshopLog.create!(
       workshop_id: primary_workshop.id,
       organization_id: aisha_org.id,
@@ -28,9 +28,9 @@ if aisha_user && all_workshops.any? && WorkshopLog.where(created_by_id: aisha_us
     )
   end
 
-  # Up to 10 other workshops with varying log counts (1–15)
-  other_workshops = all_workshops.first(10)
-  log_counts = [ 15, 12, 9, 7, 5, 4, 3, 2, 1, 1 ]
+  # A few other workshops with varying log counts
+  other_workshops = all_workshops.first(4)
+  log_counts = [ 4, 3, 2, 1 ]
   other_workshops.each_with_index do |workshop, idx|
     count = log_counts[idx] || 1
     count.times do |i|
@@ -51,12 +51,12 @@ if aisha_user && all_workshops.any? && WorkshopLog.where(created_by_id: aisha_us
       )
     end
   end
-  puts "  Created 89 logs for Aisha on 11 workshops"
+  puts "  Created #{WorkshopLog.where(created_by_id: aisha_user.id).count} logs for Aisha on #{other_workshops.count + 1} workshops"
 end
 
 # A few logs for the admin user as well
 if WorkshopLog.where(created_by_id: User.first&.id).none?
-  5.times do
+  3.times do
     workshop = Workshop.all.sample
     next unless workshop
 


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 dev-only seed counts, no app logic or schema

Local dev was seeding 89 workshop logs and 89 monthly reports — far more than needed to exercise those pages, so this trims each to ~18 while keeping the varied per-workshop/month history and date spacing.

### What is the goal of this PR and why is this important?
The dev sample dataset created 89 workshop logs and 89 monthly reports, cluttering the workspace DB with more rows than dev work needs.

### How did you approach the change?
Lowered the seed loop counts in `db/seeds/dev/workshop_logs.rb` and `db/seeds/dev/monthly_reports.rb` (primary batch 30→8, tail batches `[15,12,9,…]`→`[4,3,2,1]`, admin 5→3) and made the workshop-log summary `puts` compute its count instead of hardcoding 89.

### Anything else to add?
Dev-only seeds; no production seeds, app logic, or schema touched.