### PR TITLE
Add hide toggles to the admin activities timeline (and some design cleanup)

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -36,12 +36,18 @@ module Admin
         scope = scope.where.not(hidden.map { "ahoy_events.name LIKE ?" }.join(" OR "), *hidden)
       end
 
-      # Filter by event name. Split on any non-alphanumeric run so hyphens (and
-      # commas, dots, spaces) are interchangeable separators and each token must
-      # match — e.g. "account-auth" finds "auth.account_deactivated".
+      # One search box spans the activity name and the resource title. Split on any
+      # non-alphanumeric run so hyphens (and commas, dots, spaces) are interchangeable
+      # separators, and each token must match one or the other — e.g. "account-auth"
+      # finds "auth.account_deactivated" by name, "feelings" finds a "Feelings Collage"
+      # resource by title.
       if params[:event_name].present?
         params[:event_name].split(/[^a-z0-9]+/i).reject(&:blank?).each do |token|
-          scope = scope.where("ahoy_events.name LIKE ?", "%#{Ahoy::Event.sanitize_sql_like(token)}%")
+          like = "%#{Ahoy::Event.sanitize_sql_like(token)}%"
+          scope = scope.where(
+            "ahoy_events.name LIKE ? OR LOWER(ahoy_events.properties->>'$.resource_title') LIKE LOWER(?)",
+            like, like
+          )
         end
       end
 
@@ -68,15 +74,6 @@ module Admin
       # Filter by visit
       if params[:visit_id].present?
         scope = scope.where(visit_id: params[:visit_id])
-      end
-
-      # Filter by resource title (the human name captured in the event's properties)
-      if params[:resource_name].present?
-        term = Ahoy::Event.sanitize_sql_like(params[:resource_name])
-        scope = scope.where(
-          "LOWER(ahoy_events.properties->>'$.resource_title') LIKE LOWER(?)",
-          "%#{term}%"
-        )
       end
 
       # Filter by props (full-text search across properties JSON)

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -38,16 +38,20 @@ module Admin
 
       # One search box spans the activity name and the resource title. Split on any
       # non-alphanumeric run so hyphens (and commas, dots, spaces) are interchangeable
-      # separators, and each token must match one or the other — e.g. "account-auth"
-      # finds "auth.account_deactivated" by name, "feelings" finds a "Feelings Collage"
-      # resource by title.
+      # separators, and each token must match one of them — e.g. "account-auth" finds
+      # "auth.account_deactivated" by name, "feelings" finds a "Feelings Collage"
+      # resource by title. A plain-language chip word ("new", "edit") also matches its
+      # raw action prefix, so search matches what the reader sees in the row.
       if params[:event_name].present?
         params[:event_name].split(/[^a-z0-9]+/i).reject(&:blank?).each do |token|
           like = "%#{Ahoy::Event.sanitize_sql_like(token)}%"
-          scope = scope.where(
-            "ahoy_events.name LIKE ? OR LOWER(ahoy_events.properties->>'$.resource_title') LIKE LOWER(?)",
-            like, like
-          )
+          clauses = [ "ahoy_events.name LIKE ?", "LOWER(ahoy_events.properties->>'$.resource_title') LIKE LOWER(?)" ]
+          binds = [ like, like ]
+          Ahoy::EventDecorator.action_keys_for_label(token).each do |action|
+            clauses << "ahoy_events.name LIKE ?"
+            binds << "#{Ahoy::Event.sanitize_sql_like(action)}.%"
+          end
+          scope = scope.where(clauses.join(" OR "), *binds)
         end
       end
 

--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -29,6 +29,13 @@ module Admin
                             *prefixes.map { |p| "#{p}.%" })
       end
 
+      # Hide toggles: exclude whole categories (account, interactions) in bulk so
+      # the timeline can be pared down to changelogs and communications.
+      hidden = hidden_name_patterns
+      if hidden.present?
+        scope = scope.where.not(hidden.map { "ahoy_events.name LIKE ?" }.join(" OR "), *hidden)
+      end
+
       # Filter by event name. Split on any non-alphanumeric run so hyphens (and
       # commas, dots, spaces) are interchangeable separators and each token must
       # match — e.g. "account-auth" finds "auth.account_deactivated".
@@ -218,7 +225,7 @@ module Admin
     # A visit_id filter excludes communications — they have no visit to belong to.
     def person_communications
       email = @person.communications_email
-      return Notification.none if email.blank? || params[:visit_id].present?
+      return Notification.none if email.blank? || params[:visit_id].present? || hide_communications?
 
       scope = Notification.email(email).includes(:noticeable, sender: :person).order(created_at: :desc)
       scope = scope.where(created_at: time_range) if time_range.present?
@@ -727,6 +734,21 @@ module Admin
 
     def selected_audiences
       @selected_audiences ||= Array(params[:audience]).reject(&:blank?).presence || %w[visitors users]
+    end
+
+    def hidden_name_patterns
+      patterns = []
+      patterns.concat(Ahoy::Event::ACCOUNT_NAME_PATTERNS) if param_true?(params[:hide_account])
+      patterns.concat(Ahoy::Event::INTERACTION_NAME_PATTERNS) if param_true?(params[:hide_interactions])
+      patterns
+    end
+
+    def hide_communications?
+      param_true?(params[:hide_communications])
+    end
+
+    def param_true?(value)
+      ActiveModel::Type::Boolean.new.cast(value)
     end
 
     def scoped_visits

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -165,11 +165,25 @@ module Ahoy
         { text: [ record.title.presence, record.organization&.name, affiliation_dates(record) ].compact.join(" · "),
           path: edit_path_for(record) }
       when EventRegistration
-        { text: [ record.event&.title, record.event&.start_date&.strftime("%B %Y") ].compact.join(" · "),
+        span = [ record.event&.title, record.event&.start_date&.strftime("%b'%y") ].compact.join(" · ")
+        { text: span.present? ? "Registration: #{span}" : "Registration", path: edit_path_for(record) }
+      when Scholarship
+        headline = [ h.dollars_from_cents(record.amount_cents), record.grant&.name ].compact.join(" ")
+        { text: [ headline.presence, record.grant&.funder_name ].compact.join(" · "),
+          path: edit_path_for(record) }
+      when ContinuingEducationRegistration
+        { text: [ ce_hours_label(record), record.professional_license&.name ].compact.join(" · "),
           path: edit_path_for(record) }
       when Payment
         payment_allocation_link(record)
       end
+    end
+
+    # "13 hours" / "1 hour", dropping a trailing .0 on whole-number hours.
+    def ce_hours_label(ce_registration)
+      hours = ce_registration.hours
+      hours = hours.to_i if hours == hours.to_i
+      h.pluralize(hours, "hour")
     end
 
     # An affiliation's span: "Aug'25 - Feb'26", or "Aug'25 - present" while active.

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -33,6 +33,10 @@ module Ahoy
       ACTION_CHIPS.select { |_action, chip| chip[:label].casecmp?(term) }.keys
     end
 
+    def comment?
+      object.resource_type == "Comment"
+    end
+
     # { label:, classes: } for the leading action chip.
     def activity_chip
       ACTION_CHIPS[action_key] || { label: action_key.humanize, classes: DEFAULT_CHIP_CLASSES }

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -6,6 +6,50 @@ module Ahoy
     # Fields that title the record they belong to, in the order they should lead.
     HEADING_KEYS = %w[topic title name subject].freeze
 
+    # Plain-language chips for the raw "action.resource" event name, so a
+    # non-technical reader sees "New" / "Edit" instead of "create." / "update.".
+    # Colored ones flag record changes; everything else reads gray. Class literals
+    # live here (decorators are Tailwind-scanned) so the chip generates.
+    ACTION_CHIPS = {
+      "create"      => { label: "New",      classes: "bg-blue-100 text-blue-800" },
+      "update"      => { label: "Edit",     classes: "bg-green-100 text-green-800" },
+      "destroy"     => { label: "Delete",   classes: "bg-red-100 text-red-800" },
+      "autochange"  => { label: "Auto",     classes: "bg-gray-100 text-gray-600" },
+      "view"        => { label: "View",     classes: "bg-gray-100 text-gray-600" },
+      "print"       => { label: "Print",    classes: "bg-gray-100 text-gray-600" },
+      "download"    => { label: "Download", classes: "bg-gray-100 text-gray-600" },
+      "search"      => { label: "Search",   classes: "bg-gray-100 text-gray-600" },
+      "search_zero" => { label: "Search",   classes: "bg-gray-100 text-gray-600" },
+      "filter"      => { label: "Filter",   classes: "bg-gray-100 text-gray-600" },
+      "auth"        => { label: "Account",  classes: "bg-gray-100 text-gray-600" },
+      "dedupe"      => { label: "Merge",    classes: "bg-gray-100 text-gray-600" }
+    }.freeze
+    DEFAULT_CHIP_CLASSES = "bg-gray-100 text-gray-600".freeze
+
+    # { label:, classes: } for the leading action chip.
+    def activity_chip
+      ACTION_CHIPS[action_key] || { label: action_key.humanize, classes: DEFAULT_CHIP_CLASSES }
+    end
+
+    # The resource half of the event name, humanized: "workshop_variation" reads
+    # "Workshop variation", "account_deactivated" reads "Account deactivated".
+    def activity_resource_label
+      object.name.to_s.split(".", 2)[1].to_s.humanize
+    end
+
+    # The event's own resource, linked to its edit page so an admin can jump
+    # straight there from the timeline. Title comes from properties; the record
+    # resolves through the page cache (Analytics::EventReferenceLoader). Returns
+    # nil when there's no title; :path is nil when the record is gone or has no
+    # editable route (rendered as plain text).
+    def resource_link
+      title = properties_hash["resource_title"]
+      return nil if title.blank?
+
+      record = find_referenced_record(object.resource_type, object.resource_id)
+      { text: title, path: edit_path_for(record) }
+    end
+
     # Everything the dedicated columns don't already show.
     def extra_properties
       properties_hash.except(*REDUNDANT_KEYS)
@@ -51,6 +95,20 @@ module Ahoy
     end
 
     private
+
+    def action_key
+      object.name.to_s.split(".", 2).first.to_s
+    end
+
+    # Prefer the record's edit page (the point of the link), falling back to its
+    # show page, then to nothing when neither route exists.
+    def edit_path_for(record)
+      return nil unless record
+
+      h.edit_polymorphic_path(record)
+    rescue StandardError
+      show_path_for(record)
+    end
 
     def properties_hash
       object.properties || {}

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -96,6 +96,12 @@ module Ahoy
       extra_properties.present?
     end
 
+    # Whether the Details block has anything to show (so the merged Activity cell
+    # can skip the empty-dash placeholder).
+    def details?
+      comment_note.present? || extra_details?
+    end
+
     def changes?
       change_diffs.is_a?(Hash) && change_diffs.present?
     end

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -3,6 +3,11 @@ module Ahoy
     # Already surfaced in their own table columns, so redundant inside the details cell.
     REDUNDANT_KEYS = %w[resource_type resource_id resource_title].freeze
 
+    # An auth event names the acting user twice (record_* duplicates resource_*) and
+    # carries an updated_by that's always that same actor — all noise beside the
+    # headline, so leave them out of a login's details.
+    AUTH_REDUNDANT_KEYS = %w[record_id record_type updated_by_id].freeze
+
     # Fields that title the record they belong to, in the order they should lead.
     HEADING_KEYS = %w[topic title name subject].freeze
 
@@ -93,7 +98,12 @@ module Ahoy
 
     # Everything the dedicated columns don't already show.
     def extra_properties
-      properties_hash.except(*REDUNDANT_KEYS)
+      keys = auth? ? REDUNDANT_KEYS + AUTH_REDUNDANT_KEYS : REDUNDANT_KEYS
+      properties_hash.except(*keys)
+    end
+
+    def auth?
+      object.name.to_s.start_with?("auth.")
     end
 
     def extra_details?

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -26,6 +26,13 @@ module Ahoy
     }.freeze
     DEFAULT_CHIP_CLASSES = "bg-gray-100 text-gray-600".freeze
 
