### PR TITLE
Show funding grant and funder in scholarship FYI emails

### DIFF
--- a/app/views/scholarship_mailer/_agreement_response_fyi.html.erb
+++ b/app/views/scholarship_mailer/_agreement_response_fyi.html.erb
@@ -32,6 +32,12 @@
     <td style="padding: 4px 0; color:#6b7280;">Award amount</td>
     <td style="padding: 4px 0;"><strong><%= dollars_from_cents(@scholarship.amount_cents) %></strong></td>
   </tr>
+  <% if @scholarship.grant.present? %>
+    <tr>
+      <td style="padding: 4px 0; color:#6b7280;">Funder</td>
+      <td style="padding: 4px 0;"><strong><%= @scholarship.grant.name_with_funder %></strong></td>
+    </tr>
+  <% end %>
   <% if @response&.contribution_cents.present? %>
     <tr>
       <td style="padding: 4px 0; color:#6b7280;">They/their employer can contribute</td>

--- a/app/views/scholarship_mailer/_agreement_response_fyi.html.erb
+++ b/app/views/scholarship_mailer/_agreement_response_fyi.html.erb
@@ -34,7 +34,7 @@
   </tr>
   <% if @scholarship.grant.present? %>
     <tr>
-      <td style="padding: 4px 0; color:#6b7280;">Funder</td>
+      <td style="padding: 4px 0; color:#6b7280;">Grant</td>
       <td style="padding: 4px 0;"><strong><%= @scholarship.grant.name_with_funder %></strong></td>
     </tr>
   <% end %>

--- a/app/views/scholarship_mailer/_agreement_response_fyi.text.erb
+++ b/app/views/scholarship_mailer/_agreement_response_fyi.text.erb
@@ -18,7 +18,7 @@ Training: <%= @event.title %>
 <% end %>
 Award amount: <%= dollars_from_cents(@scholarship.amount_cents) %>
 <% if @scholarship.grant.present? %>
-Funder: <%= @scholarship.grant.name_with_funder %>
+Grant: <%= @scholarship.grant.name_with_funder %>
 <% end %>
 <% if @response&.contribution_cents.present? %>
 They/their employer can contribute: <%= dollars_from_cents(@response.contribution_cents) %>

--- a/app/views/scholarship_mailer/_agreement_response_fyi.text.erb
+++ b/app/views/scholarship_mailer/_agreement_response_fyi.text.erb
@@ -17,6 +17,9 @@
 Training: <%= @event.title %>
 <% end %>
 Award amount: <%= dollars_from_cents(@scholarship.amount_cents) %>
+<% if @scholarship.grant.present? %>
+Funder: <%= @scholarship.grant.name_with_funder %>
+<% end %>
 <% if @response&.contribution_cents.present? %>
 They/their employer can contribute: <%= dollars_from_cents(@response.contribution_cents) %>
 <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -115,6 +115,16 @@
   action_path: /forms
   pr_number: 2516
 
+- name: "Scholarship FYI emails name the funder"
+  area: scholarships
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    When a recipient accepts, declines, or asks for more support, the heads-up
+    email to the programs team now lists the funding grant and its funder, so
+    you can see at a glance which grant is paying — shown only when the award is
+    tied to a grant.
+
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting
   display_status: admin_facing

--- a/spec/mailers/scholarship_mailer_spec.rb
+++ b/spec/mailers/scholarship_mailer_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe ScholarshipMailer, type: :mailer do
       expect(mail.subject).to include("Scholarship accepted")
       expect(mail.subject).to include(scholarship.recipient.full_name)
     end
+
+    context "when the scholarship is funded by a grant" do
+      let(:funder) { create(:organization, name: "Acme Foundation") }
+      let(:grant) { create(:grant, name: "Spring 2026 Fund", funder:) }
+      let(:scholarship) { create(:scholarship, recipient: registration.registrant, amount_cents: 5_000, grant:) }
+
+      it "shows the grant and its funder in the body" do
+        body = mail.body.encoded
+        expect(body).to include("Spring 2026 Fund")
+        expect(body).to include("Acme Foundation")
+      end
+    end
   end
 
   describe "#accepted_confirmation" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small email-template change plus a mailer spec

Scholarship FYI emails to the programs team now name the funding grant and its funder, so staff can tell which grant is paying an award without opening the scholarship.

### What is the goal of this PR and why is this important?
- When a recipient accepts, declines, or requests more support, the trainings/programs team gets a heads-up email.
- Those emails didn't say what was funding the award, so staff had to open the scholarship to find out.

### How did you approach the change?
- Added a **Grant** row (grant name + funder, via `Grant#name_with_funder`) to the shared `_agreement_response_fyi` HTML and text partials, so all three FYI emails get it.
- Shown only when the scholarship is tied to a grant.
- Added a mailer spec and a `config/features.yml` entry (admin_facing).

### Anything else to add?
- "Grantor" isn't a real field — it maps to the grant's polymorphic `funder`. Recipient-facing `accepted_confirmation` is unchanged (FYI emails only).