### PR TITLE
Track Story Share admin menu edits (and fix drag-drop reorder)

### DIFF
--- a/app/controllers/story_share_admin_controller.rb
+++ b/app/controllers/story_share_admin_controller.rb
@@ -21,10 +21,15 @@ class StoryShareAdminController < ApplicationController
     moved = featured.find { |record| record.id == params[:id].to_i }
     return head :not_found unless moved
 
+    previous_position = moved.story_share_position
     featured.delete(moved)
     featured.insert([ params[:position].to_i - 1, 0 ].max, moved)
     renumber(featured)
-    track_menu_change("update.story_share_menu", moved, position: moved.story_share_position)
+
+    if moved.story_share_position != previous_position
+      track_menu_change("update.story_share_menu", moved,
+                        changes: { position: { before: previous_position, after: moved.story_share_position } })
+    end
     head :ok
   end
 

--- a/app/controllers/story_share_admin_controller.rb
+++ b/app/controllers/story_share_admin_controller.rb
@@ -1,4 +1,6 @@
 class StoryShareAdminController < ApplicationController
+  include AhoyTracking
+
   # Admin page for curating the Story Share portal's nav menus by setting
   # story_share_position on sectors (top row) and audience categories (second
   # row). story_share_position is a plain integer (NOT the positioned gem), so
@@ -22,6 +24,7 @@ class StoryShareAdminController < ApplicationController
     featured.delete(moved)
     featured.insert([ params[:position].to_i - 1, 0 ].max, moved)
     renumber(featured)
+    track_menu_change("update.story_share_menu", moved, position: moved.story_share_position)
     head :ok
   end
 
@@ -33,6 +36,7 @@ class StoryShareAdminController < ApplicationController
     max = @klass.story_share_featured.maximum(:story_share_position) || 0
     record.update_columns(story_share_position: max + 1)
     expire_menu_caches
+    track_menu_change("create.story_share_menu", record, position: record.story_share_position)
     redirect_to story_share_admin_path, notice: "Added to the Story Share menu."
   end
 
@@ -41,6 +45,7 @@ class StoryShareAdminController < ApplicationController
     record = @klass.find(params[:id])
     record.update_columns(story_share_position: nil)
     renumber(@klass.story_share_featured.to_a)
+    track_menu_change("destroy.story_share_menu", record)
     redirect_to story_share_admin_path, notice: "Removed from the Story Share menu."
   end
 
@@ -48,6 +53,18 @@ class StoryShareAdminController < ApplicationController
 
   def set_klass
     @klass = params[:type] == "category" ? Category : Sector
+  end
+
+  # These curate the menu via update_columns, which skips the AhoyTrackable
+  # callbacks, so record the change explicitly. resource_type/resource_id/
+  # resource_title get promoted to columns (config/initializers/ahoy.rb) so the
+  # activity feed links back to the sector/category that was featured.
+  def track_menu_change(name, record, extra = {})
+    track_event(name, {
+      resource_type: record.class.name,
+      resource_id: record.id,
+      resource_title: record.name
+    }.merge(extra))
   end
 
   # Rewrite story_share_position to a gapless 1..n sequence in list order.

--- a/app/controllers/story_share_admin_controller.rb
+++ b/app/controllers/story_share_admin_controller.rb
@@ -37,6 +37,8 @@ class StoryShareAdminController < ApplicationController
   # the sortable list.
   def add
     authorize! :story_share_admin, to: :add?
+    return redirect_to story_share_admin_path, alert: "Select a #{@klass.model_name.human.downcase} to add." if params[:id].blank?
+
     record = @klass.find(params[:id])
     max = @klass.story_share_featured.maximum(:story_share_position) || 0
     record.update_columns(story_share_position: max + 1)

--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -181,6 +181,7 @@ module Ahoy
 
     def compute_resource_link
       return commentable_link if comment&.commentable
+      return story_share_menu_link if story_share_menu?
 
       record = find_referenced_record(object.resource_type, object.resource_id)
       custom = custom_resource_link(record)
@@ -227,6 +228,18 @@ module Ahoy
 
     def action_key
       object.name.to_s.split(".", 2).first.to_s
+    end
+
+    # Story Share menu events curate the portal nav, not the underlying
+    # sector/category, so they link to the curation page rather than the
+    # record's edit form. The name stays the featured record's title.
+    def story_share_menu?
+      object.name.to_s.end_with?(".story_share_menu")
+    end
+
+    def story_share_menu_link
+      { text: properties_hash["resource_title"].presence || "Story share menu",
+        path: h.story_share_admin_path }
     end
 
     # The Comment this event is about, from the page cache (no extra query); nil

