### PR TITLE
Regroup admin home: Actions, Dedupers, Deprecated data

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -9,6 +9,7 @@ module Admin
       @user_content_cards    = user_content_cards
       @reference_cards       = reference_cards
       @additional_data_cards = additional_data_cards
+      @deduper_cards         = deduper_cards
       @deprecated_data_cards = deprecated_data_cards
     end
   end

--- a/app/helpers/admin_cards_helper.rb
+++ b/app/helpers/admin_cards_helper.rb
@@ -28,7 +28,6 @@ module AdminCardsHelper
   def user_content_cards
     [
       custom_card("Portal activity", admin_activities_counts_path, icon: "📊"),
-      custom_card("Data health", admin_data_health_path, icon: "🩺", color: :sky, intensity: 100),
       custom_card("Bookmarks tally", tally_bookmarks_path, icon: "🔖"),
       model_card(:notifications, icon: "🔔", title: t("communications.title")),
       custom_card("Event reports", reports_events_path, icon: "📊", color: :blue),
@@ -63,15 +62,23 @@ module AdminCardsHelper
   end
 
   # -----------------------------
-  # DEPRECATED DATA CARDS
+  # DEDUPER CARDS
   # -----------------------------
-  def deprecated_data_cards
+  def deduper_cards
     [
-      custom_card("Organization statuses", organization_statuses_path, icon: "🧮", color: :emerald, intensity: 100),
       custom_card("Dedupe people", dedupe_index_people_path, icon: "🧹", color: DomainTheme.color_for(:people), intensity: 100),
       custom_card("Dedupe organizations", dedupe_index_organizations_path, icon: "🧹", color: DomainTheme.color_for(:organizations), intensity: 100),
       custom_card("Dedupe categories", dedupe_index_categories_path, icon: "🧹", color: DomainTheme.color_for(:categories), intensity: 100),
       custom_card("Dedupe sectors", dedupe_index_sectors_path, icon: "🧹", color: DomainTheme.color_for(:sectors), intensity: 100)
+    ]
+  end
+
+  # -----------------------------
+  # DEPRECATED DATA CARDS
+  # -----------------------------
+  def deprecated_data_cards
+    [
+      custom_card("Organization statuses", organization_statuses_path, icon: "🧮", color: :emerald, intensity: 100)
     ]
   end
 
@@ -81,7 +88,6 @@ module AdminCardsHelper
   def additional_data_cards
     [
       custom_card("Allocations", allocations_path, icon: "📤", color: :sky, intensity: 100),
-      custom_card("Author credit divergences", author_credit_divergences_path, icon: "✍️", color: :sky, intensity: 100),
       custom_card("Bulk payments", bulk_payments_path, icon: "💳", color: :sky, intensity: 100),
       custom_card("Event registrations", event_registrations_path, icon: "🎟️", color: :sky, intensity: 100),
       custom_card("Features & tips", features_path, icon: "⭐", color: :sky, intensity: 100),

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -130,9 +130,9 @@
 
       <div class="mt-6 flex flex-col gap-6 md:flex-row">
         <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm md:w-1/2">
-          Deprecated data
+          Dedupers
          <div class="mt-3 columns-1 gap-2 sm:columns-2">
-            <% @deprecated_data_cards.each do |card| %>
+            <% @deduper_cards.each do |card| %>
               <a href="<%= card[:path] %>"
                class="mb-2 flex break-inside-avoid items-center gap-3 rounded-lg border border-gray-200 shadow-lg
                 <%= card[:bg_color] %> <%= card[:text_color] %>
@@ -154,6 +154,12 @@
         <div class="border-primary/10 rounded-2xl border bg-white p-6 shadow-sm md:w-1/2">
           Actions
           <div class="mt-3 flex flex-wrap gap-2">
+            <%= link_to admin_data_health_path, class: button_classes(:primary_outline) do %>
+              <i class="fa-solid fa-heart-pulse"></i> Data health
+            <% end %>
+            <%= link_to author_credit_divergences_path, class: button_classes(:primary_outline) do %>
+              <i class="fa-solid fa-pen-nib"></i> Author credit divergences
+            <% end %>
             <% if allowed_to?(:create?, Feature) %>
               <%= button_to import_features_path,
                             class: button_classes(:primary_outline),
@@ -162,6 +168,29 @@
               <% end %>
             <% end %>
           </div>
+        </div>
+      </div>
+
+      <div class="border-primary/10 mt-6 rounded-2xl border bg-white p-6 shadow-sm">
+        Deprecated data
+       <div class="mt-3 columns-1 gap-2 sm:columns-2 md:columns-3">
+          <% @deprecated_data_cards.each do |card| %>
+            <a href="<%= card[:path] %>"
+             class="mb-2 flex break-inside-avoid items-center gap-3 rounded-lg border border-gray-200 shadow-lg
+              <%= card[:bg_color] %> <%= card[:text_color] %>
+              <%= card[:hover_bg_color] %>
+              px-4 py-1 transition-colors transition-shadow duration-300">
+
+              <div class="flex-shrink-0 text-lg text-gray-700">
+                <%= card[:icon] %>
+              </div>
+
+              <div>
+                <h3 class="text-sm font-bold whitespace-nowrap text-gray-800"><%= card[:title] %></h3>
+              </div>
+
+            </a>
+          <% end %>
         </div>
       </div>
       </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3145,3 +3145,14 @@
     - "Click a Visit ID to see everything that happened in that visit."
     - "Long comment and email bodies are trimmed — hover to read the full text."
   action_path: "/admin/activities/events"
+
+- name: "Admin home actions, dedupers, and deprecated data regrouped"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    The admin home page is tidied up: Data health and Author credit divergences
+    now sit as buttons in the Actions box, the record dedupers get their own
+    "Dedupers" panel, and Organization statuses moves to a full-width
+    "Deprecated data" section.
+  action_path: "/admin"

--- a/spec/requests/admin/home_spec.rb
+++ b/spec/requests/admin/home_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe "Admin home", type: :request do
     expect(response.body).to include("Sync features")
   end
 
+  it "puts Data health and Author credit divergences in the Actions section" do
+    get "/admin"
+
+    expect(response.body).to include("Data health", "Author credit divergences")
+    expect(response.body).to include(
+      %(href="#{admin_data_health_path}"),
+      %(href="#{author_credit_divergences_path}")
+    )
+  end
+
   it "links to the form submissions index" do
     get "/admin"
 
@@ -19,14 +29,23 @@ RSpec.describe "Admin home", type: :request do
     expect(response.body).to include(%(href="#{form_submissions_path}"))
   end
 
-  it "links to the record dedupers under deprecated data" do
+  it "links to the record dedupers under the Dedupers section" do
     get "/admin"
 
+    expect(response.body).to include("Dedupers")
     expect(response.body).to include("Dedupe organizations", "Dedupe categories", "Dedupe sectors")
     expect(response.body).to include(
       %(href="#{dedupe_index_organizations_path}"),
       %(href="#{dedupe_index_categories_path}"),
       %(href="#{dedupe_index_sectors_path}")
     )
+  end
+
+  it "lists Organization statuses under the Deprecated data section" do
+    get "/admin"
+
+    expect(response.body).to include("Deprecated data")
+    expect(response.body).to include("Organization statuses")
+    expect(response.body).to include(%(href="#{organization_statuses_path}"))
   end
 end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 admin-home reshuffle — moves existing cards between sections, no logic changes

Reorganizes the admin home page so each section says what it is: the two things an admin *does* move into Actions, the dedupe tools get their own panel, and only genuinely deprecated data stays under "Deprecated data".

- **Actions** now holds **Data health** and **Author credit divergences** as buttons (were loose data-index cards).
- The record dedupers get their own **Dedupers** panel (the old "Deprecated data" half-panel, renamed).
- **Organization statuses** moves to a new full-width **Deprecated data** section below that row.
- Added a Features & tips entry for the change.