### PR TITLE
Record payments during registrant import

### DIFF
--- a/app/controllers/event_registration_imports_controller.rb
+++ b/app/controllers/event_registration_imports_controller.rb
@@ -93,6 +93,7 @@ class EventRegistrationImportsController < ApplicationController
       "#{", #{result.registrations_promoted} promoted to attended" if result.registrations_promoted.positive?}" \
       "#{", #{result.organizations_to_reconcile} orgs to reconcile" if result.organizations_to_reconcile.positive?}" \
       "#{", #{result.payments_recorded} payments (#{helpers.dollars_from_cents(result.payments_amount_cents)})" if result.payments_recorded.positive?}" \
+      "#{", #{result.discounts_recorded} discounts (#{helpers.dollars_from_cents(result.discounts_amount_cents)})" if result.discounts_recorded.positive?}" \
       "#{", #{result.skipped.size} rows skipped" if result.skipped.any?}."
   end
 end

--- a/app/controllers/event_registration_imports_controller.rb
+++ b/app/controllers/event_registration_imports_controller.rb
@@ -92,6 +92,7 @@ class EventRegistrationImportsController < ApplicationController
       "(#{result.people_created} new people, #{result.people_matched} matched)" \
       "#{", #{result.registrations_promoted} promoted to attended" if result.registrations_promoted.positive?}" \
       "#{", #{result.organizations_to_reconcile} orgs to reconcile" if result.organizations_to_reconcile.positive?}" \
+      "#{", #{result.payments_recorded} payments (#{helpers.dollars_from_cents(result.payments_amount_cents)})" if result.payments_recorded.positive?}" \
       "#{", #{result.skipped.size} rows skipped" if result.skipped.any?}."
   end
 end

--- a/app/services/event_registration_importer.rb
+++ b/app/services/event_registration_importer.rb
@@ -24,10 +24,12 @@ require "bigdecimal"
 #   * Payment — only when the row carries an AmountPaid. Finds (its own prior
 #     import payment for this person + amount + type on this event, keyed by
 #     metadata) or creates one, then finds-or-creates an Allocation applying it to
-#     the registration, capped at the registration's remaining cost. This is what
-#     makes an imported registration read as "Paid". PaymentType picks the payment
-#     kind (cash / check / card, defaulting to cash); a free event ignores the
-#     amount, since there's nothing to allocate against.
+#     the registration, capped at the registration's remaining cost. PaymentType
+#     picks the payment kind (cash / check / card, defaulting to cash); a free
+#     event ignores the amount, since there's nothing to allocate against.
+#   * Discount — the gap between the event cost and what was actually paid is
+#     comped with a Discount allocation, so a partial AmountPaid (e.g. $50 on a
+#     $750 event) still reads as "Paid". A full payment leaves no discount.
 #
 # No emails are sent, no mailing-list subscription, tags, addresses, or CE are
 # created — the sheet carries none of that, and this is a historical backfill.
@@ -125,6 +127,7 @@ class EventRegistrationImporter
     :registrations_created, :registrations_promoted, :registrations_already_attended,
     :organizations_linked, :organizations_to_reconcile,
     :payments_recorded, :payments_amount_cents,
+    :discounts_recorded, :discounts_amount_cents,
     :skipped, :rows,
     keyword_init: true
   ) do
@@ -140,6 +143,7 @@ class EventRegistrationImporter
           "already attended: #{registrations_already_attended}",
         "organizations linked: #{organizations_linked}, to reconcile: #{organizations_to_reconcile}",
         "payments recorded: #{payments_recorded} (#{MoneyFormatter.dollars_from_cents(payments_amount_cents)})",
+        "discounts recorded: #{discounts_recorded} (#{MoneyFormatter.dollars_from_cents(discounts_amount_cents)})",
         "skipped: #{skipped.size}"
       ].join("\n")
     end
@@ -150,7 +154,7 @@ class EventRegistrationImporter
     :number, :first_name, :last_name, :email, :organization_name,
     :person_status, :person_label,
     :registration_status, :organization_status,
-    :payment_status, :payment_label, :payment_amount_cents,
+    :payment_status, :payment_label, :payment_amount_cents, :discount_cents,
     :skipped_reason,
     keyword_init: true
   )
@@ -171,6 +175,7 @@ class EventRegistrationImporter
       registrations_created: 0, registrations_promoted: 0, registrations_already_attended: 0,
       organizations_linked: 0, organizations_to_reconcile: 0,
       payments_recorded: 0, payments_amount_cents: 0,
+      discounts_recorded: 0, discounts_amount_cents: 0,
       skipped: [], rows: []
     )
     @organization_cache = {}
@@ -329,8 +334,16 @@ class EventRegistrationImporter
 
     preview.payment_status = :will_record
     preview.payment_label = PAYMENT_TYPE_LABELS[payment_class.name]
