### PR TITLE
Show admins the full person record on the profile (admin-only)

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -145,6 +145,23 @@ module PersonHelper
             class: "font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
   end
 
+  # Profile pieces the person has opted to hide (a `profile_show_*` flag turned
+  # off) are still revealed to admins, with a blue admin-only wash + eye-slash
+  # badge, so admins always see the full record. `flag` is a `profile_show_*`
+  # attribute name (symbol).
+  def profile_piece_shown?(person, flag)
+    person.public_send(:"#{flag}?") || profile_piece_hidden_for_admin?(person, flag)
+  end
+
+  def profile_piece_hidden_for_admin?(person, flag)
+    !person.public_send(:"#{flag}?") && allowed_to?(:manage?, Person)
+  end
+
+  # Wash for a block-level profile piece the person hid but the admin still sees.
+  def profile_hidden_section_class
+    "admin-only rounded-xl border border-blue-200 bg-blue-100 p-4"
+  end
+
   private
 
   # Shared color palette for the person profile/edit buttons, keyed off the same

--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -162,6 +162,12 @@ module PersonHelper
     "admin-only rounded-xl border border-blue-200 bg-blue-100 p-4"
   end
 
+  # Blue admin-only pill for record data that lives only on the edit form and has
+  # no public profile home (contact/identity extras, internal fields).
+  def admin_only_chip_class
+    "admin-only inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-100 px-3 py-1 text-blue-900"
+  end
+
   private
 
   # Shared color palette for the person profile/edit buttons, keyed off the same

--- a/app/views/people/_admin_details.html.erb
+++ b/app/views/people/_admin_details.html.erb
@@ -1,0 +1,91 @@
+<%# Admin-only dossier: record data managed on the edit form that has no public
+    profile home — professional licenses, addresses, internal fields, and profile
+    preferences. Gated by `manage?` at the call site. Locals: person. %>
+<% licenses = person.professional_licenses.to_a %>
+<% addresses = person.addresses.reject(&:inactive?) %>
+<% staff_tag_names = person.staff_tags.map(&:name) %>
+<% news_topics = person.topic_subscriptions.active.map(&:topic_label).compact_blank %>
+<div class="admin-only overflow-hidden rounded-2xl border-2 border-blue-200 bg-blue-50 shadow-sm">
+  <div class="flex items-center gap-3 border-b border-blue-200 bg-blue-100 px-5 py-4 sm:px-6">
+    <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 text-blue-800">
+      <i class="fa-solid fa-lock"></i>
+    </span>
+    <h2 class="font-display text-2xl text-gray-900">Admin details</h2>
+    <span class="ml-auto"><%= render "people/admin_only_badge" %></span>
+  </div>
+  <div class="space-y-6 px-4 py-5 sm:px-6 sm:py-6">
+    <% if licenses.any? %>
+      <div>
+        <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Professional licenses</h3>
+        <div class="space-y-2">
+          <% licenses.each do |license| %>
+            <% badge = license.decorate.expiry_badge %>
+            <div class="flex flex-wrap items-center gap-2 rounded-lg border border-blue-200 bg-white px-3 py-2">
+              <span class="font-medium text-gray-900"><%= license.name %></span>
+              <% if license.issuing_state.present? %>
+                <span class="text-sm text-gray-500"><%= license.issuing_state %></span>
+              <% end %>
+              <%= render "shared/badge", label: badge.label, classes: badge.classes, icon: badge.icon %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <% if addresses.any? %>
+      <div>
+        <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Addresses</h3>
+        <div class="space-y-2">
+          <% addresses.each do |address| %>
+            <div class="rounded-lg border border-blue-200 bg-white px-3 py-2">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-medium text-gray-900"><%= address.name %></span>
+                <% if address.primary? %>
+                  <span class="text-2xs rounded-full bg-blue-100 px-2 py-0.5 tracking-wide text-blue-700 uppercase">Primary</span>
+                <% end %>
+              </div>
+              <div class="mt-0.5 flex flex-wrap gap-x-3 text-sm text-gray-500">
+                <% if address.address_type.present? %><span><%= address.address_type.titleize %></span><% end %>
+                <% if address.locality.present? %><span><%= address.locality %></span><% end %>
+                <% if address.county.present? %><span><%= address.county %> County</span><% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div>
+        <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Internal</h3>
+        <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt class="font-medium text-gray-500">FileMaker code</dt>
+          <dd class="text-gray-900"><%= person.filemaker_code.presence || "—" %></dd>
+          <dt class="font-medium text-gray-500">Racial/ethnic identity</dt>
+          <dd class="text-gray-900"><%= person.racial_ethnic_identity.presence || "—" %></dd>
+          <dt class="font-medium text-gray-500">Staff tags</dt>
+          <dd class="text-gray-900">
+            <% if staff_tag_names.any? %>
+              <span class="flex flex-wrap gap-1.5">
+                <% staff_tag_names.each do |tag_name| %>
+                  <span class="text-2xs inline-flex rounded-full border border-blue-300 bg-white px-2 py-0.5 tracking-wide text-blue-800 uppercase"><%= tag_name %></span>
+                <% end %>
+              </span>
+            <% else %>—<% end %>
+          </dd>
+          <dt class="font-medium text-gray-500">News subscriptions</dt>
+          <dd class="text-gray-900"><%= news_topics.any? ? news_topics.join(", ") : "—" %></dd>
+        </dl>
+      </div>
+      <div>
+        <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Preferences</h3>
+        <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt class="font-medium text-gray-500">Searchable</dt>
+          <dd class="text-gray-900"><%= person.profile_is_searchable? ? "Yes" : "No" %></dd>
+          <dt class="font-medium text-gray-500">Display name</dt>
+          <dd class="text-gray-900"><%= Person::DISPLAY_NAME_PREFERENCE_LABELS[person.display_name_preference] || "—" %></dd>
+          <dt class="font-medium text-gray-500">Contributions</dt>
+          <dd class="text-gray-900"><%= Person::ANONYMOUS_CONTRIBUTIONS_OPTIONS[person.anonymous_contributions] %></dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/people/_admin_details.html.erb
+++ b/app/views/people/_admin_details.html.erb
@@ -4,7 +4,7 @@
 <% licenses = person.professional_licenses.to_a %>
 <% addresses = person.addresses.reject(&:inactive?) %>
 <% staff_tag_names = person.staff_tags.map(&:name) %>
-<% news_topics = person.topic_subscriptions.active.map(&:topic_label).compact_blank %>
+<% topic_labels = person.topic_subscriptions.active.map(&:topic_label).compact_blank %>
 <div class="admin-only overflow-hidden rounded-2xl border-2 border-blue-200 bg-blue-50 shadow-sm">
   <div class="flex items-center gap-3 border-b border-blue-200 bg-blue-100 px-5 py-4 sm:px-6">
     <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 text-blue-800">
