### PR TITLE
Filter and drill into a form's results page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ This codebase (Rails 8.1)
 | `app/decorators/` | Draper decorators for view logic | ~50 files |
 | `app/policies/` | ActionPolicy authorization rules | ~63 files |
 | `app/presenters/` | Presentation objects | 6 files |
-| `app/helpers/` | View helpers | ~37 files |
+| `app/helpers/` | View helpers | ~47 files |
 | `app/mailers/` | ActionMailer classes | 6 files |
 | `app/inputs/` | Custom SimpleForm inputs | 1 file |
 

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -54,6 +54,16 @@ class FormAnswersController < ApplicationController
     if params[:answer_type].present? && FormField.answer_types.key?(params[:answer_type])
       scope = scope.joins(:form_field).where(form_fields: { answer_type: FormField.answer_types[params[:answer_type]] })
     end
-    scope
+    date_scoped(scope)
+  end
+
+  # By when the submission was made, not when the answer row was written, so this
+  # list agrees with the same date range on a form's results page.
+  def date_scoped(scope)
+    start_date = FormSubmission.parse_date(params[:start_date])
+    end_date = FormSubmission.parse_date(params[:end_date])
+    return scope unless start_date || end_date
+
+    scope.joins(:form_submission).merge(FormSubmission.submitted_between(start_date, end_date))
   end
 end

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -36,12 +36,8 @@ class FormAnswersController < ApplicationController
     if params[:organization_id].present?
       scope = scope.where(form_submission_id: FormSubmission.for_organization(params[:organization_id]).select(:id))
     end
-    if params[:person].present?
-      term = "%#{Person.sanitize_sql_like(params[:person])}%"
-      scope = scope.joins(form_submission: :person).where(
-        "people.first_name LIKE :t OR people.last_name LIKE :t OR people.email LIKE :t OR CONCAT(people.first_name, ' ', people.last_name) LIKE :t",
-        t: term
-      )
+    if params[:person_id].present?
+      scope = scope.joins(:form_submission).where(form_submissions: { person_id: params[:person_id] })
     end
     if params[:form_submission_id].present?
       scope = scope.where(form_submission_id: params[:form_submission_id])

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -33,6 +33,9 @@ class FormAnswersController < ApplicationController
     if params[:event_id].present?
       scope = scope.joins(:form_submission).where(form_submissions: { event_id: params[:event_id] })
     end
+    if params[:organization_id].present?
+      scope = scope.where(form_submission_id: FormSubmission.for_organization(params[:organization_id]).select(:id))
+    end
     if params[:person].present?
       term = "%#{Person.sanitize_sql_like(params[:person])}%"
       scope = scope.joins(form_submission: :person).where(

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -1,4 +1,10 @@
 class FormAnswersController < ApplicationController
+  # Blank answer rows are noise here (an optional question nobody filled in), so
+  # they're hidden unless the Empty answers filter asks for them. Hiding them by
+  # default also makes this list agree with the response counts on form results,
+  # which have always counted only answered questions.
+  INCLUDE_EMPTY_ANSWERS = "include".freeze
+
   def index
     authorize! FormAnswer
 
@@ -10,6 +16,8 @@ class FormAnswersController < ApplicationController
       render :form_answers_results
     else
       @forms = Form.order(:name)
+      # Names the "back to results" eyebrow when a form's results page linked here.
+      @form = Form.find_by(id: params[:form_id])
       render :index
     end
   end
@@ -18,6 +26,7 @@ class FormAnswersController < ApplicationController
 
   # Each filter is a no-op when its param is blank, so combinations stack.
   def filter_answers(scope)
+    scope = scope.answered unless params[:empty] == INCLUDE_EMPTY_ANSWERS
     if params[:q].present?
       scope = scope.where("form_answers.submitted_answer LIKE ?", "%#{FormAnswer.sanitize_sql_like(params[:q])}%")
     end

--- a/app/controllers/form_answers_controller.rb
+++ b/app/controllers/form_answers_controller.rb
@@ -30,12 +30,7 @@ class FormAnswersController < ApplicationController
     if params[:q].present?
       scope = scope.where("form_answers.submitted_answer LIKE ?", "%#{FormAnswer.sanitize_sql_like(params[:q])}%")
     end
-    if params[:question].present?
-      term = "%#{FormField.sanitize_sql_like(params[:question])}%"
-      scope = scope.left_joins(:form_field).where(
-        "form_fields.name LIKE :t OR form_answers.question_name_when_answered LIKE :t", t: term
-      )
-    end
+    scope = question_scoped(scope)
     if params[:form_id].present?
       scope = scope.joins(:form_submission).where(form_submissions: { form_id: params[:form_id] })
     end
@@ -55,6 +50,31 @@ class FormAnswersController < ApplicationController
       scope = scope.joins(:form_field).where(form_fields: { answer_type: FormField.answer_types[params[:answer_type]] })
     end
     date_scoped(scope)
+  end
+
+  # The Question box stays a free-text search: it matches any question whose name
+  # (or the name it carried when answered) contains the term. A results-card
+  # drill-down additionally sends the exact form_field_id, because that search
+  # would otherwise also sweep in a sibling question whose name contains this
+  # one's ("Email" pulling in "Email 2") and disagree with the card's count.
+  def question_scoped(scope)
+    field_id = pinned_field_id
+    return scope.where(form_field_id: field_id) if field_id
+    return scope if params[:question].blank?
+
+    term = "%#{FormField.sanitize_sql_like(params[:question])}%"
+    scope.left_joins(:form_field).where(
+      "form_fields.name LIKE :t OR form_answers.question_name_when_answered LIKE :t", t: term
+    )
+  end
+
+  # The pinned question, while the box still holds its name — editing or clearing
+  # the box releases the pin and the term searches normally again.
+  def pinned_field_id
+    id = params[:form_field_id].presence
+    return if id.blank? || params[:question].blank?
+
+    id if FormField.where(id: id).pick(:name) == params[:question]
   end
 
   # By when the submission was made, not when the answer row was written, so this

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -42,7 +42,10 @@ class FormsController < ApplicationController
   # charts, free-text questions as lists of the actual answers.
   def results
     authorize! @form
-    @aggregator = FormResponseAggregator.new(@form)
+    # Honor the event filter only for an event genuinely connected to this shared
+    # form; an unknown id falls back to the unfiltered rollup.
+    @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
+    @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id)
   end
 
   def new

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,7 +45,7 @@ class FormsController < ApplicationController
     # Honor the event filter only for an event genuinely connected to this shared
     # form; an unknown id falls back to the unfiltered rollup.
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
-    @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id)
+    @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id, question_query: params[:question])
   end
 
   def new

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,9 +45,11 @@ class FormsController < ApplicationController
     # Honor the event filter only for an event genuinely connected to this shared
     # form; an unknown id falls back to the unfiltered rollup.
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
+    @selected_person_id = params[:person_id].presence
     @selected_organization_id = params[:organization_id].presence
     @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id,
-                  organization_id: @selected_organization_id, question_query: params[:question])
+                  person_id: @selected_person_id, organization_id: @selected_organization_id,
+                  start_date: params[:start_date], end_date: params[:end_date], question_query: params[:question])
   end
 
   def new

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,7 +45,9 @@ class FormsController < ApplicationController
     # Honor the event filter only for an event genuinely connected to this shared
     # form; an unknown id falls back to the unfiltered rollup.
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
-    @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id, question_query: params[:question])
+    @selected_organization_id = params[:organization_id].presence
+    @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id,
+                  organization_id: @selected_organization_id, question_query: params[:question])
   end
 
   def new

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,8 +45,9 @@ class FormsController < ApplicationController
     # Honor the event filter only for an event genuinely connected to this shared
     # form; an unknown id falls back to the unfiltered rollup.
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
-    @selected_person_id = params[:person_id].presence
-    @selected_organization_id = params[:organization_id].presence
+    @selected_submitter = results_submitter
+    @selected_person_id = @selected_submitter.id if @selected_submitter.is_a?(Person)
+    @selected_organization_id = @selected_submitter.id if @selected_submitter.is_a?(Organization)
     @selected_start_date = params[:start_date].presence
     @selected_end_date = params[:end_date].presence
     @selected_question = params[:question].presence
@@ -158,6 +159,22 @@ class FormsController < ApplicationController
   end
 
   private
+
+  # Whose submissions the results filter is narrowed to. One picker searches
+  # people and organizations together and posts a signed global id saying which
+  # kind was chosen; a plain person_id/organization_id also resolves, so an
+  # eyebrow back from the answers list (which filters on those) lands on the same
+  # slice. An unresolvable id falls back to the unfiltered rollup.
+  def results_submitter
+    submitter = if params[:submitter_sgid].present?
+      GlobalID::Locator.locate_signed(params[:submitter_sgid])
+    elsif params[:person_id].present?
+      Person.find_by(id: params[:person_id])
+    elsif params[:organization_id].present?
+      Organization.find_by(id: params[:organization_id])
+    end
+    submitter if submitter.is_a?(Person) || submitter.is_a?(Organization)
+  end
 
   # Sorts the standalone forms for the index frame. Count columns join their
   # association and order by the aggregate; direction is a symbol resolved from

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -47,9 +47,11 @@ class FormsController < ApplicationController
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
     @selected_person_id = params[:person_id].presence
     @selected_organization_id = params[:organization_id].presence
+    @selected_start_date = params[:start_date].presence
+    @selected_end_date = params[:end_date].presence
     @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id,
                   person_id: @selected_person_id, organization_id: @selected_organization_id,
-                  start_date: params[:start_date], end_date: params[:end_date], question_query: params[:question])
+                  start_date: @selected_start_date, end_date: @selected_end_date, question_query: params[:question])
   end
 
   def new

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,16 +45,13 @@ class FormsController < ApplicationController
     # Honor the event filter only for an event genuinely connected to this shared
     # form; an unknown id falls back to the unfiltered rollup.
     @selected_event_id = @form.events.where(id: params[:event_id]).pick(:id) if params[:event_id].present?
-    @selected_submitter = results_submitter
-    @selected_person_id = @selected_submitter.id if @selected_submitter.is_a?(Person)
-    @selected_organization_id = @selected_submitter.id if @selected_submitter.is_a?(Organization)
+    @selected_organization_id = params[:organization_id].presence
     @selected_start_date = params[:start_date].presence
     @selected_end_date = params[:end_date].presence
     @selected_question = params[:question].presence
     @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id,
-                  person_id: @selected_person_id, organization_id: @selected_organization_id,
-                  start_date: @selected_start_date, end_date: @selected_end_date,
-                  question_query: @selected_question)
+                  organization_id: @selected_organization_id, start_date: @selected_start_date,
+                  end_date: @selected_end_date, question_query: @selected_question)
   end
 
   def new
@@ -159,22 +156,6 @@ class FormsController < ApplicationController
   end
 
   private
-
-  # Whose submissions the results filter is narrowed to. One picker searches
-  # people and organizations together and posts a signed global id saying which
-  # kind was chosen; a plain person_id/organization_id also resolves, so an
-  # eyebrow back from the answers list (which filters on those) lands on the same
-  # slice. An unresolvable id falls back to the unfiltered rollup.
-  def results_submitter
-    submitter = if params[:submitter_sgid].present?
-      GlobalID::Locator.locate_signed(params[:submitter_sgid])
-    elsif params[:person_id].present?
-      Person.find_by(id: params[:person_id])
-    elsif params[:organization_id].present?
-      Organization.find_by(id: params[:organization_id])
-    end
-    submitter if submitter.is_a?(Person) || submitter.is_a?(Organization)
-  end
 
   # Sorts the standalone forms for the index frame. Count columns join their
   # association and order by the aggregate; direction is a symbol resolved from

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -49,9 +49,11 @@ class FormsController < ApplicationController
     @selected_organization_id = params[:organization_id].presence
     @selected_start_date = params[:start_date].presence
     @selected_end_date = params[:end_date].presence
+    @selected_question = params[:question].presence
     @aggregator = FormResponseAggregator.new(@form, event_id: @selected_event_id,
                   person_id: @selected_person_id, organization_id: @selected_organization_id,
-                  start_date: @selected_start_date, end_date: @selected_end_date, question_query: params[:question])
+                  start_date: @selected_start_date, end_date: @selected_end_date,
+                  question_query: @selected_question)
   end
 
   def new

--- a/app/helpers/form_answers_helper.rb
+++ b/app/helpers/form_answers_helper.rb
@@ -12,6 +12,8 @@ module FormAnswersHelper
       person_id: params[:person_id].presence,
       organization_id: params[:organization_id].presence,
       form_submission_id: params[:form_submission_id].presence,
+      start_date: params[:start_date].presence,
+      end_date: params[:end_date].presence,
       empty: params[:empty].presence
     }.compact
   end

--- a/app/helpers/form_answers_helper.rb
+++ b/app/helpers/form_answers_helper.rb
@@ -1,0 +1,18 @@
+module FormAnswersHelper
+  # The index filters a submission's detail page must hand back so the trip to
+  # View a submission and back lands on the same filtered list. Blank values are
+  # dropped. Mirrors FormSubmissionsHelper#form_submission_carryover_params.
+  def form_answer_carryover_params(params)
+    {
+      q: params[:q].presence,
+      question: params[:question].presence,
+      answer_type: params[:answer_type].presence,
+      form_id: params[:form_id].presence,
+      event_id: params[:event_id].presence,
+      person_id: params[:person_id].presence,
+      organization_id: params[:organization_id].presence,
+      form_submission_id: params[:form_submission_id].presence,
+      empty: params[:empty].presence
+    }.compact
+  end
+end