+    # The raw action prefixes a plain-language chip word maps to, so the activity
+    # search can match what the reader sees: "new" finds create events, "search"
+    # finds both search and search_zero. Empty for a word that isn't a chip label.
+    def self.action_keys_for_label(term)
+      ACTION_CHIPS.select { |_action, chip| chip[:label].casecmp?(term) }.keys
+    end
+
     # { label:, classes: } for the leading action chip.
     def activity_chip
       ACTION_CHIPS[action_key] || { label: action_key.humanize, classes: DEFAULT_CHIP_CLASSES }

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -54,18 +54,27 @@ module Ahoy
     def resource_link
       return commentable_link if comment&.commentable
 
+      record = find_referenced_record(object.resource_type, object.resource_id)
+      custom = custom_resource_link(record)
+      return custom if custom
+
       title = properties_hash["resource_title"]
       return nil if title.blank?
 
-      record = find_referenced_record(object.resource_type, object.resource_id)
       { text: title, path: edit_path_for(record) }
     end
 
-    # The record a comment was left on, labeled and linked the same way the
-    # comment feeds do (CommentsHelper), so the two never drift.
+    # The record a comment was left on, labeled and linked. Reuses the same
+    # record-specific labels as direct events, falling back to the shared comment
+    # feed helper (CommentsHelper) so the two never drift.
     def commentable_link
       commentable = comment.commentable
-      { text: h.commentable_label(commentable), path: h.record_edit_path(commentable) }
+      custom_resource_link(commentable) ||
+        { text: h.commentable_label(commentable), path: h.record_edit_path(commentable) }
+    end
+
+    def comment_flagged?
+      comment&.flagged? || false
     end
 
     # A comment's topic + body, read from the record so it shows in Details
@@ -134,6 +143,35 @@ module Ahoy
       return nil unless object.resource_type == "Comment"
 
       @comment ||= find_referenced_record("Comment", object.resource_id)
+    end
+
+    # Record types that read better as a composed label than as their raw
+    # resource_title. Returns a { text:, path: } link, or nil to use the default
+    # (resource_title for events, commentable_label for comments). A payment
+    # points at what it's allocated to, not the payment row.
+    def custom_resource_link(record)
+      case record
+      when Affiliation
+        { text: [ record.title.presence, record.organization&.name ].compact.join(" · "),
+          path: edit_path_for(record) }
+      when EventRegistration
+        { text: [ record.event&.title, record.event&.start_date&.strftime("%B %Y") ].compact.join(" · "),
+          path: edit_path_for(record) }
+      when Payment
+        payment_allocation_link(record)
+      end
+    end
+
+    # A payment reads as what it paid for — its allocations' targets (an event
+    # registration, a scholarship). nil (default label) when nothing's allocated.
+    def payment_allocation_link(payment)
+      allocatables = payment.allocations.map(&:allocatable).compact
+      return nil if allocatables.empty?
+
+      descriptor = h.allocatable_descriptor(allocatables.first)
+      text = descriptor[:title]
+      text = "#{text} +#{allocatables.size - 1} more" if allocatables.size > 1
+      { text: text, path: descriptor[:path] }
     end
 
     # Prefer the record's edit page (the point of the link), falling back to its

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -162,7 +162,7 @@ module Ahoy
     def custom_resource_link(record)
       case record
       when Affiliation
