### PR TITLE
Link record-less activity rows to the page they logged

### DIFF
--- a/app/decorators/ahoy/event_decorator.rb
+++ b/app/decorators/ahoy/event_decorator.rb
@@ -31,6 +31,34 @@ module Ahoy
     }.freeze
     DEFAULT_CHIP_CLASSES = "bg-gray-100 text-gray-600".freeze
 
+    # Record-less "view.<page>" events (view.tags, view.comments, view.admin.data_health)
+    # aren't tied to a record, so resource_link can't resolve them — but they still went
+    # somewhere. Map the resource half of the name to the page it logged so the whole row
+    # links there (see activity_path). A value is a lambda taking the view helper and the
+    # event's properties hash.
+    PAGE_LINKS = {
+      "tags"                               => ->(h, _p) { h.tags_path },
+      "taggings"                           => ->(h, _p) { h.taggings_path },
+      "comments"                           => ->(h, _p) { h.comments_path },
+      "notifications"                      => ->(h, _p) { h.notifications_path },
+      "bulk_payments"                      => ->(h, _p) { h.bulk_payments_path },
+      "admin.data_health"                  => ->(h, _p) { h.admin_data_health_path },
+      "person_all_comments"                => ->(h, p) { h.all_comments_person_path(p["person_id"]) },
+      "person_comments_and_communications" => ->(h, p) { h.comments_and_communications_person_path(p["person_id"]) }
+    }.freeze
+    private_constant :PAGE_LINKS
+
+    # Event report/detail pages logged as "events.<action>" (view.events.reports,
+    # view.events.roster, …). Only these GET pages get linked — action events like
+    # events.send_reminder are POST-only and have no page to open. Collection reports
+    # carry no event_id; per-event pages do.
+    EVENT_PAGE_ACTIONS = %w[
+      dashboard attendance registrants roster onboarding staff recipients
+      bulk_payments reconcile_affiliations revenue participation reports
+      scholarships program_statuses attendees signins templates_gallery
+    ].freeze
+    private_constant :EVENT_PAGE_ACTIONS
+
     # The raw action prefixes a plain-language chip word maps to, so the activity
     # search can match what the reader sees: "new" finds create events, "search"
     # finds both search and search_zero. Empty for a word that isn't a chip label.
@@ -50,7 +78,7 @@ module Ahoy
     # The resource half of the event name, humanized: "workshop_variation" reads
     # "Workshop variation", "account_deactivated" reads "Account deactivated".
     def activity_resource_label
-      object.name.to_s.split(".", 2)[1].to_s.humanize
+      name_resource_part.to_s.humanize
     end
 
     # The event's own resource, linked to its edit page so an admin can jump
@@ -61,16 +89,14 @@ module Ahoy
     # Returns nil when there's no title; :path is nil when the record is gone or
     # has no editable route (rendered as plain text).
     def resource_link
-      return commentable_link if comment&.commentable
+      @resource_link = compute_resource_link unless defined?(@resource_link)
+      @resource_link
+    end
 
-      record = find_referenced_record(object.resource_type, object.resource_id)
-      custom = custom_resource_link(record)
-      return custom if custom
-
-      title = properties_hash["resource_title"]
-      return nil if title.blank?
-
-      { text: title, path: edit_path_for(record) }
+    # The URL the whole Activity cell links to: the record's edit/show page for a
+    # record-backed event, or the index/report page for a record-less view event.
+    def activity_path
+      resource_link&.dig(:path) || page_path
     end
 
     # The record a comment was left on, labeled and linked. Reuses the same
@@ -152,6 +178,52 @@ module Ahoy
     end
 
     private