--- a/app/helpers/form_answers_helper.rb
+++ b/app/helpers/form_answers_helper.rb
@@ -6,6 +6,8 @@ module FormAnswersHelper
     {
       q: params[:q].presence,
       question: params[:question].presence,
+      form_field_id: params[:form_field_id].presence,
+      results_question: params[:results_question].presence,
       answer_type: params[:answer_type].presence,
       form_id: params[:form_id].presence,
       event_id: params[:event_id].presence,

--- a/app/helpers/form_submissions_helper.rb
+++ b/app/helpers/form_submissions_helper.rb
@@ -6,6 +6,7 @@ module FormSubmissionsHelper
   def form_submission_carryover_params(params)
     {
       event_id: params[:event_id].presence,
+      form_field_id: params[:form_field_id].presence,
       organization_id: params[:organization_id].presence,
       role: params[:role].presence,
       search: params[:search].presence,
@@ -26,8 +27,8 @@ module FormSubmissionsHelper
 
   # True when any index filter is active — drives whether "Clear filters" shows.
   def form_submission_filters_active?(params)
-    params.values_at(:person_id, :form_id, :event_id, :organization_id, :role,
-                     :search, :org_status, :account_status, :scenario,
+    params.values_at(:person_id, :form_id, :form_field_id, :event_id, :organization_id,
+                     :role, :search, :org_status, :account_status, :scenario,
                      :start_date, :end_date).any?(&:present?)
   end
 end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -87,6 +87,18 @@ module FormsHelper
     }.compact
   end
 
+  # A results card's footer link to the Form submissions list: this form, narrowed
+  # like the rollup. form_field_id names the card for the eyebrow to return to —
+  # the submissions list doesn't filter on it.
+  def form_results_submissions_params(form, report)
+    {
+      form_id: form.id,
+      form_field_id: report.field.id,
+      return_to: "form_results",
+      **form_results_link_params
+    }.compact
+  end
+
   # A results card's drill-down into the Form answers list: this question, on
   # this form, narrowed exactly like the rollup the admin is looking at, plus the
   # origin that gives that list an eyebrow back here. `form_field_id` pins the

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -48,6 +48,23 @@ module FormsHelper
       class: "text-sm #{eyebrow_link_class} px-2 py-1"
   end
 
+  # A results card's drill-down into the Form answers list: this question, on
+  # this form, narrowed exactly like the rollup the admin is looking at, plus the
+  # origin that gives that list an eyebrow back here. Built here so every card
+  # link stays in step with the results filters.
+  def form_results_drilldown_params(form, question)
+    {
+      form_id: form.id,
+      question: question,
+      event_id: @selected_event_id,
+      person_id: @selected_person_id,
+      organization_id: @selected_organization_id,
+      start_date: @selected_start_date,
+      end_date: @selected_end_date,
+      return_to: "form_results"
+    }.compact
+  end
+
   # Human-readable role for a form: "Registration", "Bulk Payment", etc.,
   # falling back to "General" when no role is set.
   def form_role_label(form)

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -48,20 +48,49 @@ module FormsHelper
       class: "text-sm #{eyebrow_link_class} px-2 py-1"
   end
 
-  # A results card's drill-down into the Form answers list: this question, on
-  # this form, narrowed exactly like the rollup the admin is looking at, plus the
-  # origin that gives that list an eyebrow back here. Built here so every card
-  # link stays in step with the results filters.
-  def form_results_drilldown_params(form, question)
+  # Which submissions the rollup covers. The empty state reads these to tell a
+  # filtered-to-nothing view apart from a form nobody has filled in.
+  def form_results_filter_params
     {
-      form_id: form.id,
-      question: question,
       event_id: @selected_event_id,
       person_id: @selected_person_id,
       organization_id: @selected_organization_id,
       start_date: @selected_start_date,
-      end_date: @selected_end_date,
-      return_to: "form_results"
+      end_date: @selected_end_date
+    }.compact
+  end
+
+  # Everything a link out of a results card must carry to land back on the same
+  # view: those filters plus the question search, renamed because the answers
+  # list spends `question` on the one card that was drilled into.
+  def form_results_link_params
+    form_results_filter_params.merge(results_question: @selected_question).compact
+  end
+
+  # The same state read back off a page the results linked to, for its eyebrow.
+  def form_results_return_params(params)
+    {
+      event_id: params[:event_id].presence,
+      person_id: params[:person_id].presence,
+      organization_id: params[:organization_id].presence,
+      start_date: params[:start_date].presence,
+      end_date: params[:end_date].presence,
+      question: params[:results_question].presence
+    }.compact
+  end
+
+  # A results card's drill-down into the Form answers list: this question, on
+  # this form, narrowed exactly like the rollup the admin is looking at, plus the
+  # origin that gives that list an eyebrow back here. `form_field_id` pins the
+  # exact question — the name alone is a LIKE search there, which would also
+  # match a sibling question whose name contains this one's.
+  def form_results_drilldown_params(form, report)
+    {
+      form_id: form.id,
+      question: report.label,
+      form_field_id: report.field&.id,
+      return_to: "form_results",
+      **form_results_link_params
     }.compact
   end
 

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -87,9 +87,9 @@ module FormsHelper
     }.compact
   end
 
-  # A results card's footer link to the Form submissions list: this form, narrowed
-  # like the rollup. form_field_id names the card for the eyebrow to return to —
-  # the submissions list doesn't filter on it.
+  # A results card's footer link to the Form submissions list: the submissions
+  # that answered this question, narrowed like the rollup. form_field_id both
+  # filters that list and names the card for its eyebrow to return to.
   def form_results_submissions_params(form, report)
     {
       form_id: form.id,

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -53,7 +53,6 @@ module FormsHelper
   def form_results_filter_params
     {
       event_id: @selected_event_id,
-      person_id: @selected_person_id,
       organization_id: @selected_organization_id,
       start_date: @selected_start_date,
       end_date: @selected_end_date
@@ -67,15 +66,24 @@ module FormsHelper
     form_results_filter_params.merge(results_question: @selected_question).compact
   end
 
-  # The same state read back off a page the results linked to, for its eyebrow.
+  # Stable anchor for a question's card on the results page, so a page reached
+  # from that card can scroll back to exactly the card it opened. Mirrors
+  # FormSubmissionsHelper#form_submission_row_id.
+  def form_results_card_id(field_id)
+    "form-question-#{field_id}"
+  end
+
+  # The same state read back off a page the results linked to, for its eyebrow —
+  # including which card was opened, so the return lands on it rather than at the
+  # top of the rollup.
   def form_results_return_params(params)
     {
       event_id: params[:event_id].presence,
-      person_id: params[:person_id].presence,
       organization_id: params[:organization_id].presence,
       start_date: params[:start_date].presence,
       end_date: params[:end_date].presence,
-      question: params[:results_question].presence
+      question: params[:results_question].presence,
+      anchor: params[:form_field_id].presence && form_results_card_id(params[:form_field_id])
     }.compact
   end
 

--- a/app/models/form_answer.rb
+++ b/app/models/form_answer.rb
@@ -19,6 +19,10 @@ class FormAnswer < ApplicationRecord
   # display and export shows something readable.
   has_one :asset, as: :owner, dependent: :destroy
 
+  # A submission writes a row for every field it posts, so an optional question
+  # left blank still has an answer row. Only these count as responses.
+  scope :answered, -> { where.not(submitted_answer: [ nil, "" ]) }
+
   def name
     "#{question_name_when_answered.presence || form_field&.name}: #{submitted_answer}"
   end

--- a/app/models/form_submission.rb
+++ b/app/models/form_submission.rb
@@ -77,6 +77,14 @@ class FormSubmission < ApplicationRecord
     scope
   }
 
+  # Submissions that answered one particular question — the results-card
+  # drill-down into the people behind a single chart. A blank answer row (an
+  # optional question left empty) doesn't count, matching FormAnswer.answered and
+  # the response counts on a form's results.
+  scope :answered_question, ->(form_field_id) {
+    where(id: FormAnswer.answered.where(form_field_id: form_field_id).select(:form_submission_id))
+  }
+
   # Submissions this organization is directly linked to, by either link
   # (ADR-0002 D5). A matching affiliation the person happens to hold is not a
   # link and does not make the submission match.
@@ -195,6 +203,7 @@ class FormSubmission < ApplicationRecord
     form_ids = Array(params[:form_id]).reject(&:blank?)
     results = results.where(form_id: form_ids) if form_ids.any?
     results = results.where(event_id: params[:event_id]) if params[:event_id].present?
+    results = results.answered_question(params[:form_field_id]) if params[:form_field_id].present?
     results = results.where(role: params[:role]) if params[:role].present?
     results = results.for_organization(params[:organization_id]) if params[:organization_id].present?
     results = results.search(params[:search]) if params[:search].present?

--- a/app/services/form_response_aggregator.rb
+++ b/app/services/form_response_aggregator.rb
@@ -35,10 +35,9 @@ class FormResponseAggregator
   US_STATE_IDENTIFIERS = %w[mailing_state ce_license_issuing_state organization_state].to_set
   COUNTRY_IDENTIFIERS = %w[mailing_country organization_country].to_set
 
-  def initialize(form, event_id: nil, person_id: nil, organization_id: nil, start_date: nil, end_date: nil, question_query: nil)
+  def initialize(form, event_id: nil, organization_id: nil, start_date: nil, end_date: nil, question_query: nil)
     @form = form
     @event_id = event_id.presence
-    @person_id = person_id.presence
     @organization_id = organization_id.presence
     @start_date = start_date.presence
     @end_date = end_date.presence
@@ -79,12 +78,11 @@ class FormResponseAggregator
     @submissions ||= scoped_submissions.includes(:person).to_a
   end
 
-  # Optionally narrowed by event, person, organization, and submission date, so a
+  # Optionally narrowed by event, organization, and submission date, so a
   # shared form's rollup can be read a slice at a time.
   def scoped_submissions
     scope = @form.form_submissions
     scope = scope.where(event_id: @event_id) if @event_id
-    scope = scope.where(person_id: @person_id) if @person_id
     scope = scope.for_organization(@organization_id) if @organization_id
     scope.submitted_between(FormSubmission.parse_date(@start_date), FormSubmission.parse_date(@end_date))
   end

--- a/app/services/form_response_aggregator.rb
+++ b/app/services/form_response_aggregator.rb
@@ -35,9 +35,10 @@ class FormResponseAggregator
   US_STATE_IDENTIFIERS = %w[mailing_state ce_license_issuing_state organization_state].to_set
   COUNTRY_IDENTIFIERS = %w[mailing_country organization_country].to_set
 
-  def initialize(form, event_id: nil)
+  def initialize(form, event_id: nil, question_query: nil)
     @form = form
     @event_id = event_id.presence
+    @question_query = question_query.to_s.strip.downcase.presence
   end
 
   def submission_count
@@ -65,7 +66,7 @@ class FormResponseAggregator
   end
 
   def field_reports
-    @field_reports ||= input_fields.map { |field| build_report(field) }
+    @field_reports ||= reportable_fields.map { |field| build_report(field) }
   end
 
   private
@@ -88,6 +89,14 @@ class FormResponseAggregator
 
   def input_fields
     @input_fields ||= @form.form_fields.select(&:collects_input?).sort_by { |field| field.position.to_i }
+  end
+
+  # The questions to render as cards — every input field, or just those whose
+  # name matches the search. The Questions stat still counts the full set.
+  def reportable_fields
+    return input_fields unless @question_query
+
+    input_fields.select { |field| field.name.to_s.downcase.include?(@question_query) }
   end
 
   def answers_by_field_id

--- a/app/services/form_response_aggregator.rb
+++ b/app/services/form_response_aggregator.rb
@@ -35,9 +35,10 @@ class FormResponseAggregator
   US_STATE_IDENTIFIERS = %w[mailing_state ce_license_issuing_state organization_state].to_set
   COUNTRY_IDENTIFIERS = %w[mailing_country organization_country].to_set
 
-  def initialize(form, event_id: nil, question_query: nil)
+  def initialize(form, event_id: nil, organization_id: nil, question_query: nil)
     @form = form
     @event_id = event_id.presence
+    @organization_id = organization_id.presence
     @question_query = question_query.to_s.strip.downcase.presence
   end
 
@@ -75,12 +76,13 @@ class FormResponseAggregator
     @submissions ||= scoped_submissions.includes(:person).to_a
   end
 
-  # Optionally narrowed to one connected event, so a shared form's rollup can be
-  # read one event at a time.
+  # Optionally narrowed to one connected event and/or one linked organization, so
+  # a shared form's rollup can be read a slice at a time.
   def scoped_submissions
-    return @form.form_submissions unless @event_id
-
-    @form.form_submissions.where(event_id: @event_id)
+    scope = @form.form_submissions
+    scope = scope.where(event_id: @event_id) if @event_id
+    scope = scope.for_organization(@organization_id) if @organization_id
+    scope
   end
 
   def submission_by_id

--- a/app/services/form_response_aggregator.rb
+++ b/app/services/form_response_aggregator.rb
@@ -35,8 +35,9 @@ class FormResponseAggregator
   US_STATE_IDENTIFIERS = %w[mailing_state ce_license_issuing_state organization_state].to_set
   COUNTRY_IDENTIFIERS = %w[mailing_country organization_country].to_set
 
-  def initialize(form)
+  def initialize(form, event_id: nil)
     @form = form
+    @event_id = event_id.presence
   end
 
   def submission_count
@@ -70,7 +71,15 @@ class FormResponseAggregator
   private
 
   def submissions
-    @submissions ||= @form.form_submissions.includes(:person).to_a
+    @submissions ||= scoped_submissions.includes(:person).to_a
+  end
+
+  # Optionally narrowed to one connected event, so a shared form's rollup can be
+  # read one event at a time.
+  def scoped_submissions
+    return @form.form_submissions unless @event_id
+
+    @form.form_submissions.where(event_id: @event_id)
   end
 
   def submission_by_id

--- a/app/services/form_response_aggregator.rb
+++ b/app/services/form_response_aggregator.rb
@@ -35,10 +35,13 @@ class FormResponseAggregator
   US_STATE_IDENTIFIERS = %w[mailing_state ce_license_issuing_state organization_state].to_set
   COUNTRY_IDENTIFIERS = %w[mailing_country organization_country].to_set
 
-  def initialize(form, event_id: nil, organization_id: nil, question_query: nil)
+  def initialize(form, event_id: nil, person_id: nil, organization_id: nil, start_date: nil, end_date: nil, question_query: nil)
     @form = form
     @event_id = event_id.presence
+    @person_id = person_id.presence
     @organization_id = organization_id.presence
+    @start_date = start_date.presence
+    @end_date = end_date.presence
     @question_query = question_query.to_s.strip.downcase.presence
   end
 
@@ -76,13 +79,14 @@ class FormResponseAggregator
     @submissions ||= scoped_submissions.includes(:person).to_a
   end
 
-  # Optionally narrowed to one connected event and/or one linked organization, so
-  # a shared form's rollup can be read a slice at a time.
+  # Optionally narrowed by event, person, organization, and submission date, so a
+  # shared form's rollup can be read a slice at a time.
   def scoped_submissions
     scope = @form.form_submissions
     scope = scope.where(event_id: @event_id) if @event_id
+    scope = scope.where(person_id: @person_id) if @person_id
     scope = scope.for_organization(@organization_id) if @organization_id
-    scope
+    scope.submitted_between(FormSubmission.parse_date(@start_date), FormSubmission.parse_date(@end_date))
   end
 
   def submission_by_id

--- a/app/views/events/_breakdown_card.html.erb
+++ b/app/views/events/_breakdown_card.html.erb
@@ -14,7 +14,10 @@
       note:          optional hover text on an info icon beside the title, for a
                      figure whose basis needs spelling out.
       footer:        optional markup rendered inside the card below the table
-                     (e.g. a "view all" link); omit for no footer. %>
+                     (e.g. a "view all" link); omit for no footer.
+      count:         optional markup for the figure at the top right, replacing
+                     the default row count (e.g. a form results card's answer
+                     count, which links to those answers). %>
 <% chart = local_assigns.fetch(:chart, nil) %>
 <% empty_message = local_assigns.fetch(:empty_message, nil) %>
 <%# map_color: optional base hex for the choropleth ramp (e.g. the addresses color). %>
@@ -24,19 +27,19 @@
 <%# Stable section id (derived from the title) so registrants-page drill-downs can
     return here, with scroll-mt so the section clears the sticky header on return. %>
 <% anchor = title.parameterize %>
-<div id="<%= anchor %>" class="scroll-mt-24 bg-white border border-gray-200 rounded-xl shadow-sm p-4">
-  <div class="flex items-center justify-between mb-3">
+<div id="<%= anchor %>" class="scroll-mt-24 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+  <div class="mb-3 flex items-center justify-between">
     <h2 class="text-sm font-semibold text-gray-700">
       <%= title %>
       <% if local_assigns[:note] %>
-        <i class="fa-solid fa-circle-info text-gray-400 text-[0.65rem]" title="<%= local_assigns[:note] %>"></i>
+        <i class="fa-solid fa-circle-info text-[0.65rem] text-gray-400" title="<%= local_assigns[:note] %>"></i>
       <% end %>
     </h2>
-    <span class="text-xs text-gray-500"><%= data.size %></span>
+    <%= local_assigns[:count] || tag.span(data.size, class: "text-xs text-gray-500") %>
   </div>
 
   <% if data.empty? %>
-    <p class="text-sm text-gray-400 italic text-center py-8"><%= empty_message || "No data yet." %></p>
+    <p class="py-8 text-center text-sm text-gray-400 italic"><%= empty_message || "No data yet." %></p>
   <% else %>
     <% if chart == :pie %>
       <%= pie_chart data, colors: palette, legend: false, height: "220px" %>
@@ -57,7 +60,7 @@
       </div>
     <% end %>
 
-    <table class="w-full mt-3 text-sm">
+    <table class="mt-3 w-full text-sm">
       <tbody>
         <% data.each_with_index do |(label, count), i| %>
           <% path = row_paths[label] %>

--- a/app/views/form_answers/form_answers_results.html.erb
+++ b/app/views/form_answers/form_answers_results.html.erb
@@ -46,10 +46,8 @@
                 <div><%= answer.created_at.to_fs(:long) %></div>
                 <%= link_to "View submission",
                       form_submission_path(submission, return_to: "form_answers",
-                        q: params[:q].presence, question: params[:question].presence,
-                        person: params[:person].presence, form_id: params[:form_id].presence,
-                        event_id: params[:event_id].presence, answer_type: params[:answer_type].presence,
-                        form_submission_id: params[:form_submission_id].presence),
+                        origin: params[:return_to].presence,
+                        **form_answer_carryover_params(params)),
                       data: { turbo_frame: "_top" },
                       class: "mt-1 inline-block text-sm whitespace-nowrap text-blue-600 hover:underline" %>
               </td>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -36,9 +36,14 @@
                 include_blank: "All types",
                 class: search_field_class(extra: "search-select-placeholder") %>
         </div>
-        <div class="w-44">
-          <%= label_tag :person, "Person", class: search_label_class %>
-          <%= text_field_tag :person, params[:person], class: search_field_class, placeholder: "Name or email" %>
+        <div class="w-56">
+          <%= label_tag :person_id, "Person", class: search_label_class %>
+          <%= select_tag :person_id,
+                options_for_select(Person.where(id: params[:person_id]).map { |person| [ person.full_name, person.id ] }, params[:person_id]),
+                include_blank: true,
+                prompt: "Search for a person",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "person" } %>
         </div>
         <div class="w-24">
           <%= label_tag :form_submission_id, "Submission #", class: search_label_class %>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -63,6 +63,15 @@
                 class: search_field_class,
                 data: { controller: "remote-select", remote_select_model_value: "event" } %>
         </div>
+        <div class="w-56">
+          <%= label_tag :organization_id, "Organization", class: search_label_class %>
+          <%= select_tag :organization_id,
+                options_for_select(Organization.where(id: params[:organization_id]).map { |org| [ org.name, org.id ] }, params[:organization_id]),
+                include_blank: true,
+                prompt: "Search for an organization",
+                class: search_field_class,
+                data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+        </div>
         <div class="flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>
         </div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,7 +1,18 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <% topbar = capture do %>
-  <%= link_to forms_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-    <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+  <% if params[:return_to] == "form_results" && @form %>
+    <%# A form's results linked here, so the eyebrow goes back there — still
+        narrowed the same way — rather than to the generic Forms index. %>
+    <%= link_to results_form_path(@form, event_id: params[:event_id].presence,
+                                  person_id: params[:person_id].presence,
+                                  organization_id: params[:organization_id].presence),
+                class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
+    <% end %>
+  <% else %>
+    <%= link_to forms_path, class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+    <% end %>
   <% end %>
   <%= render "forms/index_subnav", current: :answers %>
 <% end %>
@@ -15,6 +26,8 @@
           data: { controller: "collection", turbo_frame: "form_answers_results" },
           autocomplete: "off",
           class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
