### PR TITLE
Fix empty person pill on Edit license page (#2480)

### DIFF
--- a/app/views/professional_licenses/_form.html.erb
+++ b/app/views/professional_licenses/_form.html.erb
@@ -15,9 +15,9 @@
   <% if professional_license.persisted? %>
     <div>
       <span class="<%= label_class %>">Person</span>
-      <p class="font-medium text-gray-900">
+      <div>
         <%= person_edit_button(professional_license.person, compact: true, width_class: "w-fit", data: { turbo_frame: "_top" }) %>
-      </p>
+      </div>
     </div>
   <% else %>
     <div>

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -121,17 +121,6 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include(person.full_name)
     end
 
-    it "renders the person edit card outside a paragraph so the browser can't split it" do
-      get edit_professional_license_path(license)
-
-      # person_edit_button renders a block <div> inside its <a>; wrapping that in a
-      # <p> is invalid nesting, and the browser parser closes the <p> early and splits
-      # the anchor into an empty pill + the real card. Keep it out of any <p>.
-      card = Nokogiri::HTML(response.body).at_css("a[href='#{edit_person_path(person)}']")
-      expect(card).to be_present
-      expect(card.ancestors("p")).to be_empty
-    end
-
     it "updates the license fields" do
       patch professional_license_path(license), params: {
         professional_license: { number: "556", kind: "LCSW", issuing_state: "NY" }

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -121,6 +121,17 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include(person.full_name)
     end
 
+    it "renders the person edit card outside a paragraph so the browser can't split it" do
+      get edit_professional_license_path(license)
+
+      # person_edit_button renders a block <div> inside its <a>; wrapping that in a
+      # <p> is invalid nesting, and the browser parser closes the <p> early and splits
+      # the anchor into an empty pill + the real card. Keep it out of any <p>.
+      card = Nokogiri::HTML(response.body).at_css("a[href='#{edit_person_path(person)}']")
+      expect(card).to be_present
+      expect(card.ancestors("p")).to be_empty
+    end
+
     it "updates the license fields" do
       patch professional_license_path(license), params: {
         professional_license: { number: "556", kind: "LCSW", issuing_state: "NY" }


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 one-tag markup fix (`<p>` → `<div>`), no logic change

The Edit license page showed a stray empty blue pill next to the person's "Edit" card. Fixed so only the one person card renders.

- `person_edit_button` renders a block `<div>` inside its `<a>`; the form wrapped that anchor in a `<p>`.
- Block-in-paragraph is invalid HTML, so the browser closes the `<p>` early and splits the anchor — leaving an empty pill plus the real card.
- Swapped the `<p>` for a `<div>`.

## Before / after
Before: empty pill overlapping the "EDIT Tester Test" card. After: single clean card (verified via system-spec screenshot).

Closes #2480