@@ -14,6 +14,30 @@
     <span class="ml-auto"><%= render "people/admin_only_badge" %></span>
   </div>
   <div class="space-y-6 px-4 py-5 sm:px-6 sm:py-6">
+    <% program_categories = person.categorizable_items.filter_map(&:category).select { |c| c.category_type&.profile_specific? && c.category_type.name != "AgeRange" }.group_by(&:category_type) %>
+    <% other_settings = person.other_workshop_setting_responses %>
+    <% if program_categories.any? || other_settings.any? %>
+      <div>
+        <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Program settings</h3>
+        <% program_categories.sort_by { |type, _| type.name.to_s.downcase }.each do |type, cats| %>
+          <div class="mb-2">
+            <h4 class="text-sm font-medium text-gray-600"><%= type.display_label %></h4>
+            <div class="mt-1 flex flex-wrap gap-1.5">
+              <% cats.sort_by { |c| c.name.to_s.downcase }.each do |category| %>
+                <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900"><%= category.name %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+        <% if other_settings.any? %>
+          <div class="mt-2 flex flex-wrap gap-1.5">
+            <% other_settings.each do |response| %>
+              <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900 italic"><%= response %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
     <% if licenses.any? %>
       <div>
         <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Professional licenses</h3>
@@ -71,8 +95,8 @@
               </span>
             <% else %>—<% end %>
           </dd>
-          <dt class="font-medium text-gray-500">News subscriptions</dt>
-          <dd class="text-gray-900"><%= news_topics.any? ? news_topics.join(", ") : "—" %></dd>
+          <dt class="font-medium text-gray-500">Topic subscriptions</dt>
+          <dd class="text-gray-900"><%= topic_labels.any? ? topic_labels.join(", ") : "—" %></dd>
         </dl>
       </div>
       <div>

--- a/app/views/people/_admin_details.html.erb
+++ b/app/views/people/_admin_details.html.erb
@@ -128,5 +128,39 @@
         </dl>
       </div>
     </div>
+    <%# Most recent 3 of the merged comments + communications feed. Same row
+        partials as the full feed; "View all" opens it. %>
+    <% if allowed_to?(:manage?, Comment) %>
+      <% comment_entries = person.comments.to_a %>
+      <% communication_entries = person.communications_scope.order(created_at: :desc).to_a %>
+      <% activity_total = comment_entries.size + communication_entries.size %>
+      <% recent_activity = (comment_entries + communication_entries).sort_by(&:created_at).reverse.first(3) %>
+      <% if recent_activity.any? %>
+        <div>
+          <div class="mb-2 flex flex-wrap items-center gap-2">
+            <h3 class="text-sm font-semibold tracking-wide text-gray-700 uppercase">Comments &amp; communications</h3>
+            <% if activity_total > recent_activity.size %>
+              <%= link_to "View all #{activity_total}", comments_and_communications_person_path(person), class: "text-xs text-blue-600 underline hover:text-blue-800", target: "_blank", rel: "noopener" %>
+            <% end %>
+          </div>
+          <div class="space-y-2">
+            <% recent_activity.each do |entry| %>
+              <% if entry.is_a?(Comment) %>
+                <div class="rounded-md border <%= comment_card_class(warning: entry.body&.include?("[AGE_RANGE_DATA]")) %> px-3 py-2">
+                  <div class="flex flex-wrap items-start gap-x-1 gap-y-1">
+                    <span class="mt-0.5 inline-flex w-4 shrink-0 justify-center leading-none" title="<%= entry.flagged? ? "Flagged for follow-up" : "Not flagged" %>">
+                      <i class="fa-flag <%= entry.flagged? ? "fa-solid text-orange-500" : "fa-regular text-gray-400" %>"></i>
+                    </span>
+                    <%= render "comments/comment_line", comment: entry %>
+                  </div>
+                </div>
+              <% else %>
+                <%= render "notifications/communication_line", notification: entry, admin: true %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/people/_admin_details.html.erb
+++ b/app/views/people/_admin_details.html.erb
@@ -2,7 +2,7 @@
     profile home — professional licenses, addresses, internal fields, and profile
     preferences. Gated by `manage?` at the call site. Locals: person. %>
 <% licenses = person.professional_licenses.to_a %>
-<% addresses = person.addresses.reject(&:inactive?) %>
+<% addresses = person.addresses.to_a %>
 <% staff_tag_names = person.staff_tags.map(&:name) %>
 <% topic_labels = person.topic_subscriptions.active.map(&:topic_label).compact_blank %>
 <div class="admin-only overflow-hidden rounded-2xl border-2 border-blue-200 bg-blue-50 shadow-sm">
@@ -60,17 +60,26 @@
         <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Addresses</h3>
         <div class="space-y-2">
           <% addresses.each do |address| %>
-            <div class="rounded-lg border border-blue-200 bg-white px-3 py-2">
+            <div class="rounded-lg border border-blue-200 bg-white px-3 py-2 <%= "opacity-60" if address.inactive? %>">
               <div class="flex flex-wrap items-center gap-2">
                 <span class="font-medium text-gray-900"><%= address.name %></span>
                 <% if address.primary? %>
                   <span class="text-2xs rounded-full bg-blue-100 px-2 py-0.5 tracking-wide text-blue-700 uppercase">Primary</span>
                 <% end %>
+                <% if address.inactive? %>
+                  <span class="text-2xs rounded-full bg-gray-100 px-2 py-0.5 tracking-wide text-gray-500 uppercase">Inactive</span>
+                <% end %>
               </div>
-              <div class="mt-0.5 flex flex-wrap gap-x-3 text-sm text-gray-500">
+              <div class="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-sm text-gray-500">
                 <% if address.address_type.present? %><span><%= address.address_type.titleize %></span><% end %>
                 <% if address.locality.present? %><span><%= address.locality %></span><% end %>
                 <% if address.county.present? %><span><%= address.county %> County</span><% end %>
+                <% if address.country.present? %><span><%= address.country %></span><% end %>
+                <% if address.district.present? %><span>District <%= address.district %></span><% end %>
+                <% if address.la_city_council_district.present? %><span>LA council district <%= address.la_city_council_district %></span><% end %>
+                <% if address.la_supervisorial_district.present? %><span>LA supervisorial district <%= address.la_supervisorial_district %></span><% end %>
+                <% if address.la_service_planning_area.present? %><span>LA SPA <%= address.la_service_planning_area %></span><% end %>
+                <% if address.phone.present? %><span><i class="fa-solid fa-phone text-2xs"></i> <%= address.phone %></span><% end %>
               </div>
             </div>
           <% end %>
@@ -82,7 +91,15 @@
         <h3 class="mb-2 text-sm font-semibold tracking-wide text-gray-700 uppercase">Internal</h3>
         <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
           <dt class="font-medium text-gray-500">FileMaker code</dt>