-        { text: [ record.title.presence, record.organization&.name ].compact.join(" · "),
+        { text: [ record.title.presence, record.organization&.name, affiliation_dates(record) ].compact.join(" · "),
           path: edit_path_for(record) }
       when EventRegistration
         { text: [ record.event&.title, record.event&.start_date&.strftime("%B %Y") ].compact.join(" · "),
@@ -170,6 +170,15 @@ module Ahoy
       when Payment
         payment_allocation_link(record)
       end
+    end
+
+    # An affiliation's span: "Aug'25 - Feb'26", or "Aug'25 - present" while active.
+    # nil when it has no start date to anchor the range.
+    def affiliation_dates(affiliation)
+      return nil unless affiliation.start_date
+
+      finish = affiliation.end_date&.strftime("%b'%y") || "present"
+      "#{affiliation.start_date.strftime("%b'%y")} - #{finish}"
     end
 
     # A payment reads as what it paid for — its allocations' targets (an event

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -45,16 +45,37 @@ module Ahoy
     end
 
     # The event's own resource, linked to its edit page so an admin can jump
-    # straight there from the timeline. Title comes from properties; the record
-    # resolves through the page cache (Analytics::EventReferenceLoader). Returns
-    # nil when there's no title; :path is nil when the record is gone or has no
-    # editable route (rendered as plain text).
+    # straight there from the timeline. A comment instead points at the record it
+    # was left on (the affiliation, scholarship, profile) — that's what an admin
+    # reads it by, not the comment's own id. Title comes from properties; the
+    # record resolves through the page cache (Analytics::EventReferenceLoader).
+    # Returns nil when there's no title; :path is nil when the record is gone or
+    # has no editable route (rendered as plain text).
     def resource_link
+      return commentable_link if comment&.commentable
+
       title = properties_hash["resource_title"]
       return nil if title.blank?
 
       record = find_referenced_record(object.resource_type, object.resource_id)
       { text: title, path: edit_path_for(record) }
+    end
+
+    # The record a comment was left on, labeled and linked the same way the
+    # comment feeds do (CommentsHelper), so the two never drift.
+    def commentable_link
+      commentable = comment.commentable
+      { text: h.commentable_label(commentable), path: h.record_edit_path(commentable) }
+    end
+
+    # A comment's topic + body, read from the record so it shows in Details
+    # regardless of how the body was captured in properties. nil for non-comments
+    # and for a comment with nothing to show (e.g. a since-deleted record).
+    def comment_note
+      return nil unless comment
+
+      note = { topic: comment.topic.presence, body: comment.body.presence }
+      note.values.any? ? note : nil
     end
 
     # Everything the dedicated columns don't already show.
@@ -105,6 +126,14 @@ module Ahoy
 
     def action_key
       object.name.to_s.split(".", 2).first.to_s
+    end
+
+    # The Comment this event is about, from the page cache (no extra query); nil
+    # for non-comment events.
+    def comment
+      return nil unless object.resource_type == "Comment"
+
+      @comment ||= find_referenced_record("Comment", object.resource_id)
     end
 
     # Prefer the record's edit page (the point of the link), falling back to its

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -11,6 +11,18 @@ class Ahoy::Event < ApplicationRecord
   # browsing belongs.
   NON_MUTATION_PREFIXES = %w[view print search filter download].freeze
 
+  # Event-name patterns the activities index can toggle off in bulk.
+  #
+  # Account = the user/account lifecycle: every auth.* callback (login, password
+  # reset, email change, lock, admin grant, account setup/delete, …) plus
+  # mutations of the User record itself, so one "account" toggle sweeps all user
+  # churn out of a person's timeline.
+  #
+  # Interaction = read/browse noise (NON_MUTATION_PREFIXES plus zero-result
+  # searches).
+  ACCOUNT_NAME_PATTERNS = [ "auth.%", "create.user", "update.user", "destroy.user" ].freeze
+  INTERACTION_NAME_PATTERNS = (NON_MUTATION_PREFIXES + %w[search_zero]).map { |prefix| "#{prefix}.%" }.freeze
+
   scope :mutations, -> {
     NON_MUTATION_PREFIXES.reduce(all) { |scope, prefix| scope.where.not(arel_table[:name].matches("#{prefix}.%")) }
   }

--- a/app/services/analytics/event_reference_loader.rb
+++ b/app/services/analytics/event_reference_loader.rb
@@ -35,7 +35,7 @@ module Analytics
     private
 
     def load_records
-      pairs = @events.flat_map { |event| references_in(event.properties || {}) }.uniq
+      pairs = @events.flat_map { |event| primary_pairs(event) + references_in(event.properties || {}) }.uniq
       pairs.group_by(&:first).each_with_object({}) do |(type, type_pairs), map|
         klass = type.safe_constantize
         next unless klass.respond_to?(:where) && klass < ApplicationRecord
@@ -45,6 +45,14 @@ module Analytics
       end
     rescue StandardError
       {}
+    end
+
+    # The event's own resource (its resource_type/resource_id columns), so the
+    # timeline can link the resource title to the record without a per-row query.
+    def primary_pairs(event)
+      return [] if event.resource_type.blank? || event.resource_id.blank?
+
+      [ [ event.resource_type.to_s, event.resource_id ] ]
     end
 
     def references_in(value)

--- a/app/views/admin/ahoy_activities/_activity_cell.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_cell.html.erb
@@ -1,15 +1,25 @@
-<%# Inner content of the Activity cell: the action chip + purple resource name
-    (with an optional flag), then the grey specific-record line. The caller wraps
-    this in a link to the resource, so group-hover:underline lights up on hover. %>
-<div class="flex items-center gap-2" title="<%= event.name %>">
-  <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
+<%# Merged Activity cell: the action chip on the left, then the name, the grey
+    resource sublabel, and the event's Details stacked in one column indented
+    under the name. The caller marks the cell `group` and overlays a link to the
+    resource, so the name underlines on hover and the whole cell navigates. %>
+<div class="flex items-start gap-2" title="<%= event.name %>">
+  <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
     <%= chip[:label] %>
   </span>
-  <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
-  <% if activity.comment_flagged? %>
-    <i class="fa-solid fa-flag text-orange-500" title="Flagged"></i>
-  <% end %>
+  <div class="min-w-0 space-y-0.5">
+    <div class="flex items-center gap-2">
+      <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
+      <% if activity.comment_flagged? %>
+        <i class="fa-solid fa-flag text-orange-500" title="Flagged"></i>
+      <% end %>
+    </div>
+    <% if resource %>
+      <div class="text-xs text-gray-500"><%= resource[:text] %></div>
+    <% end %>
+    <% if activity.details? %>
+      <div class="pt-1 text-gray-500">
+        <%= render "admin/ahoy_activities/event_details", activity: activity %>
+      </div>
+    <% end %>
+  </div>
 </div>
-<% if resource %>
-  <div class="mt-0.5 text-xs text-gray-500 group-hover:underline"><%= resource[:text] %></div>
-<% end %>

--- a/app/views/admin/ahoy_activities/_activity_cell.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_cell.html.erb
@@ -3,19 +3,22 @@
     under the name. The caller marks the cell `group` and overlays a link to the
     resource, so the name underlines on hover and the whole cell navigates. %>
 <div class="flex items-start gap-2" title="<%= event.name %>">
-  <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
-    <%= chip[:label] %>
+  <span class="mt-0.5 flex w-24 shrink-0 justify-end">
+    <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
+      <%= chip[:label] %>
+    </span>
   </span>
-  <div class="min-w-0 space-y-0.5">
-    <div class="flex items-center gap-2">
+  <div class="min-w-0">
+    <div class="flex flex-wrap items-baseline gap-x-1.5">
       <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
+      <% if resource %>
+        <span class="text-gray-300">&middot;</span>
+        <span class="text-xs text-gray-500"><%= resource[:text] %></span>
+      <% end %>
       <% if activity.comment_flagged? %>
         <i class="fa-solid fa-flag text-orange-500" title="Flagged"></i>
       <% end %>
     </div>
-    <% if resource %>
-      <div class="text-xs text-gray-500"><%= resource[:text] %></div>
-    <% end %>
     <% if activity.details? %>
       <div class="pt-1 text-gray-500">
         <%= render "admin/ahoy_activities/event_details", activity: activity %>

--- a/app/views/admin/ahoy_activities/_activity_cell.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_cell.html.erb
@@ -1,0 +1,15 @@
+<%# Inner content of the Activity cell: the action chip + purple resource name
+    (with an optional flag), then the grey specific-record line. The caller wraps
+    this in a link to the resource, so group-hover:underline lights up on hover. %>
+<div class="flex items-center gap-2" title="<%= event.name %>">
+  <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
+    <%= chip[:label] %>
+  </span>
+  <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
+  <% if activity.comment_flagged? %>
+    <i class="fa-solid fa-flag text-orange-500" title="Flagged"></i>
+  <% end %>
+</div>
+<% if resource %>
+  <div class="mt-0.5 text-xs text-gray-500 group-hover:underline"><%= resource[:text] %></div>
+<% end %>

--- a/app/views/admin/ahoy_activities/_activity_cell.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_cell.html.erb
@@ -10,10 +10,12 @@
   </span>
   <div class="min-w-0">
     <div class="flex flex-wrap items-baseline gap-x-1.5">
-      <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
       <% if resource %>
+        <span class="font-medium text-indigo-600 group-hover:underline"><%= resource[:text] %></span>
         <span class="text-gray-300">&middot;</span>
-        <span class="text-xs text-gray-500"><%= resource[:text] %></span>
+        <span class="text-xs text-gray-500"><%= activity.activity_resource_label %></span>
+      <% else %>
+        <span class="font-medium text-indigo-600 group-hover:underline"><%= activity.activity_resource_label %></span>
       <% end %>
       <% if activity.comment_flagged? %>
         <i class="fa-solid fa-flag text-orange-500" title="Flagged"></i>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -16,7 +16,13 @@
     <% end %>
   </td>
 
-  <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
+  <td data-label="Details" class="relative min-w-[16rem] px-4 py-3 align-top text-gray-500">
+    <%# Whole cell links to the resource (no text styling); inner links stay
+        clickable via z-10 in the partial. %>
+    <% if resource && resource[:path] %>
+      <%= link_to "", resource[:path], class: "absolute inset-0",
+                  aria: { label: "Open #{resource[:text]}" }, data: { turbo_frame: "_top" } %>
+    <% end %>
     <%= render "admin/ahoy_activities/event_details", activity: activity %>
   </td>
 

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,32 +1,23 @@
 <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
+<% chip = activity.activity_chip %>
+<% resource = activity.resource_link %>
+<% linked = resource && resource[:path] %>
 <tr class="transition hover:bg-gray-50">
-  <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
+  <td data-label="Time" class="px-4 py-3 align-top whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
 
-  <% chip = activity.activity_chip %>
-  <% resource = activity.resource_link %>
-  <td data-label="Activity" class="px-4 py-3">
-    <% if resource && resource[:path] %>
-      <%= link_to resource[:path], class: "group block", data: { turbo_frame: "_top" } do %>
-        <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
-      <% end %>
-    <% else %>
-      <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
-    <% end %>
-  </td>
-
-  <td data-label="Details" class="relative min-w-[16rem] px-4 py-3 align-top text-gray-500">
-    <%# Whole cell links to the resource (no text styling); inner links stay
-        clickable via z-10 in the partial. %>
-    <% if resource && resource[:path] %>
+  <%# Merged Activity + Details cell: a link overlay makes the whole cell navigate
+      to the resource without restyling the text; inner detail links keep z-10. %>
+  <td data-label="Activity" class="<%= "group " if linked %>relative px-4 py-3 align-top">
+    <% if linked %>
       <%= link_to "", resource[:path], class: "absolute inset-0",
                   aria: { label: "Open #{resource[:text]}" }, data: { turbo_frame: "_top" } %>
     <% end %>
-    <%= render "admin/ahoy_activities/event_details", activity: activity %>
+    <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
   </td>
 
-  <td data-label="User" class="w-32 px-4 py-3 text-gray-600">
+  <td data-label="User" class="w-32 px-4 py-3 align-top text-gray-600">
     <% if event.user %>
       <%= link_to event.user.full_name,
                   user_path(event.user),
@@ -38,7 +29,7 @@
     <% end %>
   </td>
 
-  <td data-label="Visit ID" class="w-16 px-4 py-3 text-gray-500">
+  <td data-label="Visit ID" class="w-16 px-4 py-3 align-top text-gray-500">
     <%= event.visit_id %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -5,21 +5,14 @@
   </td>
 
   <% chip = activity.activity_chip %>
+  <% resource = activity.resource_link %>
   <td data-label="Activity" class="px-4 py-3">
-    <div class="flex items-center gap-2" title="<%= event.name %>">
-      <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
-        <%= chip[:label] %>
-      </span>
-      <span class="font-medium text-gray-900"><%= activity.activity_resource_label %></span>
-    </div>
-    <% if (resource = activity.resource_link) %>
-      <% if resource[:path] %>
-        <%= link_to resource[:text], resource[:path],
-                    class: "mt-0.5 block text-xs text-indigo-600 hover:underline",
-                    data: { turbo_frame: "_top" } %>
-      <% else %>
-        <div class="mt-0.5 text-xs text-gray-500"><%= resource[:text] %></div>
+    <% if resource && resource[:path] %>
+      <%= link_to resource[:path], class: "group block", data: { turbo_frame: "_top" } do %>
+        <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
       <% end %>
+    <% else %>
+      <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
     <% end %>
   </td>
 

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,17 +1,28 @@
+<% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
 <tr class="transition hover:bg-gray-50">
   <td data-label="Time" class="px-4 py-3 whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
 
-  <td data-label="Activity" class="px-4 py-3 font-medium text-gray-900">
-    <%= event.name %>
+  <% chip = activity.activity_chip %>
+  <td data-label="Activity" class="px-4 py-3">
+    <div class="flex items-center gap-2" title="<%= event.name %>">
+      <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase <%= chip[:classes] %>">
+        <%= chip[:label] %>
+      </span>
+      <span class="font-medium text-gray-900"><%= activity.activity_resource_label %></span>
+    </div>
+    <% if (resource = activity.resource_link) %>
+      <% if resource[:path] %>
+        <%= link_to resource[:text], resource[:path],
+                    class: "mt-0.5 block text-xs text-indigo-600 hover:underline",
+                    data: { turbo_frame: "_top" } %>
+      <% else %>
+        <div class="mt-0.5 text-xs text-gray-500"><%= resource[:text] %></div>
+      <% end %>
+    <% end %>
   </td>
 
-  <td data-label="Resource" class="px-4 py-3 text-gray-500">
-    <%= event.properties["resource_title"].presence || "—" %>
-  </td>
-
-  <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
   <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
     <%= render "admin/ahoy_activities/event_details", activity: activity %>
   </td>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -30,6 +30,9 @@
   </td>
 
   <td data-label="Visit ID" class="w-16 px-4 py-3 align-top text-gray-500">
-    <%= event.visit_id %>
+    <% if event.visit_id %>
+      <%= link_to event.visit_id, admin_activities_visits_path(visit_id: event.visit_id),
+                  class: "text-indigo-600 hover:underline", data: { turbo_frame: "_top" } %>
+    <% end %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -27,18 +27,19 @@
     <%= render "admin/ahoy_activities/event_details", activity: activity %>
   </td>
 
-  <td data-label="User" class="px-4 py-3 text-gray-600">
+  <td data-label="User" class="w-32 px-4 py-3 text-gray-600">
     <% if event.user %>
       <%= link_to event.user.full_name,
                   user_path(event.user),
-                  class: "text-indigo-600 hover:underline",
+                  title: event.user.full_name,
+                  class: "block max-w-[8rem] truncate text-indigo-600 hover:underline",
                   data: { turbo_frame: "_top" } %>
     <% else %>
       <span class="text-gray-400 italic">Guest</span>
     <% end %>
   </td>
 
-  <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
+  <td data-label="Visit ID" class="w-16 px-4 py-3 text-gray-500">
     <%= event.visit_id %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -2,7 +2,7 @@
 <% chip = activity.activity_chip %>
 <% resource = activity.resource_link %>
 <% linked = resource && resource[:path] %>
-<tr class="transition hover:bg-gray-50">
+<tr class="<%= activity.comment? ? "#{DomainTheme.bg_class_for(:comments, intensity: 50)} transition" : "transition hover:bg-gray-50" %>">
   <td data-label="Time" class="px-4 py-3 align-top whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>

--- a/app/views/admin/ahoy_activities/_change_diff.html.erb
+++ b/app/views/admin/ahoy_activities/_change_diff.html.erb
@@ -1,0 +1,7 @@
+<%# One field's change on a single line: the struck-through old value, then the
+    new value — no "Before/After" labels, the arrow carries the direction. %>
+<div class="mt-0.5 flex flex-wrap items-baseline gap-1.5 text-xs">
+  <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= before %></span>
+  <span class="text-gray-400">&rarr;</span>
+  <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= after %></span>
+</div>

--- a/app/views/admin/ahoy_activities/_change_diff.html.erb
+++ b/app/views/admin/ahoy_activities/_change_diff.html.erb
@@ -1,7 +1,7 @@
-<%# One field's change on a single line: the struck-through old value, then the
-    new value — no "Before/After" labels, the arrow carries the direction. %>
-<div class="mt-0.5 flex flex-wrap items-baseline gap-1.5 text-xs">
+<%# One field's change, inline beside its label: the struck-through old value,
+    then the new value — the arrow carries the direction, no Before/After labels. %>
+<span class="inline-flex flex-wrap items-baseline gap-1.5">
   <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= before %></span>
   <span class="text-gray-400">&rarr;</span>
   <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= after %></span>
-</div>
+</span>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,6 +1,7 @@
 <%# A communication folded into the person timeline, laid out like an activity
-    row: a Sent/Received chip, Subject/Body in Details, and the From name in the
-    User column. Time carries the timestamp; communications have no visit. %>
+    row: a Sent/Received chip and Communication name, with Subject/Body stacked
+    under the name and the From name in the User column. A link overlay makes the
+    whole cell open the notification. Communications have no visit. %>
 <% decorated = notification.decorate %>
 <% subject = notification.email_subject.presence || notification.kind.to_s.humanize %>
 <tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
@@ -8,40 +9,35 @@
     <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
 
-  <td data-label="Activity" class="px-4 py-3 align-top">
-    <%= link_to notification_path(notification), class: "group block",
-                target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } do %>
-      <div class="flex items-center gap-2">
-        <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-          <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
-        </span>
-        <span class="font-medium text-indigo-600 group-hover:underline">Communication</span>
-      </div>
-    <% end %>
-  </td>
-
-  <td data-label="Details" class="relative min-w-[16rem] px-4 py-3 align-top text-gray-500">
-    <%# Whole cell links to the notification (no text styling). %>
+  <td data-label="Activity" class="group relative px-4 py-3 align-top">
     <%= link_to "", notification_path(notification), class: "absolute inset-0",
                 aria: { label: "Open #{subject}" },
                 target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
-    <div class="space-y-1.5">
-      <div>
-        <span class="font-medium text-gray-700">Subject:</span>
-        <span class="text-gray-600"><%= subject %></span>
-      </div>
-      <% if notification.email_body_text.present? %>
-        <div>
-          <span class="font-medium text-gray-700">Body:</span>
-          <span class="text-gray-600" title="<%= notification.email_body_text %>"><%= truncate(notification.email_body_text, length: 50) %></span>
+    <div class="flex items-start gap-2">
+      <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+      </span>
+      <div class="min-w-0 space-y-0.5">
+        <div class="font-medium text-indigo-600 group-hover:underline">Communication</div>
+        <div class="space-y-1.5 pt-1 text-gray-500">
+          <div>
+            <span class="font-medium text-gray-700">Subject:</span>
+            <span class="text-gray-600"><%= subject %></span>
+          </div>
+          <% if notification.email_body_text.present? %>
+            <div>
+              <span class="font-medium text-gray-700">Body:</span>
+              <span class="text-gray-600" title="<%= notification.email_body_text %>"><%= truncate(notification.email_body_text, length: 50) %></span>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+      </div>
     </div>
   </td>
 
-  <td data-label="User" class="w-32 px-4 py-3 text-gray-600">
+  <td data-label="User" class="w-32 px-4 py-3 align-top text-gray-600">
     <div class="max-w-[8rem] truncate"><%= decorated.from_value %></div>
   </td>
 
-  <td data-label="Visit ID" class="w-16 px-4 py-3 text-gray-400">—</td>
+  <td data-label="Visit ID" class="w-16 px-4 py-3 align-top text-gray-400">—</td>
 </tr>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -18,7 +18,7 @@
   </td>
 
   <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
-    <div class="space-y-1.5 text-xs">
+    <div class="space-y-1.5">
       <div>
         <span class="font-medium text-gray-700">Subject:</span>
         <%= link_to subject, notification_path(notification),

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -1,14 +1,42 @@
-<%# The Time column carries the timestamp, so the reused notification row drops
-    its own leading date (show_date: false). %>
+<%# A communication folded into the person timeline, laid out like an activity
+    row: a Sent/Received chip, Subject/Body in Details, and the From name in the
+    User column. Time carries the timestamp; communications have no visit. %>
+<% decorated = notification.decorate %>
+<% subject = notification.email_subject.presence || notification.kind.to_s.humanize %>
 <tr class="<%= DomainTheme.bg_class_for(:notifications, intensity: 50) %> transition">
   <td data-label="Time" class="px-4 py-3 align-top whitespace-nowrap text-gray-500">
     <%= notification.created_at.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
   </td>
-  <td data-label="Activity" class="px-4 py-3 align-top font-medium whitespace-nowrap text-gray-900">
-    <i class="fa-solid fa-bell mr-1 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>"></i>
-    <%= notification.timeline_activity_name %>
+
+  <td data-label="Activity" class="px-4 py-3 align-top">
+    <div class="flex items-center gap-2">
+      <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+      </span>
+      <span class="font-medium text-gray-900">Communication</span>
+    </div>
   </td>
-  <td data-label="Communication" colspan="3" class="px-4 py-3">
-    <%= render "notifications/notification_row", notification: notification, admin: true, show_date: false %>
+
+  <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
+    <div class="space-y-1.5 text-xs">
+      <div>
+        <span class="font-medium text-gray-700">Subject:</span>
+        <%= link_to subject, notification_path(notification),
+                    class: "text-indigo-600 hover:underline",
+                    target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
+      </div>
+      <% if notification.email_body_text.present? %>
+        <div>
+          <span class="font-medium text-gray-700">Body:</span>
+          <div class="line-clamp-3 text-gray-600"><%= notification.email_body_text %></div>
+        </div>
+      <% end %>
+    </div>
   </td>
+
+  <td data-label="User" class="w-32 px-4 py-3 text-gray-600">
+    <div class="max-w-[8rem] truncate"><%= decorated.from_value %></div>
+  </td>
+
+  <td data-label="Visit ID" class="w-16 px-4 py-3 text-gray-400">—</td>
 </tr>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -8,7 +8,7 @@
     <i class="fa-solid fa-bell mr-1 <%= DomainTheme.text_class_for(:notifications, intensity: 600) %>"></i>
     <%= notification.timeline_activity_name %>
   </td>
-  <td data-label="Communication" colspan="4" class="px-4 py-3">
+  <td data-label="Communication" colspan="3" class="px-4 py-3">
     <%= render "notifications/notification_row", notification: notification, admin: true, show_date: false %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -9,12 +9,15 @@
   </td>
 
   <td data-label="Activity" class="px-4 py-3 align-top">
-    <div class="flex items-center gap-2">
-      <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
-      </span>
-      <span class="font-medium text-gray-900">Communication</span>
-    </div>
+    <%= link_to notification_path(notification), class: "group block",
+                target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } do %>
+      <div class="flex items-center gap-2">
+        <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+          <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+        </span>
+        <span class="font-medium text-indigo-600 group-hover:underline">Communication</span>
+      </div>
+    <% end %>
   </td>
 
   <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -9,12 +9,15 @@
   </td>
 
   <td data-label="Activity" class="px-4 py-3 align-top">
