### PR TITLE
Cross-nav + filter-height fix on the form index pages

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -346,15 +346,10 @@ input.date-filter-empty::-webkit-datetime-edit {
   @apply bg-transparent;
 }
 
-/* The multiselect control carries its own `!py-2` (added by the searchable-
-   checkbox controller). That padding lives in Tailwind's `utilities` cascade
-   layer, so an unlayered `!important` on the control can't out-rank it — the
-   control keeps its vertical padding. To stop the wrapper's own `py-2` from
-   stacking on top of it (which renders the field a line taller than its
-   siblings), drop the wrapper's vertical padding instead: this is a normal
-   unlayered rule, which does beat the layered `py-2` utility. Scoped to `.multi`
-   so the single-select flat variant — which has no `!py-2` and relies on the
-   wrapper padding below — is untouched. */
+/* The multiselect control keeps a `!py-2` (from the searchable-checkbox controller)
+   that an unlayered `!important` can't beat — it's in Tailwind's utilities layer — so
+   drop the wrapper's padding instead to avoid a double-padded, too-tall field. `.multi`
+   only; the single-select flat variant has no `!py-2` and relies on the wrapper padding. */
 .ts-wrapper.ts-flat.multi {
   padding-top: 0;
   padding-bottom: 0;
@@ -365,8 +360,6 @@ input.date-filter-empty::-webkit-datetime-edit {
   background: transparent;
   border: 0;
   box-shadow: none;
-  /* Zeroes the single-select flat control's padding (no competing `!py-2`);
-     the multiselect control keeps its `!py-2`, handled by the wrapper rule above. */
   padding: 0 !important;
   min-height: 1.5rem;
 }

--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -346,13 +346,27 @@ input.date-filter-empty::-webkit-datetime-edit {
   @apply bg-transparent;
 }
 
+/* The multiselect control carries its own `!py-2` (added by the searchable-
+   checkbox controller). That padding lives in Tailwind's `utilities` cascade
+   layer, so an unlayered `!important` on the control can't out-rank it — the
+   control keeps its vertical padding. To stop the wrapper's own `py-2` from
+   stacking on top of it (which renders the field a line taller than its
+   siblings), drop the wrapper's vertical padding instead: this is a normal
+   unlayered rule, which does beat the layered `py-2` utility. Scoped to `.multi`
+   so the single-select flat variant — which has no `!py-2` and relies on the
+   wrapper padding below — is untouched. */
+.ts-wrapper.ts-flat.multi {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .ts-wrapper.ts-flat .ts-control,
 .ts-wrapper.ts-flat.focus .ts-control {
   background: transparent;
   border: 0;
   box-shadow: none;
-  /* !important beats the searchable-checkbox controller's `!py-2` on the control,
-     so a flat multiselect stays height-matched to the sibling fields. */
+  /* Zeroes the single-select flat control's padding (no competing `!py-2`);
+     the multiselect control keeps its `!py-2`, handled by the wrapper rule above. */
   padding: 0 !important;
   min-height: 1.5rem;
 }

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,13 +1,14 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+<% topbar = capture do %>
   <%= link_to forms_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Forms
   <% end %>
   <%= render "forms/index_subnav", current: :answers %>
-</div>
+<% end %>
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "Answers",
-                     subtitle: "Every answer submitted on any of the site's forms — search the answer text or filter by form, person, submission, or question type" } do %>
+                     subtitle: "Every answer submitted on any of the site's forms — search the answer text or filter by form, person, submission, or question type",
+                     topbar: topbar } do %>
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
     <%= form_with url: form_answers_path, method: :get,

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,7 +1,13 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+  <%= link_to forms_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+  <% end %>
+  <%= render "forms/index_subnav", current: :answers %>
+</div>
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "Answers",
-                     subtitle: "Every answer submitted across the site's forms — search the answer text or filter by form, person, submission, or question type" } do %>
+                     subtitle: "Every answer submitted on any of the site's forms — search the answer text or filter by form, person, submission, or question type" } do %>
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
     <%= form_with url: form_answers_path, method: :get,

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -8,7 +8,7 @@
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "Answers",
                      subtitle: "Every answer submitted on any of the site's forms — search the answer text or filter by form, person, submission, or question type",
