### PR TITLE
Reject public-form spam that omits the honeypot decoy

### DIFF
--- a/app/services/honeypot.rb
+++ b/app/services/honeypot.rb
@@ -4,6 +4,15 @@
 # in it means an automated form-filler, and the submission is dropped silently
 # rather than answered with an error a bot could learn from.
 #
+# It catches two kinds of bot:
+#   1. One that fills our rendered form, including the hidden decoy → the decoy
+#      arrives with a value.
+#   2. One that POSTs a scraped or generic version of the form that never
+#      included our decoy at all → the decoy key is missing. Because the partial
+#      renders a plain text input, a real browser always submits the decoy key
+#      (empty for humans), so a submission that omits it entirely did not come
+#      from our form. This is the case that got past the value-only check.
+#
 # The name must be something these public forms never collect, or a genuine
 # answer would read as spam — so not `website_url` (a real column on both
 # Organization and Story) and not any FormField identifier. A person's LinkedIn
@@ -16,8 +25,12 @@ class Honeypot
   # Only bots read this; it exists so the decoy looks like a real labelled field.
   LABEL = "LinkedIn profile".freeze
 
-  # `scope` is the param namespace the surrounding form posts under.
+  # `scope` is the param namespace the surrounding form posts under. Tripped when
+  # the decoy carries a value, or when the decoy is absent — including a missing
+  # scope — since our form always renders it and a real browser always submits it.
   def self.tripped?(params, scope)
-    params.dig(scope, FIELD_NAME).present?
+    fields = params[scope]
+    return true unless fields.respond_to?(:key?)
+    fields[FIELD_NAME].present? || !fields.key?(FIELD_NAME)
   end
 end

--- a/spec/requests/contact_us_spec.rb
+++ b/spec/requests/contact_us_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "ContactUs", type: :request do
         organization: "Test Agency",
         subject: "Test Subject",
         message: "Test message",
-        q: "general"
+        q: "general",
+        Honeypot::FIELD_NAME => ""
       }
     }
   end
@@ -114,7 +115,8 @@ RSpec.describe "ContactUs", type: :request do
             organization: "",
             subject: "Test",
             message: "Test",
-            q: "general"
+            q: "general",
+            Honeypot::FIELD_NAME => ""
           }
         }
         follow_redirect!
@@ -200,6 +202,20 @@ RSpec.describe "ContactUs", type: :request do
         expect(notification.recipient_role).to eq("admin")
         expect(notification.recipient_email).to eq(ENV.fetch("REPLY_TO_EMAIL", "programs@awbw.org"))
       end
+
+      it "silently drops a bot that posts a scraped form without our decoy field" do
+        spam = { contact_us: { first_name: "QaOUAKZ", last_name: "AzwiRUY",
+                               from: "spam@example.com", agency: "uDcbmOD",
+                               website_url: "https://yqupiafl.com",
+                               subject: "xlMfQz", message: "mNaceRX" } }
+
+        expect {
+          post contact_us_path, params: spam
+        }.not_to change(Notification, :count)
+
+        expect(response).to redirect_to(contact_us_path)
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
     end
 
     context "when logged in" do
@@ -214,7 +230,8 @@ RSpec.describe "ContactUs", type: :request do
             organization: "",
             subject: "Test Subject from logged in user",
             message: "Test message from logged in user",
-            q: "general"
+            q: "general",
+            Honeypot::FIELD_NAME => ""
           }
         }
       end

--- a/spec/requests/email_delivery_failure_spec.rb
+++ b/spec/requests/email_delivery_failure_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe "Email delivery failures", type: :request do
           organization: "Test Agency",
           subject: "Test Subject",
           message: "Test message",
-          q: "general"
+          q: "general",
+          Honeypot::FIELD_NAME => ""
         }
       }
 

--- a/spec/requests/events/bulk_payment_form_submissions_spec.rb
+++ b/spec/requests/events/bulk_payment_form_submissions_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
 
   def post_bulk_payment(answer)
     post event_bulk_payment_path(event),
-         params: { bulk_payment: { form_fields: { org_field.id.to_s => answer } } }
+         params: { bulk_payment: { Honeypot::FIELD_NAME => "", form_fields: { org_field.id.to_s => answer } } }
   end
 
   describe "POST create with the honeypot tripped" do
