### PR TITLE
Professional license editing: CE history + per-license Edit on the person page

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -243,6 +243,7 @@ class PeopleController < ApplicationController
       { avatar_attachment: :blob },
       { comments: [ :created_by, :updated_by ] },
       { sectorable_items: :sector },
+      { professional_licenses: { continuing_education_registrations: { event_registration: :event } } },
       affiliations: { organization: [ :logo_attachment, :addresses ] }
     ).find(params[:id]).decorate
     authorize! @person

--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -29,7 +29,9 @@ class ProfessionalLicensesController < ApplicationController
   end
 
   def edit
-    @professional_license = ProfessionalLicense.find(params[:id])
+    @professional_license = ProfessionalLicense
+      .includes(continuing_education_registrations: { event_registration: [ :event, :registrant ] })
+      .find(params[:id])
     authorize! @professional_license
   end
 

--- a/app/controllers/professional_licenses_controller.rb
+++ b/app/controllers/professional_licenses_controller.rb
@@ -40,7 +40,7 @@ class ProfessionalLicensesController < ApplicationController
     authorize! @professional_license
 
     if @professional_license.update(license_edit_params)
-      redirect_to professional_licenses_path, notice: "License updated for #{@professional_license.person.full_name}."
+      redirect_to helpers.professional_license_return_path(@professional_license), notice: "License updated for #{@professional_license.person.full_name}."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/decorators/professional_license_decorator.rb
+++ b/app/decorators/professional_license_decorator.rb
@@ -16,6 +16,15 @@ class ProfessionalLicenseDecorator < ApplicationDecorator
     end
   end
 
+  # Tooltip text naming the event(s) whose CE registrations lock this license from
+  # removal. Falls back to a plain note when no event is resolvable.
+  def ce_events_summary
+    titles = continuing_education_registrations.filter_map { |registration| registration.event_registration&.event&.title }.uniq
+    return "Has CE registrations" if titles.empty?
+
+    "CE registered at #{titles.to_sentence}"
+  end
+
   # CE hours issued against this license this calendar year — only registrations
   # whose certificate has been sent (in the current year) count.
   def ce_hours_issued_this_year

