### PR TITLE
Require unique event abbreviations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -78,7 +78,8 @@ class Event < ApplicationRecord
   validates :template, inclusion: { in: TEMPLATE_KEYS }
   validates_numericality_of :cost_cents, greater_than_or_equal_to: 0, allow_nil: true
   validates :title, length: { maximum: 255 }
-  validates :abbreviation, length: { maximum: 255 }
+  validates :abbreviation, length: { maximum: 255 },
+    uniqueness: { case_sensitive: false }, allow_blank: true
   validates :pre_title, length: { maximum: 255 }
   validates :pre_date_text, length: { maximum: 255 }
   validates :videoconference_url, length: { maximum: 255 }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe Event, type: :model do
     it { should validate_numericality_of(:cost_cents).is_greater_than_or_equal_to(0).allow_nil }
     it { should validate_inclusion_of(:template).in_array(Event::TEMPLATE_KEYS) }
 
+    describe "abbreviation uniqueness" do
+      it "rejects a duplicate abbreviation" do
+        create(:event, abbreviation: "TOS205")
+        event = build(:event, abbreviation: "TOS205")
+        expect(event).not_to be_valid
+        expect(event.errors[:abbreviation]).to be_present
+      end
+
+      it "rejects a duplicate abbreviation regardless of case" do
+        create(:event, abbreviation: "TOS205")
+        event = build(:event, abbreviation: "tos205")
+        expect(event).not_to be_valid
+        expect(event.errors[:abbreviation]).to be_present
+      end
+
+      it "allows multiple events with a blank abbreviation" do
+        create(:event, abbreviation: "")
+        expect(build(:event, abbreviation: "")).to be_valid
+      end
+    end
+
     describe "display template" do
       it "defaults to none" do
         expect(build(:event).template).to eq("none")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one uniqueness validation on Event plus model specs

Enforces that an event's abbreviation (the short code like `TOS205` shown on organization profiles) is unique, so a repeated code can't point ambiguously to two events.

### What is the goal of this PR and why is this important?
Abbreviations are short codes shown on organization profiles. A repeated code is ambiguous about which event it refers to, so we now reject duplicates.

### How did you approach the change?
Added a case-insensitive uniqueness validation on `Event#abbreviation` with `allow_blank: true`, so the event form fails to save a duplicate while still allowing multiple events to leave the abbreviation empty. Added model specs covering the duplicate, case-variant, and multiple-blank cases.

### Anything else to add?
Kept enforcement at the model level (no DB unique index) — a MySQL unique index would treat empty-string abbreviations as colliding values, and most events leave the field blank. Dev DB has no existing duplicates.