-          <dd class="text-gray-900"><%= person.filemaker_code.presence || "—" %></dd>
+          <dd class="text-gray-900">
+            <% if person.filemaker_code.present? %>
+              <% if FmRolodex.exists?(fm_id: person.filemaker_code) %>
+                <%= link_to person.filemaker_code, fm_archive_path(person.filemaker_code, table: "rolodexes"), class: "text-blue-600 underline hover:text-blue-800", target: "_blank", rel: "noopener" %>
+              <% else %>
+                <%= person.filemaker_code %>
+              <% end %>
+            <% else %>—<% end %>
+          </dd>
           <dt class="font-medium text-gray-500">Racial/ethnic identity</dt>
           <dd class="text-gray-900"><%= person.racial_ethnic_identity.presence || "—" %></dd>
           <dt class="font-medium text-gray-500">Staff tags</dt>

--- a/app/views/people/_admin_only_badge.html.erb
+++ b/app/views/people/_admin_only_badge.html.erb
@@ -1,0 +1,7 @@
+<%# Admin-only marker: record data managed on the edit form, surfaced read-only
+    for admins only (blue admin-only wash + lock). Distinct from the eye-slash
+    "Hidden from profile" badge, which marks a piece the person chose to hide. %>
+<span class="admin-only text-2xs inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-100 px-2 py-0.5 font-semibold tracking-wide text-blue-800 uppercase"
+      title="Internal admin data. Only admins can see this.">
+  <i class="fa-solid fa-lock"></i> Admin only
+</span>

--- a/app/views/people/_hidden_from_profile.html.erb
+++ b/app/views/people/_hidden_from_profile.html.erb
@@ -1,0 +1,6 @@
+<%# Admin-only marker: this piece was hidden from the public profile by the
+    person, but admins still see it (blue admin-only wash + eye-slash). %>
+<span class="admin-only text-2xs inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-100 px-2 py-0.5 font-semibold tracking-wide text-blue-800 uppercase"
+      title="Hidden from the public profile. Only admins can see this.">
+  <i class="fa-solid fa-eye-slash"></i> Hidden from profile
+</span>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -258,35 +258,9 @@
         <% end %>
       </div>
     </div>
-    <%# Program settings (profile-specific categories) — admin-only, no public home. %>
+    <!-- ADMIN DETAILS (record data with no public profile home) -->
     <% if allowed_to?(:manage?, Person) %>
-      <% program_categories = @person.categorizable_items.filter_map(&:category).select { |c| c.category_type&.profile_specific? && c.category_type.name != "AgeRange" }.group_by(&:category_type) %>
-      <% other_settings = @person.other_workshop_setting_responses %>
-      <% if program_categories.any? || other_settings.any? %>
-        <div class="admin-only rounded-xl border border-blue-200 bg-blue-100 p-4">
-          <div class="mb-3 flex flex-wrap items-center gap-2">
-            <h2 class="font-display text-2xl text-gray-900">Program settings</h2>
-            <%= render "people/admin_only_badge" %>
-          </div>
-          <% program_categories.sort_by { |type, _| type.name.to_s.downcase }.each do |type, cats| %>
-            <div class="mb-2">
-              <h3 class="text-sm font-semibold text-gray-700"><%= type.display_label %></h3>
-              <div class="mt-1 flex flex-wrap gap-1.5">
-                <% cats.sort_by { |c| c.name.to_s.downcase }.each do |category| %>
-                  <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900"><%= category.name %></span>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-          <% if other_settings.any? %>
-            <div class="mt-2 flex flex-wrap gap-1.5">
-              <% other_settings.each do |response| %>
-                <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900 italic"><%= response %></span>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+      <%= render "people/admin_details", person: @person %>
     <% end %>
     <!-- Bio -->
     <% if @person.bio.present? && profile_piece_shown?(@person, :profile_show_bio) %>
@@ -400,10 +374,6 @@
         edit page (Membership section there), not on the public-facing profile. %>
     <% if allowed_to?(:own_membership?, @person) %>
       <%= render "people/my_membership", membership: @membership, autopay: @membership_autopay %>
-    <% end %>
-    <!-- ADMIN DETAILS (record data with no public profile home) -->
-    <% if allowed_to?(:manage?, Person) %>
-      <%= render "people/admin_details", person: @person %>
     <% end %>
     <!-- SUBMITTED SECTION -->
     <% if allowed_to?(:own_record?, @person) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -93,7 +93,7 @@
               (@person.legal_first_name.present? || @person.pronunciation.present? || @person.date_of_birth.present? || @person.user&.time_zone.present?) %>
           <div class="admin-only mt-2 flex flex-wrap items-center justify-center gap-2 md:justify-start">
             <% if @person.legal_first_name.present? && @person.legal_first_name != @person.first_name %>
-              <span class="<%= admin_only_chip_class %> text-sm" title="Legal first name (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Legal: <%= @person.legal_first_name %></span>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Legal first name (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Legal first name: <%= @person.legal_first_name %></span>
             <% end %>
             <% if @person.pronunciation.present? %>
               <span class="<%= admin_only_chip_class %> text-sm" title="Name pronunciation (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Say: <%= @person.pronunciation %></span>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -376,23 +376,6 @@
     <% if allowed_to?(:own_membership?, @person) %>
       <%= render "people/my_membership", membership: @membership, autopay: @membership_autopay %>
     <% end %>
-    <!-- COMMENTS & COMMUNICATIONS (admin-only; lazy-loads the shared feed) -->
-    <% if allowed_to?(:manage?, Comment) %>
-      <div class="admin-only overflow-hidden rounded-2xl border-2 border-blue-200 bg-blue-50 shadow-sm">
-        <div class="flex items-center gap-3 border-b border-blue-200 bg-blue-100 px-5 py-4 sm:px-6">
-          <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 text-blue-800">
-            <i class="fa-solid fa-comments"></i>
-          </span>
-          <h2 class="font-display text-2xl text-gray-900">Comments &amp; communications</h2>
-          <span class="ml-auto"><%= render "people/admin_only_badge" %></span>
-        </div>
-        <div class="px-4 py-5 sm:px-6 sm:py-6">
-          <%= turbo_frame_tag "comments_and_communications_results", src: comments_and_communications_person_path(@person), loading: :lazy do %>
-            <p class="text-gray-500 italic">Loading comments &amp; communications...</p>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
     <!-- SUBMITTED SECTION -->
     <% if allowed_to?(:own_record?, @person) %>
       <div class="user-only border-2 bg-white <%= DomainTheme.border_class_for(:user_only) %> overflow-hidden rounded-2xl shadow-sm"

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -109,14 +109,15 @@
         <!-- Contact info + social -->
         <div class="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm md:justify-start">
           <% email = @person.user&.email || @person.email %>
+          <% email_type = @person.email_type.presence || @person.user&.email_type %>
           <% if email.present? %>
             <% if @person.profile_show_email? %>
               <span class="inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-gray-700">
-                <i class="fa-solid fa-envelope text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on-->
+                <i class="fa-solid fa-envelope text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on--><% if email_type.present? %> <span class="text-2xs text-gray-500 uppercase">(<%= email_type %>)</span><% end %>
               </span>
             <% elsif allowed_to?(:manage?, Person) %>
               <span class="admin-only inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-100 px-3 py-1 text-blue-900" title="Hidden from profile">
