### PR TITLE
Link person edit's User account eyebrow to user show

### DIFF
--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -30,7 +30,7 @@
     </div>
   <% end %>
   <% if @person.user %>
-    <%= link_to "User account", edit_user_path(@person.user), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+    <%= link_to "User account", user_path(@person.user), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
   <% end %>
   <% if params[:admin] == "true" && @person.filemaker_code.present? && FmRolodex.exists?(fm_id: @person.filemaker_code) %>
     <%= link_to "Rolodex", fm_archive_path(@person.filemaker_code, table: "rolodexes"), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 single-line eyebrow link target change, no logic

Clicking **User account** from the person edit page now lands on the user's profile (show) instead of dropping straight into edit mode — the eyebrow is a return/navigation link, so it should show the account, not immediately open the form.

### What is the goal of this PR and why is this important?
The "User account" eyebrow on the person edit page is a navigational link. It was pointing at `edit_user_path`, so admins were dumped into edit mode instead of the user's profile.

### How did you approach the change?
Changed the link from `edit_user_path(@person.user)` to `user_path(@person.user)`.

### Anything else to add?
Left the inline "editable by admins" link on the person form (which is explicitly edit-oriented) and the "Create user" links unchanged.