+    applied = [ cents, @event.cost_cents.to_i ].min
     @result.payments_recorded += 1
-    @result.payments_amount_cents += [ cents, @event.cost_cents.to_i ].min
+    @result.payments_amount_cents += applied
+
+    discount = @event.cost_cents.to_i - applied
+    return unless discount.positive?
+
+    preview.discount_cents = discount
+    @result.discounts_recorded += 1
+    @result.discounts_amount_cents += discount
   end
 
   def persist_registration(person, registration, values)
@@ -370,12 +383,29 @@ class EventRegistrationImporter
     return if payment_class == CheckPayment && values[:check_number].blank?
 
     to_allocate = [ cents, registration.remaining_cost ].min
-    return if to_allocate <= 0
-
-    payment = resolve_payment(person, cents, payment_class, values[:check_number])
-    registration.allocations.find_or_create_by!(source: payment) do |allocation|
-      allocation.amount = to_allocate
+    if to_allocate.positive?
+      payment = resolve_payment(person, cents, payment_class, values[:check_number])
+      registration.allocations.find_or_create_by!(source: payment) do |allocation|
+        allocation.amount = to_allocate
+      end
     end
+
+    cover_remainder_with_discount(registration)
+  end
+
+  # Comps whatever the payment didn't cover — the gap between the event cost and
+  # what was actually paid — so a partial amount still reads as "Paid". A re-run
+  # sees nothing left to cover and adds no second discount.
+  def cover_remainder_with_discount(registration)
+    registration.allocations.reset
+    remaining = registration.remaining_cost
+    return unless remaining.positive?
+
+    discount = Discount.new(amount_cents: remaining)
+    discount.created_by = @import_user if discount.respond_to?(:created_by=)
+    discount.updated_by = @import_user if discount.respond_to?(:updated_by=)
+    discount.save!
+    registration.allocations.create!(source: discount, amount: remaining)
   end
 
   # Reuses our own prior import payment for this person + amount + type on this

--- a/app/services/event_registration_importer.rb
+++ b/app/services/event_registration_importer.rb
@@ -1,4 +1,5 @@
 require "csv"
+require "bigdecimal"
 
 # Bulk-imports event registrants into one existing event from an uploaded CSV
 # (columns FirstName, LastName, Organization, EMail). Every row is treated as
@@ -20,6 +21,13 @@ require "csv"
 #     submission) and, on a facilitator-training event, a "Facilitator" affiliation
 #     is minted (AffiliationServices::CreateFromRegistration). An unmatched name is
 #     left for reconciliation; it is never invented here.
+#   * Payment — only when the row carries an AmountPaid. Finds (its own prior
+#     import payment for this person + amount + type on this event, keyed by
+#     metadata) or creates one, then finds-or-creates an Allocation applying it to
+#     the registration, capped at the registration's remaining cost. This is what
+#     makes an imported registration read as "Paid". PaymentType picks the payment
+#     kind (cash / check / card, defaulting to cash); a free event ignores the
+#     amount, since there's nothing to allocate against.
 #
 # No emails are sent, no mailing-list subscription, tags, addresses, or CE are
 # created — the sheet carries none of that, and this is a historical backfill.
@@ -53,7 +61,51 @@ class EventRegistrationImporter
     "org" => :organization,
     "email" => :email,
     "e-mail" => :email,
-    "email address" => :email
+    "email address" => :email,
+    "amount" => :amount_paid,
+    "amount paid" => :amount_paid,
+    "amount_paid" => :amount_paid,
+    "amountpaid" => :amount_paid,
+    "paid" => :amount_paid,
+    "payment amount" => :amount_paid,
+    "payment_amount" => :amount_paid,
+    "type" => :payment_type,
+    "method" => :payment_type,
+    "payment type" => :payment_type,
+    "payment_type" => :payment_type,
+    "paymenttype" => :payment_type,
+    "payment method" => :payment_type,
+    "payment_method" => :payment_type,
+    "check number" => :check_number,
+    "check_number" => :check_number,
+    "checknumber" => :check_number,
+    "check #" => :check_number,
+    "check no" => :check_number,
+    "check_no" => :check_number,
+    "checkno" => :check_number
+  }.freeze
+
+  # Normalized PaymentType token → the STI Payment subclass to create. A blank
+  # type on a row carrying an amount falls back to cash; an unrecognized token
+  # records no payment (surfaced in the preview) rather than guessing.
+  PAYMENT_TYPES = {
+    "cash" => CashPayment,
+    "check" => CheckPayment,
+    "cheque" => CheckPayment,
+    "card" => ExternalProcessorPayment,
+    "credit" => ExternalProcessorPayment,
+    "credit card" => ExternalProcessorPayment,
+    "debit" => ExternalProcessorPayment,
+    "stripe" => ExternalProcessorPayment,
+    "online" => ExternalProcessorPayment,
+    "external" => ExternalProcessorPayment
+  }.freeze
+  DEFAULT_PAYMENT_TYPE = CashPayment
+
+  PAYMENT_TYPE_LABELS = {
+    "CashPayment" => "Cash",
+    "CheckPayment" => "Check",
+    "ExternalProcessorPayment" => "Card"
   }.freeze
 
   SUPPORTED_EXTENSIONS = %w[csv].freeze
