### PR TITLE
Show outgoing email sender as "AWBW Programs"

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,15 @@ class ApplicationMailer < ActionMailer::Base
   helper ApplicationHelper
   include Rails.application.routes.url_helpers
 
-  default from: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+  FROM_NAME = "AWBW Programs".freeze
+
+  # Wraps the generic mailbox with a friendly display name so recipients see
+  # "AWBW Programs" rather than the bare "programs" local part.
+  def self.sender(address = ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"))
+    %("#{FROM_NAME}" <#{address}>)
+  end
+
+  default from: sender
   default reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
 
   layout "mailer"

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -10,7 +10,7 @@ class DeviseMailer < Devise::Mailer
   after_action :create_notification_record, unless: :preview?
   after_action :track_devise_email_event, unless: :preview?
 
-  default from: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
+  default from: ApplicationMailer.sender
   default reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org")
 
   def reset_password_instructions(record, token, opts = {})

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -12,7 +12,7 @@ class EventMailer < ApplicationMailer
 
     mail(
       to: @person.preferred_email,
-      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      from: self.class.sender(ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org")),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: "AWBW Portal: #{@event_registration.registration_subject_noun.capitalize} received for #{@event.title}"
     )
@@ -41,7 +41,7 @@ class EventMailer < ApplicationMailer
 
     mail(
       to: @person.preferred_email,
-      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      from: self.class.sender(ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org")),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: "AWBW Portal: Payment submission received for #{@event&.title}"
     )
@@ -75,7 +75,7 @@ class EventMailer < ApplicationMailer
     # page's pre-fill so the preview and the delivered email can't drift apart.
     mail(
       to: @person.preferred_email,
-      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      from: self.class.sender(ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org")),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: @custom_subject || @event.default_reminder_subject(time_zone: @time_zone)
     )
@@ -101,7 +101,7 @@ class EventMailer < ApplicationMailer
     count = @recipient_labels.size
     mail(
       to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
-      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      from: self.class.sender(ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org")),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: "AWBW Portal: [FYI] Reminder sent to #{count} registrant#{'s' if count != 1} for #{@event.title}"
     )
@@ -120,7 +120,7 @@ class EventMailer < ApplicationMailer
 
     mail(
       to: @person.preferred_email,
-      from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
+      from: self.class.sender(ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org")),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
       subject: "AWBW Portal: #{@event_registration.registration_subject_noun.capitalize} cancelled for #{@event.title}"
     )

--- a/spec/jobs/notification_mailer_job_spec.rb
+++ b/spec/jobs/notification_mailer_job_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe NotificationMailerJob, type: :job do
           sender: admin)
       end
 
-      it "sends an attributed reminder from the generic address with no display name" do
+      it "sends an attributed reminder from the generic mailbox as AWBW Programs" do
         described_class.new.perform(notification.id)
 
         mail = ActionMailer::Base.deliveries.last
         expect(mail.from).to eq([ ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org") ])
-        expect(mail[:from].display_names.compact).to be_empty
+        expect(mail[:from].display_names.compact).to eq([ ApplicationMailer::FROM_NAME ])
         expect(mail.reply_to).to eq([ ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org") ])
       end
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationMailer do
-  it 'sets the default from address' do
-    expect(described_class.default[:from]).to eq(ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"))
+  it 'sets the default from address with the AWBW Programs display name' do
+    expect(described_class.default[:from]).to eq(described_class.sender)
+    expect(described_class.default[:from]).to include(ApplicationMailer::FROM_NAME)
   end
 
   it 'uses the correct layout' do

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -210,15 +210,16 @@ RSpec.describe DeviseMailer, type: :mailer do
     end
 
     # The sender is an internal audit field only — an admin-sent invite must still
-    # reach the recipient from the generic mailbox with no personal name attached.
-    it "sends an attributed invite from the generic address with no display name" do
+    # reach the recipient from the generic mailbox as "AWBW Programs", never under
+    # the admin's own personal name.
+    it "sends an attributed invite from the generic mailbox as AWBW Programs, not the admin" do
       invitee = create(:user, :unconfirmed)
 
       invitee.send_confirmation_instructions(sender: admin)
 
       mail = ActionMailer::Base.deliveries.last
       expect(mail.from).to eq([ ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org") ])
-      expect(mail[:from].display_names.compact).to be_empty
+      expect(mail[:from].display_names.compact).to eq([ ApplicationMailer::FROM_NAME ])
       expect(mail.reply_to).to eq([ ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org") ])
       expect(mail.header.fields.map(&:to_s).join("\n")).not_to include("Dana Sender")
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small, contained mailer change — display name only, covered by updated specs

Recipients now see **AWBW Programs** as the email sender instead of the bare "programs" — a friendlier, on-brand From name after our first successful bulk send.

- Display name only: the sending address and domain are unchanged, so **deliverability / SPF / DKIM / DMARC are untouched** — no spam risk.
- Centralized in `ApplicationMailer.sender`; `DeviseMailer` and `EventMailer` share it, so every generic-mailbox email is consistent.
- Attributed admin invites still come from the generic mailbox as "AWBW Programs" — never under the admin's personal name (existing behavior preserved).
- If `REPLY_TO_EMAIL` is set in prod it must stay a **bare address** (the code adds the name); a value that already includes a display name would double-wrap.