### PR TITLE
Normalize top spacing so more pages sit at same level below the nav

### DIFF
--- a/app/views/bookmarks/personal.html.erb
+++ b/app/views/bookmarks/personal.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-6xl px-4 py-8">
+<div class="mx-auto max-w-6xl px-4">
   <div class="border-primary/10 mx-auto max-w-6xl rounded-2xl border bg-white p-6 shadow-sm">
     <h1 class="text-primary mb-4 font-display text-2xl font-semibold">
       <%= @viewing_self ? "My" : "#{@user_name}'s" %> Bookmarks

--- a/app/views/category_types/edit.html.erb
+++ b/app/views/category_types/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap justify-end gap-2">

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen">
   <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
-    <div class="admin-only rounded bg-blue-100 p-6">
       <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:category_types, intensity: 100) %>
         border-primary/10 rounded-2xl border p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="space-y-6">
@@ -97,7 +96,6 @@
           <%= tailwind_paginate @category_types %>
         </div>
       </div>
-    </div>
     </div>
   </div>
 </div>

--- a/app/views/category_types/index.html.erb
+++ b/app/views/category_types/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
     <div class="admin-only rounded bg-blue-100 p-6">
       <div class="mx-auto max-w-7xl <%= DomainTheme.bg_class_for(:category_types, intensity: 100) %>

--- a/app/views/category_types/new.html.erb
+++ b/app/views/category_types/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-3 flex items-center justify-between">

--- a/app/views/category_types/show.html.erb
+++ b/app/views/category_types/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap justify-end gap-2">

--- a/app/views/event_registrations/link_organization.html.erb
+++ b/app/views/event_registrations/link_organization.html.erb
@@ -3,7 +3,7 @@
     other-affiliations card) shares this path so a save returns here — carrying the
     origin and this page's own return_to. %>
 <% edit_affiliations_path = edit_person_path(@person, anchor: "affiliations", return_to: "registration_link", event_registration_id: @event_registration.id, link_org_return_to: params[:return_to].presence) %>
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto px-4">
   <div class="mb-4">
     <% if params[:return_to] == "onboarding" %>
       <%= link_to "← Back to onboarding", onboarding_event_row_path(@event_registration.event, @event_registration.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/events/attendance.html.erb
+++ b/app/views/events/attendance.html.erb
@@ -4,7 +4,7 @@
 <% content_for(:page_title, "#{title} — #{@event.title}") %>
 <% event = @event.decorate %>
 
-<div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border-primary/10 rounded-2xl border p-6 shadow-sm">
     <%# Timesheets has no tab of its own, so nothing in the subnav is marked current. %>
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">

--- a/app/views/events/attendees.html.erb
+++ b/app/views/events/attendees.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <% content_for(:full_width, true) %>
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-4 sm:p-6">
     <%# The report KPIs drill in here carrying both return_to and (when scoped)
         event_id, so an explicit origin wins over the event fallback — otherwise a

--- a/app/views/events/form_submissions/show.html.erb
+++ b/app/views/events/form_submissions/show.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto max-w-5xl px-4 pt-4">
+<div class="mx-auto max-w-5xl px-4">
   <%= link_to registrants_event_path(@event), class: "inline-flex items-center gap-1 text-sm #{eyebrow_link_class} px-2 py-1" do %>
     &larr; Back to registrants
   <% end %>

--- a/app/views/events/participation.html.erb
+++ b/app/views/events/participation.html.erb
@@ -2,7 +2,7 @@
 <%# Opt out of the layout's max-w-7xl cap to match the wider event manage pages. %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% label, return_path = participation_return_link %>

--- a/app/views/events/program_statuses.html.erb
+++ b/app/views/events/program_statuses.html.erb
@@ -2,7 +2,7 @@
 <%# Opt out of the layout's max-w-7xl cap to match the wider event manage pages. %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>

--- a/app/views/events/reports.html.erb
+++ b/app/views/events/reports.html.erb
@@ -2,7 +2,7 @@
 <%# Opt out of the layout's max-w-7xl cap to match the wider event manage pages. %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6">
       <% if @filter_event %>

--- a/app/views/events/revenue.html.erb
+++ b/app/views/events/revenue.html.erb
@@ -2,7 +2,7 @@
 <%# Opt out of the layout's max-w-7xl cap to match the wider event manage pages. %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>

--- a/app/views/events/sample_ticket.html.erb
+++ b/app/views/events/sample_ticket.html.erb
@@ -13,7 +13,7 @@
   <% back_label = "← Dashboard" %>
   <% back_path = dashboard_event_path(@event) %>
 <% end %>
-<div class="mx-auto flex max-w-2xl flex-wrap items-center gap-2 px-4 pt-4">
+<div class="mx-auto flex max-w-2xl flex-wrap items-center gap-2 px-4">
   <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <div class="ml-auto flex gap-2">
     <%= link_to "Edit event", edit_event_path(@event, expand: "callouts", anchor: "registration_ticket_callouts"), class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/events/scholarships.html.erb
+++ b/app/views/events/scholarships.html.erb
@@ -2,7 +2,7 @@
 <%# Opt out of the layout's max-w-7xl cap to match the wider event manage pages. %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <% if params[:return_to] == "dashboard" && params[:event_id].present? %>

--- a/app/views/events/signins.html.erb
+++ b/app/views/events/signins.html.erb
@@ -4,7 +4,7 @@
 <% title = @signins_ce ? "CE timesheets" : "Timesheets" %>
 <% content_for(:page_title, title) %>
 
-<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8 py-6">
+<div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
   <div class="<%= DomainTheme.bg_class_for(:events) %> border border-primary/10 rounded-2xl shadow-sm p-6">
     <div class="mb-6 flex flex-wrap items-center justify-between gap-2 sm:gap-4">
       <%= link_to "← Reports", reports_events_path(report_to_hub_params), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/events/templates_gallery.html.erb
+++ b/app/views/events/templates_gallery.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_bg_class, "admin-or-owner bg-blue-100") %>
 <% content_for(:full_width, true) %>
 
