### PR TITLE
Give hidden people/org rows a blue hover instead of grey

### DIFF
--- a/app/views/organizations/organizations_results.html.erb
+++ b/app/views/organizations/organizations_results.html.erb
@@ -24,7 +24,7 @@
                 affiliated people's tags — neither touches the organizations row. %>
             <% cache [organization, organization.rollup_cache_version, @program_since_display[organization.id], organization.decorate.organization_status_bucket, organization.organization_status_id, @active_people_counts[organization.id], current_user.super_user?] do %>
             <% published = organization.published? %>
-            <tr class="hover:bg-gray-50 transition <%= "admin-only bg-blue-100" unless published %>">
+            <tr class="transition <%= published ? "hover:bg-gray-50" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
               <td class="px-4 py-2">
                 <%# The affiliation-derived bucket, never the drifted legacy column (ADR-0003 D4). %>
                 <% status_label = published ? nil : organization.decorate.organization_status_label %>

--- a/app/views/organizations/organizations_results.html.erb
+++ b/app/views/organizations/organizations_results.html.erb
@@ -24,7 +24,7 @@
                 affiliated people's tags — neither touches the organizations row. %>
             <% cache [organization, organization.rollup_cache_version, @program_since_display[organization.id], organization.decorate.organization_status_bucket, organization.organization_status_id, @active_people_counts[organization.id], current_user.super_user?] do %>
             <% published = organization.published? %>
-            <tr class="transition <%= published ? "hover:bg-gray-50" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
+            <tr class="transition <%= published ? "hover:bg-gray-100" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
               <td class="px-4 py-2">
                 <%# The affiliation-derived bucket, never the drifted legacy column (ADR-0003 D4). %>
                 <% status_label = published ? nil : organization.decorate.organization_status_label %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -21,7 +21,7 @@
           <tbody class="divide-y divide-gray-200">
             <% @people.each do |person| %>
               <% cache [ person, current_user.super_user?, current_user.person_id == person.id ] do %>
-              <tr class="transition-colors duration-150 <%= person.published? ? "hover:bg-gray-50" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
+              <tr class="transition-colors duration-150 <%= person.published? ? "hover:bg-gray-100" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
                 <td class="px-4 py-2">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
                   <% if allowed_to?(:show?, person) %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -21,7 +21,7 @@
           <tbody class="divide-y divide-gray-200">
             <% @people.each do |person| %>
               <% cache [ person, current_user.super_user?, current_user.person_id == person.id ] do %>
-              <tr class="transition-colors duration-150 hover:bg-gray-50 <%= "admin-only bg-blue-100" unless person.published? %>">
+              <tr class="transition-colors duration-150 <%= person.published? ? "hover:bg-gray-50" : "admin-only bg-blue-100 hover:bg-blue-200" %>">
                 <td class="px-4 py-2">
                   <% show_email = person.profile_show_email? || allowed_to?(:manage?, Person) %>
                   <% if allowed_to?(:show?, person) %>


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only Tailwind hover color swap, no logic changes

Hidden (unpublished) people and organization rows are tinted admin-only blue in the index lists, but their hover reused the same grey as normal rows — so hovering a hidden row flattened it to look like every other row. This makes hidden rows hover to a slightly deeper blue (`bg-blue-100` → `hover:bg-blue-200`) so the hidden state stays legible on hover, while published rows keep the usual grey hover.

### How did you approach the change?
Made the hover class a ternary on `published?` so the two states are mutually exclusive (avoids `hover:bg-gray-50` and `bg-blue-100` competing, where grey won on hover).

### Anything else to add?
Both are static literal class strings, so Tailwind's JIT generates `hover:bg-blue-200`.
