### PR TITLE
Deliver contact form emails in the background

### DIFF
--- a/app/controllers/contact_us_controller.rb
+++ b/app/controllers/contact_us_controller.rb
@@ -36,13 +36,16 @@ class ContactUsController < ApplicationController
 
     user = current_user if user_signed_in?
     noticeable = user&.person || user
+    contact_us = contact_us_params
 
-    # Send emails
-    confirmation_mail = ContactUsMailer.confirmation(params[:contact_us], user).deliver_now
-    admin_mail = ContactUsMailer.hello(params[:contact_us], user).deliver_now
+    # Deliver in the background so a slow/hung SMTP server can't time out the request.
+    confirmation_mail = ContactUsMailer.confirmation(contact_us, user)
+    admin_mail = ContactUsMailer.hello(contact_us, user)
+    confirmation_mail.deliver_later
+    admin_mail.deliver_later
 
     # Create notification for the submitter
-    submitter_email = user&.email || params[:contact_us][:from]
+    submitter_email = user&.email || contact_us[:from]
     submitter_notification = NotificationServices::CreateNotification.call(
       noticeable: noticeable,
       recipient_role: :person,
@@ -51,7 +54,7 @@ class ContactUsController < ApplicationController
       notification_type: "contact_us_confirmation",
       deliver: false
     )
-    NotificationServices::PersistDeliveredEmail.call(notification: submitter_notification, mail: confirmation_mail)
+    NotificationServices::PersistDeliveredEmail.call(notification: submitter_notification, mail: confirmation_mail.message)
 
     # Create notification for admins
     admin_notification = NotificationServices::CreateNotification.call(
@@ -62,11 +65,19 @@ class ContactUsController < ApplicationController
       notification_type: "contact_us_notification",
       deliver: false
     )
-    NotificationServices::PersistDeliveredEmail.call(notification: admin_notification, mail: admin_mail)
+    NotificationServices::PersistDeliveredEmail.call(notification: admin_notification, mail: admin_mail.message)
 
     flash[:form_submitted] = true
     redirect_to contact_us_path(anchor: "thank-you", from: from, return_to: return_to)
   end
 
   private
+
+  # A plain symbol-keyed hash so the mailer args serialize for the background job.
+  def contact_us_params
+    params.require(:contact_us)
+          .permit(:first_name, :last_name, :from, :organization, :subject, :message, :q)
+          .to_h
+          .symbolize_keys
+  end
 end

--- a/app/services/email_delivery_error_handler.rb
+++ b/app/services/email_delivery_error_handler.rb
@@ -2,6 +2,8 @@ class EmailDeliveryErrorHandler
   ERRORS = [
     OpenSSL::SSL::SSLError,
     Net::SMTPError,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
     Errno::ECONNRESET
   ].freeze
 

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -162,10 +162,25 @@ RSpec.describe "ContactUs", type: :request do
         expect {
           post contact_us_path, params: valid_params
         }.to change(Notification, :count).by(2)
-        # .and have_enqueued_job.on_queue("mailers")
 
         expect(response).to redirect_to(contact_us_path(anchor: "thank-you"))
         expect(flash[:form_submitted]).to eq(true)
+      end
+
+      it "delivers both emails in the background so a slow SMTP server can't fail the request" do
+        expect {
+          post contact_us_path, params: valid_params
+        }.to have_enqueued_mail(ContactUsMailer, :confirmation)
+          .and have_enqueued_mail(ContactUsMailer, :hello)
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it "still records the rendered email bodies on the notifications" do
+        post contact_us_path, params: valid_params
+
+        expect(Notification.find_by(kind: "contact_us").email_body_html).to be_present
+        expect(Notification.find_by(kind: "contact_us_fyi").email_body_html).to be_present
       end
 
       it "creates a contact_us notification for the submitter" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small delivery-path change on one controller plus a shared error list

Contact form submissions were 500ing when SMTP was slow — a `Net::ReadTimeout` fired mid-request and the sender's message was lost (a facilitator reported it). Now the emails send in the background so the request can't hang on SMTP.

- `POST /contact_us` was the only mail flow still using `deliver_now`; switched both emails to `deliver_later`, matching how every other mail is sent.
- Rendered email bodies are still captured on the notifications (persist via the in-process `.message`, no SMTP).
- Mailer args now go through a permitted symbol-keyed hash so ActiveJob can serialize them.
- Added `Net::ReadTimeout`/`Net::OpenTimeout` to the shared `EmailDeliveryErrorHandler` list — the exact class that slipped through — as a safety net for the Devise flows that still deliver synchronously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)