-<div class="mx-auto w-full max-w-7xl px-4 pt-6 pb-16 sm:px-6 lg:px-8">
+<div class="mx-auto w-full max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
   <% if @sample_event && params[:event_id].present? %>
     <%= link_to "← Back to event", edit_event_path(@sample_event, section: "page_content", anchor: "page_content_button"), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   <% else %>

--- a/app/views/form_submissions/changes.html.erb
+++ b/app/views/form_submissions/changes.html.erb
@@ -28,7 +28,7 @@
     "Person" => "fa-user", "Organization" => "fa-building", "Affiliation" => "fa-link"
   }
 %>
-<div class="mx-auto max-w-3xl px-4 py-8">
+<div class="mx-auto max-w-3xl px-4">
   <div class="mb-4">
     <%= link_to back_link[:label], back_link[:path], class: "text-sm text-gray-500 hover:text-gray-700" %>
   </div>

--- a/app/views/form_submissions/link_organization.html.erb
+++ b/app/views/form_submissions/link_organization.html.erb
@@ -6,7 +6,7 @@
     name; linking creates the affiliations — so there is no Unlink here;
     affiliations are managed on the person record. %>
 <% edit_affiliations_path = edit_person_path(@person, anchor: "affiliations", return_to: "form_submission", form_submission_id: @form_submission.id) %>
-<div class="max-w-2xl mx-auto py-8 px-4">
+<div class="max-w-2xl mx-auto px-4">
   <div class="mb-4">
     <% if params[:return_to] == "form_submissions" %>
       <%= link_to "← Back to form submissions", form_submissions_path(highlight: @form_submission.id, anchor: form_submission_row_id(@form_submission)), class: "text-sm #{eyebrow_link_class}" %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -1,5 +1,5 @@
 <% event = @form_submission.resolved_event %>
-<div class="mx-auto max-w-2xl px-4 pt-4">
+<div class="mx-auto max-w-2xl px-4">
   <div class="flex flex-wrap items-center justify-between gap-2">
     <div class="flex flex-wrap items-center gap-2">
     <% if params[:return_to] == "form_submissions" %>

--- a/app/views/forms/edit.html.erb
+++ b/app/views/forms/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="px-4 py-6">
+<div class="px-4">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),

--- a/app/views/forms/edit_sections.html.erb
+++ b/app/views/forms/edit_sections.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="py-6 px-4">
+<div class="px-4">
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Smart fields", smart_form_settings_forms_path(form_id: @form.id, event_id: @dashboard_event&.id),

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="px-4 py-8">
+<div class="px-4">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
   </div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="mx-auto max-w-4xl px-4 py-6">
+<div class="mx-auto max-w-4xl px-4">
   <div class="mb-4 flex flex-wrap items-center justify-end gap-2">
     <%= link_to "Forms", forms_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>
     <%= link_to "Events", events_path(form_id: @form.id), class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="py-8 px-4">