-                <i class="fa-solid fa-eye-slash text-xs text-blue-700"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on-->
+                <i class="fa-solid fa-eye-slash text-xs text-blue-700"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on--><% if email_type.present? %> <span class="text-2xs text-blue-700 uppercase">(<%= email_type %>)</span><% end %>
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
@@ -163,10 +164,10 @@
               </span>
             <% end %>
             <% shown_phone = @person.phone_number %>
-            <% @person.contact_methods.reject(&:inactive?).each do |cm| %>
-              <% next if cm.phone? && cm.value == shown_phone %>
-              <span class="<%= admin_only_chip_class %>" title="<%= cm.kind.humanize %> (admin only)">
-                <i class="fa-solid fa-lock text-xs text-blue-700"></i> <%= cm.value %> <span class="text-2xs text-blue-700 uppercase">(<%= [ cm.kind, cm.contact_type ].compact_blank.join(" · ") %>)</span>
+            <% @person.contact_methods.each do |cm| %>
+              <% next if cm.phone? && !cm.inactive? && cm.value == shown_phone %>
+              <span class="<%= admin_only_chip_class %> <%= "opacity-60" if cm.inactive? %>" title="<%= cm.kind.humanize %> (admin only)">
+                <i class="fa-solid fa-lock text-xs text-blue-700"></i> <%= cm.value %> <span class="text-2xs text-blue-700 uppercase">(<%= [ cm.kind, cm.contact_type, (cm.inactive? ? "inactive" : nil) ].compact_blank.join(" · ") %>)</span>
               </span>
             <% end %>
             <% if @person.best_time_to_call.present? %>
@@ -374,6 +375,23 @@
         edit page (Membership section there), not on the public-facing profile. %>
     <% if allowed_to?(:own_membership?, @person) %>
       <%= render "people/my_membership", membership: @membership, autopay: @membership_autopay %>
+    <% end %>
+    <!-- COMMENTS & COMMUNICATIONS (admin-only; lazy-loads the shared feed) -->
+    <% if allowed_to?(:manage?, Comment) %>
+      <div class="admin-only overflow-hidden rounded-2xl border-2 border-blue-200 bg-blue-50 shadow-sm">
+        <div class="flex items-center gap-3 border-b border-blue-200 bg-blue-100 px-5 py-4 sm:px-6">
+          <span class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-200 text-blue-800">
+            <i class="fa-solid fa-comments"></i>
+          </span>
+          <h2 class="font-display text-2xl text-gray-900">Comments &amp; communications</h2>
+          <span class="ml-auto"><%= render "people/admin_only_badge" %></span>
+        </div>
+        <div class="px-4 py-5 sm:px-6 sm:py-6">
+          <%= turbo_frame_tag "comments_and_communications_results", src: comments_and_communications_person_path(@person), loading: :lazy do %>
+            <p class="text-gray-500 italic">Loading comments &amp; communications...</p>
+          <% end %>
+        </div>
+      </div>
     <% end %>
     <!-- SUBMITTED SECTION -->
     <% if allowed_to?(:own_record?, @person) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -96,7 +96,7 @@
               <span class="<%= admin_only_chip_class %> text-sm" title="Legal first name (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Legal first name: <%= @person.legal_first_name %></span>
             <% end %>
             <% if @person.pronunciation.present? %>
-              <span class="<%= admin_only_chip_class %> text-sm" title="Name pronunciation (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Say: <%= @person.pronunciation %></span>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Name pronunciation (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Pronunciation: <%= @person.pronunciation %></span>
             <% end %>
             <% if @person.date_of_birth.present? %>
               <span class="<%= admin_only_chip_class %> text-sm" title="Birthday (admin only)"><i class="fa-solid fa-cake-candles text-2xs text-blue-700"></i> <%= @person.date_of_birth.strftime("%b %-d") %></span>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -88,6 +88,24 @@
             </p>
           <% end %>
         <% end %>
+        <%# Admin-only identity extras managed on the edit form. %>
+        <% if allowed_to?(:manage?, Person) &&
+              (@person.legal_first_name.present? || @person.pronunciation.present? || @person.date_of_birth.present? || @person.user&.time_zone.present?) %>
+          <div class="admin-only mt-2 flex flex-wrap items-center justify-center gap-2 md:justify-start">
+            <% if @person.legal_first_name.present? && @person.legal_first_name != @person.first_name %>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Legal first name (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Legal: <%= @person.legal_first_name %></span>
+            <% end %>
+            <% if @person.pronunciation.present? %>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Name pronunciation (admin only)"><i class="fa-solid fa-lock text-2xs text-blue-700"></i> Say: <%= @person.pronunciation %></span>
+            <% end %>
+            <% if @person.date_of_birth.present? %>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Birthday (admin only)"><i class="fa-solid fa-cake-candles text-2xs text-blue-700"></i> <%= @person.date_of_birth.strftime("%b %-d") %></span>
+            <% end %>
+            <% if @person.user&.time_zone.present? %>
+              <span class="<%= admin_only_chip_class %> text-sm" title="Time zone (admin only)"><i class="fa-solid fa-clock text-2xs text-blue-700"></i> <%= @person.user.time_zone %></span>
+            <% end %>
+          </div>
+        <% end %>
         <!-- Contact info + social -->
         <div class="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm md:justify-start">
           <% email = @person.user&.email || @person.email %>
@@ -135,6 +153,26 @@
               </span>
             <% else %>
               <%= render "people/social_media_buttons", person: @person %>
+            <% end %>
+          <% end %>
+          <%# Admin-only contact extras that have no public profile home. %>
+          <% if allowed_to?(:manage?, Person) %>
+            <% if @person.email_2.present? %>
+              <span class="<%= admin_only_chip_class %>" title="Secondary email (admin only)">
+                <i class="fa-solid fa-lock text-xs text-blue-700"></i> <!--email_off--><%= mail_to @person.email_2, @person.email_2, class: "hover:text-primary" %><!--email_on--><% if @person.email_2_type.present? %> <span class="text-2xs text-blue-700 uppercase">(<%= @person.email_2_type %>)</span><% end %>
+              </span>
+            <% end %>
+            <% shown_phone = @person.phone_number %>
+            <% @person.contact_methods.reject(&:inactive?).each do |cm| %>
+              <% next if cm.phone? && cm.value == shown_phone %>
+              <span class="<%= admin_only_chip_class %>" title="<%= cm.kind.humanize %> (admin only)">
+                <i class="fa-solid fa-lock text-xs text-blue-700"></i> <%= cm.value %> <span class="text-2xs text-blue-700 uppercase">(<%= [ cm.kind, cm.contact_type ].compact_blank.join(" · ") %>)</span>
+              </span>
+            <% end %>
+            <% if @person.best_time_to_call.present? %>
+              <span class="<%= admin_only_chip_class %>" title="Best time to call (admin only)">
+                <i class="fa-solid fa-clock text-xs text-blue-700"></i> Best time: <%= @person.best_time_to_call %>
+              </span>
             <% end %>
           <% end %>
         </div>
@@ -220,6 +258,36 @@
         <% end %>
       </div>
     </div>
+    <%# Program settings (profile-specific categories) — admin-only, no public home. %>
+    <% if allowed_to?(:manage?, Person) %>
+      <% program_categories = @person.categorizable_items.filter_map(&:category).select { |c| c.category_type&.profile_specific? && c.category_type.name != "AgeRange" }.group_by(&:category_type) %>
+      <% other_settings = @person.other_workshop_setting_responses %>
+      <% if program_categories.any? || other_settings.any? %>
+        <div class="admin-only rounded-xl border border-blue-200 bg-blue-100 p-4">
+          <div class="mb-3 flex flex-wrap items-center gap-2">
+            <h2 class="font-display text-2xl text-gray-900">Program settings</h2>
+            <%= render "people/admin_only_badge" %>
+          </div>
+          <% program_categories.sort_by { |type, _| type.name.to_s.downcase }.each do |type, cats| %>
+            <div class="mb-2">
+              <h3 class="text-sm font-semibold text-gray-700"><%= type.display_label %></h3>
+              <div class="mt-1 flex flex-wrap gap-1.5">
+                <% cats.sort_by { |c| c.name.to_s.downcase }.each do |category| %>
+                  <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900"><%= category.name %></span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+          <% if other_settings.any? %>
+            <div class="mt-2 flex flex-wrap gap-1.5">
+              <% other_settings.each do |response| %>
+                <span class="inline-flex rounded-full border border-blue-300 bg-white px-2.5 py-0.5 text-sm text-blue-900 italic"><%= response %></span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
     <!-- Bio -->
     <% if @person.bio.present? && profile_piece_shown?(@person, :profile_show_bio) %>
       <% bio_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_bio) %>
