### PR TITLE
Match forms/answers/submissions index styling to community news

### DIFF
--- a/app/views/form_answers/index.html.erb
+++ b/app/views/form_answers/index.html.erb
@@ -1,20 +1,7 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-
-<div class="form-answers-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-2xl border border-primary/10 p-6 shadow-sm">
-  <div class="w-full">
-    <div class="mb-6 flex items-start gap-4">
-      <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
-        <i class="fa-solid fa-list-check text-xl" aria-hidden="true"></i>
-      </span>
-      <div>
-        <h2 class="text-2xl font-semibold text-gray-900">Form answers</h2>
-        <p class="mt-1 text-gray-600">
-          Every answer submitted across the site's forms — search the answer text or
-          filter by form, person, submission, or question type.
-        </p>
-      </div>
-    </div>
-
+<%= render layout: "shared/index_page",
+           locals: { domain: :forms, eyebrow: "Forms", title: "Answers",
+                     subtitle: "Every answer submitted across the site's forms — search the answer text or filter by form, person, submission, or question type" } do %>
     <%# GET filter form outside the frame. The collection controller debounce-submits
         the text boxes and submits the selects on change, into the results frame. %>
     <%= form_with url: form_answers_path, method: :get,
@@ -82,5 +69,4 @@
         <p class="mt-2 text-sm">Loading answers…</p>
       </div>
     <% end %>
-  </div>
-</div>
+<% end %>

--- a/app/views/form_submissions/index.html.erb
+++ b/app/views/form_submissions/index.html.erb
@@ -1,46 +1,36 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-
-<div class="form-submissions-index mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> rounded-2xl border border-primary/10 p-6 shadow-sm">
-  <div class="w-full">
-    <% if @form || @person %>
-      <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <% if params[:return_to] == "form_results" && @form %>
-            <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
-              <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
-            <% end %>
-          <% elsif params[:return_to] == "forms" && @form %>
-            <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-              <i class="fa-solid fa-arrow-left text-xs"></i> Forms
-            <% end %>
-          <% elsif @person %>
-            <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
-              <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
-            <% end %>
-          <% end %>
-        </div>
-        <% if @form %>
-          <%= form_page_subnav(@form, current: :submissions) %>
+<% if @form || @person %>
+  <div class="mx-auto mb-4 flex w-full max-w-7xl flex-wrap items-center justify-between gap-2">
+    <div>
+      <% if params[:return_to] == "form_results" && @form %>
+        <%= link_to results_form_path(@form), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class}" do %>
+          <i class="fa-solid fa-arrow-left text-xs"></i> <%= @form.display_name %> results
         <% end %>
-      </div>
-    <% end %>
-
-    <div class="mb-6 flex items-start gap-4">
-      <span class="hidden h-12 w-12 shrink-0 items-center justify-center rounded-xl sm:flex <%= DomainTheme.bg_class_for(:forms) %> <%= DomainTheme.text_class_for(:forms, intensity: 700) %> border <%= DomainTheme.border_class_for(:forms, intensity: 200) %> shadow-sm">
-        <i class="fa-solid fa-file-signature text-xl" aria-hidden="true"></i>
-      </span>
-      <div>
-        <h2 class="text-2xl font-semibold text-gray-900">Form submissions</h2>
-        <p class="mt-1 text-gray-600">
-          <% if @person %>
-            Forms submitted by <span class="font-medium text-gray-900"><%= @person.name %></span>.
-          <% else %>
-            Forms submitted across the site — registrations, scholarships, and public forms.
-          <% end %>
-        </p>
-      </div>
+      <% elsif params[:return_to] == "forms" && @form %>
+        <%= link_to forms_path(anchor: "form_#{@form.id}"), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+          <i class="fa-solid fa-arrow-left text-xs"></i> Forms
+        <% end %>
+      <% elsif @person %>
+        <%= link_to edit_person_path(@person), class: "inline-flex items-center gap-1.5 text-sm #{eyebrow_link_class} px-2 py-1" do %>
+          <i class="fa-solid fa-arrow-left text-xs"></i> Edit <%= @person.name %>
+        <% end %>
+      <% end %>
     </div>