+      <%# Carried so a filter change keeps the eyebrow, and the View links keep their origin. %>
+      <% if params[:return_to].present? %><%= hidden_field_tag :return_to, params[:return_to] %><% end %>
       <div class="mb-3 flex items-center gap-2 text-gray-600">
         <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
         <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>
@@ -77,6 +90,13 @@
                 class: search_field_class,
                 data: { controller: "remote-select", remote_select_model_value: "organization" } %>
         </div>
+        <div class="w-44">
+          <%= label_tag :empty, "Empty answers", class: search_label_class %>
+          <%# Hidden by default, so a question's count here matches the response count on form results. %>
+          <%= select_tag :empty,
+                options_for_select([ [ "Hidden", "" ], [ "Included", FormAnswersController::INCLUDE_EMPTY_ANSWERS ] ], params[:empty]),
+                class: search_field_class %>
+        </div>
         <div class="flex items-end">
           <%= render "shared/search_clear", url: form_answers_path %>
         </div>
@@ -85,7 +105,7 @@
 
     <% result_src = form_answers_path(request.query_parameters) %>
     <%= turbo_frame_tag :form_answers_results, src: result_src, data: { turbo: "temporary" } do %>
-      <div class="rounded-2xl border border-primary/10 bg-white py-16 text-center text-gray-400 shadow-sm">
+      <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center text-gray-400 shadow-sm">
         <i class="fa-solid fa-spinner fa-spin text-2xl" aria-hidden="true"></i>
         <p class="mt-2 text-sm">Loading answers…</p>
       </div>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -3,11 +3,7 @@
   <% if params[:return_to] == "form_results" && @form %>
     <%# A form's results linked here, so the eyebrow goes back there — still
         narrowed the same way — rather than to the generic Forms index. %>
-    <%= link_to results_form_path(@form, event_id: params[:event_id].presence,
-                                  person_id: params[:person_id].presence,
-                                  organization_id: params[:organization_id].presence,
-                                  start_date: params[:start_date].presence,
-                                  end_date: params[:end_date].presence),
+    <%= link_to results_form_path(@form, **form_results_return_params(params)),
                 class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
     <% end %>
@@ -30,6 +26,8 @@
           class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
       <%# Carried so a filter change keeps the eyebrow, and the View links keep their origin. %>
       <% if params[:return_to].present? %><%= hidden_field_tag :return_to, params[:return_to] %><% end %>
+      <%# Keeps a results drill-down pinned to its exact question while the Question box still names it. %>
+      <% if params[:form_field_id].present? %><%= hidden_field_tag :form_field_id, params[:form_field_id] %><% end %>
       <div class="mb-3 flex items-center gap-2 text-gray-600">
         <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
         <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>

--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -5,7 +5,9 @@
         narrowed the same way — rather than to the generic Forms index. %>
     <%= link_to results_form_path(@form, event_id: params[:event_id].presence,
                                   person_id: params[:person_id].presence,
-                                  organization_id: params[:organization_id].presence),
+                                  organization_id: params[:organization_id].presence,
+                                  start_date: params[:start_date].presence,
+                                  end_date: params[:end_date].presence),
                 class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
       <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
     <% end %>
@@ -89,6 +91,14 @@
                 prompt: "Search for an organization",
                 class: search_field_class,
                 data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+        </div>
+        <div class="w-44">
+          <%= label_tag :start_date, "Submitted from", class: search_label_class %>
+          <%= date_field_tag :start_date, params[:start_date], class: date_filter_class(search_field_class, params[:start_date]) %>
+        </div>
+        <div class="w-44">
+          <%= label_tag :end_date, "Submitted to", class: search_label_class %>
+          <%= date_field_tag :end_date, params[:end_date], class: date_filter_class(search_field_class, params[:end_date]) %>
         </div>
         <div class="w-44">
           <%= label_tag :empty, "Empty answers", class: search_label_class %>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -2,7 +2,7 @@
 <% topbar = capture do %>
   <div>
     <% if params[:return_to] == "form_results" && @form %>
-      <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+      <%= link_to results_form_path(@form, **form_results_return_params(params)), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
       <% end %>
     <% elsif params[:return_to] == "forms" && @form %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -7,7 +7,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form submissions
       <% end %>
     <% elsif params[:return_to] == "form_answers" %>
-      <%= link_to form_answers_path(q: params[:q].presence, question: params[:question].presence, person: params[:person].presence, form_id: params[:form_id].presence, event_id: params[:event_id].presence, answer_type: params[:answer_type].presence, form_submission_id: params[:form_submission_id].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to form_answers_path(**form_answer_carryover_params(params), return_to: params[:origin].presence), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form answers
       <% end %>
     <% elsif params[:return_to] == "form_results" && params[:form_id].present? %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -11,7 +11,7 @@
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to form answers
       <% end %>
     <% elsif params[:return_to] == "form_results" && params[:form_id].present? %>
-      <%= link_to results_form_path(params[:form_id]), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+      <%= link_to results_form_path(params[:form_id], **form_results_return_params(params)), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
         <i class="fa-solid fa-arrow-left text-xs"></i> Back to results
       <% end %>
     <% elsif event && params[:return_to] == "bulk_payments" %>

--- a/app/views/forms/_answer_count.html.erb
+++ b/app/views/forms/_answer_count.html.erb
@@ -1,0 +1,10 @@
+<%# The count in a results card's header: how many answers this question got,
+    opening exactly those answers in the Form answers list. Reads as a plain grey
+    figure until you reach for it. Locals: form, report. %>
+<% label = pluralize(report.answered_count, "answer") %>
+<% if report.answered_count.positive? %>
+  <%= link_to label, form_answers_path(**form_results_drilldown_params(form, report)),
+        class: "text-xs text-gray-500 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" %>
+<% else %>
+  <span class="text-xs text-gray-500"><%= label %></span>
+<% end %>

--- a/app/views/forms/_file_responses_card.html.erb
+++ b/app/views/forms/_file_responses_card.html.erb
@@ -10,6 +10,6 @@
     <span class="ml-1 text-sm text-gray-500"><%= "file".pluralize(report.answered_count) %> uploaded</span>
   </p>
   <% if report.answered_count.positive? %>
-    <%= render "forms/view_all_responses", form: form, count: report.answered_count %>
+    <%= render "forms/view_all_responses", form: form, count: report.answered_count, question: report.label %>
   <% end %>
 </div>

--- a/app/views/forms/_file_responses_card.html.erb
+++ b/app/views/forms/_file_responses_card.html.erb
@@ -10,6 +10,6 @@
     <span class="ml-1 text-sm text-gray-500"><%= "file".pluralize(report.answered_count) %> uploaded</span>
   </p>
   <% if report.answered_count.positive? %>
-    <%= render "forms/view_all_responses", form: form, count: report.answered_count, report: report %>
+    <%= render "forms/view_all_responses", form: form, report: report %>
   <% end %>
 </div>

--- a/app/views/forms/_file_responses_card.html.erb
+++ b/app/views/forms/_file_responses_card.html.erb
@@ -10,6 +10,6 @@
     <span class="ml-1 text-sm text-gray-500"><%= "file".pluralize(report.answered_count) %> uploaded</span>
   </p>
   <% if report.answered_count.positive? %>
-    <%= render "forms/view_all_responses", form: form, count: report.answered_count, question: report.label %>
+    <%= render "forms/view_all_responses", form: form, count: report.answered_count, report: report %>
   <% end %>
 </div>

--- a/app/views/forms/_file_responses_card.html.erb
+++ b/app/views/forms/_file_responses_card.html.erb
@@ -1,15 +1,25 @@
 <%# A file-upload question: files aren't charted or previewed here, just counted.
+    The count opens the answers themselves (each row names its uploaded file).
     Locals: report — a FormResponseAggregator::FieldReport with kind: :file; form. %>
 <div class="scroll-mt-24 break-inside-avoid rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
   <div class="mb-3 flex items-center justify-between">
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <span class="text-xs text-gray-500"><i class="fa-solid fa-paperclip" aria-hidden="true"></i></span>
   </div>
-  <p class="py-6 text-center text-gray-700">
-    <span class="text-2xl font-bold tabular-nums"><%= report.answered_count %></span>
-    <span class="ml-1 text-sm text-gray-500"><%= "file".pluralize(report.answered_count) %> uploaded</span>
-  </p>
+  <% uploaded = "#{"file".pluralize(report.answered_count)} uploaded" %>
   <% if report.answered_count.positive? %>
+    <%# The big figure inherits the link color so it greys normally and goes purple
+        on hover; the label keeps its own lighter grey. %>
+    <%= link_to form_answers_path(**form_results_drilldown_params(form, report)),
+          class: "block py-6 text-center text-gray-700 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" do %>
+      <span class="text-2xl font-bold tabular-nums"><%= report.answered_count %></span>
+      <span class="ml-1 text-sm text-gray-500"><%= uploaded %></span>
+    <% end %>
     <%= render "forms/view_all_responses", form: form, report: report %>
+  <% else %>
+    <p class="py-6 text-center text-gray-700">
+      <span class="text-2xl font-bold tabular-nums"><%= report.answered_count %></span>
+      <span class="ml-1 text-sm text-gray-500"><%= uploaded %></span>
+    </p>
   <% end %>
 </div>

--- a/app/views/forms/_numeric_card.html.erb
+++ b/app/views/forms/_numeric_card.html.erb
@@ -3,6 +3,9 @@
     the "Average / Total / Responses" figures on the funder summary. %>
 <% decimals = report.integer_valued ? 0 : 1 %>
 <div class="border-primary/10 rounded-2xl border bg-white p-5 shadow-sm">
+  <%# No "N answers" link like the other cards: answered_count here counts only the
+      answers that parse as numbers, so it would undercount the list it opened
+      (someone typing "varies" answered the question but isn't in the figures). %>
   <h3 class="font-semibold text-gray-900"><%= report.label %></h3>
 
   <% if report.answered_count.zero? %>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -31,7 +31,9 @@
               <span><%= response.submitted_at.to_date.to_fs(:long) %></span>
             <% end %>
             <span aria-hidden="true">·</span>
-            <%= link_to "View", form_submission_path(response.submission_id, return_to: "form_results", form_id: form.id, **form_results_link_params), class: link_class %>
+            <%= link_to "View", form_submission_path(response.submission_id, return_to: "form_results",
+                  form_id: form.id, form_field_id: report.field.id, **form_results_link_params),
+                  class: link_class %>
           </div>
         </li>
       <% end %>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -9,7 +9,7 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <% if report.answered_count.positive? %>
       <%= link_to report.answered_count,
-                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, organization_id: @selected_organization_id),
+                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id),
                   class: "text-xs #{link_class}" %>
     <% else %>
       <span class="text-xs text-gray-500"><%= report.answered_count %></span>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -7,7 +7,13 @@
 <div class="scroll-mt-24 break-inside-avoid rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
   <div class="mb-3 flex items-center justify-between">
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
-    <span class="text-xs text-gray-500"><%= report.answered_count %></span>
+    <% if report.answered_count.positive? %>
+      <%= link_to report.answered_count,
+                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id),
+                  class: "text-xs #{link_class}" %>
+    <% else %>
+      <span class="text-xs text-gray-500"><%= report.answered_count %></span>
+    <% end %>
   </div>
 
   <% if report.responses.empty? %>
@@ -31,6 +37,6 @@
       <% end %>
     </ul>
 
-    <%= render "forms/view_all_responses", form: form, count: report.responses.size %>
+    <%= render "forms/view_all_responses", form: form, count: report.responses.size, question: report.label %>
   <% end %>
 </div>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -9,7 +9,7 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <% if report.answered_count.positive? %>
       <%= link_to report.answered_count,
-                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id),
+                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id, return_to: "form_results"),
                   class: "text-xs #{link_class}" %>
     <% else %>
       <span class="text-xs text-gray-500"><%= report.answered_count %></span>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -3,19 +3,10 @@
       report: a FormResponseAggregator::FieldReport with kind: :text
       form:   the Form (for the header / per-response links) %>
 <% cap = 25 %>
-<% link_class = "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 <div class="scroll-mt-24 break-inside-avoid rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
   <div class="mb-3 flex items-center justify-between">
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
-    <%# Reads as a plain count until you reach for it, then shows it's this
-        question's answers. %>
-    <% if report.answered_count.positive? %>
-      <%= link_to pluralize(report.answered_count, "answer"),
-                  form_answers_path(**form_results_drilldown_params(form, report)),
-                  class: "text-xs text-gray-500 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" %>
-    <% else %>
-      <span class="text-xs text-gray-500"><%= pluralize(report.answered_count, "answer") %></span>
-    <% end %>
+    <%= render "forms/answer_count", form: form, report: report %>
   </div>
 
   <% if report.responses.empty? %>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -1,18 +1,20 @@
 <%# A free-text question's answers, listed newest-first. Long lists are capped
-    with a link out to the full, filterable responses index. Locals:
+    with a link out to the submissions behind the rollup. Locals:
       report: a FormResponseAggregator::FieldReport with kind: :text
-      form:   the Form (for the "view all" / per-response links) %>
+      form:   the Form (for the header / per-response links) %>
 <% cap = 25 %>
 <% link_class = "#{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 <div class="scroll-mt-24 break-inside-avoid rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
   <div class="mb-3 flex items-center justify-between">
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
+    <%# Reads as a plain count until you reach for it, then shows it's this
+        question's answers. %>
     <% if report.answered_count.positive? %>
-      <%= link_to report.answered_count,
+      <%= link_to pluralize(report.answered_count, "answer"),
                   form_answers_path(**form_results_drilldown_params(form, report)),
-                  class: "text-xs #{link_class}" %>
+                  class: "text-xs text-gray-500 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" %>
     <% else %>
-      <span class="text-xs text-gray-500"><%= report.answered_count %></span>
+      <span class="text-xs text-gray-500"><%= pluralize(report.answered_count, "answer") %></span>
     <% end %>
   </div>
 
@@ -24,21 +26,16 @@
         <li class="py-2">
           <%# submitted_answer is rendered escaped — never raw/simple_format (see FormAnswer). %>
           <p class="whitespace-pre-line text-sm text-gray-800"><%= response.text %></p>
-          <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-400">
-            <% if response.person_name.present? %><span><%= response.person_name %></span><% end %>
-            <% if response.submitted_at %>
-              <span aria-hidden="true">·</span>
-              <span><%= response.submitted_at.to_date.to_fs(:long) %></span>
-            <% end %>
-            <span aria-hidden="true">·</span>
-            <%= link_to "View", form_submission_path(response.submission_id, return_to: "form_results",
+          <%# The byline is the link to the submission — no separate "View". %>
+          <% byline = [ response.person_name.presence, response.submitted_at&.to_date&.to_fs(:long) ].compact %>
+          <%= link_to byline.join(" · ").presence || "Submission ##{response.submission_id}",
+                form_submission_path(response.submission_id, return_to: "form_results",
                   form_id: form.id, form_field_id: report.field.id, **form_results_link_params),
-                  class: link_class %>
-          </div>
+                class: "mt-1 inline-block text-xs text-gray-400 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" %>
         </li>
       <% end %>
     </ul>
 
-    <%= render "forms/view_all_responses", form: form, count: report.responses.size, report: report %>
+    <%= render "forms/view_all_responses", form: form, report: report %>
   <% end %>
 </div>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -9,7 +9,7 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <% if report.answered_count.positive? %>
       <%= link_to report.answered_count,
-                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id),
+                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, organization_id: @selected_organization_id),
                   class: "text-xs #{link_class}" %>
     <% else %>
       <span class="text-xs text-gray-500"><%= report.answered_count %></span>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -9,7 +9,7 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <% if report.answered_count.positive? %>
       <%= link_to report.answered_count,
-                  form_answers_path(form_id: form.id, question: report.label, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id, return_to: "form_results"),
+                  form_answers_path(**form_results_drilldown_params(form, report.label)),
                   class: "text-xs #{link_class}" %>
     <% else %>
       <span class="text-xs text-gray-500"><%= report.answered_count %></span>

--- a/app/views/forms/_text_responses_card.html.erb
+++ b/app/views/forms/_text_responses_card.html.erb
@@ -9,7 +9,7 @@
     <h2 class="text-sm font-semibold text-gray-700"><%= report.label %></h2>
     <% if report.answered_count.positive? %>
       <%= link_to report.answered_count,
-                  form_answers_path(**form_results_drilldown_params(form, report.label)),
+                  form_answers_path(**form_results_drilldown_params(form, report)),
                   class: "text-xs #{link_class}" %>
     <% else %>
       <span class="text-xs text-gray-500"><%= report.answered_count %></span>
@@ -31,12 +31,12 @@
               <span><%= response.submitted_at.to_date.to_fs(:long) %></span>
             <% end %>
             <span aria-hidden="true">·</span>
-            <%= link_to "View", form_submission_path(response.submission_id, return_to: "form_results", form_id: form.id), class: link_class %>
+            <%= link_to "View", form_submission_path(response.submission_id, return_to: "form_results", form_id: form.id, **form_results_link_params), class: link_class %>
           </div>
         </li>
       <% end %>
     </ul>
 
