### PR TITLE
Clarify bulk payment confirmation email and link the invoice

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -34,13 +34,16 @@ class EventMailer < ApplicationMailer
     # carries the event details + a "View submission" link). Bulk payments always
     # have an event; guard anyway so an event-less submission just omits the link.
     @ticket_url = bulk_payment_ticket_url(@submission.slug) if @submission.event.present? && @submission.slug.present?
+    # Itemized invoice for this payment — public to the payer (no account) for
+    # bulk-payment submissions, same as their ticket. Returns to the ticket page.
+    @invoice_url = event_invoice_url(@submission.event, submission_id: @submission.id, return_to: "bulk_payment_ticket") if @submission.event.present?
     @organization_name = ENV.fetch("ORGANIZATION_NAME", "AWBW")
 
     mail(
       to: @person.preferred_email,
       from: ENV.fetch("REPLY_TO_EMAIL", "no-reply@awbw.org"),
       reply_to: ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"),
-      subject: "AWBW Portal: Payment received for #{@event&.title}"
+      subject: "AWBW Portal: Payment submission received for #{@event&.title}"
     )
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -121,6 +121,13 @@ class Payment < ApplicationRecord
     self.amount_cents = (value.to_d * 100).to_i if value.present?
   end
 
+  # True once any of the payment has been applied to what it's paying for (e.g. a
+  # bulk payment allocated to its event registrations). A recorded-but-unapplied
+  # payment — a check keyed in before it's allocated — is not yet "allocated".
+  def allocated?
+    amount_cents_remaining.to_i < amount_cents.to_i
+  end
+
   def allocated_dollars
     (amount_cents - (amount_cents_remaining || 0)).to_d / 100
   end

--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -1,4 +1,4 @@
-<h1>Payment received</h1>
+<h1>Payment submission received</h1>
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
@@ -87,8 +87,13 @@
   <% end %>
 </div>
 
-<% if @ticket_url %>
+<% if @ticket_url || @invoice_url %>
   <p>
-    <a href="<%= @ticket_url %>" class="button">View payment</a>
+    <% if @ticket_url %>
+      <a href="<%= @ticket_url %>" class="button">View payment</a>
+    <% end %>
+    <% if @invoice_url %>
+      <a href="<%= @invoice_url %>" class="button-secondary">View invoice</a>
+    <% end %>
   </p>
 <% end %>

--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -90,7 +90,7 @@
 <% if @ticket_url || @invoice_url %>
   <p>
     <% if @ticket_url %>
-      <a href="<%= @ticket_url %>" class="button">View payment</a>
+      <a href="<%= @ticket_url %>" class="button">View ticket</a>
     <% end %>
     <% if @invoice_url %>
       <a href="<%= @invoice_url %>" class="button-secondary">View invoice</a>

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -1,4 +1,4 @@
-Payment received
+Payment submission received
 
 Hello <%= @person.full_name %>,
 
@@ -20,6 +20,8 @@ We've received your payment submission<%= " for the following event" if @event %
 <% end %><% end %>
 <% if @ticket_url %>View payment:
 <%= @ticket_url %>
+<% end %><% if @invoice_url %>View invoice:
+<%= @invoice_url %>
 <% end %>
 --
 This is an automated confirmation from <%= @organization_name %>.

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -18,7 +18,7 @@ We've received your payment submission<%= " for the following event" if @event %
 <% if @attendees.any? %>Attendees:
 <% @attendees.each do |attendee| %>- <%= [ attendee["first_name"], attendee["last_name"] ].compact_blank.join(" ") %><%= " <#{attendee['email']}>" if attendee["email"].present? %>
 <% end %><% end %>
-<% if @ticket_url %>View payment:
+<% if @ticket_url %>View ticket:
 <%= @ticket_url %>
 <% end %><% if @invoice_url %>View invoice:
 <%= @invoice_url %>

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -109,7 +109,7 @@
 
         <!-- Payment status -->
         <div>
-          <% if @payment %>
+          <% if @payment&.allocated? %>
             <span class="inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-3 py-1 text-sm font-medium text-green-700">
               <i class="fa-solid fa-circle-check text-green-500"></i> Payment received<% if total_cents.to_i > 0 %> — <%= dollars_from_cents(total_cents) %><% end %>
             </span>

--- a/app/views/layouts/mailer/_card_body.html.erb
+++ b/app/views/layouts/mailer/_card_body.html.erb
@@ -16,6 +16,17 @@
       border-radius: 6px;
       font-weight: bold;
   }
+
+  .button-secondary {
+      display: inline-block;
+      padding: 10px 16px;
+      background-color: #ffffff;
+      color: #2563eb !important;
+      text-decoration: none;
+      border-radius: 6px;
+      font-weight: bold;
+      border: 1px solid #2563eb;
+  }
 </style>
 
 <!--[if mso | IE]>

--- a/config/features.yml
+++ b/config/features.yml
@@ -36,6 +36,7 @@
     people paying by check aren't misled into thinking the payment already cleared.
     It also adds a "View invoice" button next to "View payment" that links straight
     to their itemized invoice.