-                     topbar: topbar } do %>
+                     subtitle_width: "max-w-none", topbar: topbar } do %>
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
     <%= form_with url: form_answers_path, method: :get,

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+<% topbar = capture do %>
   <div>
     <% if params[:return_to] == "form_results" && @form %>
       <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
@@ -24,7 +24,7 @@
   <% elsif !@person %>
     <%= render "forms/index_subnav", current: :submissions %>
   <% end %>
-</div>
+<% end %>
 <% subtitle = capture do %>
   <% if @person %>
     Forms submitted by <span class="font-medium text-gray-900"><%= @person.name %></span>.
@@ -34,7 +34,7 @@
 <% end %>
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "Submissions",
-                     subtitle: subtitle } do %>
+                     subtitle: subtitle, topbar: topbar } do %>
     <%# Filters. Auto-submit into the results frame on change. %>
     <%= form_with url: form_submissions_path, method: :get, autocomplete: "off",
           data: { controller: "collection searchable-checkbox", turbo_frame: "form_submissions_results" },

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -1,31 +1,35 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<% if @form || @person %>
-  <div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
-    <div>
-      <% if params[:return_to] == "form_results" && @form %>
-        <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
-        <% end %>
-      <% elsif params[:return_to] == "forms" && @form %>
-        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> Forms
-        <% end %>
-      <% elsif @person %>
-        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-          <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
-        <% end %>
+<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+  <div>
+    <% if params[:return_to] == "form_results" && @form %>
+      <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
       <% end %>
-    </div>
-    <% if @form %>
-      <%= form_page_subnav(@form, current: :submissions) %>
+    <% elsif params[:return_to] == "forms" && @form %>
+      <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+      <% end %>
+    <% elsif @person %>
+      <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
+      <% end %>
+    <% elsif !@form %>
+      <%= link_to forms_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+        <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+      <% end %>
     <% end %>
   </div>
-<% end %>
+  <% if @form %>
+    <%= form_page_subnav(@form, current: :submissions) %>
+  <% elsif !@person %>
+    <%= render "forms/index_subnav", current: :submissions %>
+  <% end %>
+</div>
 <% subtitle = capture do %>
   <% if @person %>
     Forms submitted by <span class="font-medium text-gray-900"><%= @person.name %></span>.
   <% else %>
-    Forms submitted across the site — registrations, scholarships, and public forms.
+    Forms submitted across the site — including registrations, scholarships, and public forms.
   <% end %>
 <% end %>
 <%= render layout: "shared/index_page",

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -34,7 +34,7 @@
 <% end %>
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "Submissions",
-                     subtitle: subtitle, topbar: topbar } do %>
+                     subtitle: subtitle, subtitle_width: "max-w-none", topbar: topbar } do %>
     <%# Filters. Auto-submit into the results frame on change. %>
     <%= form_with url: form_submissions_path, method: :get, autocomplete: "off",
           data: { controller: "collection searchable-checkbox", turbo_frame: "form_submissions_results" },

--- a/app/views/forms/_index_subnav.html.erb
+++ b/app/views/forms/_index_subnav.html.erb
@@ -1,0 +1,18 @@
+<%# Shared sub-navigation across the top-level Forms admin index pages.
+    Pass `current:` — one of :forms, :submissions, :answers. Styled to match
+    events/_subnav: underlined active tab, muted links. All three pages are
+    admin-only, so every tab shows to the same audience. %>
+<nav class="flex flex-wrap items-center gap-1" aria-label="Forms views">
+  <% tabs = [
+       { key: :forms, label: "Forms", path: forms_path },
+       { key: :submissions, label: "Submissions", path: form_submissions_path },
+       { key: :answers, label: "Answers", path: form_answers_path }
+     ] %>
+  <% tabs.each do |tab| %>
+    <% if tab[:key] == current %>
+      <span aria-current="page" class="border-b-2 border-indigo-600 px-2 py-1 text-sm font-semibold text-gray-900"><%= tab[:label] %></span>
+    <% else %>
+      <%= link_to tab[:label], tab[:path], class: "text-sm #{eyebrow_link_class} border-b-2 border-transparent hover:border-gray-300 px-2 py-1" %>
+    <% end %>
+  <% end %>
+</nav>