--- a/app/views/story_share_admin/_menu_section.html.erb
+++ b/app/views/story_share_admin/_menu_section.html.erb
@@ -34,6 +34,7 @@
   <%= form_with url: story_share_admin_add_path(type: type), method: :post, class: "flex items-center gap-2 mt-4" do %>
     <%= select_tag "id", options_for_select([]),
                    include_blank: "Search #{type.pluralize}…",
+                   required: true,
                    data: { controller: "remote-select",
                            remote_select_model_value: type,
                            remote_select_exclude_value: records.map(&:id).join(",") },

--- a/config/features.yml
+++ b/config/features.yml
@@ -3178,3 +3178,14 @@
     column so you can glance straight down. Admin home also groups the tagging
     tools together.
   action_path: "/taggings/matrix"
+
+- name: "Story Share menu edits show in the activity feed"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-01
+  summary: >-
+    Featuring, reordering, or removing a sector or category on the Story Share
+    admin page is now recorded on the admin Activities timeline, so there's a
+    trail of who changed the portal's nav and when.
+  action_path: "/story_share/admin"
+  pr_number: 2492

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -382,7 +382,7 @@ Rails.application.routes.draw do
   end
   resources :stories
   get "story_share/admin", to: "story_share_admin#show", as: :story_share_admin
-  match "story_share/admin/reorder", to: "story_share_admin#reorder", via: [ :put, :patch ], as: :story_share_admin_reorder
+  match "story_share/admin/reorder/:id", to: "story_share_admin#reorder", via: [ :put, :patch ], as: :story_share_admin_reorder
   post "story_share/admin/add", to: "story_share_admin#add", as: :story_share_admin_add
   delete "story_share/admin/remove", to: "story_share_admin#remove", as: :story_share_admin_remove
   resources :story_shares, path: "story_share", only: [ :index, :show, :new ]

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe Ahoy::EventDecorator do
       expect(link[:path]).to eq(Rails.application.routes.url_helpers.edit_workshop_path(workshop))
     end
 
+    it "points a story share menu event at the story share admin page, keeping the record name as the label" do
+      sector = create(:sector, :published, name: "Families")
+      event = create(:ahoy_event, name: "update.story_share_menu", resource_type: "Sector",
+                                  resource_id: sector.id, properties: { "resource_title" => "Families" }).decorate
+
+      expect(event.resource_link[:text]).to eq("Families")
+      expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.story_share_admin_path)
+    end
+
     it "is nil when there is no resource title" do
       expect(decorate("source" => "import").resource_link).to be_nil
     end

--- a/spec/requests/story_share_admin_spec.rb
+++ b/spec/requests/story_share_admin_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe "StoryShareAdmin", type: :request do
       post story_share_admin_add_path(type: "category"), params: { id: category.id }
       expect(category.reload.story_share_position).to eq(1)
     end
+
+    it "redirects back without error when nothing is selected" do
+      expect {
+        post story_share_admin_add_path(type: "sector"), params: { id: "" }
+      }.not_to raise_error
+      expect(response).to redirect_to(story_share_admin_path)
+    end
+
+    it "does not track an event when nothing is selected" do
+      expect(Analytics::AhoyTracker).not_to receive(:track_event)
+      post story_share_admin_add_path(type: "sector"), params: { id: "" }
+    end
   end
 
   describe "reorder URL template" do

--- a/spec/requests/story_share_admin_spec.rb
+++ b/spec/requests/story_share_admin_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe "StoryShareAdmin", type: :request do
     end
   end
 
+  describe "reorder URL template" do
+    # sortable_controller.js does urlValue.replace(":id", id), so the rendered
+    # template must carry a literal ":id". A query-string id encodes the colon to
+    # %3Aid, the replace misses, and every reorder hits id=:id (not_found) — so
+    # keep :id in the path segment.
+    it "keeps :id as a literal placeholder the sortable JS can substitute" do
+      url = story_share_admin_reorder_path(type: "sector", id: ":id")
+      expect(url).to include(":id")
+      expect(url).not_to include("%3A")
+    end
+  end
+
   describe "PUT /story_share/admin/reorder" do
     before { sign_in admin }
 