-
+    <% if @form %>
+      <%= form_page_subnav(@form, current: :submissions) %>
+    <% end %>
+  </div>
+<% end %>
+<% subtitle = capture do %>
+  <% if @person %>
+    Forms submitted by <span class="font-medium text-gray-900"><%= @person.name %></span>.
+  <% else %>
+    Forms submitted across the site — registrations, scholarships, and public forms.
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :forms, eyebrow: "Forms", title: "Submissions",
+                     subtitle: subtitle } do %>
     <%# Filters. Auto-submit into the results frame on change. %>
     <%= form_with url: form_submissions_path, method: :get, autocomplete: "off",
           data: { controller: "collection searchable-checkbox", turbo_frame: "form_submissions_results" },
@@ -165,5 +155,4 @@
         <p class="mt-2 text-sm">Loading submissions…</p>
       </div>
     <% end %>
-  </div>
-</div>
+<% end %>

--- a/app/views/forms/_owned_forms.html.erb
+++ b/app/views/forms/_owned_forms.html.erb
@@ -1,6 +1,6 @@
 <div class="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-4">
   <h2 class="mb-1 text-lg font-semibold text-gray-700">Owned forms</h2>
-  <p class="mb-3 max-w-2xl text-sm text-gray-500">The workshop-log and monthly-report templates. Kept for their existing answers rather than shown in the main list.</p>
+  <p class="mb-3 text-sm whitespace-nowrap text-gray-500">The workshop-log and monthly-report templates, kept for their existing answers rather than shown in the main list.</p>
   <ul class="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
     <% forms.each do |form| %>
       <% form = form.decorate %>

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,21 +1,17 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:forms) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
-  <div class="mb-6 flex items-start justify-between">
-    <div class="pr-6">
-      <h1 class="text-primary mb-2 font-display text-2xl font-semibold">Forms</h1>
-      <p class="max-w-2xl text-gray-600">Reusable forms for event registrations and other submissions</p>
+<% actions = capture do %>
+  <% if allowed_to?(:new?, Form) %>
+    <div class="admin-only bg-blue-100">
+      <%= link_to "New form",
+                  new_form_path,
+                  class: button_classes(:secondary_outline, extra: "whitespace-nowrap") %>
     </div>
-    <div class="text-end text-right">
-      <% if allowed_to?(:new?, Form) %>
-        <div class="admin-only bg-blue-100">
-          <%= link_to "New form",
-                      new_form_path,
-                      class: button_classes(:secondary_outline, extra: "whitespace-nowrap") %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
+  <% end %>
+<% end %>
+<%= render layout: "shared/index_page",
+           locals: { domain: :forms, eyebrow: "Forms", title: "All forms",
+                     subtitle: "Reusable forms for event registrations and other submissions",
+                     actions: actions } do %>
   <% result_src = forms_path + "?" + request.query_string %>
 
   <%= turbo_frame_tag :forms_results, src: result_src, data: { turbo: "temporary" } do %>
@@ -25,4 +21,4 @@
   <% if @owned_forms.any? %>
     <%= render "owned_forms", forms: @owned_forms %>
   <% end %>
-</div>
+<% end %>

--- a/spec/requests/form_answers_spec.rb
+++ b/spec/requests/form_answers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "FormAnswers", type: :request do
         get form_answers_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Form answers")
+        expect(response.body).to include("Answers")
       end
 
       it "searches by answer text" do

--- a/spec/requests/form_submissions_spec.rb
+++ b/spec/requests/form_submissions_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "FormSubmissions", type: :request do
         get form_submissions_path
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Form submissions")
+        expect(response.body).to include("Submissions")
       end
 
       it "offers a Clear filters link to the unfiltered index when a filter is active" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 view-only markup change reusing the shared index card; two spec heading assertions updated

Makes the Forms, Answers, and Submissions admin index pages look like the rest of the app — same branded card community news uses (rainbow rule, serif title, eyebrow, soft border over a domain tint), just themed with the forms purple instead of hand-rolled headers.

- Swap the three bespoke headers for the shared `index_page` layout with `domain: :forms`.
- Headings now read `Forms / All forms`, `Forms / Answers`, `Forms / Submissions` (eyebrow + serif title), matching `Community / News`.
- Submissions keeps its back-link + subnav above the card, and its person/generic subtitle.
- Tightened the "Owned forms" caption to a single non-wrapping sentence.
- Updated two request-spec heading assertions to the new titles.