--- a/app/views/forms/_index_subnav.html.erb
+++ b/app/views/forms/_index_subnav.html.erb
@@ -1,7 +1,5 @@
-<%# Shared sub-navigation across the top-level Forms admin index pages.
-    Pass `current:` — one of :forms, :submissions, :answers. Styled to match
-    events/_subnav: underlined active tab, muted links. All three pages are
-    admin-only, so every tab shows to the same audience. %>
+<%# Cross-nav across the Forms/Submissions/Answers index pages, styled like
+    events/_subnav. Pass `current:` — one of :forms, :submissions, :answers. %>
 <nav class="flex flex-wrap items-center gap-1" aria-label="Forms views">
   <% tabs = [
        { key: :forms, label: "Forms", path: forms_path },

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+<% topbar = capture do %>
   <%= link_to admin_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
   <% end %>
   <%= render "forms/index_subnav", current: :forms %>
-</div>
+<% end %>
 <% actions = capture do %>
   <% if allowed_to?(:new?, Form) %>
     <div class="admin-only bg-blue-100">
@@ -17,7 +17,7 @@
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "All forms",
                      subtitle: "Reusable forms for any need, including event registrations and collaboration agreements",
-                     actions: actions } do %>
+                     topbar: topbar, actions: actions } do %>
   <% result_src = forms_path + "?" + request.query_string %>
 
   <%= turbo_frame_tag :forms_results, src: result_src, data: { turbo: "temporary" } do %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 <% end %>
 <%= render layout: "shared/index_page",