@@ -72,6 +124,7 @@ class EventRegistrationImporter
     :rows_processed, :people_created, :people_matched,
     :registrations_created, :registrations_promoted, :registrations_already_attended,
     :organizations_linked, :organizations_to_reconcile,
+    :payments_recorded, :payments_amount_cents,
     :skipped, :rows,
     keyword_init: true
   ) do
@@ -86,6 +139,7 @@ class EventRegistrationImporter
         "registrations created: #{registrations_created}, promoted to attended: #{registrations_promoted}, " \
           "already attended: #{registrations_already_attended}",
         "organizations linked: #{organizations_linked}, to reconcile: #{organizations_to_reconcile}",
+        "payments recorded: #{payments_recorded} (#{MoneyFormatter.dollars_from_cents(payments_amount_cents)})",
         "skipped: #{skipped.size}"
       ].join("\n")
     end
@@ -96,6 +150,7 @@ class EventRegistrationImporter
     :number, :first_name, :last_name, :email, :organization_name,
     :person_status, :person_label,
     :registration_status, :organization_status,
+    :payment_status, :payment_label, :payment_amount_cents,
     :skipped_reason,
     keyword_init: true
   )
@@ -115,6 +170,7 @@ class EventRegistrationImporter
       rows_processed: 0, people_created: 0, people_matched: 0,
       registrations_created: 0, registrations_promoted: 0, registrations_already_attended: 0,
       organizations_linked: 0, organizations_to_reconcile: 0,
+      payments_recorded: 0, payments_amount_cents: 0,
       skipped: [], rows: []
     )
     @organization_cache = {}
@@ -158,7 +214,10 @@ class EventRegistrationImporter
       first_name: clean(row[:first_name]),
       last_name: clean(row[:last_name]),
       email: clean(row[:email])&.downcase,
-      organization: clean(row[:organization])
+      organization: clean(row[:organization]),
+      amount_paid: clean(row[:amount_paid]),
+      payment_type: clean(row[:payment_type]),
+      check_number: clean(row[:check_number])
     }
     preview = RowPreview.new(
       number: number, first_name: values[:first_name], last_name: values[:last_name],
@@ -177,6 +236,7 @@ class EventRegistrationImporter
     person = resolve_person(values, preview)
     registration = resolve_registration(person, preview)
     set_organization_preview(values[:organization], preview)
+    set_payment_preview(values, preview)
 
     persist_registration(person, registration, values) unless @dry_run
 
@@ -252,10 +312,36 @@ class EventRegistrationImporter
     end
   end
 
+  def set_payment_preview(values, preview)
+    return if values[:amount_paid].blank?
+
+    cents = parse_cents(values[:amount_paid])
+    return preview.payment_status = :invalid if cents.nil? || cents <= 0
+
+    preview.payment_amount_cents = cents
+    payment_class = payment_class_for(values[:payment_type])
+    if payment_class.nil?
+      preview.payment_label = values[:payment_type]
+      return preview.payment_status = :unknown_type
+    end
+    return preview.payment_status = :missing_check_number if payment_class == CheckPayment && values[:check_number].blank?
+    return preview.payment_status = :free if @event.cost_cents.to_i <= 0
+
+    preview.payment_status = :will_record
+    preview.payment_label = PAYMENT_TYPE_LABELS[payment_class.name]
+    @result.payments_recorded += 1
+    @result.payments_amount_cents += [ cents, @event.cost_cents.to_i ].min
+  end
+
   def persist_registration(person, registration, values)
     return if registration.nil?
 
     submission = import_submission(person, values)
+    link_organization(person, registration, submission, values)
+    apply_payment(person, registration, values)
+  end
+
+  def link_organization(person, registration, submission, values)
     organization = values[:organization].present? ? find_organization(values[:organization]) : nil
     return unless organization
 
@@ -270,6 +356,47 @@ class EventRegistrationImporter
       facilitator_training: @event.facilitator_training,
       event_registration: registration
     )