-    <%= render "forms/view_all_responses", form: form, count: report.responses.size, question: report.label %>
+    <%= render "forms/view_all_responses", form: form, count: report.responses.size, report: report %>
   <% end %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -7,5 +7,5 @@
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View #{count} #{"submission".pluralize(count)}",
               form_submissions_path(**form_results_submissions_params(form, report)),
-              class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
+              class: "text-sm text-gray-500 #{DomainTheme.text_class_for(:forms, intensity: 700, hover: true)} hover:underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -3,6 +3,6 @@
     Locals: form, count, question. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id),
+              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, organization_id: @selected_organization_id),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -1,7 +1,8 @@
-<%# Footer link from a results card to the full, filterable submissions list for
-    this form. Locals: form, count. %>
+<%# Footer link from a results card to the Form answers list, filtered to this
+    question's answers on this form (and the selected event, if any).
+    Locals: form, count, question. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_submissions_path(form_id: form.id, return_to: "form_results"),
+              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -3,6 +3,6 @@
     Locals: form, count, question. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, organization_id: @selected_organization_id),
+              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -1,8 +1,11 @@
-<%# Footer link from a results card to the Form answers list, filtered to this
-    question's answers on this form (and whatever the results page is narrowed to).
-    return_to gives that list an eyebrow back here. Locals: form, count, report. %>
+<%# Footer link from a results card to the Form submissions list, narrowed the
+    same way the rollup is — the submissions behind these numbers, whichever
+    question's card you are reading. The card's own answers live behind the count
+    in its header. return_to (plus the card id) gives that list an eyebrow back to
+    this card. Locals: form, report. %>
+<% count = @aggregator.submission_count %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
-  <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(**form_results_drilldown_params(form, report)),
+  <%= link_to "View #{count} #{"submission".pluralize(count)}",
+              form_submissions_path(**form_results_submissions_params(form, report)),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -3,6 +3,6 @@
     return_to gives that list an eyebrow back here. Locals: form, count, question. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id, return_to: "form_results"),
+              form_answers_path(**form_results_drilldown_params(form, question)),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -1,8 +1,8 @@
 <%# Footer link from a results card to the Form answers list, filtered to this
-    question's answers on this form (and the selected event, if any).
-    Locals: form, count, question. %>
+    question's answers on this form (and whatever the results page is narrowed to).
+    return_to gives that list an eyebrow back here. Locals: form, count, question. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id),
+              form_answers_path(form_id: form.id, question: question, event_id: @selected_event_id, person_id: @selected_person_id, organization_id: @selected_organization_id, return_to: "form_results"),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -1,8 +1,8 @@
 <%# Footer link from a results card to the Form answers list, filtered to this
     question's answers on this form (and whatever the results page is narrowed to).
-    return_to gives that list an eyebrow back here. Locals: form, count, question. %>
+    return_to gives that list an eyebrow back here. Locals: form, count, report. %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View all #{count} #{"response".pluralize(count)}",
-              form_answers_path(**form_results_drilldown_params(form, question)),
+              form_answers_path(**form_results_drilldown_params(form, report)),
               class: "text-sm #{DomainTheme.text_class_for(:forms, intensity: 600)} #{DomainTheme.text_class_for(:forms, intensity: 800, hover: true)} underline" %>
 </div>

--- a/app/views/forms/_view_all_responses.html.erb
+++ b/app/views/forms/_view_all_responses.html.erb
@@ -1,9 +1,9 @@
-<%# Footer link from a results card to the Form submissions list, narrowed the
-    same way the rollup is — the submissions behind these numbers, whichever
-    question's card you are reading. The card's own answers live behind the count
-    in its header. return_to (plus the card id) gives that list an eyebrow back to
-    this card. Locals: form, report. %>
-<% count = @aggregator.submission_count %>
+<%# Footer link from a results card to the Form submissions list, filtered to the
+    submissions that answered this question (and narrowed like the rollup) — the
+    people behind the chart, where the header count opens their answers.
+    return_to plus the card id gives that list an eyebrow back to this card.
+    Locals: form, report. %>
+<% count = report.answered_count %>
 <div class="mt-3 border-t border-gray-100 pt-3 text-center">
   <%= link_to "View #{count} #{"submission".pluralize(count)}",
               form_submissions_path(**form_results_submissions_params(form, report)),

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -24,17 +24,14 @@
 
   <% connected_events = @form.events.distinct.order(:start_date).to_a %>
   <% has_submissions = @form.form_submissions.exists? %>
-  <%# Event filter only earns its place on a form shared by more than one event;
-      organization linking is an event-registration concept, so its filter shows
-      for any event-connected form. The person/date filters need submissions to
-      slice — gated on the unscoped total so they stay put when a filter empties
-      the current view. %>
+  <%# Event filter only earns its place on a form shared by more than one event.
+      The submitter/date filters need submissions to slice — gated on the unscoped
+      total so they stay put when a filter empties the current view. %>
   <% show_event_filter = connected_events.many? %>
-  <% show_org_filter = connected_events.any? %>
   <% show_question_filter = has_submissions && @aggregator.question_count.positive? %>
-  <% show_person_filter = has_submissions %>
+  <% show_submitter_filter = has_submissions %>
   <% show_date_filter = has_submissions %>
-  <% if show_event_filter || show_org_filter || show_question_filter || show_person_filter || show_date_filter %>
+  <% if show_event_filter || show_question_filter || show_submitter_filter || show_date_filter %>
     <%# Auto-submits on change (collection controller) as a full-page Turbo visit:
         every select/date narrows the rollup, the question search narrows which
         question cards show. %>
@@ -63,26 +60,20 @@
                   class: search_field_class(extra: "search-select-placeholder") %>
           </div>
         <% end %>
-        <% if show_person_filter %>
-          <div class="w-full sm:w-44">
-            <%= label_tag :person_id, "Person", class: search_label_class %>
-            <%= select_tag :person_id,
-                  options_for_select(Person.where(id: @selected_person_id).map { |person| [ person.full_name, person.id ] }, @selected_person_id),
+        <% if show_submitter_filter %>
+          <%# One picker over people and organizations (the payer/funder pattern),
+              bound to the signed global id that says which kind was chosen. Seeded
+              with just the current pick so the value shows without preloading
+              everyone; the rest arrive from the remote search. %>
+          <% submitter = @selected_submitter&.compound_search_label %>
+          <div class="w-full sm:w-56">
+            <%= label_tag :submitter_sgid, "Person or organization", class: search_label_class %>
+            <%= select_tag :submitter_sgid,
+                  options_for_select(submitter ? [ [ submitter[:label], submitter[:id] ] ] : [], submitter&.dig(:id)),
                   include_blank: true,
-                  prompt: "All people",
+                  prompt: "All people and organizations",
                   class: search_field_class,
-                  data: { controller: "remote-select", remote_select_model_value: "person" } %>
-          </div>
-        <% end %>
-        <% if show_org_filter %>
-          <div class="w-full sm:w-44">
-            <%= label_tag :organization_id, "Organization", class: search_label_class %>
-            <%= select_tag :organization_id,
-                  options_for_select(Organization.where(id: @selected_organization_id).map { |org| [ org.name, org.id ] }, @selected_organization_id),
-                  include_blank: true,
-                  prompt: "All organizations",
-                  class: search_field_class,
-                  data: { controller: "remote-select", remote_select_model_value: "organization" } %>
+                  data: { controller: "remote-select", remote_select_model_value: "person_or_organization" } %>
           </div>
         <% end %>
         <% if show_date_filter %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -23,16 +23,21 @@
   </div>
 
   <% connected_events = @form.events.distinct.order(:start_date).to_a %>
+  <% has_submissions = @form.form_submissions.exists? %>
   <%# Event filter only earns its place on a form shared by more than one event;
       organization linking is an event-registration concept, so its filter shows
-      for any event-connected form. %>
+      for any event-connected form. The person/date filters need submissions to
+      slice — gated on the unscoped total so they stay put when a filter empties
+      the current view. %>
   <% show_event_filter = connected_events.many? %>
   <% show_org_filter = connected_events.any? %>
-  <% show_question_filter = @aggregator.question_count.positive? %>
-  <% if show_event_filter || show_org_filter || show_question_filter %>
+  <% show_question_filter = has_submissions && @aggregator.question_count.positive? %>
+  <% show_person_filter = has_submissions %>
+  <% show_date_filter = has_submissions %>
+  <% if show_event_filter || show_org_filter || show_question_filter || show_person_filter || show_date_filter %>
     <%# Auto-submits on change (collection controller) as a full-page Turbo visit:
-        the event/organization selects narrow a shared form's rollup, the question
-        search narrows which question cards show. %>
+        every select/date narrows the rollup, the question search narrows which
+        question cards show. %>
     <%= form_with url: results_form_path(@form), method: :get, autocomplete: "off",
           data: { controller: "collection" },
           class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
@@ -41,6 +46,12 @@
         <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
       </div>
       <div class="grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <% if show_question_filter %>
+          <div>
+            <%= label_tag :question, "Question", class: search_label_class %>
+            <%= text_field_tag :question, params[:question], placeholder: "Search questions", class: search_field_class %>
+          </div>
+        <% end %>
         <% if show_event_filter %>
           <div>
             <%= label_tag :event_id, "Event", class: search_label_class %>
@@ -48,6 +59,17 @@
                   options_for_select(connected_events.map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
                   include_blank: "All events",
                   class: search_field_class(extra: "search-select-placeholder") %>
+          </div>
+        <% end %>
+        <% if show_person_filter %>
+          <div>
+            <%= label_tag :person_id, "Person", class: search_label_class %>
+            <%= select_tag :person_id,
+                  options_for_select(Person.where(id: @selected_person_id).map { |person| [ person.full_name, person.id ] }, @selected_person_id),
+                  include_blank: true,
+                  prompt: "All people",
+                  class: search_field_class,
+                  data: { controller: "remote-select", remote_select_model_value: "person" } %>
           </div>
         <% end %>
         <% if show_org_filter %>
@@ -61,10 +83,14 @@
                   data: { controller: "remote-select", remote_select_model_value: "organization" } %>
           </div>
         <% end %>
-        <% if show_question_filter %>
+        <% if show_date_filter %>
           <div>
-            <%= label_tag :question, "Question", class: search_label_class %>
-            <%= text_field_tag :question, params[:question], placeholder: "Search questions", class: search_field_class %>
+            <%= label_tag :start_date, "Submitted from", class: search_label_class %>
+            <%= date_field_tag :start_date, params[:start_date], class: date_filter_class(search_field_class, params[:start_date]) %>
+          </div>
+          <div>
+            <%= label_tag :end_date, "Submitted to", class: search_label_class %>
+            <%= date_field_tag :end_date, params[:end_date], class: date_filter_class(search_field_class, params[:end_date]) %>
           </div>
         <% end %>
       </div>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -125,7 +125,7 @@
       </p>
     <% end %>
 
-    <% if @aggregator.field_reports.empty? %>
+    <% if @aggregator.field_reports.empty? && params[:question].present? %>
       <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
         <i class="fa-solid fa-magnifying-glass text-3xl text-gray-300" aria-hidden="true"></i>
         <p class="mt-3 text-gray-500">No questions match "<%= params[:question] %>".</p>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -22,9 +22,12 @@
     </div>
   </div>
 
-  <% if @form.event_connected? %>
-    <%# Shared forms roll up across every connected event; this narrows to one.
-        Auto-submits on change (collection controller) as a full-page Turbo visit. %>
+  <% show_event_filter = @form.event_connected? %>
+  <% show_question_filter = @aggregator.question_count.positive? %>
+  <% if show_event_filter || show_question_filter %>
+    <%# Auto-submits on change (collection controller) as a full-page Turbo visit:
+        the event select narrows a shared form's rollup to one event, the question
+        search narrows which question cards show. %>
     <%= form_with url: results_form_path(@form), method: :get, autocomplete: "off",
           data: { controller: "collection" },
           class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
@@ -32,12 +35,22 @@
         <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
         <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
       </div>
-      <div class="max-w-sm">
-        <%= label_tag :event_id, "Event", class: search_label_class %>
-        <%= select_tag :event_id,
-              options_for_select(@form.events.distinct.order(:start_date).map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
-              include_blank: "All events",
-              class: search_field_class(extra: "search-select-placeholder") %>
+      <div class="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
+        <% if show_event_filter %>
+          <div>
+            <%= label_tag :event_id, "Event", class: search_label_class %>
+            <%= select_tag :event_id,
+                  options_for_select(@form.events.distinct.order(:start_date).map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
+                  include_blank: "All events",
+                  class: search_field_class(extra: "search-select-placeholder") %>
+          </div>
+        <% end %>
+        <% if show_question_filter %>
+          <div>
+            <%= label_tag :question, "Question", class: search_label_class %>
+            <%= text_field_tag :question, params[:question], placeholder: "Search questions", class: search_field_class %>
+          </div>
+        <% end %>
       </div>
     <% end %>
   <% end %>
@@ -68,6 +81,13 @@
         Responses from <%= @aggregator.first_submitted_at.to_date.to_fs(:long) %>
         to <%= @aggregator.last_submitted_at.to_date.to_fs(:long) %>.
       </p>
+    <% end %>
+
+    <% if @aggregator.field_reports.empty? %>
+      <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
+        <i class="fa-solid fa-magnifying-glass text-3xl text-gray-300" aria-hidden="true"></i>
+        <p class="mt-3 text-gray-500">No questions match "<%= params[:question] %>".</p>
+      </div>
     <% end %>
 
     <%# Masonry columns (not a row-aligned grid) so cards of very different

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -22,10 +22,30 @@
     </div>
   </div>
 
+  <% if @form.event_connected? %>
+    <%# Shared forms roll up across every connected event; this narrows to one.
+        Auto-submits on change (collection controller) as a full-page Turbo visit. %>
+    <%= form_with url: results_form_path(@form), method: :get, autocomplete: "off",
+          data: { controller: "collection" },
+          class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
+      <div class="mb-3 flex items-center gap-2 text-gray-600">
+        <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
+        <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
+      </div>
+      <div class="max-w-sm">
+        <%= label_tag :event_id, "Event", class: search_label_class %>
+        <%= select_tag :event_id,
+              options_from_collection_for_select(@form.events.distinct.order(:title), :id, :name, @selected_event_id),
+              include_blank: "All events",
+              class: search_field_class(extra: "search-select-placeholder") %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% unless @aggregator.any_submissions? %>
     <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
       <i class="fa-solid fa-inbox text-3xl text-gray-300" aria-hidden="true"></i>
-      <p class="mt-3 text-gray-500">No submissions to this form yet.</p>
+      <p class="mt-3 text-gray-500"><%= @selected_event_id ? "No submissions for this event yet." : "No submissions to this form yet." %></p>
     </div>
   <% else %>
     <div class="mb-2 grid grid-cols-3 gap-3">

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -43,17 +43,19 @@
           class: "mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm" do %>
       <div class="mb-3 flex items-center gap-2 text-gray-600">
         <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
-        <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
+        <span class="text-xs font-semibold tracking-wide uppercase">Filters</span>
       </div>
-      <div class="grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <%# One row, on the bulk-payments filter bar's width scale: fixed pickers and
+          dates, the question search absorbing whatever's left. %>
+      <div class="flex flex-wrap items-end gap-3">
         <% if show_question_filter %>
-          <div>
+          <div class="min-w-44 flex-1">
             <%= label_tag :question, "Question", class: search_label_class %>
             <%= text_field_tag :question, @selected_question, placeholder: "Search questions", class: search_field_class %>
           </div>
         <% end %>
         <% if show_event_filter %>
-          <div>
+          <div class="w-full sm:w-44">
             <%= label_tag :event_id, "Event", class: search_label_class %>
             <%= select_tag :event_id,
                   options_for_select(connected_events.map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
@@ -62,7 +64,7 @@
           </div>
         <% end %>
         <% if show_person_filter %>
-          <div>
+          <div class="w-full sm:w-44">
             <%= label_tag :person_id, "Person", class: search_label_class %>
             <%= select_tag :person_id,
                   options_for_select(Person.where(id: @selected_person_id).map { |person| [ person.full_name, person.id ] }, @selected_person_id),
@@ -73,7 +75,7 @@
           </div>
         <% end %>
         <% if show_org_filter %>
-          <div>
+          <div class="w-full sm:w-44">
             <%= label_tag :organization_id, "Organization", class: search_label_class %>
             <%= select_tag :organization_id,
                   options_for_select(Organization.where(id: @selected_organization_id).map { |org| [ org.name, org.id ] }, @selected_organization_id),
@@ -84,15 +86,14 @@
           </div>
         <% end %>
         <% if show_date_filter %>
-          <div>
-            <%= label_tag :start_date, "Submitted from", class: search_label_class %>
-            <%= date_field_tag :start_date, params[:start_date], class: date_filter_class(search_field_class, params[:start_date]) %>
-          </div>
-          <div>
-            <%= label_tag :end_date, "Submitted to", class: search_label_class %>
-            <%= date_field_tag :end_date, params[:end_date], class: date_filter_class(search_field_class, params[:end_date]) %>
-          </div>
+          <%= render "events/filter_date", param: :start_date, label: "Submitted from",
+                field_class: search_field_class, wrapper_class: "w-full sm:w-36" %>
+          <%= render "events/filter_date", param: :end_date, label: "Submitted to",
+                field_class: search_field_class, wrapper_class: "w-full sm:w-36" %>
         <% end %>
+        <div class="flex items-end">
+          <%= render "shared/search_clear", url: results_form_path(@form) %>
+        </div>
       </div>
     <% end %>
   <% end %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -132,20 +132,19 @@
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, empty_message: "No responses yet.",
                        note: report.multi ? "Multiple answers allowed, so counts can exceed the submission total." : nil,
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, report: report) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, report: report) : nil %>
             <% if report.specify_rows.any? %>
-              <% specify_count = report.specify_rows.sum { |_, count| count } %>
               <div class="mt-6">
                 <%= render "events/breakdown_card", title: "#{report.label}: written-in answers",
                            data: report.specify_rows, chart: nil, palette: palette,
-                           footer: render("forms/view_all_responses", form: @form, count: specify_count, report: report) %>
+                           footer: render("forms/view_all_responses", form: @form, report: report) %>
               </div>
             <% end %>
           <% when :map %>
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, map_color: "#475569",
                        empty_message: "No responses yet.",
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, report: report) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, report: report) : nil %>
           <% when :number %>
             <%= render "forms/numeric_card", report: report %>
           <% when :text %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -35,7 +35,7 @@
         <i class="fa-solid fa-filter text-xs" aria-hidden="true"></i>
         <span class="text-xs font-semibold tracking-wide uppercase">Filter</span>
       </div>
