### PR TITLE
Greet email recipients by first name only

### DIFF
--- a/app/views/event_mailer/bulk_payment_confirmation.html.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @person.full_name %></strong>,
+    Hello <strong><%= @person.first_name %></strong>,
   </p>
 
   <p>

--- a/app/views/event_mailer/bulk_payment_confirmation.text.erb
+++ b/app/views/event_mailer/bulk_payment_confirmation.text.erb
@@ -1,6 +1,6 @@
 Payment submission received
 
-Hello <%= @person.full_name %>,
+Hello <%= @person.first_name %>,
 
 We've received your payment submission<%= " for the following event" if @event %>:
 

--- a/app/views/event_mailer/event_registration_cancelled.html.erb
+++ b/app/views/event_mailer/event_registration_cancelled.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @person.full_name %></strong>,
+    Hello <strong><%= @person.first_name %></strong>,
   </p>
 
   <p>

--- a/app/views/event_mailer/event_registration_cancelled.text.erb
+++ b/app/views/event_mailer/event_registration_cancelled.text.erb
@@ -1,6 +1,6 @@
 Event registration cancelled
 
-Hello <%= @person.full_name %>,
+Hello <%= @person.first_name %>,
 
 Your registration for the following event has been cancelled:
 

--- a/app/views/event_mailer/event_registration_confirmation.html.erb
+++ b/app/views/event_mailer/event_registration_confirmation.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @person.full_name %></strong>,
+    Hello <strong><%= @person.first_name %></strong>,
   </p>
 
   <p>

--- a/app/views/event_mailer/event_registration_confirmation.text.erb
+++ b/app/views/event_mailer/event_registration_confirmation.text.erb
@@ -1,6 +1,6 @@
 Event registration received
 
-Hello <%= @person.full_name %>,
+Hello <%= @person.first_name %>,
 
 This message confirms your registration for the following event:
 

--- a/app/views/event_mailer/event_registration_reminder.html.erb
+++ b/app/views/event_mailer/event_registration_reminder.html.erb
@@ -1,7 +1,7 @@
 <h1>Event reminder</h1>
 
 <div style="margin-top: 36px; text-align: left;">