+  end
+
+  # Applies the row's AmountPaid to the registration by finding-or-creating a
+  # payment and then an allocation, capped at what the registration still owes —
+  # so a re-run adds nothing and a fully-covered amount reads as "Paid".
+  def apply_payment(person, registration, values)
+    cents = parse_cents(values[:amount_paid])
+    return if cents.nil? || cents <= 0
+
+    payment_class = payment_class_for(values[:payment_type])
+    return if payment_class.nil?
+    return if payment_class == CheckPayment && values[:check_number].blank?
+
+    to_allocate = [ cents, registration.remaining_cost ].min
+    return if to_allocate <= 0
+
+    payment = resolve_payment(person, cents, payment_class, values[:check_number])
+    registration.allocations.find_or_create_by!(source: payment) do |allocation|
+      allocation.amount = to_allocate
+    end
+  end
+
+  # Reuses our own prior import payment for this person + amount + type on this
+  # event (keyed by the import metadata), so re-running never mints duplicates and
+  # imports into other events never steal each other's money; otherwise creates one.
+  def resolve_payment(person, cents, payment_class, check_number)
+    existing = payment_class
+      .where(person_id: person.id, amount_cents: cents)
+      .detect { |candidate| candidate.metadata&.[](IMPORT_SOURCE_KEY).present? && candidate.metadata["event_id"] == @event.id }
+    return existing if existing
+
+    payment = payment_class.new(
+      person: person, amount_cents: cents, currency: "usd",
+      metadata: { IMPORT_SOURCE_KEY => @source, "event_id" => @event.id, "name" => person.full_name, "email" => person.email }
+    )
+    payment.check_number = check_number if payment_class == CheckPayment
+    payment.skip_pay_charge_validation = true if payment.respond_to?(:skip_pay_charge_validation=)
+    payment.created_by = @import_user if payment.respond_to?(:created_by=)
+    payment.updated_by = @import_user if payment.respond_to?(:updated_by=)
+    payment.save!
+    payment
   end
 
   # The import's OWN registration submission — created alongside, never in place
@@ -317,5 +444,21 @@ class EventRegistrationImporter
 
   def clean(value)
     value.to_s.strip.presence
+  end
+
+  def payment_class_for(raw)
+    return DEFAULT_PAYMENT_TYPE if raw.blank?
+
+    PAYMENT_TYPES[normalize_header(raw)]
+  end
+
+  # Parses a money cell ("$1,099.00", "10.99", "10") to integer cents; nil on junk.
+  def parse_cents(raw)
+    cleaned = raw.to_s.gsub(/[^0-9.\-]/, "")
+    return nil if cleaned.blank?
+
+    (BigDecimal(cleaned) * 100).round
+  rescue ArgumentError
+    nil
   end
 end

--- a/app/views/event_registration_imports/create.html.erb
+++ b/app/views/event_registration_imports/create.html.erb
@@ -23,6 +23,8 @@
       [ "Orgs to reconcile", @result.organizations_to_reconcile ],
       [ "Payments", @result.payments_recorded ],
       [ "Amount", dollars_from_cents(@result.payments_amount_cents) ],
+      [ "Discounts", @result.discounts_recorded ],
+      [ "Comped", dollars_from_cents(@result.discounts_amount_cents) ],
       [ "Rows", @result.rows_processed ],
       [ "Skipped", @result.skipped.size ]
     ].each do |label, count| %>
@@ -104,6 +106,11 @@
                     <span class="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-xs text-green-800" title="<%= row.payment_label %> — applied to the registration">
                       <%= row.payment_label %> <%= dollars_from_cents(row.payment_amount_cents) %>
                     </span>
+                    <% if row.discount_cents.present? %>
+                      <span class="ml-1 inline-flex items-center rounded-md bg-purple-100 px-2 py-1 text-xs text-purple-800" title="Remainder comped so the registration reads as paid">
+                        + <%= dollars_from_cents(row.discount_cents) %> discount
+                      </span>
+                    <% end %>
                   <% when :free %>
                     <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-600" title="Free event — nothing to apply the amount against">
                       Free event — not applied

--- a/app/views/event_registration_imports/create.html.erb
+++ b/app/views/event_registration_imports/create.html.erb
@@ -21,6 +21,8 @@
       [ "Promoted to attended", @result.registrations_promoted ],
       [ "Orgs to link", @result.organizations_linked ],
       [ "Orgs to reconcile", @result.organizations_to_reconcile ],
+      [ "Payments", @result.payments_recorded ],
+      [ "Amount", dollars_from_cents(@result.payments_amount_cents) ],
       [ "Rows", @result.rows_processed ],
       [ "Skipped", @result.skipped.size ]
     ].each do |label, count| %>
@@ -49,6 +51,7 @@
             <th class="px-3 py-2 text-left">Person</th>
             <th class="px-3 py-2 text-left">Registration</th>
             <th class="px-3 py-2 text-left">Organization</th>