@@ -332,6 +400,10 @@
         edit page (Membership section there), not on the public-facing profile. %>
     <% if allowed_to?(:own_membership?, @person) %>
       <%= render "people/my_membership", membership: @membership, autopay: @membership_autopay %>
+    <% end %>
+    <!-- ADMIN DETAILS (record data with no public profile home) -->
+    <% if allowed_to?(:manage?, Person) %>
+      <%= render "people/admin_details", person: @person %>
     <% end %>
     <!-- SUBMITTED SECTION -->
     <% if allowed_to?(:own_record?, @person) %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -63,19 +63,26 @@
       </div>
       <div class="flex-1 text-center md:text-left">
         <h1 class="font-display text-primary text-4xl font-semibold tracking-tight">
-          <%= @person.name %><% if @person.profile_show_credentials? && @person.license_credentials.present? %><span class="font-normal text-gray-600">, <%= @person.license_credentials %></span><% end %>
-          <% if @person.pronouns.present? && @person.profile_show_pronouns? %>
-            <span class="font-sans text-base font-normal text-gray-500 italic">(<%= @person.pronouns %>)</span>
+          <%= @person.name %><% if @person.license_credentials.present? && profile_piece_shown?(@person, :profile_show_credentials) %><% if profile_piece_hidden_for_admin?(@person, :profile_show_credentials) %><span class="admin-only rounded bg-blue-100 px-1.5 font-sans text-base font-normal text-blue-800" title="Hidden from profile"><i class="fa-solid fa-eye-slash text-2xs"></i> <%= @person.license_credentials %></span><% else %><span class="font-normal text-gray-600">, <%= @person.license_credentials %></span><% end %><% end %>
+          <% if @person.pronouns.present? && profile_piece_shown?(@person, :profile_show_pronouns) %>
+            <% if profile_piece_hidden_for_admin?(@person, :profile_show_pronouns) %>
+              <span class="admin-only rounded bg-blue-100 px-1.5 font-sans text-base font-normal text-blue-800 italic" title="Hidden from profile"><i class="fa-solid fa-eye-slash text-2xs not-italic"></i> (<%= @person.pronouns %>)</span>
+            <% else %>
+              <span class="font-sans text-base font-normal text-gray-500 italic">(<%= @person.pronouns %>)</span>
+            <% end %>
           <% end %>
         </h1>
-        <% if @person.profile_show_member_since? %>
+        <% if profile_piece_shown?(@person, :profile_show_member_since) %>
+          <% member_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_member_since) %>
           <% if @person.facilitator_since_date.present? %>
-            <p class="mt-1 text-sm text-gray-600">
+            <p class="mt-1 text-sm text-gray-600 <%= "admin-only inline-flex items-center gap-1.5 rounded bg-blue-100 px-2 py-0.5" if member_hidden %>">
+              <% if member_hidden %><i class="fa-solid fa-eye-slash text-2xs text-blue-700" title="Hidden from profile"></i><% end %>
               Facilitator since
               <span class="text-primary font-semibold"><%= @person.facilitator_since_date.strftime("%B %Y") %></span>
             </p>
           <% elsif @person.affiliated_since_date.present? %>
-            <p class="mt-1 text-sm text-gray-600">
+            <p class="mt-1 text-sm text-gray-600 <%= "admin-only inline-flex items-center gap-1.5 rounded bg-blue-100 px-2 py-0.5" if member_hidden %>">
+              <% if member_hidden %><i class="fa-solid fa-eye-slash text-2xs text-blue-700" title="Hidden from profile"></i><% end %>
               Affiliated since
               <span class="text-primary font-semibold"><%= @person.affiliated_since_date.strftime("%B %Y") %></span>
             </p>
@@ -90,8 +97,8 @@
                 <i class="fa-solid fa-envelope text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on-->
               </span>
             <% elsif allowed_to?(:manage?, Person) %>
-              <span class="admin-only inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-gray-700">
-                <i class="fa-solid fa-envelope text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on-->
+              <span class="admin-only inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-100 px-3 py-1 text-blue-900" title="Hidden from profile">
+                <i class="fa-solid fa-eye-slash text-xs text-blue-700"></i> <!--email_off--><%= mail_to email, email, class: "hover:text-primary" %><!--email_on-->
               </span>
             <% end %>
             <% if @person.user&.unconfirmed_email.present? && allowed_to?(:show_email_change?, @person) %>
@@ -108,13 +115,27 @@
             <% end %>
           <% end %>
           <% phone = @person.phone_number || @person.user&.phone %>