-      <div class="grid max-w-2xl grid-cols-1 gap-4 sm:grid-cols-2">
+      <div class="grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <% if show_event_filter %>
           <div>
             <%= label_tag :event_id, "Event", class: search_label_class %>
@@ -43,6 +43,15 @@
                   options_for_select(@form.events.distinct.order(:start_date).map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
                   include_blank: "All events",
                   class: search_field_class(extra: "search-select-placeholder") %>
+          </div>
+          <div>
+            <%= label_tag :organization_id, "Organization", class: search_label_class %>
+            <%= select_tag :organization_id,
+                  options_for_select(Organization.where(id: @selected_organization_id).map { |org| [ org.name, org.id ] }, @selected_organization_id),
+                  include_blank: true,
+                  prompt: "All organizations",
+                  class: search_field_class,
+                  data: { controller: "remote-select", remote_select_model_value: "organization" } %>
           </div>
         <% end %>
         <% if show_question_filter %>
@@ -58,7 +67,7 @@
   <% unless @aggregator.any_submissions? %>
     <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
       <i class="fa-solid fa-inbox text-3xl text-gray-300" aria-hidden="true"></i>
-      <p class="mt-3 text-gray-500"><%= @selected_event_id ? "No submissions for this event yet." : "No submissions to this form yet." %></p>
+      <p class="mt-3 text-gray-500"><%= @selected_event_id || @selected_organization_id ? "No submissions match the selected filters yet." : "No submissions to this form yet." %></p>
     </div>
   <% else %>
     <div class="mb-2 grid grid-cols-3 gap-3">

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -101,20 +101,20 @@
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, empty_message: "No responses yet.",
                        note: report.multi ? "Multiple answers allowed, so counts can exceed the submission total." : nil,
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, question: report.label) : nil %>
             <% if report.specify_rows.any? %>
               <% specify_count = report.specify_rows.sum { |_, count| count } %>
               <div class="mt-6">
                 <%= render "events/breakdown_card", title: "#{report.label}: written-in answers",
                            data: report.specify_rows, chart: nil, palette: palette,
-                           footer: render("forms/view_all_responses", form: @form, count: specify_count) %>
+                           footer: render("forms/view_all_responses", form: @form, count: specify_count, question: report.label) %>
               </div>
             <% end %>
           <% when :map %>
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, map_color: "#475569",
                        empty_message: "No responses yet.",
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, question: report.label) : nil %>
           <% when :number %>
             <%= render "forms/numeric_card", report: report %>
           <% when :text %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -132,18 +132,21 @@
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, empty_message: "No responses yet.",
                        note: report.multi ? "Multiple answers allowed, so counts can exceed the submission total." : nil,
+                       count: render("forms/answer_count", form: @form, report: report),
                        footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, report: report) : nil %>
             <% if report.specify_rows.any? %>
               <div class="mt-6">
+                <%# No footer: this is a subset of the question above, whose own footer
+                    already links to the submissions that answered it. %>
                 <%= render "events/breakdown_card", title: "#{report.label}: written-in answers",
-                           data: report.specify_rows, chart: nil, palette: palette,
-                           footer: render("forms/view_all_responses", form: @form, report: report) %>
+                           data: report.specify_rows, chart: nil, palette: palette %>
               </div>
             <% end %>
           <% when :map %>
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, map_color: "#475569",
                        empty_message: "No responses yet.",
+                       count: render("forms/answer_count", form: @form, report: report),
                        footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, report: report) : nil %>
           <% when :number %>
             <%= render "forms/numeric_card", report: report %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -136,10 +136,13 @@
                        footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, report: report) : nil %>
             <% if report.specify_rows.any? %>
               <div class="mt-6">
-                <%# No footer: this is a subset of the question above, whose own footer
-                    already links to the submissions that answered it. %>
+                <%# The write-ins are a subset of the question above, and there's no way
+                    to filter a list down to just them — so the count and the footer
+                    here are that question's, same as on its own card. %>
                 <%= render "events/breakdown_card", title: "#{report.label}: written-in answers",
-                           data: report.specify_rows, chart: nil, palette: palette %>
+                           data: report.specify_rows, chart: nil, palette: palette,
+                           count: render("forms/answer_count", form: @form, report: report),
+                           footer: render("forms/view_all_responses", form: @form, report: report) %>
               </div>
             <% end %>
           <% when :map %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -25,13 +25,13 @@
   <% connected_events = @form.events.distinct.order(:start_date).to_a %>
   <% has_submissions = @form.form_submissions.exists? %>
   <%# Event filter only earns its place on a form shared by more than one event.
-      The submitter/date filters need submissions to slice — gated on the unscoped
+      The organization/date filters need submissions to slice — gated on the unscoped
       total so they stay put when a filter empties the current view. %>
   <% show_event_filter = connected_events.many? %>
   <% show_question_filter = has_submissions && @aggregator.question_count.positive? %>
-  <% show_submitter_filter = has_submissions %>
+  <% show_org_filter = has_submissions %>
   <% show_date_filter = has_submissions %>
-  <% if show_event_filter || show_question_filter || show_submitter_filter || show_date_filter %>
+  <% if show_event_filter || show_question_filter || show_org_filter || show_date_filter %>
     <%# Auto-submits on change (collection controller) as a full-page Turbo visit:
         every select/date narrows the rollup, the question search narrows which
         question cards show. %>
@@ -60,20 +60,15 @@
                   class: search_field_class(extra: "search-select-placeholder") %>
           </div>
         <% end %>
-        <% if show_submitter_filter %>
-          <%# One picker over people and organizations (the payer/funder pattern),
-              bound to the signed global id that says which kind was chosen. Seeded
-              with just the current pick so the value shows without preloading
-              everyone; the rest arrive from the remote search. %>
-          <% submitter = @selected_submitter&.compound_search_label %>
+        <% if show_org_filter %>
           <div class="w-full sm:w-56">
-            <%= label_tag :submitter_sgid, "Person or organization", class: search_label_class %>
-            <%= select_tag :submitter_sgid,
-                  options_for_select(submitter ? [ [ submitter[:label], submitter[:id] ] ] : [], submitter&.dig(:id)),
+            <%= label_tag :organization_id, "Organization", class: search_label_class %>
+            <%= select_tag :organization_id,
+                  options_for_select(Organization.where(id: @selected_organization_id).map { |org| [ org.name, org.id ] }, @selected_organization_id),
                   include_blank: true,
-                  prompt: "All people and organizations",
+                  prompt: "All organizations",
                   class: search_field_class,
-                  data: { controller: "remote-select", remote_select_model_value: "person_or_organization" } %>
+                  data: { controller: "remote-select", remote_select_model_value: "organization" } %>
           </div>
         <% end %>
         <% if show_date_filter %>
@@ -129,7 +124,9 @@
         the tall charts. Each card avoids breaking across a column. %>
     <div class="columns-1 gap-6 lg:columns-2 xl:columns-3">
       <% @aggregator.field_reports.each do |report| %>
-        <div class="mb-6 break-inside-avoid">
+        <%# scroll-mt clears the card of the top of the viewport when a return link
+            anchors here. %>
+        <div id="<%= form_results_card_id(report.field.id) %>" class="mb-6 scroll-mt-24 break-inside-avoid">
           <% case report.kind %>
           <% when :select %>
             <%= render "events/breakdown_card", title: report.label, data: report.rows,

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -22,11 +22,16 @@
     </div>
   </div>
 
-  <% show_event_filter = @form.event_connected? %>
+  <% connected_events = @form.events.distinct.order(:start_date).to_a %>
+  <%# Event filter only earns its place on a form shared by more than one event;
+      organization linking is an event-registration concept, so its filter shows
+      for any event-connected form. %>
+  <% show_event_filter = connected_events.many? %>
+  <% show_org_filter = connected_events.any? %>
   <% show_question_filter = @aggregator.question_count.positive? %>
-  <% if show_event_filter || show_question_filter %>
+  <% if show_event_filter || show_org_filter || show_question_filter %>
     <%# Auto-submits on change (collection controller) as a full-page Turbo visit:
-        the event select narrows a shared form's rollup to one event, the question
+        the event/organization selects narrow a shared form's rollup, the question
         search narrows which question cards show. %>
     <%= form_with url: results_form_path(@form), method: :get, autocomplete: "off",
           data: { controller: "collection" },
@@ -40,10 +45,12 @@
           <div>
             <%= label_tag :event_id, "Event", class: search_label_class %>
             <%= select_tag :event_id,
-                  options_for_select(@form.events.distinct.order(:start_date).map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
+                  options_for_select(connected_events.map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
                   include_blank: "All events",
                   class: search_field_class(extra: "search-select-placeholder") %>
           </div>
+        <% end %>
+        <% if show_org_filter %>
           <div>
             <%= label_tag :organization_id, "Organization", class: search_label_class %>
             <%= select_tag :organization_id,

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -49,7 +49,7 @@
         <% if show_question_filter %>
           <div>
             <%= label_tag :question, "Question", class: search_label_class %>
-            <%= text_field_tag :question, params[:question], placeholder: "Search questions", class: search_field_class %>
+            <%= text_field_tag :question, @selected_question, placeholder: "Search questions", class: search_field_class %>
           </div>
         <% end %>
         <% if show_event_filter %>
@@ -100,7 +100,7 @@
   <% unless @aggregator.any_submissions? %>
     <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
       <i class="fa-solid fa-inbox text-3xl text-gray-300" aria-hidden="true"></i>
-      <p class="mt-3 text-gray-500"><%= @selected_event_id || @selected_organization_id ? "No submissions match the selected filters yet." : "No submissions to this form yet." %></p>
+      <p class="mt-3 text-gray-500"><%= form_results_filter_params.any? ? "No submissions match the selected filters yet." : "No submissions to this form yet." %></p>
     </div>
   <% else %>
     <div class="mb-2 grid grid-cols-3 gap-3">
@@ -125,10 +125,10 @@
       </p>
     <% end %>
 
-    <% if @aggregator.field_reports.empty? && params[:question].present? %>
+    <% if @aggregator.field_reports.empty? && @selected_question %>
       <div class="border-primary/10 rounded-2xl border bg-white py-16 text-center shadow-sm">
         <i class="fa-solid fa-magnifying-glass text-3xl text-gray-300" aria-hidden="true"></i>
-        <p class="mt-3 text-gray-500">No questions match "<%= params[:question] %>".</p>
+        <p class="mt-3 text-gray-500">No questions match "<%= @selected_question %>".</p>
       </div>
     <% end %>
 
@@ -143,20 +143,20 @@
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, empty_message: "No responses yet.",
                        note: report.multi ? "Multiple answers allowed, so counts can exceed the submission total." : nil,
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, question: report.label) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, report: report) : nil %>
             <% if report.specify_rows.any? %>
               <% specify_count = report.specify_rows.sum { |_, count| count } %>
               <div class="mt-6">
                 <%= render "events/breakdown_card", title: "#{report.label}: written-in answers",
                            data: report.specify_rows, chart: nil, palette: palette,
-                           footer: render("forms/view_all_responses", form: @form, count: specify_count, question: report.label) %>
+                           footer: render("forms/view_all_responses", form: @form, count: specify_count, report: report) %>
               </div>
             <% end %>
           <% when :map %>
             <%= render "events/breakdown_card", title: report.label, data: report.rows,
                        chart: report.chart, palette: palette, map_color: "#475569",
                        empty_message: "No responses yet.",
-                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, question: report.label) : nil %>
+                       footer: report.answered_count.positive? ? render("forms/view_all_responses", form: @form, count: report.answered_count, report: report) : nil %>
           <% when :number %>
             <%= render "forms/numeric_card", report: report %>
           <% when :text %>

--- a/app/views/forms/results.html.erb
+++ b/app/views/forms/results.html.erb
@@ -35,7 +35,7 @@
       <div class="max-w-sm">
         <%= label_tag :event_id, "Event", class: search_label_class %>
         <%= select_tag :event_id,
-              options_from_collection_for_select(@form.events.distinct.order(:title), :id, :name, @selected_event_id),
+              options_for_select(@form.events.distinct.order(:start_date).map { |event| [ event.decorate.title_with_month_year, event.id ] }, @selected_event_id),
               include_blank: "All events",
               class: search_field_class(extra: "search-select-placeholder") %>
       </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -43,9 +43,9 @@
   released_on: 2026-09-02
   summary: >-
     A form's Results page gained filters at the top — narrow the rolled-up answers
-    to one event (for forms shared across several events), to a single organization,
-    or search by question name. Each question's response count now links straight to
-    the Form answers list, pre-filtered to that question (and event).
+    by question name, event (for forms shared across several events), person,
+    organization, or submission date. Each question's response count now links
+    straight to the Form answers list, pre-filtered to that question.
   pr_number: 2508
 
 - name: "Jump from the activity timeline to the page each row logged"

--- a/config/features.yml
+++ b/config/features.yml
@@ -37,14 +37,15 @@
     internal notes from communications at a glance. Rows line up in even columns
     and show up to two lines of text.
   pr_number: 2515
-- name: "Filter a form's results by event"
+- name: "Filter and drill into a form's results"
   area: reporting
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    When a form is used by more than one event, its Results page now has an event
-    filter at the top so you can read the rolled-up answers one event at a time,
-    instead of every event's submissions mixed together.
+    A form's Results page gained filters at the top — narrow the rolled-up answers
+    to one event (for forms shared across several events) or search by question
+    name. Each question's response count now links straight to the Form answers
+    list, pre-filtered to that question (and event).
   pr_number: 2508
 
 - name: "Jump from the activity timeline to the page each row logged"

--- a/config/features.yml
+++ b/config/features.yml
@@ -45,7 +45,7 @@
     When a form is used by more than one event, its Results page now has an event
     filter at the top so you can read the rolled-up answers one event at a time,
     instead of every event's submissions mixed together.
-  pr_number: 2507
+  pr_number: 2508
 
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting

--- a/config/features.yml
+++ b/config/features.yml
@@ -37,6 +37,15 @@
     internal notes from communications at a glance. Rows line up in even columns
     and show up to two lines of text.
   pr_number: 2515
+- name: "Filter a form's results by event"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    When a form is used by more than one event, its Results page now has an event
+    filter at the top so you can read the rolled-up answers one event at a time,
+    instead of every event's submissions mixed together.
+  pr_number: 2507
 
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting

--- a/config/features.yml
+++ b/config/features.yml
@@ -48,6 +48,17 @@
     straight to the Form answers list, pre-filtered to that question.
   pr_number: 2508
 
+- name: "Form answers list hides blank answers"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    The Form answers list now leaves out the blank rows an optional question
+    nobody filled in leaves behind, so its counts match the response counts on a
+    form's Results page. Switch "Empty answers" to Included to see them again.
+  action_path: /form_answers
+  pr_number: 2508
+
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting
   display_status: admin_facing

--- a/config/features.yml
+++ b/config/features.yml
@@ -43,9 +43,9 @@
   released_on: 2026-09-02
   summary: >-
     A form's Results page gained filters at the top — narrow the rolled-up answers
-    to one event (for forms shared across several events) or search by question
-    name. Each question's response count now links straight to the Form answers
-    list, pre-filtered to that question (and event).
+    to one event (for forms shared across several events), to a single organization,
+    or search by question name. Each question's response count now links straight to
+    the Form answers list, pre-filtered to that question (and event).
   pr_number: 2508
 
 - name: "Jump from the activity timeline to the page each row logged"

--- a/config/features.yml
+++ b/config/features.yml
@@ -48,14 +48,15 @@
     straight to the Form answers list, pre-filtered to that question.
   pr_number: 2508
 
-- name: "Form answers list hides blank answers"
+- name: "Form answers list hides blank answers, and filters by date"
   area: reporting
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
     The Form answers list now leaves out the blank rows an optional question