+  pr_number: 2486
 
 - name: "Compact training registrations on the subscriptions page"
   area: communications

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,16 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "Clearer bulk payment confirmation email"
+  area: payments
+  display_status: user_facing
+  released_on: 2026-09-01
+  summary: >-
+    The bulk-payment confirmation email now reads "Payment submission received" so
+    people paying by check aren't misled into thinking the payment already cleared.
+    It also adds a "View invoice" button next to "View payment" that links straight
+    to their itemized invoice.
+
 - name: "Compact training registrations on the subscriptions page"
   area: communications
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -33,10 +33,9 @@
   released_on: 2026-09-01
   summary: >-
     The bulk-payment confirmation email now reads "Payment submission received" so
-    people paying by check aren't misled into thinking the payment already cleared.
-    It also adds a "View invoice" button next to "View payment" that links straight
-    to their itemized invoice. The payment ticket now shows "Payment received" only
-    once the payment is actually allocated to a registration, not just recorded.
+    check-payers don't think it already cleared, and adds a "View invoice" button.
+    The payment ticket shows "Payment received" only once the payment is allocated
+    to a registration.
   pr_number: 2486
 
 - name: "Compact training registrations on the subscriptions page"

--- a/config/features.yml
+++ b/config/features.yml
@@ -35,7 +35,8 @@
     The bulk-payment confirmation email now reads "Payment submission received" so
     people paying by check aren't misled into thinking the payment already cleared.
     It also adds a "View invoice" button next to "View payment" that links straight
-    to their itemized invoice.
+    to their itemized invoice. The payment ticket now shows "Payment received" only
+    once the payment is actually allocated to a registration, not just recorded.
   pr_number: 2486
 
 - name: "Compact training registrations on the subscriptions page"

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -151,6 +151,17 @@ RSpec.describe EventMailer, type: :mailer do
       # Event cost (1099¢) × 4 attendees = $43.96
       expect(mail.body.encoded).to include("$43.96")
     end
+
+    it "frames it as a submission received (not a processed payment) in the subject" do
+      expect(mail.subject).to include("Payment submission received")
+    end
+
+    it "links to the payer's invoice" do
+      body = mail.body.encoded
+      expect(body).to include("View invoice")
+      expect(body).to include("/events/#{event.id}/invoice")
+      expect(body).to include("submission_id=#{submission.id}")
+    end
   end
 
   describe "#event_registration_reminder" do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -301,6 +301,20 @@ RSpec.describe Payment, type: :model do
     end
   end
 
+  describe "#allocated?" do
+    it "is false when nothing has been applied yet" do
+      expect(build(:payment, amount_cents: 1000, amount_cents_remaining: 1000)).not_to be_allocated
+    end
+
+    it "is true once part of the payment is applied" do
+      expect(build(:payment, amount_cents: 1000, amount_cents_remaining: 400)).to be_allocated
+    end
+
+    it "is true when fully applied" do
+      expect(build(:payment, amount_cents: 1000, amount_cents_remaining: 0)).to be_allocated
+    end
+  end
+
   describe "#payer" do
     it "returns the person when payer_type is Person" do
       person = create(:person)

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -307,6 +307,25 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
       expect(response.body).not_to include("Cancel registration")
     end
 
+    it "shows payment pending when a payment exists but nothing is allocated yet" do
+      create(:payment, form_submission: submission, person: payer,
+                       amount_cents: 1000, amount_cents_remaining: 1000)
+
+      get_ticket
+
+      expect(response.body).to include("Payment pending")
+      expect(response.body).not_to include("Payment received")
+    end
+
+    it "shows payment received once the payment is allocated to a registration" do
+      create(:payment, form_submission: submission, person: payer,
+                       amount_cents: 1000, amount_cents_remaining: 0)
+
+      get_ticket
+
+      expect(response.body).to include("Payment received")
+    end
+
     it "links the invoice back to the ticket" do
       get_ticket
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 email copy plus a small payment-status gate; low blast radius

Clears up two spots where check-payers were told their payment was settled when it wasn't yet: the confirmation email now says "Payment submission received," and the payment ticket only shows the green "Payment received" pill once the payment is actually allocated to a registration.

### What is the goal of this PR and why is this important?
- People paying by check saw "Payment received" (email heading/subject) and a green "Payment received" pill (ticket) and thought the money had cleared. Now both reflect reality.
- Payers also had no direct path to their invoice from the email; added a "View invoice" button next to "View payment."

### How did you approach the change?
- Reworded the email heading/subject (HTML + text) to "Payment submission received."
- Added `@invoice_url` to the email (the existing itemized invoice, public to bulk-payment payers via `FormSubmissionPolicy#show_invoice?`), rendered as a secondary outlined button + a `.button-secondary` mailer style.
- Added `Payment#allocated?` (any amount applied) and gated the ticket's green pill on it — an unallocated payment now reads "Payment pending."
- Added specs (email subject/invoice link, ticket pending-vs-received, `Payment#allocated?`) and a `/features` entry.

### Anything else to add?
- `allocated?` is true for partial allocation too; a recorded-but-unapplied payment reads pending.