### PR TITLE
Compact training registrations and widen the subscriptions/taggings indexes

### DIFF
--- a/app/views/staff_taggings/index.html.erb
+++ b/app/views/staff_taggings/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-  <div class="w-full">
+<% content_for(:full_width, true) %>
+<%# Opt out of the layout's max-w-7xl cap so the wide taggings table has room. %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+  <div class="w-full <%= DomainTheme.bg_class_for(:people) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
     <div class="mb-4">
       <%= link_to "← Staff tags", staff_tags_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     </div>

--- a/app/views/topic_subscriptions/index.html.erb
+++ b/app/views/topic_subscriptions/index.html.erb
@@ -1,43 +1,47 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<% content_for(:full_width, true) %>
 
-<div class="max-w-7xl mx-auto <%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-primary/10 rounded-2xl shadow-sm p-6">
-  <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
-    <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-    <div class="flex items-center gap-4">
-      <% if allowed_to?(:index?, Person) %>
-        <%= link_to "People", people_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <% end %>
-      <% if allowed_to?(:index?, StaffTagging) %>
-        <%= link_to "Staff taggings", staff_taggings_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <% end %>
-      <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
-      <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+<%# Opt out of the layout's max-w-7xl cap so the wide subscriptions table has room. %>
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
+  <div class="<%= DomainTheme.bg_class_for(:topic_subscriptions) %> border border-primary/10 rounded-2xl shadow-sm p-6">
+    <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6">
+      <%= link_to "← Home", root_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      <div class="flex items-center gap-4">
+        <% if allowed_to?(:index?, Person) %>
+          <%= link_to "People", people_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% end %>
+        <% if allowed_to?(:index?, StaffTagging) %>
+          <%= link_to "Staff taggings", staff_taggings_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <% end %>
+        <%= link_to "Email addresses", email_addresses_topic_subscriptions_path(request.query_parameters), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+        <%= link_to "Manage topics", topic_subscription_types_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
+      </div>
     </div>
+
+    <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+      <div>
+        <h1 class="font-display flex items-center gap-2 text-2xl font-semibold text-primary">
+          <i class="fa-solid fa-envelope-open-text <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
+          Subscriptions
+        </h1>
+        <p class="text-gray-600 mt-1">People with whom we are corresponding about a topic.</p>
+      </div>
+      <div class="flex items-center gap-2">
+        <%# Carry the index's filters so the form prefills from them (person, topic)
+            and the eyebrow/Cancel/post-save redirect land back on this filtered
+            list; a person filter reads as person context and returns to their page. %>
+        <%= link_to new_topic_subscription_path(topic_subscription_index_filters.merge(return_to: params[:person_id].present? ? "person" : "index")), class: button_classes(:primary, extra: "inline-flex items-center gap-1.5") do %>
+          <i class="fa-solid fa-plus text-xs"></i>
+          New subscription
+        <% end %>
+      </div>
+    </div>
+
+    <%= render "search_boxes" %>
+
+    <% result_src = topic_subscriptions_path + "?" + request.query_string %>
+    <%= turbo_frame_tag :topic_subscriptions_results, src: result_src, data: { turbo: "temporary" } do %>
+      <%= render "results_skeleton" %>
+    <% end %>
   </div>
-
-  <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
-    <div>
-      <h1 class="font-display flex items-center gap-2 text-2xl font-semibold text-primary">
-        <i class="fa-solid fa-envelope-open-text <%= DomainTheme.text_class_for(:topic_subscriptions, intensity: 600) %>"></i>
-        Subscriptions
-      </h1>
-      <p class="text-gray-600 mt-1">People with whom we are corresponding about a topic.</p>
-    </div>
-    <div class="flex items-center gap-2">
-      <%# Carry the index's filters so the form prefills from them (person, topic)
-          and the eyebrow/Cancel/post-save redirect land back on this filtered
-          list; a person filter reads as person context and returns to their page. %>
-      <%= link_to new_topic_subscription_path(topic_subscription_index_filters.merge(return_to: params[:person_id].present? ? "person" : "index")), class: button_classes(:primary, extra: "inline-flex items-center gap-1.5") do %>
-        <i class="fa-solid fa-plus text-xs"></i>
-        New subscription
-      <% end %>
-    </div>
-  </div>
-
-  <%= render "search_boxes" %>
-
-  <% result_src = topic_subscriptions_path + "?" + request.query_string %>
-  <%= turbo_frame_tag :topic_subscriptions_results, src: result_src, data: { turbo: "temporary" } do %>
-    <%= render "results_skeleton" %>
-  <% end %>
 </div>

--- a/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
+++ b/app/views/topic_subscriptions/topic_subscriptions_results.html.erb
@@ -1,7 +1,7 @@
 <% sort_base = params.permit(:person_id, :organization_name, :topic_subscription_type_id, :comment_status, :marked, :status).to_h.symbolize_keys %>
 <% sort_link = sort_header_link(frame: "topic_subscriptions_results", path: ->(p) { topic_subscriptions_path(p) }, base: sort_base) %>
 <%= turbo_frame_tag :topic_subscriptions_results do %>