-    nobody filled in leaves behind, so its counts match the response counts on a
-    form's Results page. Switch "Empty answers" to Included to see them again.
+    nobody filled in leaves behind, so its counts match a form's Results page.
+    Switch "Empty answers" to Included to see them. It also filters by
+    organization and by the date a form was submitted.
   action_path: /form_answers
   pr_number: 2508
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -37,26 +37,47 @@
     internal notes from communications at a glance. Rows line up in even columns
     and show up to two lines of text.
   pr_number: 2515
-- name: "Filter and drill into a form's results"
+- name: "Filter a form's results"
   area: reporting
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    A form's Results page gained filters at the top — narrow the rolled-up answers
-    by question name, event (for forms shared across several events), person,
-    organization, or submission date. Each question's response count now links
-    straight to the Form answers list, pre-filtered to that question.
+    A form's Results page gained a filter row at the top — narrow the rolled-up
+    answers by question name, event (for forms used by several events),
+    organization, or the date a form was submitted, and clear the lot with one
+    button.
   pr_number: 2508
 
-- name: "Form answers list hides blank answers, and filters by date"
+- name: "Open the answers or the submissions behind a results chart"
   area: reporting
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    The Form answers list now leaves out the blank rows an optional question
-    nobody filled in leaves behind, so its counts match a form's Results page.
-    Switch "Empty answers" to Included to see them. It also filters by
-    organization and by the date a form was submitted.
+    Each question on a form's Results page now says how many answers it got, and
+    that count opens the Form answers list showing just those answers. The link
+    under each chart opens the submissions behind the whole rollup. Either way,
+    coming back lands you on the question you left.
+  pr_number: 2508
+
+- name: "Form answers list hides blank answers"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    An optional question nobody filled in used to leave a blank row in the Form
+    answers list, so its counts disagreed with a form's Results page. Those rows
+    are now hidden. Switch "Empty answers" to Included to see them again.
+  action_path: /form_answers
+  pr_number: 2508
+
+- name: "Filter form answers by organization and submission date"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    The Form answers list gained an Organization filter and a submitted-date
+    range. The dates read the date the form was submitted, so they answer the
+    same question a form's Results page does.
   action_path: /form_answers
   pr_number: 2508
 

--- a/db/seeds/dev/form_results_showcase.rb
+++ b/db/seeds/dev/form_results_showcase.rb
@@ -5,8 +5,9 @@
 # (/forms/:id/results) has something rich to look at: pie + bar charts for the
 # select/checkbox questions (including the dynamic sector/age-group fields that
 # store ids), "Other / please specify" write-in lists, free-text answer lists,
-# and a file-upload count. Group-header and informational fields are included so
-# the input-less types are represented too (they're skipped in the rollup).
+# an average/total/range summary for the number questions, and a file-upload
+# count. Group-header and informational fields are included so the input-less
+# types are represented too (they're skipped in the rollup).
 #
 # Idempotent: the form is looked up by slug, fields by name, submissions by
 # (form, person), and each answer is skipped when already present. Distributions
@@ -25,10 +26,12 @@ end
 age_categories = CategoryType.find_by(name: "AgeRange")&.categories&.published&.order(:position)&.to_a || []
 sectors = Sector.published.order(:name).first(6)
 
-def upsert_field!(form, name, answer_type, position, options: [], field_identifier: nil, required: false)
+def upsert_field!(form, name, answer_type, position, options: [], field_identifier: nil, required: false,
+                  input_type: :text_alphanumeric)
   field = form.form_fields.find_by(name: name)
   field ||= form.form_fields.create!(name: name, answer_type: answer_type, position: position,
-                                     status: :active, required: required, field_identifier: field_identifier)
+                                     status: :active, required: required, field_identifier: field_identifier,
+                                     input_type: input_type)
   options.each_with_index do |option_name, index|
     answer_option = AnswerOption.find_or_create_by!(name: option_name) { |ao| ao.position = index + 1 }
     FormFieldAnswerOption.find_or_create_by!(form_field: field, answer_option: answer_option)
@@ -55,6 +58,12 @@ state_field = upsert_field!(form, "Which state are you in?", :free_form_input_on
 country_field = upsert_field!(form, "Which country are you in?", :free_form_input_one_line, 11, field_identifier: "mailing_country")
 info = upsert_field!(form, "Thanks for sharing — the rest is optional.", :no_user_input, 12)
 upload = upsert_field!(form, "Upload a sample of your work", :file_upload, 13)
+# Number questions are one-line inputs with a numeric input_type — that's what
+# makes them roll up as average / total / range instead of a text answer list.
+served = upsert_field!(form, "People served in a typical month", :free_form_input_one_line, 14,
+                       input_type: :number_integer)
+hours = upsert_field!(form, "Hours of programming you run each week", :free_form_input_one_line, 15,
+                      input_type: :number_decimal)
 
 states = [ "California", "Texas", "New York", "Florida", "Washington", "Illinois", "Massachusetts", "Oregon", "Georgia", "Ohio" ]
 countries = [ "United States", "United States", "United States", "Canada", "United Kingdom", "Australia", "Mexico" ]
@@ -78,6 +87,11 @@ heard_answers = [
 mediums = [ "Painting", "Collage", "Clay", "Drawing", "Journaling" ]
 regions = [ "Pacific", "Mountain", "Midwest", "Southwest", "Southeast", "Northeast", "Mid-Atlantic", "International" ]
 all_topics = [ "Self-care", "Grief", "Empathy", "Communication", "Safety and security" ]
+# Wide spread so the average, total, and range each read differently. The blank
+# and the "varies" leave a partial answer rate, and show that a non-numeric stray
+# is dropped from the figures rather than skewing them.
+served_counts = [ "12", "45", "8", "120", "30", "", "64", "6", "250", "18", "varies" ]
+weekly_hours = [ "2.5", "6", "1.5", "12", "3.75", "8", "", "4", "20.5", "0.5" ]
 
 respondent_count = 30
 
@@ -103,7 +117,9 @@ respondent_count.times do |i|
     # A rotating 1–3 topic subset, so the multi-select bar chart varies.
     topics => all_topics.each_with_index.select { |_, j| (i + j) % 3 == 0 }.map(&:first).join(", "),
     # Every third respondent skips the file upload, for a realistic count.
-    upload => (i % 3 == 2 ? "" : "sample_#{i + 1}.jpg")
+    upload => (i % 3 == 2 ? "" : "sample_#{i + 1}.jpg"),
+    served => served_counts[i % served_counts.size],
+    hours => weekly_hours[i % weekly_hours.size]
   }
   answers[age_group] = age_categories[i % age_categories.size].id.to_s if age_categories.any?
   # 1–3 sectors as their ids, joined like a real multi-select submission.

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -120,6 +120,52 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("short-answer")
       end
 
+      it "hides the blank answer rows an unfilled optional question leaves behind" do
+        form = create(:form)
+        create(:form_answer, submitted_answer: "answered-it",
+               form_field: create(:form_field, form: form, name: "Answered question"))
+        create(:form_answer, submitted_answer: "",
+               form_field: create(:form_field, form: form, name: "Skipped question"))
+
+        get form_answers_path, headers: frame_headers
+
+        expect(response.body).to include("Answered question")
+        expect(response.body).not_to include("Skipped question")
+      end
+
+      it "includes the blank rows when the empty filter asks for them" do
+        form = create(:form)
+        create(:form_answer, submitted_answer: "",
+               form_field: create(:form_field, form: form, name: "Skipped question"))
+
+        get form_answers_path(empty: "include"), headers: frame_headers
+
+        expect(response.body).to include("Skipped question")
+      end
+
+      it "links back to the form's results page when it linked here" do
+        form = create(:form, name: "Volunteer interest")
+        create(:form_answer, form_submission: create(:form_submission, form: form))
+
+        get form_answers_path(form_id: form.id, return_to: "form_results")
+
+        expect(response.body).to include(CGI.escapeHTML(results_form_path(form)))
+        expect(response.body).to include("Volunteer interest results")
+      end
+
+      it "keeps every filter on the round trip through a submission" do
+        org = create(:organization)
+        submission = create(:form_submission)
+        submission.link_organization!(org.id)
+        create(:form_answer, form_submission: submission)
+
+        get form_answers_path(organization_id: org.id), headers: frame_headers
+
+        expect(response.body).to include(CGI.escapeHTML(
+          form_submission_path(submission, return_to: "form_answers", organization_id: org.id)
+        ))
+      end
+
       it "breaks the View link out of the results frame" do
         create(:form_answer)
         get form_answers_path, headers: frame_headers

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -199,6 +199,19 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).to include("Volunteer interest results")
       end
 
+      it "anchors the way back to the results card the drill-down opened" do
+        form = create(:form, name: "Volunteer interest")
+        field = create(:form_field, form: form, name: "Any thoughts")
+        create(:form_answer, form_field: field, form_submission: create(:form_submission, form: form))
+
+        get form_answers_path(form_id: form.id, return_to: "form_results",
+                              question: "Any thoughts", form_field_id: field.id)
+
+        expect(response.body).to include(CGI.escapeHTML(
+          results_form_path(form, anchor: "form-question-#{field.id}")
+        ))
+      end
+
       it "restores the results page's own question search on the way back" do
         form = create(:form, name: "Volunteer interest")
         create(:form_answer, form_submission: create(:form_submission, form: form))

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("for-other-org")
       end
 
-      it "filters by person name" do
+      it "filters by person" do
         priya = create(:person, first_name: "Priya", last_name: "Patel")
         other = create(:person, first_name: "Sam", last_name: "Jones")
         create(:form_answer, submitted_answer: "priya-answer",
@@ -89,7 +89,7 @@ RSpec.describe "FormAnswers", type: :request do
         create(:form_answer, submitted_answer: "sam-answer",
                form_submission: create(:form_submission, person: other))
 
-        get form_answers_path(person: "Priya"), headers: frame_headers
+        get form_answers_path(person_id: priya.id), headers: frame_headers
 
         expect(response.body).to include("priya-answer")
         expect(response.body).not_to include("sam-answer")

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -68,6 +68,19 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("at-other-event")
       end
 
+      it "filters by organization" do
+        org = create(:organization)
+        linked = create(:form_submission)
+        linked.link_organization!(org.id)
+        create(:form_answer, submitted_answer: "for-this-org", form_submission: linked)
+        create(:form_answer, submitted_answer: "for-other-org", form_submission: create(:form_submission))
+
+        get form_answers_path(organization_id: org.id), headers: frame_headers
+
+        expect(response.body).to include("for-this-org")
+        expect(response.body).not_to include("for-other-org")
+      end
+
       it "filters by person name" do
         priya = create(:person, first_name: "Priya", last_name: "Patel")
         other = create(:person, first_name: "Sam", last_name: "Jones")

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -157,6 +157,38 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).to include("Skipped question")
       end
 
+      # The Question box is a free-text search, so on its own it would also match a
+      # sibling question whose name contains this one's. A results drill-down sends
+      # the field id alongside so its list matches the count on the card.
+      it "pins a results drill-down to the exact question it names" do
+        form = create(:form)
+        email = create(:form_field, form: form, name: "Email")
+        create(:form_field, form: form, name: "Email 2")
+        create(:form_answer, form_field: email, submitted_answer: "pinned-answer",
+               form_submission: create(:form_submission, form: form))
+        create(:form_answer, form_field: form.form_fields.find_by(name: "Email 2"),
+               submitted_answer: "sibling-answer", form_submission: create(:form_submission, form: form))
+
+        get form_answers_path(form_id: form.id, question: "Email", form_field_id: email.id), headers: frame_headers
+
+        expect(response.body).to include("pinned-answer")
+        expect(response.body).not_to include("sibling-answer")
+      end
+
+      it "searches by name again once the question box no longer names the pinned question" do
+        form = create(:form)
+        email = create(:form_field, form: form, name: "Email")
+        create(:form_answer, form_field: email, submitted_answer: "pinned-answer",
+               form_submission: create(:form_submission, form: form))
+        create(:form_answer, form_field: create(:form_field, form: form, name: "Phone"),
+               submitted_answer: "phone-answer", form_submission: create(:form_submission, form: form))
+
+        get form_answers_path(form_id: form.id, question: "Phone", form_field_id: email.id), headers: frame_headers
+
+        expect(response.body).to include("phone-answer")
+        expect(response.body).not_to include("pinned-answer")
+      end
+
       it "links back to the form's results page when it linked here" do
         form = create(:form, name: "Volunteer interest")
         create(:form_answer, form_submission: create(:form_submission, form: form))
@@ -165,6 +197,16 @@ RSpec.describe "FormAnswers", type: :request do
 
         expect(response.body).to include(CGI.escapeHTML(results_form_path(form)))
         expect(response.body).to include("Volunteer interest results")
+      end
+
+      it "restores the results page's own question search on the way back" do
+        form = create(:form, name: "Volunteer interest")
+        create(:form_answer, form_submission: create(:form_submission, form: form))
+
+        get form_answers_path(form_id: form.id, return_to: "form_results",
+                              question: "Any thoughts", results_question: "thoughts")
+
+        expect(response.body).to include(CGI.escapeHTML(results_form_path(form, question: "thoughts")))
       end
 
       it "keeps every filter on the round trip through a submission" do

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -120,6 +120,20 @@ RSpec.describe "FormAnswers", type: :request do
         expect(response.body).not_to include("short-answer")
       end
 
+      # By the submission's date, not the answer row's, so this list and a form's
+      # results page answer the same date range the same way.
+      it "filters by when the submission was made" do
+        create(:form_answer, submitted_answer: "winter-answer",
+               form_submission: create(:form_submission, created_at: Date.new(2026, 1, 5)))
+        create(:form_answer, submitted_answer: "summer-answer",
+               form_submission: create(:form_submission, created_at: Date.new(2026, 6, 5)))
+
+        get form_answers_path(start_date: "2026-05-01", end_date: "2026-07-01"), headers: frame_headers
+
+        expect(response.body).to include("summer-answer")
+        expect(response.body).not_to include("winter-answer")
+      end
+
       it "hides the blank answer rows an unfilled optional question leaves behind" do
         form = create(:form)
         create(:form_answer, submitted_answer: "answered-it",

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -122,6 +122,22 @@ RSpec.describe "FormSubmissions", type: :request do
         expect(response.body).not_to include(form_submission_path(other))
       end
 
+      # The results-card footer sends form_field_id, so its "View N submissions"
+      # count matches the list it opens.
+      it "filters to the submissions that answered one question" do
+        form = create(:form)
+        field = create(:form_field, form: form, name: "Phone")
+        answered = create(:form_submission, form: form)
+        skipped = create(:form_submission, form: form)
+        create(:form_answer, form_submission: answered, form_field: field, submitted_answer: "(555) 111-2222")
+        create(:form_answer, form_submission: skipped, form_field: field, submitted_answer: "")
+
+        get form_submissions_path(form_id: form.id, form_field_id: field.id), headers: frame_headers
+
+        expect(response.body).to include(form_submission_path(answered))
+        expect(response.body).not_to include(form_submission_path(skipped))
+      end
+
       it "carries the new filters back through each View link" do
         event = create(:event)
         submission = create(:form_submission, event: event, role: "registration")

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -993,20 +993,18 @@ RSpec.describe "Forms", type: :request do
         expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
       end
 
-      it "searches people and organizations from one picker" do
+      it "filters by organization, not by person" do
         form = create(:form, :standalone)
         create(:form_submission, form: form)
 
         get results_form_path(form)
 
-        picker = Nokogiri::HTML(response.body).at_css("select#submitter_sgid")
-        expect(picker).to be_present
-        expect(picker["data-remote-select-model-value"]).to eq("person_or_organization")
-        expect(Nokogiri::HTML(response.body).at_css("select#person_id")).to be_nil
-        expect(Nokogiri::HTML(response.body).at_css("select#organization_id")).to be_nil
+        doc = Nokogiri::HTML(response.body)
+        expect(doc.at_css("select#organization_id")).to be_present
+        expect(doc.at_css("select#person_id")).to be_nil
       end
 
-      it "renders the results filters as question, event, person or organization, submitted from, submitted to" do
+      it "renders the results filters as question, event, organization, submitted from, submitted to" do
         form = create(:form)
         create(:event_form, form: form, event: create(:event), role: "registration")
         create(:event_form, form: form, event: create(:event), role: "continuing_education")
@@ -1017,79 +1015,20 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         ids = doc.css("form label").map { |l| l["for"] }.compact
-        ids &= %w[question event_id submitter_sgid start_date end_date]
-        expect(ids).to eq(%w[question event_id submitter_sgid start_date end_date])
-      end
-
-      it "narrows the rollup to a person picked through the combined picker" do
-        form = create(:form, :standalone)
-        person = create(:person)
-        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
-        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
-                             form_field: color, submitted_answer: "Blue")
-        create(:form_answer, form_submission: create(:form_submission, form: form, person: create(:person)),
-                             form_field: color, submitted_answer: "Red")
-
-        get results_form_path(form, submitter_sgid: person.to_sgid.to_s)
-
-        expect(response.body).to include("Blue")
-        expect(response.body).not_to include("Red")
-      end
-
-      it "narrows the rollup to an organization picked through the combined picker" do
-        form = create(:form, :standalone)
-        org = create(:organization)
-        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
-        linked = create(:form_submission, form: form)
-        linked.link_organization!(org.id)
-        create(:form_answer, form_submission: linked, form_field: color, submitted_answer: "Blue")
-        create(:form_answer, form_submission: create(:form_submission, form: form),
-                             form_field: color, submitted_answer: "Red")
-
-        get results_form_path(form, submitter_sgid: org.to_sgid.to_s)
-
-        expect(response.body).to include("Blue")
-        expect(response.body).not_to include("Red")
-      end
-
-      # An eyebrow back from the answers list hands plain ids, not a signed one.
-      it "seeds the picker from a plain person_id handed back by a return link" do
-        form = create(:form, :standalone)
-        person = create(:person, first_name: "Priya", last_name: "Patel")
-        create(:form_submission, form: form, person: person)
-
-        get results_form_path(form, person_id: person.id)
-
-        option = Nokogiri::HTML(response.body).at_css("select#submitter_sgid option[selected]")
-        expect(option.text).to include("Priya Patel")
-        expect(GlobalID::Locator.locate_signed(option["value"])).to eq(person)
+        ids &= %w[question event_id organization_id start_date end_date]
+        expect(ids).to eq(%w[question event_id organization_id start_date end_date])
       end
 
       it "offers a clear-filters control that drops back to the unfiltered rollup" do
         form = create(:form, :standalone)
         create(:form_submission, form: form)
 