-          <% if @person.profile_show_phone? && phone.present? %>
-            <span class="inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-gray-700">
-              <i class="fa-solid fa-phone text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-primary" %>
-            </span>
+          <% if phone.present? && profile_piece_shown?(@person, :profile_show_phone) %>
+            <% if profile_piece_hidden_for_admin?(@person, :profile_show_phone) %>
+              <span class="admin-only inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-100 px-3 py-1 text-blue-900" title="Hidden from profile">
+                <i class="fa-solid fa-eye-slash text-xs text-blue-700"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-primary" %>
+              </span>
+            <% else %>
+              <span class="inline-flex items-center gap-1.5 rounded-full border border-black/5 bg-white px-3 py-1 text-gray-700">
+                <i class="fa-solid fa-phone text-xs <%= DomainTheme.text_class_for(:people, intensity: 600) %>"></i> <%= link_to phone, "tel:#{phone}", class: "hover:text-primary" %>
+              </span>
+            <% end %>
           <% end %>
-          <% if @person.profile_show_social_media? %>
-            <%= render "people/social_media_buttons", person: @person %>
+          <% has_social = [ @person.linked_in_url, @person.instagram_url, @person.facebook_url, @person.twitter_url, @person.youtube_url ].any?(&:present?) %>
+          <% if has_social && profile_piece_shown?(@person, :profile_show_social_media) %>
+            <% if profile_piece_hidden_for_admin?(@person, :profile_show_social_media) %>
+              <span class="admin-only inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-100 px-2 py-1" title="Hidden from profile">
+                <i class="fa-solid fa-eye-slash text-xs text-blue-700"></i>
+                <%= render "people/social_media_buttons", person: @person %>
+              </span>
+            <% else %>
+              <%= render "people/social_media_buttons", person: @person %>
+            <% end %>
           <% end %>
         </div>
         <!-- Badges -->
@@ -134,9 +155,13 @@
     <div>
       <div class="grid grid-cols-1 gap-8 md:grid-cols-5">
         <!-- Organization affiliations -->
-        <% if @person.profile_show_affiliations? %>
-          <div id="affiliations" class="scroll-mt-4 md:col-span-3">
-            <h2 class="mb-3 font-display text-2xl text-gray-900">Affiliations</h2>
+        <% if profile_piece_shown?(@person, :profile_show_affiliations) %>
+          <% affiliations_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_affiliations) %>
+          <div id="affiliations" class="scroll-mt-4 md:col-span-3 <%= profile_hidden_section_class if affiliations_hidden %>">
+            <div class="mb-3 flex flex-wrap items-center gap-2">
+              <h2 class="font-display text-2xl text-gray-900">Affiliations</h2>
+              <%= render "people/hidden_from_profile" if affiliations_hidden %>
+            </div>
             <%= turbo_frame_tag "person_affiliations_section", src: person_path(@person, section: "affiliations"), loading: :lazy do %>
               <p class="text-gray-500 italic">Loading affiliations...</p>
             <% end %>
@@ -147,10 +172,12 @@
             stray legacy tagging is dropped from the displayed list. %>
         <% sectorable_items = @person.sectorable_items.includes(:sector).reject { |si| si.sector&.name == Sector::OTHER_SECTOR_NAME }.sort_by { |si| [ si.is_primary? ? 0 : 1, si.sector&.name.to_s.downcase ] } %>
         <% other_sectors = @person.other_sector_responses %>
-        <% show_sectors = @person.profile_show_sectors? %>
+        <% show_sectors = profile_piece_shown?(@person, :profile_show_sectors) %>
+        <% sectors_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_sectors) %>
         <% primary_age_groups = @person.primary_age_groups.to_a %>
         <% additional_age_groups = @person.additional_age_groups.to_a %>
-        <% show_age = @person.profile_show_age_ranges? && (primary_age_groups.any? || additional_age_groups.any?) %>
+        <% show_age = profile_piece_shown?(@person, :profile_show_age_ranges) && (primary_age_groups.any? || additional_age_groups.any?) %>
+        <% age_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_age_ranges) %>
         <% if show_sectors || show_age %>
           <div class="md:col-span-2">
             <div class="flex items-start gap-4">
@@ -158,8 +185,11 @@
                 <%# One combined list: the primary sector leads as a darker-green
                     starred chip, then additional sectors alphabetically and any
                     free-text "Other" responses. %>
-                <div class="min-w-0 flex-1">
-                  <h2 class="mb-3 font-display text-2xl text-gray-900">Sectors</h2>
+                <div class="min-w-0 flex-1 <%= profile_hidden_section_class if sectors_hidden %>">
+                  <div class="mb-3 flex flex-wrap items-center gap-2">
+                    <h2 class="font-display text-2xl text-gray-900">Sectors</h2>
+                    <%= render "people/hidden_from_profile" if sectors_hidden %>
+                  </div>
                   <% if sectorable_items.any? || other_sectors.any? %>
                     <div class="flex flex-wrap gap-2">
                       <% sectorable_items.each do |si| %>
@@ -177,8 +207,11 @@
                 </div>
               <% end %>
               <% if show_age %>
-                <div class="w-32 flex-shrink-0">
-                  <h2 class="mb-3 font-display text-2xl text-gray-900">Age ranges</h2>
+                <div class="w-32 flex-shrink-0 <%= profile_hidden_section_class if age_hidden %>">
+                  <div class="mb-3 flex flex-wrap items-center gap-2">
+                    <h2 class="font-display text-2xl text-gray-900">Age ranges</h2>
+                    <%= render "people/hidden_from_profile" if age_hidden %>
+                  </div>
                   <%= render "shared/age_group_tags", primary: primary_age_groups, additional: additional_age_groups, compact: true %>
                 </div>
               <% end %>
@@ -188,20 +221,23 @@
       </div>
     </div>
     <!-- Bio -->
-    <% if @person.profile_show_bio? && @person.bio.present? %>
-      <div class="<%= DomainTheme.bg_class_for(:person_bio, intensity: 50) %>
-          border-2 <%= DomainTheme.border_class_for(:person_bio) %> rounded-2xl p-5 sm:p-6">
-        <h2 class="mb-3 font-display text-2xl text-gray-900">Bio</h2>
+    <% if @person.bio.present? && profile_piece_shown?(@person, :profile_show_bio) %>
+      <% bio_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_bio) %>
+      <div class="rounded-2xl border-2 p-5 sm:p-6 <%= bio_hidden ? "admin-only border-blue-200 bg-blue-100" : "#{DomainTheme.bg_class_for(:person_bio, intensity: 50)} #{DomainTheme.border_class_for(:person_bio)}" %>">
+        <div class="mb-3 flex flex-wrap items-center gap-2">
+          <h2 class="font-display text-2xl text-gray-900">Bio</h2>
+          <%= render "people/hidden_from_profile" if bio_hidden %>
+        </div>
         <div class="leading-relaxed text-gray-700">
           <%= sanitize(@person.bio, tags: %w[p br strong em a ul ol li b i], attributes: %w[href]) %>
         </div>
       </div>
     <% end %>
     <!-- AUTHORED SECTION -->