@@ -143,7 +143,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
 
     it "redirects to Stripe Checkout when paying by credit card" do
       post event_bulk_payment_path(event),
-           params: { bulk_payment: { form_fields: payer_params.merge(
+           params: { bulk_payment: { Honeypot::FIELD_NAME => "", form_fields: payer_params.merge(
              org_field.id.to_s => "this answer has enough words for validation",
              payment_method_field.id.to_s => "Credit card (now)"
            ) } }
@@ -154,7 +154,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
 
     it "does not redirect when payment method is not credit card" do
       post event_bulk_payment_path(event),
-           params: { bulk_payment: { form_fields: payer_params.merge(
+           params: { bulk_payment: { Honeypot::FIELD_NAME => "", form_fields: payer_params.merge(
              org_field.id.to_s => "this answer has enough words for validation",
              payment_method_field.id.to_s => "Check"
            ) } }
@@ -168,7 +168,7 @@ RSpec.describe "Events::BulkPaymentFormSubmissions", type: :request do
       event.update!(cost_cents: 0)
 
       post event_bulk_payment_path(event),
-           params: { bulk_payment: { form_fields: payer_params.merge(
+           params: { bulk_payment: { Honeypot::FIELD_NAME => "", form_fields: payer_params.merge(
              org_field.id.to_s => "this answer has enough words for validation"
            ) } }
 

--- a/spec/requests/events/professional_field_identifiers_spec.rb
+++ b/spec/requests/events/professional_field_identifiers_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Events::PublicRegistrations professional fields", type: :request
         let(:submission) { form.form_submissions.find_by!(person: registrant) }
 
         before do
-          post event_public_registration_path(event), params: { public_registration: { form_fields: {
+          post event_public_registration_path(event), params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
             fid("first_name") => "Robin",
             fid("last_name") => "Avery",
             fid("primary_email") => "robin.avery@example.com",

--- a/spec/requests/events/public_registrations_spec.rb
+++ b/spec/requests/events/public_registrations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
   def post_registration(answer)
     post event_public_registration_path(event),
-         params: { public_registration: { form_fields: { essay_field.id.to_s => answer } } }
+         params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: { essay_field.id.to_s => answer } } }
   end
 
   describe "POST create with a minimum word count" do
@@ -52,7 +52,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
     it "re-renders the form with an error instead of raising" do
       expect {
         post event_public_registration_path(event),
-             params: { public_registration: { form_fields: {
+             params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
                essay_field.id.to_s => "this answer has plenty of words",
                fid("first_name") => "Pat",
                fid("last_name") => "Lee",
@@ -85,7 +85,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       email = create(:form_field, form: form, field_identifier: "primary_email", name: "Email", required: false)
 
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              essay_field.id.to_s => "this answer has plenty of words",
              first.id.to_s => "Pat",
              last.id.to_s => "Lee",
@@ -105,7 +105,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     def post_bio(answer)
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              essay_field.id.to_s => "this answer has plenty of words",
              bio_field.id.to_s => answer
            } } }
@@ -140,7 +140,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       post event_public_registration_path(event),
            params: {
              scholarship_requested: "true",
-             public_registration: { form_fields: {
+             public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
                essay_field.id.to_s => "this answer has plenty of words",
                scholarship_essay.id.to_s => scholarship_answer
              } }
@@ -209,7 +209,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     it "redirects to Stripe Checkout when paying by credit card" do
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              essay_field.id.to_s => "this answer has enough words for validation",
              payment_method_field.id.to_s => "Credit card (now)"
            } } }
@@ -220,7 +220,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     it "does not redirect when payment method is not credit card" do
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              essay_field.id.to_s => "this answer has enough words for validation",
              payment_method_field.id.to_s => "Check"
            } } }
@@ -234,7 +234,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       event.update!(cost_cents: 0)
 
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              essay_field.id.to_s => "this answer has enough words for validation"
            } } }
 
@@ -576,7 +576,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
              name: "Name", required: true)
 
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: {
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
              field.id.to_s => "Other: chartreuse",
              required.id.to_s => ""
            } } }
