### PR TITLE
Preserve activity/visit filters across a page refresh

### DIFF
--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -32,9 +32,10 @@
       <div class="bg-white border border-primary/10 rounded-2xl shadow-sm p-6 mb-6">
         <%# Selects submit on change and the text boxes debounce-submit as you type,
             all into the activity_results frame — the filter form stays put (and
-            focused) while just the rows swap. %>
+            focused) while just the rows swap. turbo_action: "advance" mirrors the
+            filter state into the address bar so a hard refresh restores it. %>
         <%= form_with url: request.path, method: :get,
-              data: { controller: "collection", turbo_frame: "activity_results" },
+              data: { controller: "collection", turbo_frame: "activity_results", turbo_action: "advance" },
               autocomplete: "off" do %>
 
           <%# These scope the timeline (person History, per-user history, a record's

--- a/app/views/admin/ahoy_activities/visits.html.erb
+++ b/app/views/admin/ahoy_activities/visits.html.erb
@@ -25,9 +25,10 @@
       <div class="border-primary/10 mb-6 rounded-2xl border bg-white p-6 shadow-sm">
         <%# Selects submit on change and the text boxes debounce-submit as you type,
             all into the visit_results frame — the filter form stays put (and
-            focused) while just the rows swap. %>
+            focused) while just the rows swap. turbo_action: "advance" mirrors the
+            filter state into the address bar so a hard refresh restores it. %>
         <%= form_with url: request.path, method: :get,
-              data: { controller: "collection", turbo_frame: "visit_results" },
+              data: { controller: "collection", turbo_frame: "visit_results", turbo_action: "advance" },
               autocomplete: "off" do %>
 
           <div class="flex flex-wrap gap-4 lg:flex-nowrap">

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -139,6 +139,12 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it "advances the URL on filter submit so a refresh restores the filters" do
+        get index_path
+
+        expect(response.body).to include('data-turbo-action="advance"')
+      end
+
       it "breaks the row's user link out of the results frame" do
         get index_path, params: { visit_id: visit_for_user.id }, headers: frame_headers
 
@@ -504,6 +510,12 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
     end
 
     describe "GET /admin/activities/visits" do
+      it "advances the URL on filter submit so a refresh restores the filters" do
+        get visits_path
+
+        expect(response.body).to include('data-turbo-action="advance"')
+      end
+
       it "renders the shell ok on a full-page load" do
         get visits_path
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 two-line view change (turbo_action) plus regression specs; contained behavior

Refreshing the admin **events** and **visits** activity pages now keeps whatever filters you had set — including the visitors/users/admins audience checkboxes — instead of snapping back to defaults.

- Filter forms submitted into a Turbo frame but never advanced the address bar, so a hard refresh reloaded the bare URL and every filter reverted.
- Added `turbo_action: "advance"` to both filter forms so the live filter state is mirrored into the query string; the existing param-driven form fields and frame `src` already restore it on reload.
- No controller/JS changes needed — the plumbing to read filters from the URL was already there.

## Test
- Request specs assert the shell renders `data-turbo-action="advance"` on both pages.