+            <th class="px-3 py-2 text-left">Payment</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -58,7 +61,7 @@
               <td class="px-3 py-2 text-gray-900"><%= "#{row.first_name} #{row.last_name}".strip.presence || "—" %></td>
               <td class="px-3 py-2 text-gray-600"><%= row.email.presence || "—" %></td>
               <% if row.skipped_reason %>
-                <td class="px-3 py-2" colspan="3">
+                <td class="px-3 py-2" colspan="4">
                   <span class="inline-flex items-center rounded-md bg-red-100 px-2 py-1 text-xs text-red-700">
                     Skipped — <%= row.skipped_reason %>
                   </span>
@@ -90,6 +93,32 @@
                   <% when :to_reconcile %>
                     <span class="inline-flex items-center rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800" title="No organization by this name yet — queued for the link-organization reconciliation page">
                       Reconcile: <%= row.organization_name %>
+                    </span>
+                  <% else %>
+                    <span class="text-gray-400">—</span>
+                  <% end %>
+                </td>
+                <td class="px-3 py-2">
+                  <% case row.payment_status %>
+                  <% when :will_record %>
+                    <span class="inline-flex items-center rounded-md bg-green-100 px-2 py-1 text-xs text-green-800" title="<%= row.payment_label %> — applied to the registration">
+                      <%= row.payment_label %> <%= dollars_from_cents(row.payment_amount_cents) %>
+                    </span>
+                  <% when :free %>
+                    <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-600" title="Free event — nothing to apply the amount against">
+                      Free event — not applied
+                    </span>
+                  <% when :unknown_type %>
+                    <span class="inline-flex items-center rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800" title="Unrecognized payment type — no payment recorded">
+                      Unknown type<%= ": #{row.payment_label}" if row.payment_label.present? %>
+                    </span>
+                  <% when :missing_check_number %>
+                    <span class="inline-flex items-center rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800" title="Check payment needs a check number — no payment recorded">
+                      Check # missing
+                    </span>
+                  <% when :invalid %>
+                    <span class="inline-flex items-center rounded-md bg-amber-100 px-2 py-1 text-xs text-amber-800" title="Amount could not be read — no payment recorded">
+                      Bad amount
                     </span>
                   <% else %>
                     <span class="text-gray-400">—</span>

--- a/app/views/event_registration_imports/new.html.erb
+++ b/app/views/event_registration_imports/new.html.erb
@@ -24,7 +24,8 @@
     <span class="font-medium">AmountPaid</span> (and
     <span class="font-medium">PaymentType</span> — cash, check, or card — plus a
     <span class="font-medium">CheckNumber</span> for checks) to record payment and
-    mark the registration paid. Export your spreadsheet as a .csv first.
+    mark the registration paid — a partial amount is topped up with a discount so it
+    still reads as paid. Export your spreadsheet as a .csv first.
   </p>
 
   <div class="rounded bg-white p-6">

--- a/app/views/event_registration_imports/new.html.erb
+++ b/app/views/event_registration_imports/new.html.erb
@@ -20,7 +20,11 @@
     Expected columns: <span class="font-medium">FirstName</span>,
     <span class="font-medium">LastName</span>,
     <span class="font-medium">Organization</span>,
-    <span class="font-medium">EMail</span>. Export your spreadsheet as a .csv first.
+    <span class="font-medium">EMail</span>. Optionally add
+    <span class="font-medium">AmountPaid</span> (and
+    <span class="font-medium">PaymentType</span> — cash, check, or card — plus a
+    <span class="font-medium">CheckNumber</span> for checks) to record payment and
+    mark the registration paid. Export your spreadsheet as a .csv first.
   </p>
 
   <div class="rounded bg-white p-6">

--- a/config/features.yml
+++ b/config/features.yml
@@ -2642,12 +2642,13 @@
   action_path: "/event_registrations/import"
   summary: >-
     Bulk-add attended registrants to an event from a CSV roster. Every row becomes an
-    attended registration, exactly as if the person had registered — matched to an
-    existing person by email and name (no duplicates), with the organization linked
-    when we recognize it.
+    attended registration — matched to an existing person by email and name (no
+    duplicates), with the organization linked when we recognize it. An amount-paid
+    column marks the registration paid too.
   pro_tips:
     - "Expected columns: FirstName, LastName, Organization, EMail. Export your spreadsheet as a .csv first."
-    - "You get a full preview — new vs. matched people, new vs. promoted registrations, and which orgs will link vs. need reconciling — before anything is saved."
+    - "To record payment, add an AmountPaid column (plus PaymentType — cash, check, or card — and a CheckNumber for checks). The amount is applied to the registration so it shows as paid; free events ignore it."
+    - "You get a full preview — new vs. matched people, new vs. promoted registrations, which orgs will link vs. need reconciling, and the payments to record — before anything is saved."
     - "Organizations we don't recognize aren't created; they're queued on each registrant's \"link organization\" page so you can reconcile them the same way as a normal registration."
     - "On facilitator trainings, a linked organization also adds the person's facilitator affiliation."
     - "No emails are sent, so it's safe for historical rosters. Reach it from the \"Import registrants\" button on the registrants page."