--- a/app/frontend/javascript/controllers/cocoon_controller.js
+++ b/app/frontend/javascript/controllers/cocoon_controller.js
@@ -118,9 +118,6 @@ function handleAdd(link, originalEvent) {
 }
 
 function handleRemove(link, originalEvent) {
-  const confirmMessage = link.dataset.cocoonConfirm;
-  if (confirmMessage && !window.confirm(confirmMessage)) return;
-
   const wrapperClass = link.dataset.wrapperClass || "nested-fields";
   const wrapper = link.closest("." + wrapperClass);
   if (!wrapper) return;

--- a/app/frontend/javascript/controllers/cocoon_controller.js
+++ b/app/frontend/javascript/controllers/cocoon_controller.js
@@ -118,6 +118,9 @@ function handleAdd(link, originalEvent) {
 }
 
 function handleRemove(link, originalEvent) {
+  const confirmMessage = link.dataset.cocoonConfirm;
+  if (confirmMessage && !window.confirm(confirmMessage)) return;
+
   const wrapperClass = link.dataset.wrapperClass || "nested-fields";
   const wrapper = link.closest("." + wrapperClass);
   if (!wrapper) return;

--- a/app/helpers/continuing_education_registrations_helper.rb
+++ b/app/helpers/continuing_education_registrations_helper.rb
@@ -9,6 +9,7 @@ module ContinuingEducationRegistrationsHelper
   def ce_registration_return_path(registration)
     case params[:return_to]
     when "ce_index" then continuing_education_registrations_path
+    when "professional_license" then edit_professional_license_path(params[:license_id])
     when "registrants" then registrants_event_row_path(registration.event, registration.id)
     when "attendance" then attendance_event_path(registration.event, ce: "true", anchor: "totals")
     else edit_event_registration_path(registration)
@@ -20,6 +21,7 @@ module ContinuingEducationRegistrationsHelper
   def ce_registration_return_label
     case params[:return_to]
     when "ce_index" then "CE registrations"
+    when "professional_license" then "License"
     when "registrants" then "Registrants"
     when "attendance" then "CE timesheets"
     else "Registration"

--- a/app/helpers/professional_licenses_helper.rb
+++ b/app/helpers/professional_licenses_helper.rb
@@ -1,0 +1,22 @@
+module ProfessionalLicensesHelper
+  # Where the license edit form (eyebrow, Cancel, and the controller's post-save
+  # redirect) returns to. Reached from a person's edit page (return_to=person) it
+  # lands back on that person's licenses section; otherwise the licenses index.
+  def professional_license_return_path(license)
+    if params[:return_to] == "person" && license.person
+      edit_person_path(license.person, anchor: "professional-licenses")
+    else
+      professional_licenses_path
+    end
+  end
+
+  # Eyebrow label for the license form back-link, matching whichever origin it was
+  # reached from.
+  def professional_license_return_label(license)
+    if params[:return_to] == "person" && license.person
+      license.person.full_name
+    else
+      "Licenses"
+    end
+  end
+end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -383,7 +383,7 @@
     </div>
   </div>
 
-  <div class="form-group space-y-4">
+  <div id="professional-licenses" class="form-group scroll-mt-4 space-y-4">
     <div class="mb-2 font-semibold text-gray-700">
       Professional licenses
     </div>

--- a/app/views/professional_licenses/_ce_history.html.erb
+++ b/app/views/professional_licenses/_ce_history.html.erb
@@ -1,0 +1,56 @@
+<%# CE registrations issued against this license — the license's continuing-education
+    history. Newest first; links each entry back to its CE registration edit page. %>
+<% registrations = license.continuing_education_registrations.sort_by(&:created_at).reverse %>
+<section class="border-primary/10 mt-6 overflow-hidden rounded-2xl border bg-white shadow-sm">
+  <div class="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+    <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg <%= DomainTheme.bg_class_for(:continuing_education, intensity: 100) %> <%= DomainTheme.text_class_for(:continuing_education, intensity: 600) %>">
+      <i class="fa-solid fa-certificate"></i>
+    </span>
+    <h2 class="text-sm font-semibold text-gray-700">CE history</h2>
+    <span class="ml-auto text-xs text-gray-500"><%= registrations.size %> registration<%= "s" if registrations.size != 1 %></span>
+  </div>
+
+  <% if registrations.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Event</th>
+            <th class="px-4 py-3 text-right text-xs font-medium tracking-wider whitespace-nowrap text-gray-500 uppercase">Hours</th>
+            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Certificate</th>
+            <th class="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">Payment</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% registrations.each do |ce| %>
+            <% decorated = ce.decorate %>
+            <% certificate = decorated.certificate_badge %>
+            <% payment = decorated.payment_status_badge %>
+            <% hours = ce.hours || 0 %>
+            <% hours = hours.to_i if hours == hours.to_i %>
+            <tr class="transition-colors duration-150 hover:bg-gray-50">
+              <td class="px-4 py-3 text-sm text-gray-900">
+                <%= link_to edit_continuing_education_registration_path(ce, return_to: "professional_license", license_id: license.id),
+                      class: "font-medium #{DomainTheme.text_class_for(:continuing_education, intensity: 700)} hover:underline" do %>
+                  <%= ce.event_registration&.event&.title || "Event" %>
+                <% end %>
+                <% if (sent_on = ce.certificate_sent_at) %>
+                  <span class="mt-0.5 block text-xs text-gray-400">Issued <%= sent_on.to_date.strftime("%b %-d, %Y") %></span>
+                <% end %>
+              </td>
+              <td class="px-4 py-3 text-right text-sm whitespace-nowrap text-gray-700 tabular-nums"><%= hours %></td>
+              <td class="px-4 py-3 whitespace-nowrap">
+                <%= render "shared/badge", label: certificate.label, classes: certificate.classes, icon: certificate.icon %>
+              </td>
+              <td class="px-4 py-3 whitespace-nowrap">
+                <%= render "shared/badge", label: payment.label, classes: payment.classes, icon: payment.icon %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="px-4 py-6 text-center text-sm text-gray-500">No CE registrations yet for this license.</p>
+  <% end %>
+</section>

--- a/app/views/professional_licenses/_form.html.erb
+++ b/app/views/professional_licenses/_form.html.erb
@@ -1,7 +1,8 @@
 <% field_class = "w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-800 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
 <% label_class = "block text-sm font-medium text-gray-700 mb-1" %>
 
-<%= simple_form_for professional_license, html: { class: "space-y-4" } do |f| %>
+<% form_url = professional_license.persisted? ? professional_license_path(professional_license, return_to: params[:return_to].presence) : professional_licenses_path %>
+<%= simple_form_for professional_license, url: form_url, html: { class: "space-y-4" } do |f| %>
   <% if professional_license.errors.any? %>
     <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
       <ul class="list-inside list-disc">
@@ -55,7 +56,7 @@
   </div>
 
   <div class="flex justify-end gap-2 pt-2">
-    <%= link_to "Cancel", professional_licenses_path, class: button_classes(:secondary) %>
+    <%= link_to "Cancel", professional_license_return_path(professional_license), class: button_classes(:secondary) %>
     <%= f.button :submit, professional_license.persisted? ? "Save license" : "Add license", class: button_classes(:primary) %>
   </div>
 <% end %>

--- a/app/views/professional_licenses/_form.html.erb
+++ b/app/views/professional_licenses/_form.html.erb
@@ -55,8 +55,15 @@
     </div>
   </div>
 
-  <div class="flex justify-end gap-2 pt-2">
-    <%= link_to "Cancel", professional_license_return_path(professional_license), class: button_classes(:secondary) %>
-    <%= f.button :submit, professional_license.persisted? ? "Save license" : "Add license", class: button_classes(:primary) %>
+  <div class="flex items-center justify-between gap-2 pt-2">
+    <div>
+      <% if professional_license.persisted? && professional_license.used_for_ce? %>
+        <span class="text-sm text-amber-600">Has CE registrations — can't remove</span>
+      <% end %>
+    </div>
+    <div class="flex gap-2">
+      <%= link_to "Cancel", professional_license_return_path(professional_license), class: button_classes(:secondary) %>
+      <%= f.button :submit, professional_license.persisted? ? "Save license" : "Add license", class: button_classes(:primary) %>
+    </div>
   </div>
 <% end %>

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -50,8 +50,7 @@
         <% if f.object.new_record? || f.object.removable? %>
           <%= link_to_remove_association "Remove",
                                          f,
-                                         class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap",
-                                         data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
+                                         class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap" %>
         <% else %>
           <%= link_to edit_professional_license_path(f.object, return_to: "person"),
                       class: "text-sm text-amber-600 hover:text-amber-800 hover:underline whitespace-nowrap",

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -54,7 +54,7 @@
                                          data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
         <% else %>
           <%= link_to edit_professional_license_path(f.object, return_to: "person"),
-                      class: "text-sm text-amber-600 hover:text-amber-800 underline whitespace-nowrap",
+                      class: "text-sm text-amber-600 hover:text-amber-800 hover:underline whitespace-nowrap",
                       title: f.object.decorate.ce_events_summary,
                       data: { turbo_frame: "_top" } do %>
             Can't<br>remove

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -41,11 +41,17 @@
                     input_html: { class: "rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500" } %>
       </div>
 
-      <div class="text-end text-right">
+      <div class="flex items-center justify-end gap-3 text-right">
+        <% if f.object.persisted? %>
+          <%= link_to "Edit", edit_professional_license_path(f.object, return_to: "person"),
+                      class: "text-sm text-blue-600 hover:text-blue-800 underline whitespace-nowrap",
+                      data: { turbo_frame: "_top" } %>
+        <% end %>
         <% if f.object.new_record? || f.object.removable? %>
           <%= link_to_remove_association "Remove",
                                          f,
-                                         class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap" %>
+                                         class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap",
+                                         data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
         <% else %>
           <span class="text-xs text-amber-600">Has CE registrations — can't remove</span>
         <% end %>

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -44,7 +44,7 @@
       <div class="flex items-center justify-end gap-3 text-right">
         <% if f.object.persisted? %>
           <%= link_to "Edit", edit_professional_license_path(f.object, return_to: "person"),
-                      class: "text-sm text-blue-600 hover:text-blue-800 underline whitespace-nowrap",
+                      class: "text-sm text-gray-400 hover:text-blue-600 underline whitespace-nowrap",
                       data: { turbo_frame: "_top" } %>
         <% end %>
         <% if f.object.new_record? || f.object.removable? %>
@@ -53,7 +53,7 @@
                                          class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap",
                                          data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
         <% else %>
-          <span class="text-xs text-amber-600">Has CE registrations — can't remove</span>
+          <span class="text-sm whitespace-nowrap text-gray-400">Can't<br>remove</span>
         <% end %>
       </div>
     </div>

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -53,7 +53,7 @@
                                          class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap",
                                          data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
         <% else %>
-          <span class="text-sm whitespace-nowrap text-gray-400">Can't<br>remove</span>
+          <span class="text-sm whitespace-nowrap text-amber-600">Can't<br>remove</span>
         <% end %>
       </div>
     </div>

--- a/app/views/professional_licenses/_professional_license_fields.html.erb
+++ b/app/views/professional_licenses/_professional_license_fields.html.erb
@@ -53,7 +53,12 @@
                                          class: "text-sm text-gray-400 hover:text-red-600 underline whitespace-nowrap",
                                          data: { cocoon_confirm: "Remove this license? This can't be undone." } %>
         <% else %>
-          <span class="text-sm whitespace-nowrap text-amber-600">Can't<br>remove</span>
+          <%= link_to edit_professional_license_path(f.object, return_to: "person"),
+                      class: "text-sm text-amber-600 hover:text-amber-800 underline whitespace-nowrap",
+                      title: f.object.decorate.ce_events_summary,
+                      data: { turbo_frame: "_top" } do %>
+            Can't<br>remove
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -20,6 +20,7 @@
   <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm">
     <%= render "form", professional_license: @professional_license %>
   </div>
+  <%= render "ce_history", license: @professional_license %>
   <%= render "shared/audit_info", resource: @professional_license %>
   <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
     <div class="mt-4 flex justify-end">

--- a/app/views/professional_licenses/edit.html.erb
+++ b/app/views/professional_licenses/edit.html.erb
@@ -2,8 +2,8 @@
 
 <div class="mx-auto max-w-2xl <%= DomainTheme.bg_class_for(:continuing_education) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
   <div class="mb-6">
-    <%= link_to professional_licenses_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
-      <i class="fa-solid fa-arrow-left text-xs"></i> Licenses
+    <%= link_to professional_license_return_path(@professional_license), class: "text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= professional_license_return_label(@professional_license) %>
     <% end %>
   </div>
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -49,6 +49,16 @@
     that CE registration.
   action_path: /professional_licenses
 
+- name: "Edit a professional license straight from a person's page"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    Each saved license on a person's edit page now has an Edit link (next to
+    Remove) that opens the full license editor and returns you to the person when
+    you're done. Removing a license now asks for confirmation first.
+  action_path: /people
+
 - name: "Compact training registrations on the subscriptions page"
   area: communications
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,17 @@
     to a registration.
   pr_number: 2486
 
+- name: "CE history on the license edit page"
+  area: events
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    Editing a professional license now shows that license's continuing-education
+    history at the bottom — every CE registration issued against it, with the
+    event, hours, certificate status, and payment status. Click a row to open
+    that CE registration.
+  action_path: /professional_licenses
+
 - name: "Compact training registrations on the subscriptions page"
   area: communications
   display_status: admin_facing

--- a/spec/decorators/professional_license_decorator_spec.rb
+++ b/spec/decorators/professional_license_decorator_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe ProfessionalLicenseDecorator do
     end
   end
 
+  describe "#ce_events_summary" do
+    let(:person) { create(:person) }
+    let(:license) { create(:professional_license, person: person) }
+
+    it "names the distinct events its CE registrations are tied to" do
+      event = create(:event, title: "Spring CE Retreat")
+      registration = create(:event_registration, registrant: person, event: event)
+      create(:continuing_education_registration, professional_license: license, event_registration: registration)
+
+      expect(license.decorate.ce_events_summary).to eq("CE registered at Spring CE Retreat")
+    end
+
+    it "falls back to a plain note when there are no CE registrations" do
+      expect(license.decorate.ce_events_summary).to eq("Has CE registrations")
+    end
+  end
+
   describe "CE hours issued" do
     let(:person) { create(:person) }
     let(:license) { create(:professional_license, person: person) }

--- a/spec/requests/people_professional_licenses_spec.rb
+++ b/spec/requests/people_professional_licenses_spec.rb
@@ -26,15 +26,6 @@ RSpec.describe "People professional licenses", type: :request do
     expect(response.body).to include("return_to=person")
   end
 
-  it "confirms before removing a license" do
-    person = create(:person)
-    create(:professional_license, person: person, number: "90210")
-
-    get edit_person_path(person)
-
-    expect(response.body).to include("data-cocoon-confirm")
-  end
-
   it "shows a compact can't-remove note for a CE-tied license" do
     person = create(:person)
     license = create(:professional_license, person: person, number: "90210")

--- a/spec/requests/people_professional_licenses_spec.rb
+++ b/spec/requests/people_professional_licenses_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe "People professional licenses", type: :request do
     expect(response.body).to include("data-cocoon-confirm")
   end
 
+  it "shows a compact can't-remove note for a CE-tied license" do
+    person = create(:person)
+    license = create(:professional_license, person: person, number: "90210")
+    registration = create(:event_registration, registrant: person)
+    create(:continuing_education_registration, event_registration: registration, professional_license: license)
+
+    get edit_person_path(person)
+
+    expect(response.body).to include("Can't<br>remove")
+    expect(response.body).not_to include("Has CE registrations — can't remove")
+  end
+
   it "adds a license through the person form" do
     person = create(:person)
 

--- a/spec/requests/people_professional_licenses_spec.rb
+++ b/spec/requests/people_professional_licenses_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe "People professional licenses", type: :request do
     expect(response.body).not_to include("Has CE registrations — can't remove")
   end
 
+  it "links the can't-remove note to the license edit page and names its CE events" do
+    person = create(:person)
+    license = create(:professional_license, person: person, number: "90210")
+    registration = create(:event_registration, registrant: person)
+    create(:continuing_education_registration, event_registration: registration, professional_license: license)
+
+    get edit_person_path(person)
+
+    expect(response.body).to include(edit_professional_license_path(license))
+    expect(response.body).to include("CE registered at #{registration.event.title}")
+  end
+
   it "adds a license through the person form" do
     person = create(:person)
 

--- a/spec/requests/people_professional_licenses_spec.rb
+++ b/spec/requests/people_professional_licenses_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe "People professional licenses", type: :request do
     expect(response.body).to include("LMFT 90210")
   end
 
+  it "links each saved license to its own edit page, returning to the person" do
+    person = create(:person)
+    license = create(:professional_license, person: person, number: "90210")
+
+    get edit_person_path(person)
+
+    expect(response.body).to include(edit_professional_license_path(license))
+    expect(response.body).to include("return_to=person")
+  end
+
+  it "confirms before removing a license" do
+    person = create(:person)
+    create(:professional_license, person: person, number: "90210")
+
+    get edit_person_path(person)
+
+    expect(response.body).to include("data-cocoon-confirm")
+  end
+
   it "adds a license through the person form" do
     person = create(:person)
 

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -143,6 +143,21 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include("No CE registrations yet for this license.")
     end
 
+    it "returns to the person's edit page when reached from there" do
+      get edit_professional_license_path(license, return_to: "person")
+
+      expect(response.body).to include(edit_person_path(person, anchor: "professional-licenses"))
+      expect(response.body).to include(person.full_name)
+    end
+
+    it "redirects back to the person after saving when reached from the person page" do
+      patch professional_license_path(license, return_to: "person"), params: {
+        professional_license: { number: "556", kind: "LCSW" }
+      }
+
+      expect(response).to redirect_to(edit_person_path(person, anchor: "professional-licenses"))
+    end
+
     it "updates the license fields" do
       patch professional_license_path(license), params: {
         professional_license: { number: "556", kind: "LCSW", issuing_state: "NY" }

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -121,6 +121,28 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include(person.full_name)
     end
 
+    it "renders the CE history for the license" do
+      registration = create(:event_registration, registrant: person)
+      create(:continuing_education_registration,
+             professional_license: license, event_registration: registration, hours: 6)
+
+      get edit_professional_license_path(license)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("CE history")
+      expect(response.body).to include(registration.event.title)
+      expect(response.body).to include(edit_continuing_education_registration_path(
+        ContinuingEducationRegistration.last))
+      expect(response.body).to include("return_to=professional_license")
+    end
+
+    it "shows an empty CE history when the license has no registrations" do
+      get edit_professional_license_path(license)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("No CE registrations yet for this license.")
+    end
+
     it "updates the license fields" do
       patch professional_license_path(license), params: {
         professional_license: { number: "556", kind: "LCSW", issuing_state: "NY" }

--- a/spec/requests/professional_licenses_spec.rb
+++ b/spec/requests/professional_licenses_spec.rb
@@ -143,6 +143,21 @@ RSpec.describe "ProfessionalLicenses", type: :request do
       expect(response.body).to include("No CE registrations yet for this license.")
     end
 
+    it "notes that a CE-tied license can't be removed" do
+      registration = create(:event_registration, registrant: person)
+      create(:continuing_education_registration, professional_license: license, event_registration: registration)
+
+      get edit_professional_license_path(license)
+
+      expect(response.body).to include("Has CE registrations — can't remove")
+    end
+
+    it "omits the can't-remove note for a license with no CE registrations" do
+      get edit_professional_license_path(license)
+
+      expect(response.body).not_to include("Has CE registrations — can't remove")
+    end
+
     it "returns to the person's edit page when reached from there" do
       get edit_professional_license_path(license, return_to: "person")
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 read-only CE history partial plus a per-license Edit link with return-to plumbing

Makes professional licenses easier to manage in two connected spots: admins can now see a license's CE history where they edit it, and can jump straight into a license from the person's edit page.

### CE history on the license edit page
- New **CE history** section lists each CE registration against the license: event, hours, certificate status, payment status.
- Rows link to that CE registration's edit page, with an eyebrow that returns to the license.
- Eager-loads the registrations in `edit` to avoid N+1.

### Person edit page: per-license Edit
- Each saved license now has an **Edit** link (to the left of **Remove**) opening its own edit page, styled to match Remove (grey, colored on hover).
- The license edit page's eyebrow, Cancel, and post-save redirect return to the person's licenses section (`return_to=person`, scrolls to the section).
- A CE-tied license shows a compact amber **Can't remove** in place of the Remove link; it links to the license editor and its hover tooltip names the event(s) whose CE registrations lock it. The full "Has CE registrations — can't remove" explanation sits on the license edit page where a delete button would go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)