-    <div class="flex items-center gap-2">
-      <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
-      </span>
-      <span class="font-medium text-indigo-600">Communication</span>
-    </div>
+    <%= link_to notification_path(notification), class: "group block",
+                target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } do %>
+      <div class="flex items-center gap-2">
+        <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+          <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+        </span>
+        <span class="font-medium text-indigo-600 group-hover:underline">Communication</span>
+      </div>
+    <% end %>
   </td>
 
   <td data-label="Details" class="relative min-w-[16rem] px-4 py-3 align-top text-gray-500">

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -14,8 +14,10 @@
                 aria: { label: "Open #{subject}" },
                 target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
     <div class="flex items-start gap-2">
-      <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+      <span class="mt-0.5 flex w-24 shrink-0 justify-end">
+        <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+          <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+        </span>
       </span>
       <div class="min-w-0 space-y-0.5">
         <div class="font-medium text-indigo-600 group-hover:underline">Communication</div>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -29,7 +29,7 @@
           <% if notification.email_body_text.present? %>
             <div>
               <span class="font-medium text-gray-700">Body:</span>
-              <span class="text-gray-600" title="<%= notification.email_body_text %>"><%= truncate(notification.email_body_text, length: 50) %></span>
+              <span class="text-gray-600" title="<%= notification.email_body_text %>"><%= truncate(notification.email_body_text, length: 150) %></span>
             </div>
           <% end %>
         </div>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -13,7 +13,7 @@
       <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
         <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
       </span>
-      <span class="font-medium text-gray-900">Communication</span>
+      <span class="font-medium text-indigo-600">Communication</span>
     </div>
   </td>
 

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -17,13 +17,15 @@
     </div>
   </td>
 
-  <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
+  <td data-label="Details" class="relative min-w-[16rem] px-4 py-3 align-top text-gray-500">
+    <%# Whole cell links to the notification (no text styling). %>
+    <%= link_to "", notification_path(notification), class: "absolute inset-0",
+                aria: { label: "Open #{subject}" },
+                target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
     <div class="space-y-1.5">
       <div>
         <span class="font-medium text-gray-700">Subject:</span>