--- a/config/features.yml
+++ b/config/features.yml
@@ -2647,7 +2647,7 @@
     column marks the registration paid too.
   pro_tips:
     - "Expected columns: FirstName, LastName, Organization, EMail. Export your spreadsheet as a .csv first."
-    - "To record payment, add an AmountPaid column (plus PaymentType — cash, check, or card — and a CheckNumber for checks). The amount is applied to the registration so it shows as paid; free events ignore it."
+    - "To record payment, add an AmountPaid column (plus PaymentType — cash, check, or card — and a CheckNumber for checks). The amount is applied to the registration so it shows as paid; a partial amount is topped up with a discount for the difference. Free events ignore it."
     - "You get a full preview — new vs. matched people, new vs. promoted registrations, which orgs will link vs. need reconciling, and the payments to record — before anything is saved."
     - "Organizations we don't recognize aren't created; they're queued on each registrant's \"link organization\" page so you can reconcile them the same way as a normal registration."
     - "On facilitator trainings, a linked organization also adds the person's facilitator affiliation."

--- a/spec/fixtures/files/event_registrants_import.csv
+++ b/spec/fixtures/files/event_registrants_import.csv
@@ -1,6 +1,6 @@
 FirstName,LastName,Organization,EMail,AmountPaid,PaymentType,CheckNumber
-Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,$10.99,Cash,
+Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,$5.00,Cash,
 Mariel,Acosta,Unknown Org LLC,macosta@wrcnbc.org,10.99,Check,12345
 Kaela,Adams,A New Leaf,kadams@rcoe.us,,,
-Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,10.99,Cash,
+Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,5.00,Cash,
 Angel,,A New Leaf,angel.agudo@alvordschools.org,10.99,Cash,

--- a/spec/fixtures/files/event_registrants_import.csv
+++ b/spec/fixtures/files/event_registrants_import.csv
@@ -1,6 +1,6 @@
-FirstName,LastName,Organization,EMail
-Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org
-Mariel,Acosta,Unknown Org LLC,macosta@wrcnbc.org
-Kaela,Adams,A New Leaf,kadams@rcoe.us
-Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org
-Angel,,A New Leaf,angel.agudo@alvordschools.org
+FirstName,LastName,Organization,EMail,AmountPaid,PaymentType,CheckNumber
+Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,$10.99,Cash,
+Mariel,Acosta,Unknown Org LLC,macosta@wrcnbc.org,10.99,Check,12345
+Kaela,Adams,A New Leaf,kadams@rcoe.us,,,
+Cidney,Acosta,A New Leaf,cacosta@turnanewleaf.org,10.99,Cash,
+Angel,,A New Leaf,angel.agudo@alvordschools.org,10.99,Cash,

--- a/spec/requests/event_registration_imports_spec.rb
+++ b/spec/requests/event_registration_imports_spec.rb
@@ -97,11 +97,13 @@ RSpec.describe "Event registration imports", type: :request do
       expect(flash[:notice]).to match(/3 attended registrations created/)
     end
 
-    it "records the payments carried on the sheet" do
+    it "records the payments and comping discounts carried on the sheet" do
       expect {
         post confirm_event_registration_import_path,
              params: { signed_id: signed_blob, event_id: event.id }
-      }.to change(Payment, :count).by(2).and change(Allocation, :count).by(2)
+      }.to change(Payment, :count).by(2)
+        .and change(Discount, :count).by(1)
+        .and change(Allocation, :count).by(3)
 
       expect(flash[:notice]).to match(/2 payments/)
     end

--- a/spec/requests/event_registration_imports_spec.rb
+++ b/spec/requests/event_registration_imports_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe "Event registration imports", type: :request do
       expect(flash[:notice]).to match(/3 attended registrations created/)
     end
 
+    it "records the payments carried on the sheet" do
+      expect {
+        post confirm_event_registration_import_path,
+             params: { signed_id: signed_blob, event_id: event.id }
+      }.to change(Payment, :count).by(2).and change(Allocation, :count).by(2)
+
+      expect(flash[:notice]).to match(/2 payments/)
+    end
+
     it "redirects with an alert when the upload is gone" do
       post confirm_event_registration_import_path,
            params: { signed_id: "bogus", event_id: event.id }

--- a/spec/services/event_registration_importer_spec.rb
+++ b/spec/services/event_registration_importer_spec.rb
@@ -52,9 +52,16 @@ RSpec.describe EventRegistrationImporter do
       expect(result.organizations_to_reconcile).to eq(1)
     end
 