-        get results_form_path(form, person_id: create(:person).id)
+        get results_form_path(form, organization_id: create(:organization).id)
 
         doc = Nokogiri::HTML(response.body)
         clear = doc.css("a").find { |a| a.text.strip == "Clear filters" }
         expect(clear).to be_present
         expect(clear["href"]).to eq(results_form_path(form))
-      end
-
-      it "narrows the rollup to the selected person's submissions" do
-        form = create(:form, :standalone)
-        person = create(:person)
-        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
-        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
-                             form_field: color, submitted_answer: "Blue")
-        create(:form_answer, form_submission: create(:form_submission, form: form, person: create(:person)),
-                             form_field: color, submitted_answer: "Red")
-
-        get results_form_path(form, person_id: person.id)
-
-        expect(response.body).to include("Blue")
-        expect(response.body).not_to include("Red")
       end
 
       it "narrows the rollup to submissions in the selected date range" do
@@ -1193,21 +1132,6 @@ RSpec.describe "Forms", type: :request do
                                                    event_id: event.id, return_to: "form_results"))
       end
 
-      it "carries the selected person into the form answers links" do
-        form = create(:form, :standalone)
-        person = create(:person)
-        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
-        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
-                             form_field: thoughts, submitted_answer: "Loved it")
-
-        get results_form_path(form, person_id: person.id)
-
-        doc = Nokogiri::HTML(response.body)
-        hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", form_field_id: thoughts.id,
-                                                   person_id: person.id, return_to: "form_results"))
-      end
-
       it "carries the submitted date range into the form answers links" do
         form = create(:form, :standalone)
         thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
@@ -1241,18 +1165,30 @@ RSpec.describe "Forms", type: :request do
                                                    organization_id: org.id, return_to: "form_results"))
       end
 
-      it "carries the results filters into a response's View submission link, so the eyebrow comes back filtered" do
+      it "carries the results filters and the card into a response's View submission link" do
         form = create(:form, :standalone)
-        person = create(:person)
+        org = create(:organization)
         thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
-        submission = create(:form_submission, form: form, person: person)
+        submission = create(:form_submission, form: form)
+        submission.link_organization!(org.id)
         create(:form_answer, form_submission: submission, form_field: thoughts, submitted_answer: "Loved it")
 
-        get results_form_path(form, person_id: person.id)
+        get results_form_path(form, organization_id: org.id)
 
         hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_submission_path(submission, return_to: "form_results",
-                                                      form_id: form.id, person_id: person.id))
+        expect(hrefs).to include(form_submission_path(submission, return_to: "form_results", form_id: form.id,
+                                                      form_field_id: thoughts.id, organization_id: org.id))
+      end
+
+      it "anchors each question card so a return link can scroll back to it" do
+        form = create(:form, :standalone)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: color, submitted_answer: "Blue")
+
+        get results_form_path(form)
+
+        expect(Nokogiri::HTML(response.body).at_css("#form-question-#{color.id}")).to be_present
       end
 
       it "carries the question search out as results_question, so `question` stays the drilled-into card" do
@@ -1273,7 +1209,7 @@ RSpec.describe "Forms", type: :request do
         form = create(:form, :standalone)
         create(:form_submission, form: form)
 
-        get results_form_path(form, person_id: create(:person).id)
+        get results_form_path(form, organization_id: create(:organization).id)
 
         expect(response.body).to include("No submissions match the selected filters yet.")
         expect(response.body).not_to include("No submissions to this form yet.")

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -966,10 +966,10 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).not_to include("Duplicate form")
       end
 
-      it "shows an event filter for an event-connected form" do
+      it "shows an event filter for a form shared across more than one event" do
         form = create(:form)
-        event = create(:event, title: "Spring Cohort")
-        create(:event_form, form: form, event: event, role: "registration")
+        create(:event_form, form: form, event: create(:event, title: "Spring Cohort"), role: "registration")
+        create(:event_form, form: form, event: create(:event, title: "Fall Cohort"), role: "registration")
 
         get results_form_path(form)
 
@@ -977,10 +977,18 @@ RSpec.describe "Forms", type: :request do
         select = doc.at_css("select#event_id")
         expect(select).to be_present
         expect(select.text).to include("Spring Cohort")
+        expect(select.text).to include("Fall Cohort")
       end
 
       it "omits the event filter for a form with no connected events" do
         form = create(:form, :standalone)
+        get results_form_path(form)
+        expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
+      end
+
+      it "omits the event filter for a form connected to a single event" do
+        form = create(:form)
+        create(:event_form, form: form, event: create(:event), role: "registration")
         get results_form_path(form)
         expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
       end
@@ -1067,6 +1075,22 @@ RSpec.describe "Forms", type: :request do
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
         expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id))
+      end
+
+      it "carries the selected organization into the form answers links" do
+        form = create(:form)
+        org = create(:organization)
+        create(:event_form, form: form, event: create(:event), role: "registration")
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        linked = create(:form_submission, form: form)
+        linked.link_organization!(org.id)
+        create(:form_answer, form_submission: linked, form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, organization_id: org.id)
+
+        doc = Nokogiri::HTML(response.body)
+        hrefs = doc.css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", organization_id: org.id))
       end
     end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1121,6 +1121,20 @@ RSpec.describe "Forms", type: :request do
         expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id))
       end
 
+      it "carries the selected person into the form answers links" do
+        form = create(:form, :standalone)
+        person = create(:person)
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
+                             form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, person_id: person.id)
+
+        doc = Nokogiri::HTML(response.body)
+        hrefs = doc.css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", person_id: person.id))
+      end
+
       it "carries the selected organization into the form answers links" do
         form = create(:form)
         org = create(:organization)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1180,6 +1180,52 @@ RSpec.describe "Forms", type: :request do
                                                       form_field_id: thoughts.id, organization_id: org.id))
       end
 
+      it "footers each card with a link to the submissions behind the rollup" do
+        form = create(:form, :standalone, name: "Survey")
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: thoughts, submitted_answer: "Loved it")
+        create(:form_submission, form: form)
+
+        get results_form_path(form)
+
+        expect(response.body).to include("View 2 submissions")
+        hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_submissions_path(form_id: form.id, form_field_id: thoughts.id,
+                                                       return_to: "form_results"))
+      end
+
+      it "counts a text question's own answers in its header, linking to them" do
+        form = create(:form, :standalone)
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: thoughts, submitted_answer: "Loved it")
+        create(:form_submission, form: form)
+
+        get results_form_path(form)
+
+        expect(response.body).to include("1 answer")
+        expect(response.body).not_to include("View all 1 response")
+      end
+
+      it "hangs a response's submission link on its byline rather than a View label" do
+        form = create(:form, :standalone)
+        person = create(:person, first_name: "Priya", last_name: "Patel")
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        submission = create(:form_submission, form: form, person: person)
+        create(:form_answer, form_submission: submission, form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form)
+
+        byline = Nokogiri::HTML(response.body).css("a").find do |a|
+          a["href"] == form_submission_path(submission, return_to: "form_results",
+                                            form_id: form.id, form_field_id: thoughts.id)
+        end
+        expect(byline).to be_present
+        expect(byline.text).to include("Priya Patel")
+        expect(byline.text.strip).not_to eq("View")
+      end
+
       it "anchors each question card so a return link can scroll back to it" do
         form = create(:form, :standalone)
         color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -985,6 +985,33 @@ RSpec.describe "Forms", type: :request do
         expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
       end
 
+      it "shows an organization filter for an event-connected form" do
+        form = create(:form)
+        create(:event_form, form: form, event: create(:event), role: "registration")
+
+        get results_form_path(form)
+
+        expect(Nokogiri::HTML(response.body).at_css("select#organization_id")).to be_present
+      end
+
+      it "narrows the rollup to the selected organization's submissions" do
+        form = create(:form)
+        event = create(:event)
+        org = create(:organization)
+        create(:event_form, form: form, event: event, role: "registration")
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        linked = create(:form_submission, form: form, event: event)
+        linked.link_organization!(org.id)
+        create(:form_answer, form_submission: linked, form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form, event: event),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form, organization_id: org.id)
+
+        expect(response.body).to include("Blue")
+        expect(response.body).not_to include("Red")
+      end
+
       it "narrows the rollup to the selected event's submissions" do
         form = create(:form)
         event = create(:event)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1002,6 +1002,50 @@ RSpec.describe "Forms", type: :request do
         expect(Nokogiri::HTML(response.body).at_css("select#organization_id")).to be_present
       end
 
+      it "renders the results filters as question, event, person, organization, submitted from, submitted to" do
+        form = create(:form)
+        create(:event_form, form: form, event: create(:event), role: "registration")
+        create(:event_form, form: form, event: create(:event), role: "continuing_education")
+        create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+        create(:form_submission, form: form)
+
+        get results_form_path(form)
+
+        doc = Nokogiri::HTML(response.body)
+        ids = doc.css("form label").map { |l| l["for"] }.compact
+        ids &= %w[question event_id person_id organization_id start_date end_date]
+        expect(ids).to eq(%w[question event_id person_id organization_id start_date end_date])
+      end
+
+      it "narrows the rollup to the selected person's submissions" do
+        form = create(:form, :standalone)
+        person = create(:person)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
+                             form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form, person: create(:person)),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form, person_id: person.id)
+
+        expect(response.body).to include("Blue")
+        expect(response.body).not_to include("Red")
+      end
+
+      it "narrows the rollup to submissions in the selected date range" do
+        form = create(:form, :standalone)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form, created_at: Date.new(2026, 1, 10)),
+                             form_field: color, submitted_answer: "Old")
+        create(:form_answer, form_submission: create(:form_submission, form: form, created_at: Date.new(2026, 6, 10)),
+                             form_field: color, submitted_answer: "New")
+
+        get results_form_path(form, start_date: "2026-05-01", end_date: "2026-07-01")
+
+        expect(response.body).to include("New")
+        expect(response.body).not_to include("Old")
+      end
+
       it "narrows the rollup to the selected organization's submissions" do
         form = create(:form)
         event = create(:event)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1001,6 +1001,18 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include("Blue")
         expect(response.body).not_to include("Red")
       end
+
+      it "narrows the visible question cards to those matching the question filter" do
+        form = create(:form, :standalone)
+        create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_field, form: form, name: "Favorite food", answer_type: :single_select_radio)
+        create(:form_submission, form: form)
+
+        get results_form_path(form, question: "color")
+
+        expect(response.body).to include("Favorite color")
+        expect(response.body).not_to include("Favorite food")
+      end
     end
 
     context "as a regular user" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1013,6 +1013,34 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include("Favorite color")
         expect(response.body).not_to include("Favorite food")
       end
+
+      it "links a text question's responses to the form answers index filtered to that question" do
+        form = create(:form, :standalone, name: "Survey")
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form)
+
+        doc = Nokogiri::HTML(response.body)
+        hrefs = doc.css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts"))
+      end
+
+      it "carries the selected event into the form answers links" do
+        form = create(:form)
+        event = create(:event)
+        create(:event_form, form: form, event: event, role: "registration")
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form, event: event),
+                             form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, event_id: event.id)
+
+        doc = Nokogiri::HTML(response.body)
+        hrefs = doc.css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id))
+      end
     end
 
     context "as a regular user" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -965,6 +965,42 @@ RSpec.describe "Forms", type: :request do
         get results_form_path(form)
         expect(response.body).not_to include("Duplicate form")
       end
+
+      it "shows an event filter for an event-connected form" do
+        form = create(:form)
+        event = create(:event, title: "Spring Cohort")
+        create(:event_form, form: form, event: event, role: "registration")
+
+        get results_form_path(form)
+
+        doc = Nokogiri::HTML(response.body)
+        select = doc.at_css("select#event_id")
+        expect(select).to be_present
+        expect(select.text).to include("Spring Cohort")
+      end
+
+      it "omits the event filter for a form with no connected events" do
+        form = create(:form, :standalone)
+        get results_form_path(form)
+        expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
+      end
+
+      it "narrows the rollup to the selected event's submissions" do
+        form = create(:form)
+        event = create(:event)
+        other_event = create(:event)
+        create(:event_form, form: form, event: event, role: "registration")
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form, event: event),
+                             form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form, event: other_event),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form, event_id: event.id)
+
+        expect(response.body).to include("Blue")
+        expect(response.body).not_to include("Red")
+      end
     end
 
     context "as a regular user" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1180,7 +1180,8 @@ RSpec.describe "Forms", type: :request do
                                                       form_field_id: thoughts.id, organization_id: org.id))
       end
 
-      it "footers each card with a link to the submissions behind the rollup" do
+      # The footer counts who answered this question, not who submitted the form.
+      it "footers each card with the submissions that answered that question" do
         form = create(:form, :standalone, name: "Survey")
         thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
         create(:form_answer, form_submission: create(:form_submission, form: form),
@@ -1189,10 +1190,26 @@ RSpec.describe "Forms", type: :request do
 
         get results_form_path(form)
 
-        expect(response.body).to include("View 2 submissions")
+        expect(response.body).to include("View 1 submission")
         hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
         expect(hrefs).to include(form_submissions_path(form_id: form.id, form_field_id: thoughts.id,
                                                        return_to: "form_results"))
+      end
+
+      it "counts a charted question's answers in its header too, linking to them" do
+        form = create(:form, :standalone)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form)
+
+        count = Nokogiri::HTML(response.body).css("a").find { |a| a.text.strip == "2 answers" }
+        expect(count).to be_present
+        expect(count["href"]).to eq(form_answers_path(form_id: form.id, question: "Favorite color",
+                                                      form_field_id: color.id, return_to: "form_results"))
       end
 
       it "counts a text question's own answers in its header, linking to them" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1113,7 +1113,8 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", return_to: "form_results"))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts",
+                                                   form_field_id: thoughts.id, return_to: "form_results"))
       end
 
       it "carries the selected event into the form answers links" do
@@ -1128,7 +1129,8 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id, return_to: "form_results"))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", form_field_id: thoughts.id,
+                                                   event_id: event.id, return_to: "form_results"))
       end
 
       it "carries the selected person into the form answers links" do
@@ -1142,7 +1144,8 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", person_id: person.id, return_to: "form_results"))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", form_field_id: thoughts.id,
+                                                   person_id: person.id, return_to: "form_results"))
       end
 
       it "carries the submitted date range into the form answers links" do
@@ -1156,6 +1159,7 @@ RSpec.describe "Forms", type: :request do
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
         expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts",
+                                                   form_field_id: thoughts.id,
                                                    start_date: "2026-05-01", end_date: "2026-07-01",
                                                    return_to: "form_results"))
       end
@@ -1173,7 +1177,46 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", organization_id: org.id, return_to: "form_results"))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", form_field_id: thoughts.id,
+                                                   organization_id: org.id, return_to: "form_results"))
+      end
+
+      it "carries the results filters into a response's View submission link, so the eyebrow comes back filtered" do
+        form = create(:form, :standalone)
+        person = create(:person)
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        submission = create(:form_submission, form: form, person: person)
+        create(:form_answer, form_submission: submission, form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, person_id: person.id)
+
+        hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_submission_path(submission, return_to: "form_results",
+                                                      form_id: form.id, person_id: person.id))
+      end
+
+      it "carries the question search out as results_question, so `question` stays the drilled-into card" do
+        form = create(:form, :standalone)
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, question: "thoughts")
+
+        hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts",
+                                                   form_field_id: thoughts.id, results_question: "thoughts",
+                                                   return_to: "form_results"))
+      end
+
+      it "says a filter emptied the rollup rather than that the form has no submissions" do
+        form = create(:form, :standalone)
+        create(:form_submission, form: form)
+
+        get results_form_path(form, person_id: create(:person).id)
+
+        expect(response.body).to include("No submissions match the selected filters yet.")
+        expect(response.body).not_to include("No submissions to this form yet.")
       end
     end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1196,6 +1196,39 @@ RSpec.describe "Forms", type: :request do
                                                        return_to: "form_results"))
       end
 