-        <%= link_to subject, notification_path(notification),
-                    class: "text-indigo-600 hover:underline",
-                    target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
+        <span class="text-gray-600"><%= subject %></span>
       </div>
       <% if notification.email_body_text.present? %>
         <div>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -9,15 +9,12 @@
   </td>
 
   <td data-label="Activity" class="px-4 py-3 align-top">
-    <%= link_to notification_path(notification), class: "group block",
-                target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } do %>
-      <div class="flex items-center gap-2">
-        <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-          <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
-        </span>
-        <span class="font-medium text-indigo-600 group-hover:underline">Communication</span>
-      </div>
-    <% end %>
+    <div class="flex items-center gap-2">
+      <span class="inline-flex items-center rounded-full <%= DomainTheme.bg_class_for(:notifications, intensity: 100) %> <%= DomainTheme.text_class_for(:notifications, intensity: 700) %> px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+        <i class="fa-solid fa-bell mr-1"></i><%= notification.incoming? ? "Received" : "Sent" %>
+      </span>
+      <span class="font-medium text-gray-900">Communication</span>
+    </div>
   </td>
 
   <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
@@ -29,9 +26,9 @@
                     target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
       </div>
       <% if notification.email_body_text.present? %>
-        <div>
+        <div class="line-clamp-3">
           <span class="font-medium text-gray-700">Body:</span>
-          <div class="line-clamp-3 text-gray-600"><%= notification.email_body_text %></div>
+          <span class="text-gray-600"><%= notification.email_body_text %></span>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/ahoy_activities/_communication_row.html.erb
+++ b/app/views/admin/ahoy_activities/_communication_row.html.erb
@@ -26,9 +26,9 @@
                     target: "_blank", rel: "noopener", data: { turbo_frame: "_top" } %>
       </div>
       <% if notification.email_body_text.present? %>
-        <div class="line-clamp-3">
+        <div>
           <span class="font-medium text-gray-700">Body:</span>
-          <span class="text-gray-600"><%= notification.email_body_text %></span>
+          <span class="text-gray-600" title="<%= notification.email_body_text %>"><%= truncate(notification.email_body_text, length: 50) %></span>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -30,7 +30,7 @@
         <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
         <% if row[:link] %>
           <% if row[:link][:path] %>
-            <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline", data: { turbo_frame: "_top" } %>
+            <%= link_to row[:link][:text], row[:link][:path], class: "relative z-10 text-indigo-600 hover:underline", data: { turbo_frame: "_top" } %>
           <% else %>
             <span class="text-gray-600"><%= row[:link][:text] %></span>
           <% end %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -7,7 +7,7 @@
       <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
     <% end %>
     <% if activity.comment_note[:body] %>
-      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600"><%= activity.comment_note[:body] %></span></div>
+      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
     <% end %>
   </div>
 <% elsif activity.extra_details? %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -1,7 +1,16 @@
 <%# Inline before/after + property rows for one Ahoy event. Shared by the admin
     activities table's Details column and any record's inline change log, so both
     read the same way. %>
-<% if activity.extra_details? %>
+<% if activity.comment_note %>
+  <div class="space-y-1.5 text-xs">
+    <% if activity.comment_note[:topic] %>
+      <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
+    <% end %>
+    <% if activity.comment_note[:body] %>
+      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600"><%= activity.comment_note[:body] %></span></div>
+    <% end %>
+  </div>
+<% elsif activity.extra_details? %>
   <div class="space-y-1.5">
     <% if activity.changes? %>
       <ul class="space-y-1.5">

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -8,16 +8,7 @@
         <% activity.changes_summary.each do |change| %>
           <li>
             <span class="font-medium text-gray-700"><%= change[:field] %></span>
-            <div class="mt-0.5 space-y-0.5 text-xs">
-              <div class="flex flex-wrap items-baseline gap-1">
-                <span class="text-gray-400">Before:</span>
-                <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= change[:before] %></span>
-              </div>
-              <div class="flex flex-wrap items-baseline gap-1">
-                <span class="text-gray-400">After:</span>
-                <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= change[:after] %></span>
-              </div>
-            </div>
+            <%= render "admin/ahoy_activities/change_diff", before: change[:before], after: change[:after] %>
           </li>
         <% end %>
       </ul>
@@ -35,16 +26,7 @@
             <span class="text-gray-600"><%= row[:link][:text] %></span>
           <% end %>
         <% elsif row[:change] %>
-          <div class="mt-0.5 space-y-0.5">
-            <div class="flex flex-wrap items-baseline gap-1">
-              <span class="text-gray-400">Before:</span>
-              <span class="rounded bg-gray-100 px-1.5 py-0.5 text-gray-500 line-through"><%= row[:change][:before] %></span>
-            </div>
-            <div class="flex flex-wrap items-baseline gap-1">
-              <span class="text-gray-400">After:</span>
-              <span class="rounded bg-green-50 px-1.5 py-0.5 text-green-700"><%= row[:change][:after] %></span>
-            </div>
-          </div>
+          <%= render "admin/ahoy_activities/change_diff", before: row[:change][:before], after: row[:change][:after] %>
         <% elsif row[:value] %>
           <span class="<%= row[:emphasis] ? "font-semibold text-gray-900" : "text-gray-600" %>"><%= row[:value] %></span>
         <% end %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -7,7 +7,7 @@
       <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
     <% end %>
     <% if activity.comment_note[:body] %>
-      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
+      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 150) %></span></div>
     <% end %>
   </div>
 <% elsif activity.extra_details? %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -2,7 +2,7 @@
     activities table's Details column and any record's inline change log, so both
     read the same way. %>
 <% if activity.comment_note %>
-  <div class="space-y-1.5 text-xs">
+  <div class="space-y-1.5">
     <% if activity.comment_note[:topic] %>
       <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
     <% end %>
@@ -15,8 +15,8 @@
     <% if activity.changes? %>
       <ul class="space-y-1.5">
         <% activity.changes_summary.each do |change| %>
-          <li>
-            <span class="font-medium text-gray-700"><%= change[:field] %></span>
+          <li class="flex flex-wrap items-baseline gap-1.5">
+            <span class="font-medium text-gray-700"><%= change[:field] %>:</span>
             <%= render "admin/ahoy_activities/change_diff", before: change[:before], after: change[:after] %>
           </li>
         <% end %>
@@ -25,7 +25,7 @@
     <% activity.detail_rows.each do |row| %>
       <div class="text-xs" style="padding-left: <%= row[:depth] * 12 %>px;">
         <% if row[:label] %>
-          <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] %></span>
+          <span class="font-medium text-gray-700"><%= row[:label] %><%= ":" if row[:value] || row[:link] || row[:change] %></span>
         <% end %>
         <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
         <% if row[:link] %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -7,7 +7,7 @@
       <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
     <% end %>
     <% if activity.comment_note[:body] %>
-      <div><span class="font-medium text-gray-700">Comment:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
+      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
     <% end %>
   </div>
 <% elsif activity.extra_details? %>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -7,7 +7,7 @@
       <div><span class="font-medium text-gray-700">Topic:</span> <span class="text-gray-600"><%= activity.comment_note[:topic] %></span></div>
     <% end %>
     <% if activity.comment_note[:body] %>
-      <div><span class="font-medium text-gray-700">Body:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
+      <div><span class="font-medium text-gray-700">Comment:</span> <span class="text-gray-600" title="<%= activity.comment_note[:body] %>"><%= truncate(activity.comment_note[:body], length: 50) %></span></div>
     <% end %>
   </div>
 <% elsif activity.extra_details? %>

--- a/app/views/admin/ahoy_activities/_filter_toggles.html.erb
+++ b/app/views/admin/ahoy_activities/_filter_toggles.html.erb
@@ -1,0 +1,22 @@
+<%# Bulk hide toggles: pare the timeline down to changelogs and communications by
+    switching off whole event categories. Each sr-only checkbox is the peer; its
+    sibling span is the track and the knob is the track's ::after. Checked = "1"
+    means hide, so the collection controller auto-submits the exclusion. %>
+<%
+  cast = ActiveModel::Type::Boolean.new
+  toggles = [
+    ["hide_account", "Hide account", cast.cast(params[:hide_account])],
+    ["hide_interactions", "Hide interactions", cast.cast(params[:hide_interactions])],
+    ["hide_communications", "Hide communications", cast.cast(params[:hide_communications])]
+  ]
+%>
+<div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+  <span class="text-sm font-medium text-gray-600">Hide:</span>
+  <% toggles.each do |name, label, checked| %>
+    <label class="flex items-center gap-2 cursor-pointer select-none">
+      <%= check_box_tag name, "1", checked, class: "peer sr-only" %>
+      <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-indigo-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
+      <span class="text-sm text-gray-700"><%= label %></span>
+    </label>
+  <% end %>
+</div>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag :activity_results do %>
   <%= turbo_stream.replace "activities_count", partial: "count" %>
   <%
