### PR TITLE
Point Pay for Other(s) form at the right destination

### DIFF
--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -7,10 +7,7 @@ module Events
     def new
       authorize! :form_submission
 
-      @form_fields = visible_form_fields
-      @event = @event.decorate
-
-      @attendees_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
+      prepare_new_form
     end
 
     def create
@@ -25,9 +22,7 @@ module Events
 
       @field_errors = validate_required_fields
       if @field_errors.any?
-        @form_fields = visible_form_fields
-        @event = @event.decorate
-        @attendees_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
+        prepare_new_form
         render :new, status: :unprocessable_content
         return
       end
@@ -48,9 +43,7 @@ module Events
                       notice: "Your payment information has been submitted."
         end
       else
-        @form_fields = visible_form_fields
-        @event = @event.decorate
-        @attendees_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
+        prepare_new_form
         flash.now[:alert] = result.errors.join(", ")
         render :new, status: :unprocessable_content
       end
@@ -100,6 +93,20 @@ module Events
     end
 
     private
+
+    def prepare_new_form
+      @form_fields = visible_form_fields
+      @event = @event.decorate
+      @attendees_field = @form.form_fields.find_by(field_identifier: "bulk_payment_attendees")
+      @registration = current_registration
+    end
+
+    def current_registration
+      person = current_user&.person
+      return unless person
+
+      @event.event_registrations.find_by(registrant_id: person.id)
+    end
 
     def visible_form_fields
       scope = @form.form_fields.reorder(position: :asc)

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -47,7 +47,7 @@
         <i class="fa-solid fa-circle-info mt-0.5 text-blue-500"></i>
         <div class="space-y-2 text-sm">
           <p><strong>Use this form to pay for other people who are attending.</strong> That includes
-            paying for one or more other attendees — and you can add yourself too, if you're attending
+            paying for one or more attendees — and you can add yourself too, if you're attending
             and want to cover yourself and others in a single payment.</p>
           <p><strong>Only paying for your own spot?</strong> You don't need this form.
             <% if @registration %>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -59,7 +59,7 @@
             <% end %>
           </p>
           <% if @event.registerable? %>
-            <p><strong>Haven't registered yet?</strong>
+            <p><strong>Attending and haven't registered yet?</strong>
               <%= link_to "Register for #{@event.title}", new_event_public_registration_path(@event), class: "font-semibold underline" %>
               first — this form is only for covering other people's costs.</p>
           <% end %>

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -37,7 +37,7 @@
         </div>
         <div>
           <h2 class="text-xl leading-tight font-semibold tracking-wide"><%= Form::BULK_PAYMENT_PUBLIC_NAME %> Form</h2>
-          <p class="text-sm text-blue-200">Use this form to pay for one or more other attendees.</p>
+          <p class="text-sm text-blue-200">Cover the cost for one or more other people attending <%= @event.title %>.</p>
         </div>
       </div>
     </div>
@@ -49,9 +49,20 @@
           <p><strong>Use this form to pay for other people who are attending.</strong> That includes
             paying for one or more other attendees — and you can add yourself too, if you're attending
             and want to cover yourself and others in a single payment.</p>
-          <p><strong>Only paying for your own spot?</strong> You don't need this form. When you
-            registered, we emailed you a confirmation with a link to your digital ticket — open that
-            ticket and use the payment link on it.</p>
+          <p><strong>Only paying for your own spot?</strong> You don't need this form.
+            <% if @registration %>
+              Open <%= link_to "your digital ticket", registration_ticket_path(@registration.slug), class: "font-semibold underline" %>
+              and use the payment link on it.
+            <% else %>
+              When you registered, we emailed you a confirmation with a link to your digital ticket —
+              open that ticket and use the payment link on it.
+            <% end %>
+          </p>
+          <% if @event.registerable? %>
+            <p><strong>Haven't registered yet?</strong>
+              <%= link_to "Register for #{@event.title}", new_event_public_registration_path(@event), class: "font-semibold underline" %>
+              first — this form is only for covering other people's costs.</p>
+          <% end %>
         </div>
       </div>
       <% if flash[:alert] %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,16 @@
   action_path: /topic_subscriptions
   pr_number: 2482
 
+- name: "Clearer Pay for Other(s) form with register and ticket links"
+  area: payments
+  display_status: public_facing
+  released_on: 2026-09-01
+  summary: >-
+    The public "Pay for Other(s)" form now names the event in its header and links
+    out to the right place: a "Haven't registered yet?" link to the event's
+    registration form, and — for a signed-in attendee who already registered — a
+    direct link to their own digital ticket to pay for just their own spot.
+
 # ── 2026-08 ─────────────────────────────────────────────────────────────────
 
 - name: "No-show trainings no longer count toward program status"

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
       get new_event_bulk_payment_path(event)
 
       expect(response.body).to include(new_event_public_registration_path(event))
-      expect(response.body).to include("Haven't registered yet?")
+      expect(response.body).to include("Attending and haven't registered yet?")
     end
 
     it "hides the registration link once registration has closed" do
@@ -100,7 +100,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
 
       get new_event_bulk_payment_path(event)
 
-      expect(response.body).not_to include("Haven't registered yet?")
+      expect(response.body).not_to include("Attending and haven't registered yet?")
     end
 
     context "when the signed-in user has their own registration for the event" do

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -87,6 +87,39 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
 
       expect(response.body).to include("md:col-span-6")
     end
+
+    it "links to the event's registration form" do
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include(new_event_public_registration_path(event))
+      expect(response.body).to include("Haven't registered yet?")
+    end
+
+    it "hides the registration link once registration has closed" do
+      event.update!(registration_close_date: 1.day.ago)
+
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).not_to include("Haven't registered yet?")
+    end
+
+    context "when the signed-in user has their own registration for the event" do
+      let(:admin) { create(:user, :admin, :with_person) }
+      let!(:registration) { create(:event_registration, event: event, registrant: admin.person) }
+
+      it "links straight to their own digital ticket" do
+        get new_event_bulk_payment_path(event)
+
+        expect(response.body).to include(registration_ticket_path(registration.slug))
+        expect(response.body).to include("your digital ticket")
+      end
+    end
+
+    it "falls back to the emailed-ticket note when the viewer has no registration" do
+      get new_event_bulk_payment_path(event)
+
+      expect(response.body).to include("we emailed you a confirmation")
+    end
   end
 
   describe "POST create with credit card payment" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small contained view/controller change with request-spec coverage

The public "Pay for Other(s)" form now sends people where they actually need to go — many who land here really need to register, or just pay for their own spot.

- Header names the event instead of a generic line.
- **Haven't registered yet?** links to the event's registration form (only while registration is open).
- **Only paying for your own spot?** links straight to the signed-in attendee's own digital ticket when they already have a registration; falls back to the emailed-confirmation note otherwise.
- Controller refactor: the repeated `new`-render setup is pulled into `prepare_new_form`, which also resolves the current user's registration for the event.

Also added a `/features` entry.