+
+    def compute_resource_link
+      return commentable_link if comment&.commentable
+
+      record = find_referenced_record(object.resource_type, object.resource_id)
+      custom = custom_resource_link(record)
+      return custom if custom
+
+      title = properties_hash["resource_title"]
+      return nil if title.blank?
+
+      { text: title, path: edit_path_for(record) }
+    end
+
+    # The page a record-less view event went to (index/report pages), or nil.
+    # Guarded so a renamed route degrades to a plain-text row rather than 500-ing
+    # the activity frame.
+    def page_path
+      builder = PAGE_LINKS[name_resource_part]
+      return builder.call(h, properties_hash) if builder
+
+      events_page_path
+    rescue StandardError
+      nil
+    end
+
+    # events.<action> → the matching event report/page path. Per-event pages take
+    # the event_id from properties; a collection report scoped to one event keeps
+    # it as a filter query param so the link reopens the same view.
+    def events_page_path
+      prefix, action = name_resource_part.to_s.split(".", 2)
+      return nil unless prefix == "events" && EVENT_PAGE_ACTIONS.include?(action)
+
+      event_id = properties_hash["event_id"].presence
+      member = "#{action}_event_path"
+      return h.public_send(member, event_id) if event_id && h.respond_to?(member)
+
+      collection = "#{action}_events_path"
+      return nil unless h.respond_to?(collection)
+
+      event_id ? h.public_send(collection, event_id: event_id) : h.public_send(collection)
+    end
+
+    def name_resource_part
+      object.name.to_s.split(".", 2)[1]
+    end
 
     def action_key
       object.name.to_s.split(".", 2).first.to_s

--- a/app/views/admin/ahoy_activities/_activity_row.html.erb
+++ b/app/views/admin/ahoy_activities/_activity_row.html.erb
@@ -1,7 +1,7 @@
 <% activity = event.decorate(context: { record_cache: local_assigns[:record_cache] }) %>
 <% chip = activity.activity_chip %>
 <% resource = activity.resource_link %>
-<% linked = resource && resource[:path] %>
+<% path = activity.activity_path %>
 <tr class="<%= activity.comment? ? "#{DomainTheme.bg_class_for(:comments, intensity: 50)} transition" : "transition hover:bg-gray-50" %>">
   <td data-label="Time" class="px-4 py-3 align-top whitespace-nowrap text-gray-500">
     <%= event.time.in_time_zone.strftime("%Y-%m-%d %H:%M %Z") %>
@@ -9,10 +9,10 @@
 
   <%# Merged Activity + Details cell: a link overlay makes the whole cell navigate
       to the resource without restyling the text; inner detail links keep z-10. %>
-  <td data-label="Activity" class="<%= "group " if linked %>relative px-4 py-3 align-top">
-    <% if linked %>
-      <%= link_to "", resource[:path], class: "absolute inset-0",
-                  aria: { label: "Open #{resource[:text]}" }, data: { turbo_frame: "_top" } %>
+  <td data-label="Activity" class="<%= "group " if path %>relative px-4 py-3 align-top">
+    <% if path %>
+      <%= link_to "", path, class: "absolute inset-0",
+                  aria: { label: "Open #{resource ? resource[:text] : activity.activity_resource_label}" }, data: { turbo_frame: "_top" } %>
     <% end %>
     <%= render "admin/ahoy_activities/activity_cell", activity: activity, event: event, chip: chip, resource: resource %>
   </td>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "Jump from the activity timeline to the page each row logged"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    Rows in the admin activity timeline for index and report page views (Tags,
+    Comments, Events reports, Data health, and more) are now clickable and open
+    that page, instead of showing as plain text.
+  action_path: /admin/activities/events
+  pr_number: 2499
+
 - name: "Clearer bulk payment confirmation email"
   area: payments
   display_status: user_facing

--- a/spec/decorators/ahoy/event_decorator_spec.rb
+++ b/spec/decorators/ahoy/event_decorator_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Ahoy::EventDecorator do
     create(:ahoy_event, name: name).decorate
   end
 
+  def decorate_page(name, properties)
+    create(:ahoy_event, name: name, properties: properties).reload.decorate
+  end
+
   describe "#activity_chip" do
     it "reads create as a New chip and update as an Edit chip" do
       expect(decorate_named("create.comment").activity_chip[:label]).to eq("New")
@@ -154,6 +158,55 @@ RSpec.describe Ahoy::EventDecorator do
 
       expect(event.resource_link[:text]).to include("Event registration for")
       expect(event.resource_link[:path]).to eq(Rails.application.routes.url_helpers.edit_event_registration_path(registration))