-  <div class="overflow-hidden rounded-2xl border border-primary/10 bg-white shadow-sm blur-on-submit">
+  <div class="border-primary/10 overflow-hidden rounded-2xl border bg-white shadow-sm blur-on-submit">
     <%# Outside the empty check: with nothing to list, the toggle is the only way
         back to the other status. It navigates the whole page rather than this
         frame so the filter form — which lives outside the frame and carries the
@@ -106,14 +106,22 @@
                 <td class="px-4 py-2 text-sm text-gray-800">
                   <% registrations = subscription.person_facilitator_training_registrations %>
                   <% if registrations.any? %>
-                    <ul class="space-y-1">
+                    <%# One compact attendance-status pill per training, so a person's
+                        trainings stay on one line; hover reveals the training and its date. %>
+                    <div class="flex flex-wrap gap-1.5">
                       <% registrations.each do |registration| %>
-                        <li class="flex flex-wrap items-center gap-2">
-                          <%= link_to registration.event.title, edit_event_registration_path(registration), class: "text-blue-600 hover:text-blue-800 hover:underline", data: { turbo_frame: "_top" } %>
-                          <span class="text-xs text-gray-500">(<%= registration.attendance_status_label %>)</span>
-                        </li>
+                        <% deco = registration.decorate %>
+                        <% event = registration.event %>
+                        <% event_date = event.start_date&.strftime("%b %-d, %Y") %>
+                        <%= link_to edit_event_registration_path(registration),
+                                    title: [ event.title, event_date ].compact.join(" · "),
+                                    class: "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition hover:opacity-80 hover:shadow-sm #{deco.attendance_status_classes}",
+                                    data: { turbo_frame: "_top" } do %>
+                          <i class="fas <%= deco.attendance_status_icon %> text-2xs"></i>
+                          <%= registration.attendance_status_label %>
+                        <% end %>
                       <% end %>
-                    </ul>
+                    </div>
                   <% else %>
                     <span class="text-gray-400">—</span>
                   <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -36,6 +36,7 @@
     compact attendance-status pills on one line instead of a stacked list. Hover a
     pill to see the training's name and date.
   action_path: /topic_subscriptions
+  pr_number: 2482
 
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -25,6 +25,18 @@
 #                   expand this in the WYSIWYG with screenshots.
 #   external_url:   Optional link to a full process doc (e.g. a Google/Word doc).
 
+# ── 2026-09 ─────────────────────────────────────────────────────────────────
+
+- name: "Compact training registrations on the subscriptions page"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    On the topic subscriptions page, a person's facilitator trainings now show as
+    compact attendance-status pills on one line instead of a stacked list. Hover a
+    pill to see the training's name and date.
+  action_path: /topic_subscriptions
+
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
 - name: "No-show trainings no longer count toward program status"

--- a/spec/requests/topic_subscriptions_spec.rb
+++ b/spec/requests/topic_subscriptions_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe "TopicSubscriptions", type: :request do
 
     it "lists subscriptions and shows the person's facilitator-training registrations" do
       person = create(:person, first_name: "Dana", last_name: "Rivers")
-      training = create(:event, title: "TAC263 Spring Training", facilitator_training: true)
+      training = create(:event, title: "TAC263 Spring Training", start_date: Time.zone.local(2024, 5, 3, 9), facilitator_training: true)
       other_event = create(:event, title: "Community Open House", facilitator_training: false)
-      create(:event_registration, registrant: person, event: training)
+      create(:event_registration, registrant: person, event: training, status: "attended")
       create(:event_registration, registrant: person, event: other_event)
       create(:topic_subscription, person: person, topic_subscription_type: trainings, interested_event: nil)
 
@@ -33,8 +33,11 @@ RSpec.describe "TopicSubscriptions", type: :request do
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Dana Rivers")
-      # The registrations column surfaces only facilitator-training events.
-      expect(response.body).to include("TAC263 Spring Training")
+      # The registrations column collapses to a compact attendance-status pill.
+      expect(response.body).to include("Attended")
+      # The training's name and date ride along in the pill's hover tooltip.
+      expect(response.body).to include("TAC263 Spring Training · May 3, 2024")
+      # Only facilitator-training events appear.
       expect(response.body).not_to include("Community Open House")
       # Row action is a plain link (no JS) to the subscription's edit page.
       expect(response.body).to include(edit_topic_subscription_path(TopicSubscription.last, return_to: "index"))


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only tweaks to two admin index pages; one column re-rendered, two width caps lifted

Two readability tweaks to the topic subscriptions admin area, so facilitators can scan these wide tables without scrolling.

## Compact training registrations (subscriptions page)
- A person's facilitator trainings were a stacked `title (Status)` list that ate several rows each.
- Now one colored attendance-status pill per training on a single wrapping line; hover for the training's name and date. Each pill still links to the registration.
- Reuses the attendance-status colors/icons from `EventRegistrationDecorator`.

## Wider indexes
- The subscriptions and staff-taggings indexes were capped at `max-w-7xl` (1280px).
- Both now opt into the layout's full-width mode with the same `max-w-[96rem]` gutter wrapper the roster/manage pages use, giving the multi-column tables more room.
