### PR TITLE
Group staff tags/taggings on admin home and counts page

### DIFF
--- a/app/controllers/taggings_controller.rb
+++ b/app/controllers/taggings_controller.rb
@@ -107,6 +107,12 @@ class TaggingsController < ApplicationController
         }
       end
     end
+
+    @staff_tags = authorized_scope(StaffTag.all).published.ordered
+    @staff_tagging_counts = StaffTagging
+      .where(staff_tag_id: @staff_tags.map(&:id), staff_taggable_type: "Person")
+      .group(:staff_tag_id)
+      .count
   end
 
   private

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -12,6 +12,7 @@ module AdminCardsHelper
       model_card(:resources, icon: "📚"),
       model_card(:stories, icon: "🗣️"),
       custom_card("Story share admin", story_share_admin_path, icon: "⚙️", color: :sky, intensity: 100),
+      custom_card("Staff taggings", staff_taggings_path, icon: "🏷️", color: :sky, intensity: 100),
       custom_card("Tagging counts", taggings_matrix_path, icon: "🧮", color: :lime),
       model_card(:workshops, icon: "🎨"),
       model_card(:workshop_variations, icon: "🔀"),
@@ -57,6 +58,7 @@ module AdminCardsHelper
                  title: "Sectors",
                  params: { published: true }),
       model_card(:topic_subscription_types, icon: "✉️", intensity: 100, title: "Subscription topics"),
+      custom_card("Staff tags", staff_tags_path, icon: "🏷️", color: :lime, intensity: 100),
       custom_card("Windows audiences", windows_types_path, icon: "🪟")
     ]
   end
@@ -100,7 +102,6 @@ module AdminCardsHelper
       custom_card("Bookmarks", bookmarks_path, icon: "🔖", color: :sky, intensity: 100),
       custom_card("CE registrations", continuing_education_registrations_path, icon: "📜", color: :sky, intensity: 100),
       custom_card("Comments", comments_path, icon: "💬", color: :sky, intensity: 100),
-      custom_card("Staff taggings", staff_taggings_path, icon: "🏷️", color: :sky, intensity: 100),
       disabled_card("Affiliations", icon: "🤝"),
       disabled_card("Reports", icon: "📄"),
       disabled_card("Discounts", icon: "💲"),

--- a/app/views/taggings/matrix.html.erb
+++ b/app/views/taggings/matrix.html.erb
@@ -104,42 +104,29 @@
               </tr>
             <% end %>
 
-            </tbody>
-          </table>
-        </div>
-      </div>
+            <!-- STAFF TAGS HEADER -->
+            <tr class="border-t border-gray-200 bg-gray-100">
+              <td colspan="<%= Tag::TAGGABLE_META.size + 1 %>"
+                  class="px-4 py-2 font-semibold text-gray-700">
+                <div class="flex items-center justify-between gap-4">
+                  <span>Staff tags (people carrying each internal tag)</span>
+                  <%= link_to "View staff taggings", staff_taggings_path,
+                              class: "text-sm font-medium text-indigo-900 hover:underline" %>
+                </div>
+              </td>
+            </tr>
 
-      <!-- STAFF TAGGINGS -->
-      <section class="mt-12 border-t border-gray-200 pt-8">
-        <div class="mb-4 flex items-start justify-between gap-6">
-          <div>
-            <h2 class="text-primary mb-1 font-display text-2xl font-semibold">
-              Staff taggings
-            </h2>
-            <p class="max-w-2xl text-gray-600">
-              Internal, admin-only labels — people carrying each staff tag
-            </p>
-          </div>
-          <%= link_to "View staff taggings", staff_taggings_path,
-                      class: button_classes(:secondary_outline, extra: "whitespace-nowrap") %>
-        </div>
+            <% if @staff_tags.any? %>
+              <% @staff_tags.each do |staff_tag| %>
+                <tr class="<%= cycle('bg-white', 'bg-gray-50') %> border-t border-gray-200">
+                  <td class="px-4 py-2 font-medium text-gray-900">
+                    <%= staff_tag.name %>
+                  </td>
 