-  <p>Hello <strong><%= @person.full_name %></strong>,</p>
+  <p>Hello <strong><%= @person.first_name %></strong>,</p>
 
   <%#
     Editable intro the admin sets on the bulk-reminder page (defaults to the

--- a/app/views/event_mailer/event_registration_reminder.text.erb
+++ b/app/views/event_mailer/event_registration_reminder.text.erb
@@ -1,4 +1,4 @@
-Event reminder Hello<%= @person.full_name %>,
+Event reminder Hello <%= @person.first_name %>,
 <% if @custom_message.present? %>
   <%= strip_tags(@custom_message).strip %>
 <% end %>

--- a/app/views/notification_mailer/form_link_request.html.erb
+++ b/app/views/notification_mailer/form_link_request.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @person.name %></strong>,
+    Hello <strong><%= @person.first_name %></strong>,
   </p>
 
   <p>

--- a/app/views/notification_mailer/form_link_request.text.erb
+++ b/app/views/notification_mailer/form_link_request.text.erb
@@ -1,6 +1,6 @@
 The <%= @form_name %> to complete
 
-Hello <%= @person.name %>,
+Hello <%= @person.first_name %>,
 
 <% if @sender %><%= @sender.full_name %> from A Window Between Worlds sent you the <%= @form_name %> to complete.<% else %>A Window Between Worlds sent you the <%= @form_name %> to complete.<% end %> Please follow the link below to fill it out.
 

--- a/app/views/notification_mailer/form_submission_confirmation.html.erb
+++ b/app/views/notification_mailer/form_submission_confirmation.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @person.name %></strong>,
+    Hello <strong><%= @person.first_name %></strong>,
   </p>
 
   <p>

--- a/app/views/notification_mailer/form_submission_confirmation.text.erb
+++ b/app/views/notification_mailer/form_submission_confirmation.text.erb
@@ -1,6 +1,6 @@
 We received your response
 
-Hello <%= @person.name %>,
+Hello <%= @person.first_name %>,
 
 Thank you for your response to <%= @form.display_name %>. We have received it and will be in touch if any follow-up is needed.
 

--- a/app/views/notification_mailer/idea_submitted.html.erb
+++ b/app/views/notification_mailer/idea_submitted.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @user.full_name %></strong>,
+    Hello <strong><%= @user.first_name_or_email %></strong>,
   </p>
 
   <p>

--- a/app/views/notification_mailer/idea_submitted.text.erb
+++ b/app/views/notification_mailer/idea_submitted.text.erb
@@ -1,6 +1,6 @@
 Submission received
 
-Hello <%= @user.full_name %>,
+Hello <%= @user.first_name_or_email %>,
 
 Thank you for your submission. We have received your <%= @noticeable_klass.model_name.human.downcase %> and will review it shortly.
 

--- a/app/views/notification_mailer/story_promoted.html.erb
+++ b/app/views/notification_mailer/story_promoted.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @user.full_name %></strong>,
+    Hello <strong><%= @user.first_name_or_email %></strong>,
   </p>
 
   <p>

--- a/app/views/notification_mailer/story_promoted.text.erb
+++ b/app/views/notification_mailer/story_promoted.text.erb
@@ -1,6 +1,6 @@
 Your story has been shared
 
-Hello <%= @user.full_name %>,
+Hello <%= @user.first_name_or_email %>,
 
 Wonderful news — the story idea you shared with us has been developed into a story. Thank you for helping others see the healing power of art.
 

--- a/app/views/notification_mailer/workshop_log_submitted.html.erb
+++ b/app/views/notification_mailer/workshop_log_submitted.html.erb
@@ -2,7 +2,7 @@
 
 <div style="margin-top: 36px; text-align: left;">
   <p>
-    Hello <strong><%= @user.name %></strong>,
+    Hello <strong><%= @user.first_name_or_email %></strong>,
   </p>
 
   <p>

--- a/app/views/notification_mailer/workshop_log_submitted.text.erb
+++ b/app/views/notification_mailer/workshop_log_submitted.text.erb
@@ -1,6 +1,6 @@
 Workshop log received
 
-Hello <%= @user.name %>,
+Hello <%= @user.first_name_or_email %>,
 
 Thank you for submitting your workshop log. We have received it and will review it shortly.
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -3347,6 +3347,7 @@
     Consultant. Every other event keeps the standard certificate of completion.
   action_path: /events
   pr_number: 2504
+
 - name: "Slider questions on forms"
   area: registration
   display_status: admin_facing
@@ -3370,3 +3371,12 @@
     across all people, filterable by keyword, author, date, and follow-up. Add
     a note or log a communication right from it by picking a person.
   action_path: "/comments_and_communications"
+
+- name: "Emails greet you by first name"
+  area: communications
+  display_status: user_facing
+  summary: >-
+    Portal emails now open with just your first name ("Hello Jane,") instead of
+    your full name, so confirmations, reminders, and other messages read a little
+    warmer and less form-letter.
+  released_on: 2026-09-02

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EventMailer, type: :mailer do
     end
 
     it "includes the registrant name in the body" do
-      expect(mail.body.encoded).to include(event_registration.registrant.full_name)
+      expect(mail.body.encoded).to include(event_registration.registrant.first_name)
     end
 
     it "links to the registrant's ticket" do
@@ -185,7 +185,7 @@ RSpec.describe EventMailer, type: :mailer do
     end
 
     it "includes the registrant name in the body" do
-      expect(mail.body.encoded).to include(event_registration.registrant.full_name)
+      expect(mail.body.encoded).to include(event_registration.registrant.first_name)
     end
 
     context "when the event is CE-eligible and has deadlines" do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe NotificationMailer, type: :mailer do
       expect(mail.subject).to include("Link to complete Collaboration agreement (job change)")
       expect(mail.body.encoded).to include("the Collaboration agreement (job change) to complete")
       expect(mail.body.encoded).to include("http://example.com/f/collab-job-change")
-      expect(mail.body.encoded).to include("Fay Facilitator")
+      expect(mail.body.encoded).to include("Hello Fay,")
     end
   end
 
@@ -315,7 +315,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it "names the story and greets the submitter" do
       body = described_class.story_promoted(notification).body.encoded
       expect(body).to include("A Healing Story")
-      expect(body).to include(submitter.full_name)
+      expect(body).to include(submitter.first_name_or_email)
     end
   end
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 copy-only change across email greetings, plus 3 spec assertions and a features.yml entry

Portal emails now open with just the recipient's first name ("Hello Jane,") instead of their full name — warmer, less form-letter.

- **Greetings only.** 18 templates (HTML + text) across event and notification mailers now use `@person.first_name` (validated present) or `@user.first_name_or_email` (falls back to email when a user has no linked person).
- **Staff FYI/notification emails unchanged** — they keep full name + email so staff can still tell two people apart.
- Devise, contact-us, and scholarship-acceptance emails already greeted by first name; left as-is.
- Updated 3 mailer specs that asserted the full name appeared in the greeting.
- Added a `config/features.yml` entry.