-    <% if @person.profile_show_workshops? ||
-            @person.profile_show_workshop_variations? ||
-            @person.profile_show_stories? ||
-            @person.profile_show_resources?  %>
+    <% if profile_piece_shown?(@person, :profile_show_workshops) ||
+            profile_piece_shown?(@person, :profile_show_workshop_variations) ||
+            profile_piece_shown?(@person, :profile_show_stories) ||
+            profile_piece_shown?(@person, :profile_show_resources) %>
       <div class="person-only border-2 bg-white <%= DomainTheme.border_class_for(:workshops) %> overflow-hidden rounded-2xl shadow-sm">
         <!-- Header -->
         <div class="section-header flex items-center gap-3 border-b px-5 py-4 sm:px-6 <%= DomainTheme.border_class_for(:workshops, intensity: 200) %>">
@@ -213,36 +249,52 @@
         <!-- Contributed Content -->
         <div class="section-content space-y-8 px-4 py-5 sm:space-y-10 sm:px-6 sm:py-6">
           <!-- Workshops authored -->
-          <% if @person.profile_show_workshops? %>
-            <div>
-              <h3 class="mb-3 font-display text-xl text-gray-900">Workshops authored</h3>
+          <% if profile_piece_shown?(@person, :profile_show_workshops) %>
+            <% workshops_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_workshops) %>
+            <div class="<%= profile_hidden_section_class if workshops_hidden %>">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <h3 class="font-display text-xl text-gray-900">Workshops authored</h3>
+                <%= render "people/hidden_from_profile" if workshops_hidden %>
+              </div>
               <%= turbo_frame_tag "person_workshops_section", src: person_path(@person, section: "workshops"), loading: :lazy  do %>
                 <p class="text-gray-500 italic">Loading workshops...</p>
               <% end %>
             </div>
           <% end %>
           <!-- Workshop variations  -->
-          <% if @person.profile_show_workshop_variations? %>
-            <div>
-              <h3 class="mb-3 font-display text-xl text-gray-900">Workshop variations authored</h3>
+          <% if profile_piece_shown?(@person, :profile_show_workshop_variations) %>
+            <% workshop_variations_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_workshop_variations) %>
+            <div class="<%= profile_hidden_section_class if workshop_variations_hidden %>">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <h3 class="font-display text-xl text-gray-900">Workshop variations authored</h3>
+                <%= render "people/hidden_from_profile" if workshop_variations_hidden %>
+              </div>
               <%= turbo_frame_tag "person_workshop_variations_section", src: person_path(@person, section: "workshop_variations"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading workshop variations...</p>
               <% end %>
             </div>
           <% end %>
           <!-- Stories authored -->
-          <% if @person.profile_show_stories? %>
-            <div>
-              <h3 class="mb-3 font-display text-xl text-gray-900">Stories authored/featured</h3>
+          <% if profile_piece_shown?(@person, :profile_show_stories) %>
+            <% stories_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_stories) %>
+            <div class="<%= profile_hidden_section_class if stories_hidden %>">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <h3 class="font-display text-xl text-gray-900">Stories authored/featured</h3>
+                <%= render "people/hidden_from_profile" if stories_hidden %>
+              </div>
               <%= turbo_frame_tag "person_stories_section", src: person_path(@person, section: "stories"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading stories...</p>
               <% end %>
             </div>
           <% end %>
           <!-- Resources authored -->
-          <% if @person.profile_show_resources? %>
-            <div>
-              <h3 class="mb-3 font-display text-xl text-gray-900">Resources authored</h3>
+          <% if profile_piece_shown?(@person, :profile_show_resources) %>
+            <% resources_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_resources) %>
+            <div class="<%= profile_hidden_section_class if resources_hidden %>">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <h3 class="font-display text-xl text-gray-900">Resources authored</h3>
+                <%= render "people/hidden_from_profile" if resources_hidden %>
+              </div>
               <%= turbo_frame_tag "person_resources_section", src: person_path(@person, section: "resources"), loading: :lazy do %>
                 <p class="text-gray-500 italic">Loading resources...</p>
               <% end %>
@@ -252,7 +304,8 @@
       </div>
     <% end %>
     <!-- PARTICIPATION SECTION -->
-    <% if @person.profile_show_events_registered? %>
+    <% if profile_piece_shown?(@person, :profile_show_events_registered) %>
+      <% events_hidden = profile_piece_hidden_for_admin?(@person, :profile_show_events_registered) %>
       <div class="person-only border-2 bg-white <%= DomainTheme.border_class_for(:events) %> overflow-hidden rounded-2xl shadow-sm">
         <!-- Header -->
         <div class="section-header flex items-center gap-3 border-b px-5 py-4 sm:px-6 <%= DomainTheme.border_class_for(:events, intensity: 200) %>">
@@ -263,14 +316,15 @@
         </div>
         <!-- Events attended -->
         <div class="section-content space-y-8 px-4 py-5 sm:space-y-10 sm:px-6 sm:py-6">
-          <% if @person.profile_show_events_registered? %>
-            <div>
-              <h3 class="mb-3 font-display text-xl text-gray-900">Events attended</h3>
-              <%= turbo_frame_tag "person_events_section", src: person_path(@person, section: "events"), loading: :lazy do %>
-                <p class="text-gray-500 italic">Loading events...</p>
-              <% end %>
+          <div class="<%= profile_hidden_section_class if events_hidden %>">
+            <div class="mb-3 flex flex-wrap items-center gap-2">
+              <h3 class="font-display text-xl text-gray-900">Events attended</h3>
+              <%= render "people/hidden_from_profile" if events_hidden %>
             </div>
-          <% end %>
+            <%= turbo_frame_tag "person_events_section", src: person_path(@person, section: "events"), loading: :lazy do %>
+              <p class="text-gray-500 italic">Loading events...</p>
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,16 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "See a person's full record on their profile"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-09-03
+  summary: >-
+    Admins now see a person's full record on their profile: pieces they hid
+    (email, phone, bio, and more) still show to you, marked "Hidden from
+    profile", and data that used to live only on the edit form now sits in an
+    "Admin details" panel.
+  pr_number: 2502
 - name: "Tell comments from emails at a glance on the activity feed"
   area: communications
   display_status: admin_facing