-        <div class="border-primary/10 rounded-2xl border bg-white shadow-sm">
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm">
-              <thead class="border-b border-gray-200 bg-gray-50">
-                <tr>
-                  <th class="px-4 py-3 text-left font-semibold text-gray-700">Staff tag</th>
-                  <th class="px-4 py-3 text-center font-semibold text-gray-700">People</th>
-                </tr>
-              </thead>
-              <tbody>
-                <% if @staff_tags.any? %>
-                  <% @staff_tags.each do |staff_tag| %>
-                    <% count = @staff_tagging_counts.fetch(staff_tag.id, 0) %>
-                    <tr class="<%= cycle("bg-white", "bg-gray-50") %> border-t border-gray-200">
-                      <td class="px-4 py-2 font-medium text-gray-900"><%= staff_tag.name %></td>
-                      <td class="px-4 py-2 text-center">
+                  <% Tag::TAGGABLE_META.each_key do |key| %>
+                    <td class="px-4 py-2 text-center">
+                      <% if key == :people %>
+                        <% count = @staff_tagging_counts.fetch(staff_tag.id, 0) %>
                         <% if count.positive? %>
                           <%= link_to count,
                                       staff_taggings_path(staff_tag_ids: staff_tag.id),
@@ -147,20 +134,23 @@
                         <% else %>
                           <span class="text-gray-400">0</span>
                         <% end %>
-                      </td>
-                    </tr>
-                  <% end %>
-                <% else %>
-                  <tr>
-                    <td colspan="2" class="px-4 py-4 text-center text-gray-500">
-                      No staff tags yet.
+                      <% end %>
                     </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+                  <% end %>
+                </tr>
+              <% end %>
+            <% else %>
+              <tr class="border-t border-gray-200">
+                <td colspan="<%= Tag::TAGGABLE_META.size + 1 %>"
+                    class="px-4 py-4 text-center text-gray-500">
+                  No staff tags yet.
+                </td>
+              </tr>
+            <% end %>
+
+            </tbody>
+          </table>
         </div>
-      </section>
+      </div>
     </div>
 </div>

--- a/app/views/taggings/matrix.html.erb
+++ b/app/views/taggings/matrix.html.erb
@@ -108,5 +108,59 @@
           </table>
         </div>
       </div>
+
+      <!-- STAFF TAGGINGS -->
+      <section class="mt-12 border-t border-gray-200 pt-8">
+        <div class="mb-4 flex items-start justify-between gap-6">
+          <div>
+            <h2 class="text-primary mb-1 font-display text-2xl font-semibold">
+              Staff taggings
+            </h2>
+            <p class="max-w-2xl text-gray-600">
+              Internal, admin-only labels — people carrying each staff tag
+            </p>
+          </div>
+          <%= link_to "View staff taggings", staff_taggings_path,
+                      class: button_classes(:secondary_outline, extra: "whitespace-nowrap") %>
+        </div>
+
+        <div class="border-primary/10 rounded-2xl border bg-white shadow-sm">
+          <div class="overflow-x-auto">
+            <table class="min-w-full text-sm">
+              <thead class="border-b border-gray-200 bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-700">Staff tag</th>
+                  <th class="px-4 py-3 text-center font-semibold text-gray-700">People</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% if @staff_tags.any? %>
+                  <% @staff_tags.each do |staff_tag| %>
+                    <% count = @staff_tagging_counts.fetch(staff_tag.id, 0) %>
+                    <tr class="<%= cycle("bg-white", "bg-gray-50") %> border-t border-gray-200">
+                      <td class="px-4 py-2 font-medium text-gray-900"><%= staff_tag.name %></td>
+                      <td class="px-4 py-2 text-center">
+                        <% if count.positive? %>
+                          <%= link_to count,
+                                      staff_taggings_path(staff_tag_ids: staff_tag.id),
+                                      class: "font-medium text-indigo-900 hover:underline" %>
+                        <% else %>
+                          <span class="text-gray-400">0</span>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                <% else %>
+                  <tr>
+                    <td colspan="2" class="px-4 py-4 text-center text-gray-500">
+                      No staff tags yet.
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </div>
 </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3173,9 +3173,8 @@
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    The Tagging counts table now ends with a Staff tags section — every published
+    The Tagging counts table now ends with a Staff tags section — each published
     staff tag with the number of people carrying it, lined up under the People
     column so you can glance straight down. Admin home also groups the tagging