+<div class="px-4">
   <%# Reached from either form editor, so the way back is whichever one sent us —
       carrying the event so the editor reopens in its dashboard context. %>
   <div class="flex flex-wrap items-center justify-end gap-2 mb-4">

--- a/app/views/organizations/check_duplicates.html.erb
+++ b/app/views/organizations/check_duplicates.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen py-10">
+<div class="min-h-screen">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
     <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-lg sm:p-8">
       <div class="mb-6 flex items-center">

--- a/app/views/people/check_duplicates.html.erb
+++ b/app/views/people/check_duplicates.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen py-10">
+<div class="min-h-screen">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
     <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-lg sm:p-8">
       <div class="mb-6 flex items-center">

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-or-owner-or-member") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 space-y-6 rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
 

--- a/app/views/staff_taggings/edit.html.erb
+++ b/app/views/staff_taggings/edit.html.erb
@@ -14,7 +14,7 @@
   <% back_label = "← Staff tags" %>
 <% end %>
 <% tag_options = (StaffTag.published.ordered.to_a | [ @staff_tagging.staff_tag ]).compact %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
     <div class="mb-4">
       <%= link_to back_label, back_path, class: "text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/staff_taggings/new.html.erb
+++ b/app/views/staff_taggings/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto rounded-2xl border bg-white p-6 shadow-lg">
       <div class="mb-4">

--- a/app/views/staff_tags/edit.html.erb
+++ b/app/views/staff_tags/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2">

--- a/app/views/staff_tags/index.html.erb
+++ b/app/views/staff_tags/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
     <div class="admin-only rounded bg-blue-100 p-6">
       <div class="border-primary/10 mx-auto max-w-7xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">

--- a/app/views/staff_tags/index.html.erb
+++ b/app/views/staff_tags/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 <div class="min-h-screen">
   <div class="mx-auto max-w-full px-4 sm:px-6 lg:px-8">
-    <div class="admin-only rounded bg-blue-100 p-6">
       <div class="border-primary/10 mx-auto max-w-7xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="space-y-6">
         <!-- Header -->
@@ -82,7 +81,6 @@
           <%= tailwind_paginate @staff_tags %>
         </div>
       </div>
-    </div>
     </div>
   </div>
 </div>

--- a/app/views/staff_tags/new.html.erb
+++ b/app/views/staff_tags/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center gap-2">

--- a/app/views/staff_tags/show.html.erb
+++ b/app/views/staff_tags/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
-<div class="min-h-screen py-8">
+<div class="min-h-screen">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="border-primary/10 mx-auto max-w-5xl rounded-2xl border bg-white p-6 shadow-lg transition-shadow duration-200 hover:shadow-xl">
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2">

--- a/app/views/story_share_admin/show.html.erb
+++ b/app/views/story_share_admin/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-only bg-blue-100") %>
 
-<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
   <div class="mb-6">
     <%= link_to "← Story Share portal", story_shares_path, class: "text-sm text-purple-700 hover:underline" %>
   </div>

--- a/app/views/users/check_duplicates.html.erb
+++ b/app/views/users/check_duplicates.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen py-10">
+<div class="min-h-screen">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:px-8">
     <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-lg sm:p-8">
       <div class="mb-6 flex items-center">


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only Tailwind class removal across 36 pages, no logic or data changes

A lot of pages, esp admin/internal pages sat at inconsistent heights below the nav — now every admin page lines up at the same spot.

### How did you approach the change?
Dropped the redundant outer-wrapper top padding from 36 pages: the full-width event pages (`reports`, `revenue`, `participation`, `scholarships`, `attendees`, `signins`, `program_statuses`, `attendance`, `templates_gallery`) plus admin/internal pages (`forms/*`, `form_submissions/*`, `events/form_submissions/show`, `events/sample_ticket`, `category_types/*`, `staff_tags/*`, `staff_taggings/*`, `reports/show`, `bookmarks/personal`, `story_share_admin/show`, both `link_organization` pages, and the `check_duplicates` pages).

### Anything else to add?
Left deliberately: **public standalone** pages (registration confirmation/tickets, public forms/thank-you) and **print** document layouts (invoices/receipts) keep their own vertical rhythm — those aren't part of the admin page family. View-only; card internals and `full_width` opt-outs untouched. Ran `ai/tw-sort` (class order clean).