-    sort_base = params.permit(:event_name, :props, :resource_name, :user_search, :visit_id, :time_period, :from, :to, :per_page, audience: []).to_h.symbolize_keys
+    sort_base = params.permit(:event_name, :props, :resource_name, :user_search, :visit_id, :time_period, :from, :to, :per_page, :hide_account, :hide_interactions, :hide_communications, :person_id, :user_id, :resource_type, :resource_id, audience: []).to_h.symbolize_keys
     sort_icon = ->(column) {
       next "fa-sort" unless @sort == column
       @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -72,8 +72,7 @@
       <thead class="bg-gray-50 text-xs tracking-wider text-gray-600 uppercase">
       <tr>
         <th class="rounded-tl-xl px-4 py-3 text-left"><%= @person ? "Time" : sort_link.call("time", "Time") %></th>
-        <th class="px-4 py-3 text-left"><%= @person ? "Activity" : sort_link.call("name", "Activity") %></th>
-        <th class="min-w-[16rem] px-4 py-3 text-left">Details</th>
+        <th class="min-w-[24rem] px-4 py-3 text-left"><%= @person ? "Activity" : sort_link.call("name", "Activity") %></th>
         <th class="w-32 px-4 py-3 text-left"><%= @person ? "User" : sort_link.call("user", "User") %></th>
         <th class="w-16 rounded-tr-xl px-4 py-3 text-left">Visit ID</th>
       </tr>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -74,8 +74,8 @@
         <th class="rounded-tl-xl px-4 py-3 text-left"><%= @person ? "Time" : sort_link.call("time", "Time") %></th>
         <th class="px-4 py-3 text-left"><%= @person ? "Activity" : sort_link.call("name", "Activity") %></th>
         <th class="min-w-[16rem] px-4 py-3 text-left">Details</th>
-        <th class="px-4 py-3 text-left"><%= @person ? "User" : sort_link.call("user", "User") %></th>
-        <th class="rounded-tr-xl px-4 py-3 text-left">Visit ID</th>
+        <th class="w-32 px-4 py-3 text-left"><%= @person ? "User" : sort_link.call("user", "User") %></th>
+        <th class="w-16 rounded-tr-xl px-4 py-3 text-left">Visit ID</th>
       </tr>
       </thead>
 

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag :activity_results do %>
   <%= turbo_stream.replace "activities_count", partial: "count" %>
   <%
-    sort_base = params.permit(:event_name, :props, :resource_name, :user_search, :visit_id, :time_period, :from, :to, :per_page, :hide_account, :hide_interactions, :hide_communications, :person_id, :user_id, :resource_type, :resource_id, audience: []).to_h.symbolize_keys
+    sort_base = params.permit(:event_name, :props, :user_search, :visit_id, :time_period, :from, :to, :per_page, :hide_account, :hide_interactions, :hide_communications, :person_id, :user_id, :resource_type, :resource_id, audience: []).to_h.symbolize_keys
     sort_icon = ->(column) {
       next "fa-sort" unless @sort == column
       @sort_direction == "asc" ? "fa-arrow-up" : "fa-arrow-down"
@@ -73,7 +73,6 @@
       <tr>
         <th class="rounded-tl-xl px-4 py-3 text-left"><%= @person ? "Time" : sort_link.call("time", "Time") %></th>
         <th class="px-4 py-3 text-left"><%= @person ? "Activity" : sort_link.call("name", "Activity") %></th>
-        <th class="px-4 py-3 text-left">Resource</th>
         <th class="min-w-[16rem] px-4 py-3 text-left">Details</th>
         <th class="px-4 py-3 text-left"><%= @person ? "User" : sort_link.call("user", "User") %></th>
         <th class="rounded-tr-xl px-4 py-3 text-left">Visit ID</th>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -125,9 +125,13 @@
 
           </div>
 
+          <div class="mt-6">
+            <%= render "filter_toggles" %>
+          </div>
+
           <div class="flex items-center gap-3 mt-6 text-sm">
             <span class="text-gray-500">Quick:</span>
-            <% safe_params = params.slice(:event_name, :visit_id, :props, :resource_name, :person_id, :user_search, :from, :to).to_unsafe_h %>
+            <% safe_params = params.slice(:event_name, :visit_id, :props, :resource_name, :person_id, :user_search, :from, :to, :hide_account, :hide_interactions, :hide_communications).to_unsafe_h %>
             <%= link_to "24h",
                         url_for(safe_params.merge(from: 1.day.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -51,21 +51,11 @@
 
             <div class="min-w-0 flex-[2]">
               <label class="<%= search_label_class %>">
-                Activity name
+                Activity
               </label>
               <%= text_field_tag :event_name,
                                  params[:event_name],
-                                 placeholder: "e.g. view workshop, account-auth",
-                                 class: search_field_class %>
-            </div>
-
-            <div class="min-w-0 flex-1">
-              <label class="<%= search_label_class %>">
-                Resource title
-              </label>
-              <%= text_field_tag :resource_name,
-                                 params[:resource_name],
-                                 placeholder: "e.g. a workshop name",
+                                 placeholder: "e.g. update workshop, a resource name",
                                  class: search_field_class %>
             </div>
 
@@ -141,7 +131,7 @@
 
           <div class="mt-6 flex items-center gap-3 text-sm">
             <span class="text-gray-500">Quick:</span>
-            <% safe_params = params.slice(:event_name, :visit_id, :props, :resource_name, :person_id, :user_search, :from, :to, :hide_account, :hide_interactions, :hide_communications).to_unsafe_h %>
+            <% safe_params = params.slice(:event_name, :visit_id, :props, :person_id, :user_search, :from, :to, :hide_account, :hide_interactions, :hide_communications).to_unsafe_h %>
             <%= link_to "24h",
                         url_for(safe_params.merge(from: 1.day.ago.to_date)),
                         class: "text-indigo-600 hover:underline" %>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border border-primary/10 rounded-2xl shadow-sm p-6">
+<div class="<%= DomainTheme.bg_class_for(:admin_only) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
 
-      <div class="flex flex-wrap items-center gap-y-2 mb-2">
+      <div class="mb-2 flex flex-wrap items-center gap-y-2">
         <%# Scoped to a person (from their edit page's History card, or the filter) —
             return to that person, not the generic Admin default. %>
         <% if @person %>
@@ -37,9 +37,19 @@
               data: { controller: "collection", turbo_frame: "activity_results" },
               autocomplete: "off" do %>
 
-          <div class="flex flex-wrap lg:flex-nowrap gap-4">
+          <%# These scope the timeline (person History, per-user history, a record's
+              audit trail) but have no visible control, so carry them as hidden
+              fields — otherwise submitting the form drops them and reverts to the
+              global feed. %>
+          <% %i[person_id user_id resource_type resource_id].each do |scoping_param| %>
+            <% if params[scoping_param].present? %>
+              <%= hidden_field_tag scoping_param, params[scoping_param] %>
+            <% end %>
+          <% end %>
 
-            <div class="flex-[2] min-w-0">
+          <div class="flex flex-wrap gap-4 lg:flex-nowrap">
+
+            <div class="min-w-0 flex-[2]">
               <label class="<%= search_label_class %>">
                 Activity name
               </label>
@@ -49,7 +59,7 @@
                                  class: search_field_class %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 Resource title
               </label>
@@ -59,7 +69,7 @@
                                  class: search_field_class %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 Details
               </label>
@@ -69,7 +79,7 @@
                                  class: search_field_class %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 User
               </label>
@@ -79,11 +89,11 @@
                                  class: search_field_class %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 Time Period
               </label>
@@ -95,7 +105,7 @@
                              class: search_field_class %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 From
               </label>
@@ -104,7 +114,7 @@
                                  class: date_filter_class(search_field_class, params[:from]) %>
             </div>
 
-            <div class="flex-1 min-w-0">
+            <div class="min-w-0 flex-1">
               <label class="<%= search_label_class %>">
                 To
               </label>
@@ -113,7 +123,7 @@
                                  class: date_filter_class(search_field_class, params[:to]) %>
             </div>
 
-            <div class="flex-none w-24">
+            <div class="w-24 flex-none">
               <label class="<%= search_label_class %>">
                 Visit ID
               </label>
@@ -129,7 +139,7 @@
             <%= render "filter_toggles" %>
           </div>
 
-          <div class="flex items-center gap-3 mt-6 text-sm">
+          <div class="mt-6 flex items-center gap-3 text-sm">
             <span class="text-gray-500">Quick:</span>
             <% safe_params = params.slice(:event_name, :visit_id, :props, :resource_name, :person_id, :user_search, :from, :to, :hide_account, :hide_interactions, :hide_communications).to_unsafe_h %>
             <%= link_to "24h",

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -55,7 +55,7 @@
               </label>
               <%= text_field_tag :event_name,
                                  params[:event_name],
-                                 placeholder: "e.g. update workshop, a resource name",
+                                 placeholder: "e.g. new workshop, a resource name",
                                  class: search_field_class %>
             </div>
 

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -21,7 +21,14 @@
   user_ids = params[:user_id].to_s.split("--").reject(&:blank?)
   filtered_users = user_ids.any? ? User.where(id: user_ids) : User.none
 
-  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || params[:resource_name].present? || params[:user_search].present? || params[:ip].present? || params[:user_agent].present? || @person.present? || filtered_users.exists?
+  cast = ActiveModel::Type::Boolean.new
+  hidden_labels = {
+    "Account hidden" => cast.cast(params[:hide_account]),
+    "Interactions hidden" => cast.cast(params[:hide_interactions]),
+    "Communications hidden" => cast.cast(params[:hide_communications])
+  }.select { |_label, on| on }.keys
+
+  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || params[:resource_name].present? || params[:user_search].present? || params[:ip].present? || params[:user_agent].present? || @person.present? || filtered_users.exists? || hidden_labels.any?
 %>
 <div class="flex flex-wrap items-center gap-2">
   <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Filters applied</h3>
@@ -76,6 +83,11 @@
                 class: "inline-flex items-center px-3 py-1 rounded-full bg-green-100 text-green-800 font-medium hover:bg-green-200" do %>
       User: <%= user.full_name %>
     <% end %>
+  <% end %>
+  <% hidden_labels.each do |label| %>
+    <span class="inline-flex items-center rounded-full bg-gray-200 px-3 py-1 font-medium text-gray-700">
+      <%= label %>
+    </span>
   <% end %>
   <% unless any_filters %>
     <span class="text-gray-400">None</span>

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -28,7 +28,7 @@
     "Communications hidden" => cast.cast(params[:hide_communications])
   }.select { |_label, on| on }.keys
 
-  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:props].present? || params[:resource_name].present? || params[:user_search].present? || params[:ip].present? || params[:user_agent].present? || @person.present? || filtered_users.exists? || hidden_labels.any?
+  any_filters = time_label || audience_labels.any? || params[:visit_id].present? || params[:event_name].present? || params[:props].present? || params[:user_search].present? || params[:ip].present? || params[:user_agent].present? || @person.present? || filtered_users.exists? || hidden_labels.any?
 %>
 <div class="flex flex-wrap items-center gap-2">
   <h3 class="text-sm font-semibold tracking-wide text-gray-500 uppercase">Filters applied</h3>
@@ -47,9 +47,9 @@
       Visit: <%= params[:visit_id] %>
     </span>
   <% end %>
-  <% if params[:resource_name].present? %>
+  <% if params[:event_name].present? %>
     <span class="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 font-medium text-purple-800">
-      Resource title: <%= params[:resource_name] %>
+      Activity: <%= params[:event_name] %>
     </span>
   <% end %>
   <% if params[:props].present? %>

--- a/app/views/people/_associated_records.html.erb
+++ b/app/views/people/_associated_records.html.erb
@@ -34,7 +34,9 @@
         so the column flow lands it in the otherwise-empty bottom-right cell. %>
     <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
       <li class="mb-2 break-inside-avoid">
-        <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff]),
+        <%# Default the timeline to changelogs and communications — account and
+            interaction noise start hidden (toggle back on from the filters). %>
+        <%= link_to admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff], hide_account: "1", hide_interactions: "1"),
                     data: { turbo_prefetch: false },
                     class: "group flex items-center gap-3 w-full px-3 py-2 rounded-lg admin-only bg-blue-50 hover:bg-blue-100 border border-gray-200 transition-colors duration-200 shadow-sm" do %>
           <span class="w-5 text-center text-gray-500"><i class="fa-solid fa-clock-rotate-left"></i></span>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3062,3 +3062,16 @@
     - "Set the word on the topic (Manage topics) or the staff tag (Manage staff tags); it defaults to \"Marked\" until you name it."
     - "Flip the mark slider or filter to Yes/No to work through the list."
     - "The notes box saves when you click away, and shows up in that row's comment log."