-    tools: Staff tags sits with the other base data, and Staff taggings sits next
-    to Tagging counts.
+    tools together.
   action_path: "/taggings/matrix"

--- a/config/features.yml
+++ b/config/features.yml
@@ -3173,9 +3173,9 @@
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    The Tagging counts page now ends with a Staff taggings breakdown — every
-    published staff tag and how many people carry it — so admins can see internal
-    label usage alongside the sector and category counts. Admin home also groups
-    the tagging tools: Staff tags sits with the other base data, and Staff
-    taggings sits next to Tagging counts.
+    The Tagging counts table now ends with a Staff tags section — every published
+    staff tag with the number of people carrying it, lined up under the People
+    column so you can glance straight down. Admin home also groups the tagging
+    tools: Staff tags sits with the other base data, and Staff taggings sits next
+    to Tagging counts.
   action_path: "/taggings/matrix"

--- a/config/features.yml
+++ b/config/features.yml
@@ -3167,3 +3167,15 @@
     "Dedupers" panel, and Organization statuses moves to a full-width
     "Deprecated data" section.
   action_path: "/admin"
+
+- name: "Staff taggings on the Tagging counts page"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    The Tagging counts page now ends with a Staff taggings breakdown — every
+    published staff tag and how many people carry it — so admins can see internal
+    label usage alongside the sector and category counts. Admin home also groups
+    the tagging tools: Staff tags sits with the other base data, and Staff
+    taggings sits next to Tagging counts.
+  action_path: "/taggings/matrix"

--- a/spec/requests/taggings_matrix_spec.rb
+++ b/spec/requests/taggings_matrix_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe "Taggings matrix", type: :request do
     let!(:staff_tag) { create(:staff_tag, name: "Board member") }
     let!(:staff_tagging) { create(:staff_tagging, staff_tag: staff_tag) }
 
-    it "renders a staff taggings section with per-tag counts" do
+    it "renders a staff tags section with per-tag people counts" do
       get taggings_matrix_path
 
-      expect(response.body).to include("Staff taggings")
+      expect(response.body).to include("Staff tags (people carrying each internal tag)")
       expect(response.body).to include("Board member")
       expect(response.body).to include(staff_taggings_path(staff_tag_ids: staff_tag.id))
     end

--- a/spec/requests/taggings_matrix_spec.rb
+++ b/spec/requests/taggings_matrix_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe "Taggings matrix", type: :request do
     end
   end
 
+  describe "staff taggings section" do
+    let!(:staff_tag) { create(:staff_tag, name: "Board member") }
+    let!(:staff_tagging) { create(:staff_tagging, staff_tag: staff_tag) }
+
+    it "renders a staff taggings section with per-tag counts" do
+      get taggings_matrix_path
+
+      expect(response.body).to include("Staff taggings")
+      expect(response.body).to include("Board member")
+      expect(response.body).to include(staff_taggings_path(staff_tag_ids: staff_tag.id))
+    end
+  end
+
   context "when no taggings exist" do
     before do
       SectorableItem.delete_all


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/helper reorg plus one new counts-table section with a request spec

Reorganizes where the staff tag/tagging tools live so admins find them where they'd expect, and adds a staff-tags breakdown to the Tagging counts page.

- **Admin home:** *Staff tags* (reference data) now lives in the **Base data** section; the *Staff taggings* shortcut moves up next to *Tagging counts* so the tagging tools sit together.
- **Tagging counts page:** new **Staff tags** section at the bottom of the same table — each published staff tag with the number of people carrying it. Counts sit **in the People column** so you can glance straight down the page.
- Feature entry added to `config/features.yml`.