@@ -649,7 +649,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
       signed_id = signed_id_for("sample.png", "image/png")
 
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: identity_answers.merge(
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: identity_answers.merge(
              essay_field.id.to_s => "too few",
              upload_field.id.to_s => signed_id
            ) } }
@@ -667,6 +667,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
       post event_public_registration_path(event),
            params: { public_registration: {
+             Honeypot::FIELD_NAME => "",
              form_fields: identity_answers.merge(
                essay_field.id.to_s => "this answer has plenty of words",
                upload_field.id.to_s => ""
@@ -682,7 +683,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
 
     it "re-renders with an error instead of raising on an unusable signed id" do
       post event_public_registration_path(event),
-           params: { public_registration: { form_fields: identity_answers.merge(
+           params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: identity_answers.merge(
              essay_field.id.to_s => "this answer has plenty of words",
              upload_field.id.to_s => "not-a-signed-id"
            ) } }
@@ -936,7 +937,7 @@ RSpec.describe "Events::PublicRegistrations", type: :request do
         tracked << [ name, props ]
       end
 
-      post event_public_registration_path(event), params: { public_registration: { form_fields: {
+      post event_public_registration_path(event), params: { public_registration: { Honeypot::FIELD_NAME => "", form_fields: {
         essay_field.id.to_s => "this answer has more than five words",
         first_field.id.to_s => "Dana",
         last_field.id.to_s => "Ruiz",

--- a/spec/requests/public_forms_spec.rb
+++ b/spec/requests/public_forms_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "PublicForms", type: :request do
   def submission_params(first: "Sam", last: "Rivera", email: "sam@example.com")
     {
       public_registration: {
+        Honeypot::FIELD_NAME => "",
         form_fields: {
           first_name_field.id.to_s => first,
           last_name_field.id.to_s => last,

--- a/spec/services/honeypot_spec.rb
+++ b/spec/services/honeypot_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe Honeypot do
       expect(described_class.tripped?(params_with(described_class::FIELD_NAME => ""), :contact_us)).to be(false)
     end
 
-    it "is false when the decoy field is absent entirely" do
-      expect(described_class.tripped?(params_with(message: "hello"), :contact_us)).to be(false)
+    it "is true when the decoy field is absent, since our form always renders it" do
+      expect(described_class.tripped?(params_with(message: "hello"), :contact_us)).to be(true)
     end
 
-    it "is false when the whole scope is missing" do
-      expect(described_class.tripped?(ActionController::Parameters.new, :contact_us)).to be(false)
+    it "is true when the whole scope is missing, as a real submission never omits it" do
+      expect(described_class.tripped?(ActionController::Parameters.new, :contact_us)).to be(true)
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-method behavior change in the shared honeypot, rest is spec updates

The bug: Our honeypot has a hidden decoy field. It only caught bots that filled the decoy. This bot instead posted a scraped/old version of the form that didn’t include the decoy at all — so nothing tripped.

The fix: One change in Honeypot.tripped? — now a submission is also rejected when the decoy field is missing entirely. Since every real browser always submits our decoy (empty), a submission without it didn’t come from our form → drop it.

Scope: One method in the shared Honeypot service, so it hardens all four public forms at once. Plus a test replaying that exact bot payload, and spec updates.

--

Stops a class of spam bot that slipped through the honeypot on all four public forms — the one that just dropped a junk message into our contact inbox.

## Why
A bot POSTed a scraped/old version of the contact form (foreign fields `agency`, `website_url`; no decoy) and sailed through, because the honeypot only checked whether the decoy field carried a *value*. It never asked whether the decoy was there at all.

## What
- `Honeypot.tripped?` now also trips when the decoy key is **absent** (or the whole scope is missing).
- Safe because every public form renders the hidden decoy `<input>`, so a real browser always submits `linkedin_profile` (empty for humans). A submission missing it didn't come from our form.
- One change in the shared `Honeypot` PORO → hardens contact-us, public registration, bulk payment, and public forms at once.

## Tests
- New regression test replays the exact bot payload from the logs and asserts it's silently dropped (no notifications, no email).
- Happy-path request specs updated to include the decoy, mirroring what a browser sends.