+
+- name: "Hide toggles on the activities timeline"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    The admin Activities page has three switches to hide whole categories of
+    noise — account/login churn, read-and-browse interactions, and
+    communications — so you can pare a timeline down to record changelogs.
+  pro_tips:
+    - "A person's History link opens with account and interaction events already hidden, so you land on their changelogs and communications; flip the switches back on to see everything."
+    - "\"Account\" covers logins, password resets, email changes, admin grants, and User-record edits; \"Interactions\" covers views, prints, downloads, and searches."
+  action_path: "/admin/activities/events"

--- a/config/features.yml
+++ b/config/features.yml
@@ -3075,3 +3075,18 @@
     - "A person's History link opens with account and interaction events already hidden, so you land on their changelogs and communications; flip the switches back on to see everything."
     - "\"Account\" covers logins, password resets, email changes, admin grants, and User-record edits; \"Interactions\" covers views, prints, downloads, and searches."
   action_path: "/admin/activities/events"
+
+- name: "Activities timeline reads like a feed"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    The admin Activities page is redesigned to read at a glance: each event leads
+    with the record it touched, a plain-language action chip (New, Edit, Auto…),
+    and its details — field changes, a comment's text, or a communication's
+    subject and body — stacked in one column.
+  pro_tips:
+    - "Click anywhere in a row's Activity cell to open the record it's about; a comment opens what it was left on (the affiliation, scholarship, or profile), and a communication opens the message."
+    - "Click a Visit ID to see everything that happened in that visit."
+    - "Long comment and email bodies are trimmed — hover to read the full text."
+  action_path: "/admin/activities/events"

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -59,6 +59,17 @@ RSpec.describe Ahoy::EventDecorator do
                                   resource_id: 0, properties: { "resource_title" => "Ghost" }).decorate
       expect(event.resource_link[:path]).to be_nil
     end
+
+    it "points a comment at the record it was left on, and surfaces its topic/body" do
+      person = create(:person)
+      comment = create(:comment, commentable: person, topic: "Follow-up", body: "Called to confirm.")
+      event = create(:ahoy_event, name: "create.comment", resource_type: "Comment",
+                                  resource_id: comment.id, properties: { "resource_title" => "Comment" }).decorate
+
+      expect(event.resource_link[:text]).to eq("Profile")
+      expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_person_path(person))
+      expect(event.comment_note).to eq(topic: "Follow-up", body: "Called to confirm.")
+    end
   end
 
   describe "#extra_properties" do

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_affiliation_path(affiliation))
     end
 
+    it "appends an affiliation's date span, or 'present' while active" do
+      org = create(:organization, name: "Harbor Shelter")
+      ended = create(:affiliation, title: "Facilitator", organization: org,
+                                   start_date: Date.new(2025, 8, 1), end_date: Date.new(2026, 2, 1))
+      active = create(:affiliation, title: "Facilitator", organization: org,
+                                    start_date: Date.new(2025, 8, 1), end_date: nil)
+
+      ended_event = create(:ahoy_event, name: "update.affiliation", resource_type: "Affiliation",
+                                        resource_id: ended.id, properties: {}).decorate
+      active_event = create(:ahoy_event, name: "update.affiliation", resource_type: "Affiliation",
+                                         resource_id: active.id, properties: {}).decorate
+
+      expect(ended_event.resource_link[:text]).to eq("Facilitator · Harbor Shelter · Aug'25 - Feb'26")
+      expect(active_event.resource_link[:text]).to eq("Facilitator · Harbor Shelter · Aug'25 - present")
+    end
+
     it "labels an event registration as its event and start month" do
       registration = create(:event_registration)
       registration.event.update!(title: "Spring Training", start_date: Time.zone.local(2025, 9, 1))

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Ahoy::EventDecorator do
     end
   end
 
+  describe ".action_keys_for_label" do
+    it "maps a chip word back to its raw action prefixes, case-insensitively" do
+      expect(described_class.action_keys_for_label("new")).to eq(%w[create])
+      expect(described_class.action_keys_for_label("Edit")).to eq(%w[update])
+      expect(described_class.action_keys_for_label("search")).to eq(%w[search search_zero])
+    end
+
+    it "is empty for a word that isn't a chip label" do
+      expect(described_class.action_keys_for_label("workshop")).to eq([])
+    end
+  end
+
   describe "#activity_resource_label" do
     it "humanizes the resource half of the name" do
       expect(decorate_named("update.workshop_variation").activity_resource_label).to eq("Workshop variation")

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -104,13 +104,33 @@ RSpec.describe Ahoy::EventDecorator do
       expect(active_event.resource_link[:text]).to eq("Facilitator · Harbor Shelter · Aug'25 - present")
     end
 
-    it "labels an event registration as its event and start month" do
+    it "labels an event registration with the event and abbreviated start month" do
       registration = create(:event_registration)
       registration.event.update!(title: "Spring Training", start_date: Time.zone.local(2025, 9, 1))
       event = create(:ahoy_event, name: "update.event_registration", resource_type: "EventRegistration",
                                   resource_id: registration.id, properties: { "resource_title" => "reg" }).decorate
 
-      expect(event.resource_link[:text]).to eq("Spring Training · September 2025")
+      expect(event.resource_link[:text]).to eq("Registration: Spring Training · Sep'25")
+    end
+
+    it "labels a scholarship as its amount, grant, and funder" do
+      org = create(:organization, name: "Acme Foundation")
+      grant = create(:grant, name: "Healing Arts Fund", funder: org)
+      scholarship = create(:scholarship, amount_cents: 24_000, grant: grant)
+      event = create(:ahoy_event, name: "create.scholarship", resource_type: "Scholarship",
+                                  resource_id: scholarship.id, properties: {}).decorate
+
+      expect(event.resource_link[:text]).to eq("$240 Healing Arts Fund · Acme Foundation")
+    end
+
+    it "labels a CE registration as its hours and license" do
+      ce = create(:continuing_education_registration, hours: 13)
+      ce.professional_license.update!(kind: "LMFT", number: "2345")
+      event = create(:ahoy_event, name: "create.continuing_education_registration",
+                                  resource_type: "ContinuingEducationRegistration",
+                                  resource_id: ce.id, properties: {}).decorate
+
+      expect(event.resource_link[:text]).to eq("13 hours · LMFT 2345")
     end
 
     it "labels a payment as what it's allocated to" do

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -5,6 +5,50 @@ RSpec.describe Ahoy::EventDecorator do
     create(:ahoy_event, properties: properties).reload.decorate
   end
 
+  def decorate_named(name)
+    create(:ahoy_event, name: name).decorate
+  end
+
+  describe "#activity_chip" do
+    it "reads create as a New chip and update as an Edit chip" do
+      expect(decorate_named("create.comment").activity_chip[:label]).to eq("New")
+      expect(decorate_named("update.workshop").activity_chip[:label]).to eq("Edit")
+    end
+
+    it "humanizes an unmapped action" do
+      expect(decorate_named("something.workshop").activity_chip[:label]).to eq("Something")
+    end
+  end
+
+  describe "#activity_resource_label" do
+    it "humanizes the resource half of the name" do
+      expect(decorate_named("update.workshop_variation").activity_resource_label).to eq("Workshop variation")
+      expect(decorate_named("auth.account_deactivated").activity_resource_label).to eq("Account deactivated")
+    end
+  end
+
+  describe "#resource_link" do
+    it "links the resource title to the record's edit page" do
+      workshop = create(:workshop)
+      event = create(:ahoy_event, name: "create.workshop", resource_type: "Workshop",
+                                  resource_id: workshop.id, properties: { "resource_title" => "Feelings Collage" }).decorate
+
+      link = event.resource_link
+      expect(link[:text]).to eq("Feelings Collage")
+      expect(link[:path]).to eq(Rails.application.routes.url_helpers.edit_workshop_path(workshop))
+    end
+
+    it "is nil when there is no resource title" do
+      expect(decorate("source" => "import").resource_link).to be_nil
+    end
+
+    it "leaves the path nil when the record no longer exists" do
+      event = create(:ahoy_event, name: "create.workshop", resource_type: "Workshop",
+                                  resource_id: 0, properties: { "resource_title" => "Ghost" }).decorate
+      expect(event.resource_link[:path]).to be_nil
+    end
+  end
+
   describe "#extra_properties" do
     it "drops the keys already shown in their own columns" do
       event = decorate(

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -70,6 +70,43 @@ RSpec.describe Ahoy::EventDecorator do
       expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_person_path(person))
       expect(event.comment_note).to eq(topic: "Follow-up", body: "Called to confirm.")
     end
+
+    it "flags a flagged comment" do
+      comment = create(:comment, commentable: create(:person), flagged: true)
+      event = create(:ahoy_event, name: "create.comment", resource_type: "Comment",
+                                  resource_id: comment.id, properties: { "resource_title" => "Comment" }).decorate
+      expect(event.comment_flagged?).to be(true)
+    end
+
+    it "labels an affiliation as its title and organization" do
+      org = create(:organization, name: "Harbor Shelter")
+      affiliation = create(:affiliation, title: "Facilitator", organization: org)
+      event = create(:ahoy_event, name: "update.affiliation", resource_type: "Affiliation",
+                                  resource_id: affiliation.id, properties: { "resource_title" => "Facilitator" }).decorate
+
+      expect(event.resource_link[:text]).to eq("Facilitator · Harbor Shelter")
+      expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_affiliation_path(affiliation))
+    end
+
+    it "labels an event registration as its event and start month" do
+      registration = create(:event_registration)
+      registration.event.update!(title: "Spring Training", start_date: Time.zone.local(2025, 9, 1))
+      event = create(:ahoy_event, name: "update.event_registration", resource_type: "EventRegistration",
+                                  resource_id: registration.id, properties: { "resource_title" => "reg" }).decorate
+
+      expect(event.resource_link[:text]).to eq("Spring Training · September 2025")
+    end
+
+    it "labels a payment as what it's allocated to" do
+      registration = create(:event_registration)
+      payment = create(:payment)
+      create(:allocation, source: payment, allocatable: registration)
+      event = create(:ahoy_event, name: "create.payment", resource_type: "Payment",
+                                  resource_id: payment.id, properties: { "resource_title" => "Membership dues" }).decorate
+
+      expect(event.resource_link[:text]).to include("Event registration for")
+      expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_event_registration_path(registration))
+    end
   end
 
   describe "#extra_properties" do

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Ahoy::EventDecorator do
     end
   end
 