+    it "counts the rows carrying a payment and their total" do
+      expect(result.payments_recorded).to eq(2)
+      expect(result.payments_amount_cents).to eq(2198)
+    end
+
     it "writes nothing" do
       expect { import(dry_run: true) }.not_to change(Person, :count)
       expect { import(dry_run: true) }.not_to change(FormSubmission, :count)
+      expect { import(dry_run: true) }.not_to change(Payment, :count)
+      expect { import(dry_run: true) }.not_to change(Allocation, :count)
     end
   end
 
@@ -172,6 +179,65 @@ RSpec.describe EventRegistrationImporter do
         person = Person.find_by(email: "cacosta@turnanewleaf.org")
         expect(registration_for("cacosta@turnanewleaf.org").organizations.pluck(:name)).to eq([ "A New Leaf" ])
         expect(person.affiliations.where(title: Affiliation::FACILITATOR_TITLE)).to be_empty
+      end
+    end
+  end
+
+  describe "payments" do
+    it "records a payment and allocation that marks the registration paid" do
+      import(dry_run: false)
+      registration = registration_for("cacosta@turnanewleaf.org")
+
+      expect(registration).to be_paid_in_full
+      expect(registration).to be_payment_received
+      allocation = registration.allocations.find_by(source_type: "Payment")
+      expect(allocation.amount).to eq(1099)
+      expect(allocation.source).to be_a(CashPayment)
+    end
+
+    it "uses the check number for a check-type row" do
+      import(dry_run: false)
+      registration = registration_for("macosta@wrcnbc.org")
+      payment = registration.allocations.find_by(source_type: "Payment").source
+
+      expect(payment).to be_a(CheckPayment)
+      expect(payment.check_number).to eq("12345")
+    end
+
+    it "records no payment for a row without an amount" do
+      import(dry_run: false)
+      registration = registration_for("kadams@rcoe.us")
+      expect(registration.allocations).to be_empty
+    end
+
+    it "creates one payment per paying row" do
+      expect { import(dry_run: false) }.to change(Payment, :count).by(2)
+    end
+
+    it "stamps the payment as imported and scoped to the event" do
+      import(dry_run: false)
+      payment = registration_for("cacosta@turnanewleaf.org").allocations.find_by(source_type: "Payment").source
+      expect(payment.metadata).to include("imported_from", "event_id" => event.id)
+    end
+
+    it "reports the payments recorded and their total" do
+      result = import(dry_run: false)
+      expect(result.payments_recorded).to eq(2)
+      expect(result.payments_amount_cents).to eq(2198)
+    end
+
+    it "is idempotent — re-running adds no duplicate payments or allocations" do
+      import(dry_run: false)
+      expect { import(dry_run: false) }.not_to change(Payment, :count)
+      expect { import(dry_run: false) }.not_to change(Allocation, :count)
+    end
+
+    context "on a free event" do
+      let(:event) { create(:event, cost_cents: 0, facilitator_training: true) }
+
+      it "ignores the amount and records no payment" do
+        expect { import(dry_run: false) }.not_to change(Payment, :count)
+        expect(registration_for("cacosta@turnanewleaf.org").allocations).to be_empty
       end
     end
   end

--- a/spec/services/event_registration_importer_spec.rb
+++ b/spec/services/event_registration_importer_spec.rb
@@ -54,13 +54,19 @@ RSpec.describe EventRegistrationImporter do
 
     it "counts the rows carrying a payment and their total" do
       expect(result.payments_recorded).to eq(2)
-      expect(result.payments_amount_cents).to eq(2198)
+      expect(result.payments_amount_cents).to eq(1599)
+    end
+
+    it "counts the discount that comps an underpaid row" do
+      expect(result.discounts_recorded).to eq(1)
+      expect(result.discounts_amount_cents).to eq(599)
     end
 
     it "writes nothing" do
       expect { import(dry_run: true) }.not_to change(Person, :count)
       expect { import(dry_run: true) }.not_to change(FormSubmission, :count)
       expect { import(dry_run: true) }.not_to change(Payment, :count)
+      expect { import(dry_run: true) }.not_to change(Discount, :count)
       expect { import(dry_run: true) }.not_to change(Allocation, :count)
     end
   end
@@ -184,15 +190,32 @@ RSpec.describe EventRegistrationImporter do
   end
 
   describe "payments" do
-    it "records a payment and allocation that marks the registration paid" do
+    it "records the payment actually paid and marks the registration paid in full" do
       import(dry_run: false)
       registration = registration_for("cacosta@turnanewleaf.org")
 
       expect(registration).to be_paid_in_full
       expect(registration).to be_payment_received
       allocation = registration.allocations.find_by(source_type: "Payment")