-           locals: { domain: :forms, eyebrow: "Forms", title: "All forms",
+           locals: { domain: :forms, title: "Forms",
                      subtitle: "Reusable forms for any need, including event registrations and collaboration agreements",
                      topbar: topbar, actions: actions } do %>
   <% result_src = forms_path + "?" + request.query_string %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,4 +1,10 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
+<div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+  <%= link_to admin_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+    <i class="fa-solid fa-arrow-left text-xs"></i> Admin home
+  <% end %>
+  <%= render "forms/index_subnav", current: :forms %>
+</div>
 <% actions = capture do %>
   <% if allowed_to?(:new?, Form) %>
     <div class="admin-only bg-blue-100">
@@ -10,7 +16,7 @@
 <% end %>
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, eyebrow: "Forms", title: "All forms",
-                     subtitle: "Reusable forms for event registrations and other submissions",
+                     subtitle: "Reusable forms for any need, including event registrations and collaboration agreements",
                      actions: actions } do %>
   <% result_src = forms_path + "?" + request.query_string %>
 

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -17,7 +17,7 @@
 <%= render layout: "shared/index_page",
            locals: { domain: :forms, title: "Forms",
                      subtitle: "Reusable forms for any need, including event registrations and collaboration agreements",
-                     topbar: topbar, actions: actions } do %>
+                     subtitle_width: "max-w-none", topbar: topbar, actions: actions } do %>
   <% result_src = forms_path + "?" + request.query_string %>
 
   <%= turbo_frame_tag :forms_results, src: result_src, data: { turbo: "temporary" } do %>

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -2,11 +2,16 @@
     soft domain border) over the domain's own tint, then the serif title with an
     optional eyebrow, subtitle and right-hand actions, and the page body as a block.
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
-    actions (captured markup), surface (defaults to the domain's 50 tint). %>
+    actions (captured markup), surface (defaults to the domain's 50 tint),
+    topbar (captured markup for a back-eyebrow / sub-nav row, laid out
+    justify-between at the top of the card — pass a left group and a right group). %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
   <%= render "shared/brand_accent_strip", rounded: true %>
   <div class="w-full p-6">
+    <% if local_assigns[:topbar].present? %>
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-2"><%= topbar %></div>
+    <% end %>
     <div class="mb-6 flex items-start justify-between gap-4">
       <div class="pr-6">
         <% if local_assigns[:eyebrow].present? %>

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -3,7 +3,8 @@
     optional eyebrow, subtitle and right-hand actions, and the page body as a block.
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
     actions (captured markup), surface (defaults to the domain's 50 tint),
-    topbar (captured back-eyebrow / sub-nav row, justify-between at the card top). %>
+    topbar (captured back-eyebrow / sub-nav row, justify-between at the card top),
+    subtitle_width (subtitle max-width class, defaults to max-w-3xl). %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
   <%= render "shared/brand_accent_strip", rounded: true %>
@@ -12,13 +13,13 @@
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2"><%= topbar %></div>
     <% end %>
     <div class="mb-6 flex items-start justify-between gap-4">
-      <div class="pr-6">
+      <div class="min-w-0 flex-1 pr-6">
         <% if local_assigns[:eyebrow].present? %>
           <span class="text-2xs font-semibold tracking-widest uppercase <%= DomainTheme.text_class_for(domain, intensity: 700) %>"><%= eyebrow %></span>
         <% end %>
         <h1 class="text-primary font-display text-3xl"><%= title %></h1>
         <% if local_assigns[:subtitle].present? %>
-          <div class="mt-2 max-w-3xl text-gray-600"><%= subtitle %></div>
+          <div class="mt-2 <%= local_assigns[:subtitle_width] || "max-w-3xl" %> text-gray-600"><%= subtitle %></div>
         <% end %>
       </div>
       <% if local_assigns[:actions].present? %>

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -3,8 +3,7 @@
     optional eyebrow, subtitle and right-hand actions, and the page body as a block.
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
     actions (captured markup), surface (defaults to the domain's 50 tint),
-    topbar (captured markup for a back-eyebrow / sub-nav row, laid out
-    justify-between at the top of the card — pass a left group and a right group). %>
+    topbar (captured back-eyebrow / sub-nav row, justify-between at the card top). %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
   <%= render "shared/brand_accent_strip", rounded: true %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3200,3 +3200,14 @@
     — the same referral-source breakdown shown on a form's results page, scoped to
     the training(s) in view.
   pr_number: 2513
+
+- name: "Jump between Forms, Submissions, and Answers"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    The Forms, Submissions, and Answers admin pages now share a sub-navigation
+    bar, so you can move straight between them instead of going back through the
+    menu — with a back link (to Admin home, or to Forms) at the top of each.
+  action_path: "/forms"
+  pr_number: 2506


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view + one scoped CSS fix across the three form index pages

Adds cross-navigation between the Forms, Answers, and Submissions admin index pages and fixes the Form filter rendering a line too tall.

Rebased onto main, so this now builds on the shared `index_page` shell from #2510.

### Navigation
- Each page gets a top bar: a back-eyebrow (Forms → Admin home; Answers/Submissions → Forms) and an events-style tab subnav (`forms/_index_subnav`) linking the three.
- The submissions bar keeps its form-/person-scoped back links and form subnav; only the global index shows the cross-nav.
- Reworded the three page blurbs.

### Filter height fix
- The Form multiselect filter rendered a line taller than its siblings: the `searchable-checkbox` controller adds Tailwind's `!py-2` to the tom-select control (a `utilities`-layer `!important`, which an unlayered `!important` can't out-rank), and it stacked on the wrapper's own `py-2`.
- Fix drops the wrapper's vertical padding for the `.multi` flat variant; the single-select flat field is untouched. Verified in-browser: 58px → 42px, matching siblings. No JS changed.