+      it "links a file question's upload count to those answers" do
+        form = create(:form, :standalone)
+        upload = create(:form_field, form: form, name: "Sample of your work", answer_type: :file_upload)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: upload, submitted_answer: "sample.jpg")
+
+        get results_form_path(form)
+
+        count = Nokogiri::HTML(response.body).css("a").find { |a| a.text.include?("file uploaded") }
+        expect(count).to be_present
+        expect(count["href"]).to eq(form_answers_path(form_id: form.id, question: "Sample of your work",
+                                                      form_field_id: upload.id, return_to: "form_results"))
+      end
+
+      # answered_count on a number question counts only the answers that parse as
+      # numbers, so a link would undercount the list it opened.
+      it "leaves a number question's card unlinked" do
+        form = create(:form, :standalone)
+        served = create(:form_field, form: form, name: "People served",
+                        answer_type: :free_form_input_one_line, input_type: :number_integer)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: served, submitted_answer: "12")
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: served, submitted_answer: "varies")
+
+        get results_form_path(form)
+
+        expect(response.body).to include("People served")
+        hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
+        expect(hrefs).not_to include(form_answers_path(form_id: form.id, question: "People served",
+                                                       form_field_id: served.id, return_to: "form_results"))
+      end
+
       it "counts a charted question's answers in its header too, linking to them" do
         form = create(:form, :standalone)
         color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1017,6 +1017,18 @@ RSpec.describe "Forms", type: :request do
         expect(ids).to eq(%w[question event_id person_id organization_id start_date end_date])
       end
 
+      it "offers a clear-filters control that drops back to the unfiltered rollup" do
+        form = create(:form, :standalone)
+        create(:form_submission, form: form)
+
+        get results_form_path(form, person_id: create(:person).id)
+
+        doc = Nokogiri::HTML(response.body)
+        clear = doc.css("a").find { |a| a.text.strip == "Clear filters" }
+        expect(clear).to be_present
+        expect(clear["href"]).to eq(results_form_path(form))
+      end
+
       it "narrows the rollup to the selected person's submissions" do
         form = create(:form, :standalone)
         person = create(:person)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -993,16 +993,20 @@ RSpec.describe "Forms", type: :request do
         expect(Nokogiri::HTML(response.body).at_css("select#event_id")).to be_nil
       end
 
-      it "shows an organization filter for an event-connected form" do
-        form = create(:form)
-        create(:event_form, form: form, event: create(:event), role: "registration")
+      it "searches people and organizations from one picker" do
+        form = create(:form, :standalone)
+        create(:form_submission, form: form)
 
         get results_form_path(form)
 
-        expect(Nokogiri::HTML(response.body).at_css("select#organization_id")).to be_present
+        picker = Nokogiri::HTML(response.body).at_css("select#submitter_sgid")
+        expect(picker).to be_present
+        expect(picker["data-remote-select-model-value"]).to eq("person_or_organization")
+        expect(Nokogiri::HTML(response.body).at_css("select#person_id")).to be_nil
+        expect(Nokogiri::HTML(response.body).at_css("select#organization_id")).to be_nil
       end
 
-      it "renders the results filters as question, event, person, organization, submitted from, submitted to" do
+      it "renders the results filters as question, event, person or organization, submitted from, submitted to" do
         form = create(:form)
         create(:event_form, form: form, event: create(:event), role: "registration")
         create(:event_form, form: form, event: create(:event), role: "continuing_education")
@@ -1013,8 +1017,52 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         ids = doc.css("form label").map { |l| l["for"] }.compact
-        ids &= %w[question event_id person_id organization_id start_date end_date]
-        expect(ids).to eq(%w[question event_id person_id organization_id start_date end_date])
+        ids &= %w[question event_id submitter_sgid start_date end_date]
+        expect(ids).to eq(%w[question event_id submitter_sgid start_date end_date])
+      end
+
+      it "narrows the rollup to a person picked through the combined picker" do
+        form = create(:form, :standalone)
+        person = create(:person)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        create(:form_answer, form_submission: create(:form_submission, form: form, person: person),
+                             form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form, person: create(:person)),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form, submitter_sgid: person.to_sgid.to_s)
+
+        expect(response.body).to include("Blue")
+        expect(response.body).not_to include("Red")
+      end
+
+      it "narrows the rollup to an organization picked through the combined picker" do
+        form = create(:form, :standalone)
+        org = create(:organization)
+        color = create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio)
+        linked = create(:form_submission, form: form)
+        linked.link_organization!(org.id)
+        create(:form_answer, form_submission: linked, form_field: color, submitted_answer: "Blue")
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: color, submitted_answer: "Red")
+
+        get results_form_path(form, submitter_sgid: org.to_sgid.to_s)
+
+        expect(response.body).to include("Blue")
+        expect(response.body).not_to include("Red")
+      end
+
+      # An eyebrow back from the answers list hands plain ids, not a signed one.
+      it "seeds the picker from a plain person_id handed back by a return link" do
+        form = create(:form, :standalone)
+        person = create(:person, first_name: "Priya", last_name: "Patel")
+        create(:form_submission, form: form, person: person)
+
+        get results_form_path(form, person_id: person.id)
+
+        option = Nokogiri::HTML(response.body).at_css("select#submitter_sgid option[selected]")
+        expect(option.text).to include("Priya Patel")
+        expect(GlobalID::Locator.locate_signed(option["value"])).to eq(person)
       end
 
       it "offers a clear-filters control that drops back to the unfiltered rollup" do

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1145,6 +1145,21 @@ RSpec.describe "Forms", type: :request do
         expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", person_id: person.id, return_to: "form_results"))
       end
 
+      it "carries the submitted date range into the form answers links" do
+        form = create(:form, :standalone)
+        thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
+        create(:form_answer, form_submission: create(:form_submission, form: form, created_at: Date.new(2026, 6, 5)),
+                             form_field: thoughts, submitted_answer: "Loved it")
+
+        get results_form_path(form, start_date: "2026-05-01", end_date: "2026-07-01")
+
+        doc = Nokogiri::HTML(response.body)
+        hrefs = doc.css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts",
+                                                   start_date: "2026-05-01", end_date: "2026-07-01",
+                                                   return_to: "form_results"))
+      end
+
       it "carries the selected organization into the form answers links" do
         form = create(:form)
         org = create(:organization)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1093,6 +1093,16 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).not_to include("Favorite food")
       end
 
+      it "says nothing about a question search on a form that asks no questions" do
+        form = create(:form, :standalone)
+        create(:form_field, form: form, answer_type: :group_header)
+        create(:form_submission, form: form)
+
+        get results_form_path(form)
+
+        expect(response.body).not_to include("No questions match")
+      end
+
       it "links a text question's responses to the form answers index filtered to that question" do
         form = create(:form, :standalone, name: "Survey")
         thoughts = create(:form_field, form: form, name: "Any thoughts", answer_type: :free_form_input_paragraph)
@@ -1103,7 +1113,7 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts"))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", return_to: "form_results"))
       end
 
       it "carries the selected event into the form answers links" do
@@ -1118,7 +1128,7 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", event_id: event.id, return_to: "form_results"))
       end
 
       it "carries the selected person into the form answers links" do
@@ -1132,7 +1142,7 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", person_id: person.id))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", person_id: person.id, return_to: "form_results"))
       end
 
       it "carries the selected organization into the form answers links" do
@@ -1148,7 +1158,7 @@ RSpec.describe "Forms", type: :request do
 
         doc = Nokogiri::HTML(response.body)
         hrefs = doc.css("a").map { |a| a["href"] }.compact
-        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", organization_id: org.id))
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: "Any thoughts", organization_id: org.id, return_to: "form_results"))
       end
     end
 

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -1196,6 +1196,27 @@ RSpec.describe "Forms", type: :request do
                                                        return_to: "form_results"))
       end
 
+      # No list can be narrowed to "only the write-ins", so the sub-card borrows its
+      # question's counts and destinations rather than showing a number it can't open.
+      it "gives the written-in sub-card its question's answer and submission links" do
+        form = create(:form, :standalone)
+        heard = create(:form_field, form: form, name: "How did you hear about us?",
+                       answer_type: :single_select_radio)
+        # The write-in card only appears for an option the field marks as "specify".
+        heard.answer_options << AnswerOption.create!(name: "Other", position: 1)
+        create(:form_answer, form_submission: create(:form_submission, form: form),
+                             form_field: heard, submitted_answer: "Other: Facebook group")
+
+        get results_form_path(form)
+
+        expect(response.body).to include("How did you hear about us?: written-in answers")
+        hrefs = Nokogiri::HTML(response.body).css("a").map { |a| a["href"] }.compact
+        expect(hrefs).to include(form_answers_path(form_id: form.id, question: heard.name,
+                                                   form_field_id: heard.id, return_to: "form_results"))
+        expect(hrefs).to include(form_submissions_path(form_id: form.id, form_field_id: heard.id,
+                                                       return_to: "form_results"))
+      end
+
       it "links a file question's upload count to those answers" do
         form = create(:form, :standalone)
         upload = create(:form_field, form: form, name: "Sample of your work", answer_type: :file_upload)

--- a/spec/services/form_response_aggregator_spec.rb
+++ b/spec/services/form_response_aggregator_spec.rb
@@ -241,6 +241,22 @@ RSpec.describe FormResponseAggregator do
     end
   end
 
+  describe "organization scoping" do
+    it "narrows the rollup to submissions linked to the organization" do
+      org = create(:organization)
+      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+      linked = create(:form_submission, form: form)
+      linked.link_organization!(org.id)
+      answer(linked, field, "Blue")
+      answer(create(:form_submission, form: form), field, "Red")
+
+      aggregator = described_class.new(form, organization_id: org.id)
+
+      expect(aggregator.submission_count).to eq(1)
+      expect(aggregator.field_reports.first.rows).to eq([ [ "Blue", 1 ] ])
+    end
+  end
+
   describe "question name filtering" do
     before do
       create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio, position: 1)

--- a/spec/services/form_response_aggregator_spec.rb
+++ b/spec/services/form_response_aggregator_spec.rb
@@ -217,4 +217,27 @@ RSpec.describe FormResponseAggregator do
 
     expect(labels).to eq([ "First", "Second" ])
   end
+
+  describe "event scoping" do
+    it "narrows the rollup to one event's submissions when given an event_id" do
+      event = create(:event)
+      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+      answer(create(:form_submission, form: form, event: event), field, "Blue")
+      answer(create(:form_submission, form: form, event: create(:event)), field, "Red")
+
+      aggregator = described_class.new(form, event_id: event.id)
+
+      expect(aggregator.submission_count).to eq(1)
+      expect(aggregator.field_reports.first.rows).to eq([ [ "Blue", 1 ] ])
+    end
+
+    it "rolls up every submission when no event_id is given" do
+      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+      answer(create(:form_submission, form: form, event: create(:event)), field, "Blue")
+      answer(create(:form_submission, form: form, event: create(:event)), field, "Red")
+
+      expect(described_class.new(form).submission_count).to eq(2)
+      expect(described_class.new(form, event_id: nil).submission_count).to eq(2)
+    end
+  end
 end

--- a/spec/services/form_response_aggregator_spec.rb
+++ b/spec/services/form_response_aggregator_spec.rb
@@ -257,20 +257,6 @@ RSpec.describe FormResponseAggregator do
     end
   end
 
-  describe "person scoping" do
-    it "narrows the rollup to one person's submissions" do
-      person = create(:person)
-      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
-      answer(create(:form_submission, form: form, person: person), field, "Blue")
-      answer(create(:form_submission, form: form, person: create(:person)), field, "Red")
-
-      aggregator = described_class.new(form, person_id: person.id)
-
-      expect(aggregator.submission_count).to eq(1)
-      expect(aggregator.field_reports.first.rows).to eq([ [ "Blue", 1 ] ])
-    end
-  end
-
   describe "submission date scoping" do
     it "narrows the rollup to submissions in the date range" do
       field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)

--- a/spec/services/form_response_aggregator_spec.rb
+++ b/spec/services/form_response_aggregator_spec.rb
@@ -240,4 +240,27 @@ RSpec.describe FormResponseAggregator do
       expect(described_class.new(form, event_id: nil).submission_count).to eq(2)
     end
   end
+
+  describe "question name filtering" do
+    before do
+      create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio, position: 1)
+      create(:form_field, form: form, name: "Favorite food", answer_type: :single_select_radio, position: 2)
+      create(:form_submission, form: form)
+    end
+
+    it "reports only the questions whose name matches, case-insensitively" do
+      labels = described_class.new(form, question_query: "COLOR").field_reports.map(&:label)
+      expect(labels).to eq([ "Favorite color" ])
+    end
+
+    it "still counts every question in the Questions total" do
+      aggregator = described_class.new(form, question_query: "color")
+      expect(aggregator.field_reports.size).to eq(1)
+      expect(aggregator.question_count).to eq(2)
+    end
+
+    it "reports every question when the query is blank" do
+      expect(described_class.new(form, question_query: "  ").field_reports.size).to eq(2)
+    end
+  end
 end

--- a/spec/services/form_response_aggregator_spec.rb
+++ b/spec/services/form_response_aggregator_spec.rb
@@ -257,6 +257,33 @@ RSpec.describe FormResponseAggregator do
     end
   end
 
+  describe "person scoping" do
+    it "narrows the rollup to one person's submissions" do
+      person = create(:person)
+      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+      answer(create(:form_submission, form: form, person: person), field, "Blue")
+      answer(create(:form_submission, form: form, person: create(:person)), field, "Red")
+
+      aggregator = described_class.new(form, person_id: person.id)
+
+      expect(aggregator.submission_count).to eq(1)
+      expect(aggregator.field_reports.first.rows).to eq([ [ "Blue", 1 ] ])
+    end
+  end
+
+  describe "submission date scoping" do
+    it "narrows the rollup to submissions in the date range" do
+      field = create(:form_field, form: form, name: "Color", answer_type: :single_select_radio)
+      answer(create(:form_submission, form: form, created_at: Date.new(2026, 1, 10)), field, "Old")
+      answer(create(:form_submission, form: form, created_at: Date.new(2026, 6, 10)), field, "New")
+
+      aggregator = described_class.new(form, start_date: "2026-05-01", end_date: "2026-07-01")
+
+      expect(aggregator.submission_count).to eq(1)
+      expect(aggregator.field_reports.first.rows).to eq([ [ "New", 1 ] ])
+    end
+  end
+
   describe "question name filtering" do
     before do
       create(:form_field, form: form, name: "Favorite color", answer_type: :single_select_radio, position: 1)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained logic across two admin pages, the aggregator service, and the response-card partials

### What is the goal of this PR and why is this important?
A form's Results page rolled every submission into one set of question charts with no way to slice it, so admins couldn't focus on one event, person, or organization's answers, find a specific question, or jump to the underlying answers. This adds filters at the top of the page and turns each question's response count into a link to the pre-filtered Form answers list.

### How did you approach the change?
`FormResponseAggregator` gained optional `event_id:`, `person_id:`, `organization_id:` (via the existing `FormSubmission.for_organization`), `start_date:`/`end_date:` (via `submitted_between`), and `question_query:` (narrows which question cards render, while the Questions stat still counts the whole form). The filter panel is one row on the bulk-payments filter bar's width scale — question search, event dropdown (only when the form is shared across more than one event), organization, submitted-from/to dates, and the shared Clear filters button; all auto-submit via the existing `collection` Stimulus controller, so there's no new JavaScript. Each card has two exits with different jobs: the header count reads "N answers" and opens `form_answers` pinned to that question, while the footer reads "View N submissions" and opens the submissions that answered it (a new `FormSubmission.answered_question` scope, so the count and the list agree). Both carry the results filters and the card's anchor, so the eyebrow back lands on the question you left. The Form answers index gained matching organization and person_id filters (the person field is now a person picker rather than a free-text name search). Covered by aggregator and request specs and logged on the Features & tips page.

The drill-down is a round trip, not a one-way door:

- The Form answers list hides blank answer rows by default — a submission writes a row for every field it posts, so an optional question nobody filled in left rows that made the list disagree with the count that linked to it. An "Empty answers" filter brings them back.
- The drill-down pins the exact `form_field_id` as well as the question name. The Question box stays a free-text LIKE search, which on its own would also match a sibling question containing this one's name ("Email" pulling in "Email 2") and disagree with the count on the card. The pin holds while the box still reads that question's name; editing or clearing it searches normally again.
- That list gets a back-to-results eyebrow when results linked it, and keeps the origin through a submission and back. The eyebrow anchors to the question card the drill-down opened, so you return to what you were reading rather than the top of a masonry column.
- The list also filters by submitted date, so a date-narrowed rollup drills into a date-narrowed list. It filters on the *submission's* date, matching the rollup.
- `FormAnswersHelper#form_answer_carryover_params` holds the filters threaded through that trip. On the results side, `FormsHelper` builds each link once — `form_results_filter_params` (what the rollup covers, also read by the empty state), `form_results_link_params` (those plus the question search, sent as `results_question` because `question` names the drilled-into card), and `form_results_return_params` (the same state read back for an eyebrow) — so a new filter can't be half-threaded.

### Anything else to add?
The event filter is hidden for single-event and standalone forms (no-op); the organization and date filters show whenever the form has submissions. Organization filtering reaches standalone forms too, matching the submissions and answers indexes, which never gated it — an admin can link an organization to any submission, not just an event registration.