-      expect(allocation.amount).to eq(1099)
+      expect(allocation.amount).to eq(500)
       expect(allocation.source).to be_a(CashPayment)
+    end
+
+    it "comps the unpaid remainder with a discount so a partial payment reads as paid" do
+      import(dry_run: false)
+      registration = registration_for("cacosta@turnanewleaf.org")
+      discount_allocation = registration.allocations.find_by(source_type: "Discount")
+
+      expect(discount_allocation.amount).to eq(599)
+      expect(registration.allocations_sum).to eq(1099)
+    end
+
+    it "creates no discount when the payment covers the full cost" do
+      import(dry_run: false)
+      registration = registration_for("macosta@wrcnbc.org")
+
+      expect(registration.allocations.where(source_type: "Discount")).to be_empty
+      expect(registration.allocations.find_by(source_type: "Payment").amount).to eq(1099)
     end
 
     it "uses the check number for a check-type row" do
@@ -204,14 +227,16 @@ RSpec.describe EventRegistrationImporter do
       expect(payment.check_number).to eq("12345")
     end
 
-    it "records no payment for a row without an amount" do
+    it "records no payment or discount for a row without an amount" do
       import(dry_run: false)
       registration = registration_for("kadams@rcoe.us")
       expect(registration.allocations).to be_empty
     end
 
-    it "creates one payment per paying row" do
-      expect { import(dry_run: false) }.to change(Payment, :count).by(2)
+    it "creates one payment per paying row and a discount only for the underpaid one" do
+      expect { import(dry_run: false) }
+        .to change(Payment, :count).by(2)
+        .and change(Discount, :count).by(1)
     end
 
     it "stamps the payment as imported and scoped to the event" do
@@ -220,23 +245,27 @@ RSpec.describe EventRegistrationImporter do
       expect(payment.metadata).to include("imported_from", "event_id" => event.id)
     end
 
-    it "reports the payments recorded and their total" do
+    it "reports the payments and discounts recorded" do
       result = import(dry_run: false)
       expect(result.payments_recorded).to eq(2)
-      expect(result.payments_amount_cents).to eq(2198)
+      expect(result.payments_amount_cents).to eq(1599)
+      expect(result.discounts_recorded).to eq(1)
+      expect(result.discounts_amount_cents).to eq(599)
     end
 
-    it "is idempotent — re-running adds no duplicate payments or allocations" do
+    it "is idempotent — re-running adds no duplicate payments, discounts, or allocations" do
       import(dry_run: false)
       expect { import(dry_run: false) }.not_to change(Payment, :count)
+      expect { import(dry_run: false) }.not_to change(Discount, :count)
       expect { import(dry_run: false) }.not_to change(Allocation, :count)
     end
 
     context "on a free event" do
       let(:event) { create(:event, cost_cents: 0, facilitator_training: true) }
 
-      it "ignores the amount and records no payment" do
+      it "ignores the amount, recording no payment or discount" do
         expect { import(dry_run: false) }.not_to change(Payment, :count)
+        expect { import(dry_run: false) }.not_to change(Discount, :count)
         expect(registration_for("cacosta@turnanewleaf.org").allocations).to be_empty
       end
     end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained addition to one service + its preview view; money math (payment + comping discount) capped at remaining cost, covered by specs

Roster imports now mark registrations paid, so facilitators don't have to re-enter payments by hand after importing a spreadsheet of attendees.

## What changed
- **New optional CSV columns**: `AmountPaid`, `PaymentType` (cash / check / card, defaults to cash), `CheckNumber` (for checks).
- Each paying row **finds-or-creates a payment**, then an **allocation** applied to the registration.
- **Partial amounts are comped**: when `AmountPaid` is less than the event cost, a `Discount` allocation covers the difference (e.g. $50 paid on a $750 event → $700 discount), so the registration reads **Paid**. A full payment leaves no discount.
- The preview shows a **Payment** column (with the comping discount) and **Payments / Amount / Discounts / Comped** tiles before anything is saved.

## Why it's safe with money
- The payment match is keyed by the import's own metadata **+ person + amount + type + event id**, so re-running the import adds nothing and imports into different events never steal each other's payments.
- Both allocations are capped at the registration's `remaining_cost`; **free events ignore the amount** (nothing to allocate against).
- It reuses only its *own* import-created payments — it does not attach unrelated existing payments. (Matching pre-existing FileMaker/Stripe payments from the payments index is a possible follow-up — flagged as riskier since the sheet has no reliable key to match those on.)

## Notes
- **The comp always tops up to the full cost.** Every underpaid row is treated as fully settled (paid + comped). If some imported registrants genuinely still owe a balance, that's a different rule — say the word and I'll gate it behind a column.
- Bad amount, unknown payment type, and a check row missing its number are surfaced in the preview and simply record no payment (the registration is still created).