+  describe "auth event details" do
+    it "drops the redundant record and updated_by rows, keeping the rest" do
+      event = create(:ahoy_event, name: "auth.login", properties: {
+        "record_id" => 1, "record_type" => "User", "updated_by_id" => nil,
+        "resource_type" => "User", "resource_id" => 1,
+        "resource_title" => "Umberto (u@example.com)", "sign_in_count" => 2
+      }).reload.decorate
+
+      expect(event.extra_properties.keys).to eq(%w[sign_in_count])
+    end
+  end
+
   describe "#activity_resource_label" do
     it "humanizes the resource half of the name" do
       expect(decorate_named("update.workshop_variation").activity_resource_label).to eq("Workshop variation")

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -400,9 +400,21 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include("activity_row_marker")
         # The communication row reads as a human Sent/Received chip, not the raw name.
         expect(response.body).to include("Communication")
+        expect(response.body).to include("Sent")
         expect(response.body).not_to include("communication.sent")
         # Newer communication sorts above the older activity event.
         expect(response.body.index("Comms row marker xyz")).to be < response.body.index("activity_row_marker")
+      end
+
+      it "labels an incoming communication as Received" do
+        person = create(:person)
+        create(:notification, :incoming, recipient_email: person.communications_email, email_subject: "Inbound note")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time",
+                                  audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Received")
       end
 
       it "activity name search matches the communication's synthetic name (direction-aware)" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -184,6 +184,34 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include("create.bookmark")
       end
 
+      it "keeps person_id as a hidden field so the filter form stays person-scoped" do
+        person = create(:person, first_name: "Ada", last_name: "Lovelace")
+
+        get index_path, params: { person_id: person.id, time_period: "all_time" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/<input[^>]*type="hidden"[^>]*name="person_id"[^>]*value="#{person.id}"/)
+      end
+
+      it "stays person-scoped (no org autochange leak) when a toggle re-submits with person_id" do
+        person = create(:person)
+        org = create(:organization)
+        create(:ahoy_event, name: "autochange.organization", user: nil,
+                            visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
+                            resource_type: "Organization", resource_id: org.id, time: 1.hour.ago,
+                            properties: { "resource_title" => "org_autochange_marker" })
+        create(:ahoy_event, name: "update.person", visit: visit_for_admin,
+                            resource_type: "Person", resource_id: person.id, time: 2.hours.ago,
+                            properties: { "resource_type" => "Person", "resource_id" => person.id, "resource_title" => "person_change_marker" })
+
+        get index_path, params: { person_id: person.id, time_period: "all_time", audience: %w[visitors users staff],
+                                  hide_account: "1", hide_interactions: "1" }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("person_change_marker")
+        expect(response.body).not_to include("org_autochange_marker")
+      end
+
       it "hide_communications drops a person's communications from the timeline" do
         person = create(:person)
         create(:notification, recipient_email: person.communications_email, email_subject: "Hidden comm marker")

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("create.bookmark")
       end
 
-      it "filters events by resource title from their properties" do
+      it "filters events by resource title from their properties via the activity search" do
         create(:ahoy_event, name: "view.workshop_match", user: nil,
                             visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
                             time: 1.day.ago, properties: { "resource_title" => "Feelings Collage" })
@@ -275,17 +275,17 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
                             visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
                             time: 1.day.ago, properties: { "resource_title" => "Anger Masks" })
 
-        get index_path, params: { resource_name: "feelings", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+        get index_path, params: { event_name: "feelings", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("view.workshop_match")
         expect(response.body).not_to include("view.workshop_miss")
       end
 
-      it "surfaces a resource title chip in the applied filters" do
-        get index_path, params: { resource_name: "Feelings Collage" }
+      it "surfaces an activity search chip in the applied filters" do
+        get index_path, params: { event_name: "Feelings Collage" }
 
-        expect(response.body).to include("Resource title: Feelings Collage")
+        expect(response.body).to include("Activity: Feelings Collage")
       end
 
       it "sorts events by activity name" do

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -398,8 +398,9 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         # Both streams render in the same activities table (no separate panel).
         expect(response.body).to include("Comms row marker xyz")
         expect(response.body).to include("activity_row_marker")
-        # The communication row carries its synthetic activity name.
-        expect(response.body).to include("communication.sent")
+        # The communication row reads as a human Sent/Received chip, not the raw name.
+        expect(response.body).to include("Communication")
+        expect(response.body).not_to include("communication.sent")
         # Newer communication sorts above the older activity event.
         expect(response.body.index("Comms row marker xyz")).to be < response.body.index("activity_row_marker")
       end

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -255,6 +255,18 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).not_to include("auth.login")
       end
 
+      it "matches a plain-language chip word to its raw action (new finds create)" do
+        create(:ahoy_event, name: "update.workshop", user: nil,
+                            visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
+                            time: 1.day.ago, properties: {})
+
+        get index_path, params: { event_name: "new", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("create.bookmark")
+        expect(response.body).not_to include("update.workshop")
+      end
+
       it "filters by hyphen-separated tokens in any order (account-auth)" do
         create(:ahoy_event, name: "auth.account_deactivated", user: nil,
                             visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -160,6 +160,44 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response.body).to include("create.bookmark")
       end
 
+      it "hide_account excludes auth and user-record events but keeps other changelogs" do
+        create(:ahoy_event, name: "update.user", user: user, visit: visit_for_user,
+                            resource_type: "User", resource_id: user.id, time: 2.days.ago,
+                            properties: { "resource_title" => "user_record_marker" })
+
+        get index_path, params: { hide_account: "1", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("auth.login")
+        expect(response.body).not_to include("user_record_marker")
+        expect(response.body).to include("create.bookmark")
+      end
+
+      it "hide_interactions excludes view/print/download/search noise but keeps changelogs" do
+        create(:ahoy_event, name: "view.workshop", user: user, visit: visit_for_user,
+                            time: 2.days.ago, properties: { "resource_title" => "interaction_noise_marker" })
+
+        get index_path, params: { hide_interactions: "1", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("interaction_noise_marker")
+        expect(response.body).to include("create.bookmark")
+      end
+
+      it "hide_communications drops a person's communications from the timeline" do
+        person = create(:person)
+        create(:notification, recipient_email: person.communications_email, email_subject: "Hidden comm marker")
+        create(:ahoy_event, name: "update.person", visit: visit_for_admin,
+                            resource_type: "Person", resource_id: person.id, time: 1.day.ago,
+                            properties: { "resource_type" => "Person", "resource_id" => person.id, "resource_title" => "kept_change_marker" })
+
+        get index_path, params: { person_id: person.id, hide_communications: "1", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Hidden comm marker")
+        expect(response.body).to include("kept_change_marker")
+      end
+
       it "filters by from/to dates" do
         get index_path,
             params: {

--- a/spec/services/analytics/event_reference_loader_spec.rb
+++ b/spec/services/analytics/event_reference_loader_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Analytics::EventReferenceLoader do
       expect(map[[ "Sector", sector.id ]]).to eq(sector)
     end
 
+    it "loads each event's own resource from its resource_type/resource_id columns" do
+      workshop = create(:workshop)
+      events = [ build(:ahoy_event, resource_type: "Workshop", resource_id: workshop.id, properties: {}) ]
+
+      map = described_class.new(events).records
+
+      expect(map[[ "Workshop", workshop.id ]]).to eq(workshop)
+    end
+
     it "omits records that no longer exist" do
       events = [ event("associated_records" => [ { "record_type" => "Workshop", "record_id" => 0 } ]) ]
       expect(described_class.new(events).records).to eq({})

--- a/spec/views/people/edit.html.erb_spec.rb
+++ b/spec/views/people/edit.html.erb_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "people/edit", type: :view do
   it "shows a History card linking to the person's full Ahoy activity" do
     expect(rendered).to have_link(
       "History",
-      href: admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff])
+      href: admin_activities_events_path(person_id: person.id, time_period: "all_time", audience: %w[visitors users staff], hide_account: "1", hide_interactions: "1")
     )
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained filter logic on the activities index + a taxonomy decision and a form-scoping bug fix

Three switches on the admin **Activities** page hide whole categories of noise so a timeline can be pared down to record changelogs and communications — facilitators kept wading through login/password churn to find the edits that matter.

## What's new
- **Hide account** — excludes `auth.*` (login, password reset, email change, lock, admin grant, account setup/delete, …) **and** User-record mutations (`create/update/destroy.user`).
- **Hide interactions** — excludes view / print / download / search / filter / zero-result-search noise.
- **Hide communications** — drops a person's email communications from their timeline.

## Person History defaults
- The **History** link on a person's page opens with **account + interaction hidden**, so you land on changelogs + comms; flip the switches to see everything.

## Bug fix: filter form kept losing the person/user/record scope
- The filter form submitted only its visible fields to `request.path`, so `person_id` (and `user_id` / `resource_type` / `resource_id`) were dropped on any toggle/search/audience/time change — the page silently reverted to the **global** feed and unrelated events (org autochanges, everyone's logins) reappeared.
- Now carried as hidden fields; the sort-header links preserve the hide toggles + scope too.

## Worth a look
- "Account" deliberately also hides `update.user` churn (fires alongside auth callbacks), not just `auth.*`. Meaningful account changes still surface via their dedicated `auth.*` events (email changed, admin granted, …).
- Toggles are `check_box_tag` sliders inside the existing filter form, so the `collection` controller auto-submits into the `activity_results` frame — no new JS.

<img width="1005" height="587" alt="Screenshot 2026-09-01 at 3 08 25 PM" src="https://github.com/user-attachments/assets/8497b941-31a5-4ddf-be44-5b62379958b3" />