+    end
+  end
+
+  describe "#activity_path" do
+    let(:routes) { Rails.application.routes.url_helpers }
+
+    it "uses the record's edit page for a record-backed event" do
+      workshop = create(:workshop)
+      event = create(:ahoy_event, name: "view.workshop", resource_type: "Workshop",
+                                  resource_id: workshop.id, properties: { "resource_title" => "Feelings Collage" }).decorate
+
+      expect(event.activity_path).to eq(routes.edit_workshop_path(workshop))
+    end
+
+    it "links a record-less index view to its index page" do
+      expect(decorate_named("view.tags").activity_path).to eq(routes.tags_path)
+      expect(decorate_named("view.comments").activity_path).to eq(routes.comments_path)
+      expect(decorate_named("view.taggings").activity_path).to eq(routes.taggings_path)
+      expect(decorate_named("view.notifications").activity_path).to eq(routes.notifications_path)
+      expect(decorate_named("view.bulk_payments").activity_path).to eq(routes.bulk_payments_path)
+      expect(decorate_named("view.admin.data_health").activity_path).to eq(routes.admin_data_health_path)
+    end
+
+    it "links a person-scoped page view using its person_id property" do
+      event = decorate_page("view.person_all_comments", "person_id" => 42)
+      expect(event.activity_path).to eq(routes.all_comments_person_path(42))
+    end
+
+    it "links a collection report to its collection path" do
+      expect(decorate_named("view.events.reports").activity_path).to eq(routes.reports_events_path)
+    end
+
+    it "keeps the event_id filter on a collection report scoped to one event" do
+      event = decorate_page("view.events.reports", "event_id" => 7)
+      expect(event.activity_path).to eq(routes.reports_events_path(event_id: 7))
+    end
+
+    it "links a per-event page view to that event's member page" do
+      event = decorate_page("view.events.roster", "event_id" => 9)
+      expect(event.activity_path).to eq(routes.roster_event_path(9))
+    end
+
+    it "does not link a POST-only action event that has no page" do
+      event = decorate_page("view.events.send_reminder", "event_id" => 3)
+      expect(event.activity_path).to be_nil
+    end
+
+    it "is nil for a record-less view with no known page" do
+      expect(decorate_named("view.mystery").activity_path).to be_nil
     end
   end
 

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -151,6 +151,20 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect_frame_breakout(response.body, user_path(user))
       end
 
+      it "links a record-less index/page view to its page, breaking out of the frame" do
+        create(:ahoy_event, name: "view.tags", user: user, visit: visit_for_user,
+                            time: 1.hour.ago, properties: { "page" => "index" })
+        create(:ahoy_event, name: "view.events.reports", user: user, visit: visit_for_user,
+                            time: 2.hours.ago)
+
+        get index_path, params: { time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("activity_results")
+        expect_frame_breakout(response.body, tags_path)
+        expect_frame_breakout(response.body, reports_events_path)
+      end
+
       it "filters by prefixes=auth" do
         get index_path, params: { prefixes: "auth" }, headers: frame_headers
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained decorator + view change on one admin page, well covered by specs

The admin activity timeline now links index/report page views to their actual pages — so an admin can click "Tags", "Comments", "Events.reports", or "Admin.data health" and land there, instead of staring at dead text.

- These `view.<page>` events log no resource record, so `resource_link` returned nil and the whole row was unclickable.
- Added `Ahoy::EventDecorator#activity_path`: record-backed events still link to the record's edit/show page; record-less page views resolve through a name→path map (`PAGE_LINKS`) plus an `events.<action>` builder (`EVENT_PAGE_ACTIONS`).
- Only linkable GET pages are mapped — POST-only action events (e.g. `events.send_reminder`) stay plain, and unknown names degrade to text rather than 500-ing the results frame.
- A collection report scoped to one event keeps its `event_id` as a filter param so the link reopens the same view.

Out of scope: story-share events (deliberately left for a later PR).