--- a/spec/requests/people_admin_details_spec.rb
+++ b/spec/requests/people_admin_details_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Person profile admin-only details", type: :request do
   admin_visible = [
     "Admin details",
     "Admin only",
-    "Legal: Legalname",
+    "Legal first name: Legalname",
     "SAY-it",
     "Mar 14",
     "secondary@example.com",

--- a/spec/requests/people_admin_details_spec.rb
+++ b/spec/requests/people_admin_details_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe "Person profile admin-only details", type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:owner_user) { create(:user, :with_person) }
+  let(:person) { owner_user.person }
+
+  before do
+    person.update!(
+      first_name: "Realfirst",
+      legal_first_name: "Legalname",
+      pronunciation: "SAY-it",
+      date_of_birth: Date.new(1990, 3, 14),
+      email_2: "secondary@example.com",
+      email_2_type: "work",
+      best_time_to_call: "Mornings",
+      filemaker_code: "FMK-12345",
+      racial_ethnic_identity: "Demographic detail here",
+      display_name_preference: "first_name_only"
+    )
+    person.contact_methods.create!(kind: "whatsapp", value: "555-777-1212", contact_type: "personal")
+    create(:professional_license, person: person, number: "LIC-ADMINTEST", kind: "LCSW", issuing_state: "CA")
+    create(:address, addressable: person, street_address: "123 Admin St")
+    tag = create(:staff_tag, name: "Pipeline VIP")
+    create(:staff_tagging, staff_tag: tag, staff_taggable: person)
+  end
+
+  # Every edit-only piece surfaced on the profile, and the marker text a non-admin
+  # must never see.
+  admin_visible = [
+    "Admin details",
+    "Admin only",
+    "Legal: Legalname",
+    "SAY-it",
+    "Mar 14",
+    "secondary@example.com",
+    "Mornings",
+    "555-777-1212",
+    "LIC-ADMINTEST",
+    "123 Admin St",
+    "Pipeline VIP",
+    "FMK-12345",
+    "Demographic detail here",
+    "First name only"
+  ]
+
+  context "when an admin views the profile" do
+    before do
+      sign_in admin
+      get person_path(person)
+    end
+
+    admin_visible.each do |marker|
+      it "surfaces #{marker.inspect} as admin-only content" do
+        expect(response.body).to include(marker)
+      end
+    end
+  end
+
+  context "when the owner (non-admin) views their own profile" do
+    before do
+      sign_in owner_user
+      get person_path(person)
+    end
+
+    admin_visible.each do |marker|
+      it "hides #{marker.inspect} from the non-admin owner" do
+        expect(response.body).not_to include(marker)
+      end
+    end
+  end
+end

--- a/spec/requests/people_admin_details_spec.rb
+++ b/spec/requests/people_admin_details_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe "Person profile admin-only details", type: :request do
     "Pipeline VIP",
     "FMK-12345",
     "Demographic detail here",
-    "First name only"
+    "First name only",
+    "Comments &amp; communications"
   ]
 
   context "when an admin views the profile" do
@@ -68,5 +69,13 @@ RSpec.describe "Person profile admin-only details", type: :request do
         expect(response.body).not_to include(marker)
       end
     end
+  end
+
+  it "renders the comments & communications frame without error for an admin" do
+    sign_in admin
+    get comments_and_communications_person_path(person),
+        headers: { "Turbo-Frame" => "comments_and_communications_results" }
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("comments_and_communications_results")
   end
 end

--- a/spec/requests/people_admin_details_spec.rb
+++ b/spec/requests/people_admin_details_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Person profile admin-only details", type: :request do
     create(:address, addressable: person, street_address: "123 Admin St")
     tag = create(:staff_tag, name: "Pipeline VIP")
     create(:staff_tagging, staff_tag: tag, staff_taggable: person)
+    create(:comment, commentable: person, body: "Internal note here", created_by: admin)
   end
 
   # Every edit-only piece surfaced on the profile, and the marker text a non-admin
@@ -42,7 +43,8 @@ RSpec.describe "Person profile admin-only details", type: :request do
     "FMK-12345",
     "Demographic detail here",
     "First name only",
-    "Comments &amp; communications"
+    "Comments &amp; communications",
+    "Internal note here"
   ]
 
   context "when an admin views the profile" do

--- a/spec/requests/people_profile_flags_spec.rb
+++ b/spec/requests/people_profile_flags_spec.rb
@@ -39,10 +39,11 @@ RSpec.describe "Person profile flag visibility", type: :request do
           expect(response.body).not_to include(marker)
         end
 
-        it "hides content when admin views profile" do
+        it "reveals content with admin-only styling when admin views profile" do
           sign_in admin
           get person_path(person)
-          expect(response.body).not_to include(marker)
+          expect(response.body).to include(marker)
+          expect(response.body).to include("Hidden from profile")
         end
       end
 
@@ -75,6 +76,13 @@ RSpec.describe "Person profile flag visibility", type: :request do
         get person_path(person)
         expect(response.body).not_to include("LCSW")
       end
+
+      it "reveals the license credentials with admin-only styling when admin views profile" do
+        sign_in admin
+        get person_path(person)
+        expect(response.body).to include("LCSW")
+        expect(response.body).to include("Hidden from profile")
+      end
     end
 
     context "when true" do
@@ -102,6 +110,13 @@ RSpec.describe "Person profile flag visibility", type: :request do
         sign_in owner_user
         get person_path(person)
         expect(response.body).not_to include("fa-linkedin-in")
+      end
+
+      it "reveals social media with admin-only styling when admin views profile" do
+        sign_in admin
+        get person_path(person)
+        expect(response.body).to include("fa-linkedin-in")
+        expect(response.body).to include("Hidden from profile")
       end
     end
 
@@ -138,7 +153,7 @@ RSpec.describe "Person profile flag visibility", type: :request do
         sign_in admin
         get person_path(person)
         expect(response.body).to include(email)
-        expect(response.body).to include("admin-only bg-blue-100")
+        expect(response.body).to include("Hidden from profile")
       end
     end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 admin-only reads across the profile view + request specs; reuses the existing comments feed, no data writes

Admins now see the **full person record on the profile** — every piece the person hid, plus all record data that previously lived only on the edit form. Everything added is admin-only (gated on `manage?` / `Comment#manage?`); non-admins, including the profile's own owner, see none of it.

## Reveal hidden pieces
Every `profile_show_*` piece a person hides is still shown to admins — blue-washed with an eye-slash **"Hidden from profile"** badge (extends what email already did). Covers pronouns, credentials, member-since, phone, social, sectors, age ranges, affiliations, bio, and the Published content / Participation sections.

## Surface edit-only fields (blue wash + lock "Admin only")
- **Inline chips** — legal first name, name pronunciation, birthday, time zone, secondary email + type, primary email type, contact methods (incl. inactive, dimmed), best time to call
- **Admin details panel** (up by the sectors) — program settings (profile-specific categories), professional licenses (with expiry), addresses (full fields: LA districts, district, country, phone; incl. inactive), FileMaker code (links to its archive when present), racial/ethnic identity, staff tags, topic subscriptions, and the searchable / display-name / contributions preferences
- **Comments & communications** — admin-only section that lazy-loads the existing shared feed via the `comments_and_communications` turbo frame (reuses the row partials + aggregator; no form builder)

## Notes
- Two markers keep semantics distinct: eye-slash "Hidden from profile" (person opted out) vs. lock "Admin only" (internal record data).
- Sensitive fields (FileMaker, racial/ethnic identity, staff tags, DOB) are included — admins already see all of them on the edit form, so exposure doesn't widen.
- **Not carried over (by design):** the `profile_show_*` toggles themselves (they *drive* the reveal) and the agreement-form-link *action* (a button, not record data).
- Specs: `people_profile_flags_spec` (reveal), `people_admin_details_spec` (edit-only fields + comments frame, admin-sees / owner-hidden), existing authorization/notifications specs stay green.