### PR TITLE
Polish admin activity log: comment details, column order, frame breakout

### DIFF
--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -11,11 +11,17 @@
     <%= event.properties["resource_title"].presence || "—" %>
   </td>
 
+  <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
+  <td data-label="Details" class="min-w-[16rem] px-4 py-3 align-top text-gray-500">
+    <%= render "admin/ahoy_activities/event_details", activity: activity %>
+  </td>
+
   <td data-label="User" class="px-4 py-3 text-gray-600">
     <% if event.user %>
       <%= link_to event.user.full_name,
                   user_path(event.user),
-                  class: "text-indigo-600 hover:underline" %>
+                  class: "text-indigo-600 hover:underline",
+                  data: { turbo_frame: "_top" } %>
     <% else %>
       <span class="text-gray-400 italic">Guest</span>
     <% end %>
@@ -23,10 +29,5 @@
 
   <td data-label="Visit ID" class="px-4 py-3 text-gray-500">
     <%= event.visit_id %>
-  </td>
-
-  <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
-  <td data-label="Details" class="px-4 py-3 align-top text-gray-500">
-    <%= render "admin/ahoy_activities/event_details", activity: activity %>
   </td>
 </tr>

--- a/app/views/admin/ahoy_activities/_event_details.html.erb
+++ b/app/views/admin/ahoy_activities/_event_details.html.erb
@@ -30,7 +30,7 @@
         <% if row[:action] %><span class="text-gray-400"><%= row[:action] %></span><% end %>
         <% if row[:link] %>
           <% if row[:link][:path] %>
-            <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline" %>
+            <%= link_to row[:link][:text], row[:link][:path], class: "text-indigo-600 hover:underline", data: { turbo_frame: "_top" } %>
           <% else %>
             <span class="text-gray-600"><%= row[:link][:text] %></span>
           <% end %>

--- a/app/views/admin/ahoy_activities/activity_results.html.erb
+++ b/app/views/admin/ahoy_activities/activity_results.html.erb
@@ -74,9 +74,9 @@
         <th class="rounded-tl-xl px-4 py-3 text-left"><%= @person ? "Time" : sort_link.call("time", "Time") %></th>
         <th class="px-4 py-3 text-left"><%= @person ? "Activity" : sort_link.call("name", "Activity") %></th>
         <th class="px-4 py-3 text-left">Resource</th>
+        <th class="min-w-[16rem] px-4 py-3 text-left">Details</th>
         <th class="px-4 py-3 text-left"><%= @person ? "User" : sort_link.call("user", "User") %></th>
-        <th class="px-4 py-3 text-left">Visit ID</th>
-        <th class="rounded-tr-xl px-4 py-3 text-left">Details</th>
+        <th class="rounded-tr-xl px-4 py-3 text-left">Visit ID</th>
       </tr>
       </thead>
 

--- a/app/views/notifications/_notification_row.html.erb
+++ b/app/views/notifications/_notification_row.html.erb
@@ -33,7 +33,7 @@
       <%= decorated.channel_icon %>
       <%# A regular outgoing message is the norm here — only the exceptions get a flag. %>
       <%= decorated.flag_badges %>
-      <span class="font-semibold text-gray-900"><%= subject %></span>
+      <span class="font-semibold text-gray-900" title="<%= body.presence || subject %>"><%= subject %></span>
       <% if body.present? %>
         <% if body_admin_only && mark_admin_only %>
           <%# Internal staff note on a page non-admins can view — flag it admin-only. %>

--- a/db/seeds/dev/affiliation_history.rb
+++ b/db/seeds/dev/affiliation_history.rb
@@ -54,7 +54,9 @@ else
     note = ->(subject, body, at, topic: nil) do
       comment = subject.comments.create!(body: body, topic: topic, created_by: actor, updated_by: actor)
       comment.update_columns(created_at: at, updated_at: at)
-      track.("create", comment, at, { resource_title: body.truncate(60) })
+      # The note's body belongs in the Details column (like a real tracked comment),
+      # not jammed into the Resource title.
+      track.("create", comment, at, { resource_title: "Comment", "topic" => topic, "body" => body }.compact_blank)
       comment
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/seed changes to the admin activity log, no data migration

Makes the admin person-activity log easier to read: comment notes now show their body in the Details column (with the Resource reading "Comment") instead of being jammed into the Resource title.

### What is the goal of this PR and why is this important?
Admins reviewing a person's history couldn't see what a comment actually said in a scannable way, and clicking a row's user link errored with the turbo "Oopsie" box.

### How did you approach the change?
- Seed the demo persona's `create.comment` events with the body/topic as Details properties and a `"Comment"` resource title, matching how real tracked comments render.
- Reorder the activity table to Time · Activity · Resource · Details · User · Visit ID, and widen Details.
- Add `data: { turbo_frame: "_top" }` to the user link and Details reference links so they break out of the results frame instead of triggering the frame-missing "Oopsie".
- Show a communication's full body on hover of its subject, matching the message text.

### Anything else to add?
The seed change only affects freshly seeded data (the persona is guarded to seed once); no production data migration.