--- a/spec/requests/story_share_admin_spec.rb
+++ b/spec/requests/story_share_admin_spec.rb
@@ -77,6 +77,42 @@ RSpec.describe "StoryShareAdmin", type: :request do
     end
   end
 
+  describe "Ahoy tracking" do
+    before { sign_in admin }
+
+    it "records an event when a sector is added to the menu" do
+      sector = create(:sector, :published, name: "Homelessness")
+      expect(Analytics::AhoyTracker).to receive(:track_event)
+        .with(anything, "create.story_share_menu",
+              hash_including(resource_type: "Sector", resource_id: sector.id, resource_title: "Homelessness"))
+      post story_share_admin_add_path(type: "sector"), params: { id: sector.id }
+    end
+
+    it "records an event when a category is added to the menu" do
+      category = create(:category, :published)
+      expect(Analytics::AhoyTracker).to receive(:track_event)
+        .with(anything, "create.story_share_menu", hash_including(resource_type: "Category", resource_id: category.id))
+      post story_share_admin_add_path(type: "category"), params: { id: category.id }
+    end
+
+    it "records an event when a menu item is reordered" do
+      a = create(:sector, :published, story_share_position: 1)
+      b = create(:sector, :published, story_share_position: 2)
+      expect(Analytics::AhoyTracker).to receive(:track_event)
+        .with(anything, "update.story_share_menu",
+              hash_including(resource_type: "Sector", resource_id: b.id, position: 1))
+      put story_share_admin_reorder_path(type: "sector", id: b.id), params: { position: 1 }
+    end
+
+    it "records an event when a menu item is removed" do
+      sector = create(:sector, :published, story_share_position: 1)
+      expect(Analytics::AhoyTracker).to receive(:track_event)
+        .with(anything, "destroy.story_share_menu",
+              hash_including(resource_type: "Sector", resource_id: sector.id))
+      delete story_share_admin_remove_path(type: "sector", id: sector.id)
+    end
+  end
+
   describe "GET /search/:model for the pickers" do
     it "returns sectors for an admin" do
       sign_in admin

--- a/spec/requests/story_share_admin_spec.rb
+++ b/spec/requests/story_share_admin_spec.rb
@@ -107,13 +107,21 @@ RSpec.describe "StoryShareAdmin", type: :request do
       post story_share_admin_add_path(type: "category"), params: { id: category.id }
     end
 
-    it "records an event when a menu item is reordered" do
+    it "records a before/after position change when a menu item is reordered" do
       a = create(:sector, :published, story_share_position: 1)
       b = create(:sector, :published, story_share_position: 2)
       expect(Analytics::AhoyTracker).to receive(:track_event)
         .with(anything, "update.story_share_menu",
-              hash_including(resource_type: "Sector", resource_id: b.id, position: 1))
+              hash_including(resource_type: "Sector", resource_id: b.id,
+                             changes: { position: { before: 2, after: 1 } }))
       put story_share_admin_reorder_path(type: "sector", id: b.id), params: { position: 1 }
+    end
+
+    it "does not record an event when the position is unchanged" do
+      a = create(:sector, :published, story_share_position: 1)
+      create(:sector, :published, story_share_position: 2)
+      expect(Analytics::AhoyTracker).not_to receive(:track_event)
+      put story_share_admin_reorder_path(type: "sector", id: a.id), params: { position: 1 }
     end
 
     it "records an event when a menu item is removed" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small controller tracking + a one-line route fix, both covered by red-green specs

Two related fixes for the Story Share admin menu (`/story_share/admin`).

## Admin edits now show in the activity feed
- Featuring/reordering/removing a sector or category mutated `story_share_position` via `update_columns`, which skips the `AhoyTrackable` callbacks — so these changes left no trail.
- Each action now records an event (`create`/`update`/`destroy.story_share_menu`) carrying the sector/category, so the admin Activities feed links back to it.
- Note: the feed's default audience is "visitors + users", so **enable the Staff filter** to see admin-made changes.

## Drag-to-reorder actually saves now (pre-existing bug)
- `sortable_controller.js` does `urlValue.replace(":id", id)`, but the reorder route carried `id` as a query param — so the path helper encoded the colon to `%3Aid`, the substitution silently missed, and every reorder hit `id=:id` → `not_found`.
- Reordering never persisted (or tracked). Moving `:id` into the path segment (like the other sortable callers) fixes it.

## Testing
- `ai/test spec/requests/story_share_admin_spec.rb` — red-green specs for each tracked action and for the reorder URL template.