### PR TITLE
Noindex public ticket pages and hidden-from-search resources

### DIFF
--- a/app/controllers/concerns/search_engine_hideable.rb
+++ b/app/controllers/concerns/search_engine_hideable.rb
@@ -1,0 +1,12 @@
+module SearchEngineHideable
+  extend ActiveSupport::Concern
+
+  private
+
+  # Tell compliant crawlers not to index this response. Sent as an HTTP header so
+  # it also covers non-HTML responses (downloads, redirects) a <meta> tag can't
+  # reach. Advisory only — the slug/ticket token remains the actual access gate.
+  def noindex!
+    response.set_header("X-Robots-Tag", "noindex, nofollow")
+  end
+end

--- a/app/controllers/events/bulk_payment_form_submissions_controller.rb
+++ b/app/controllers/events/bulk_payment_form_submissions_controller.rb
@@ -1,6 +1,8 @@
 module Events
   class BulkPaymentFormSubmissionsController < ApplicationController
+    include SearchEngineHideable
     skip_before_action :authenticate_user!, only: [ :new, :create, :show, :ticket, :resend_confirmation ]
+    before_action :noindex!, only: [ :new, :create, :show, :ticket, :resend_confirmation ]
     before_action :set_event, only: [ :new, :create, :show ]
     before_action :set_form, only: [ :new, :create ]
 

--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -4,9 +4,11 @@ module Events
   # Each is reachable by the registration slug — the slug is the authorization,
   # so no login is required (mirrors the public ticket/invoice pages).
   class CalloutsController < ApplicationController
+    include SearchEngineHideable
     # Real registrant pages are public (the slug is the authorization); the
     # sample-ticket previews instead require an admin (authorized in #authorize_callout).
     skip_before_action :authenticate_user!, unless: :sample_preview?
+    before_action :noindex!
     before_action :set_event_registration
     before_action :authorize_callout
     before_action :set_event

--- a/app/controllers/events/invoices_controller.rb
+++ b/app/controllers/events/invoices_controller.rb
@@ -3,8 +3,10 @@ module Events
   # event's content (line item + cost); when a `submission_id` is supplied it
   # autofills the bill-to/attention from that bulk-payment submission.
   class InvoicesController < ApplicationController
+    include SearchEngineHideable
     # Bulk-payment payers have no account; authorization (below) gates access.
     skip_before_action :authenticate_user!, only: [ :show ]
+    before_action :noindex!, only: [ :show ]
     before_action :set_event
 
     def show

--- a/app/controllers/events/public_registrations_controller.rb
+++ b/app/controllers/events/public_registrations_controller.rb
@@ -1,6 +1,8 @@
 module Events
   class PublicRegistrationsController < ApplicationController
+    include SearchEngineHideable
     skip_before_action :authenticate_user!, only: [ :new, :create, :show ]
+    before_action :noindex!, only: [ :new, :create, :show ]
     before_action :set_event
     before_action :ensure_registerable, only: [ :new, :create ]
 

--- a/app/controllers/events/registrations_controller.rb
+++ b/app/controllers/events/registrations_controller.rb
@@ -1,5 +1,7 @@
 module Events
   class RegistrationsController < ApplicationController
+    include SearchEngineHideable
+    before_action :noindex!, only: [ :show, :invoice, :receipt ]
     before_action :authenticate_user!, only: [ :create ]
     before_action :set_event, only: [ :create ]
     before_action :set_registrant, only: [ :create ]

--- a/app/controllers/public_forms_controller.rb
+++ b/app/controllers/public_forms_controller.rb
@@ -2,7 +2,9 @@
 # (/f/:slug). Reuses the public-registration field partials, so answers arrive
 # under the shared `public_registration[form_fields]` param namespace.
 class PublicFormsController < ApplicationController
+  include SearchEngineHideable
   skip_before_action :authenticate_user!, only: %i[show create thank_you]
+  before_action :noindex!, only: %i[show create thank_you]
   before_action :set_form
 
   def show

--- a/app/controllers/registration_ticket_callouts_controller.rb
+++ b/app/controllers/registration_ticket_callouts_controller.rb
@@ -1,5 +1,7 @@
 class RegistrationTicketCalloutsController < ApplicationController
+  include SearchEngineHideable
   skip_before_action :authenticate_user!, only: [ :show ]
+  before_action :noindex!, only: [ :show ]
   before_action :set_event
 
   # Public detail page for a single registration ticket callout, linked from the

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,5 @@
 class ResourcesController < ApplicationController
-  include ExternallyRedirectable, AhoyTracking, TagAssignable, MentionableScopable
+  include ExternallyRedirectable, AhoyTracking, TagAssignable, MentionableScopable, SearchEngineHideable
 
   skip_before_action :authenticate_user!, only: [ :index, :show, :download ]
 
@@ -69,6 +69,7 @@ class ResourcesController < ApplicationController
       gallery_assets: :file_attachment,
     ).find(resource_id_param).decorate
     authorize! @resource
+    noindex! if @resource.hidden_from_search
     track_view(@resource)
     @mentioners = authorized_scope_mentions(@resource.mentioner_records_grouped)
     @mentionees = authorized_scope_mentions(@resource.mentionee_records_grouped)

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,17 @@
     and show up to two lines of text.
   pr_number: 2515
 
+- name: "Keep tickets and hidden resources out of search engines"
+  area: content
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    Personal registration tickets, invoices, receipts, and public form pages —
+    plus resources flagged "hidden from search" — now tell Google and other
+    search engines not to index them, so they stay out of public search results.
+  action_path: /resources
+  pr_number: 2512
+
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting
   display_status: admin_facing

--- a/spec/requests/events/registrations_spec.rb
+++ b/spec/requests/events/registrations_spec.rb
@@ -84,6 +84,11 @@ RSpec.describe "Events::Registrations", type: :request do
         get registration_ticket_path(registration.slug)
         expect(response).to have_http_status(:success)
       end
+
+      it "tells search engines not to index the public ticket" do
+        get registration_ticket_path(registration.slug)
+        expect(response.headers["X-Robots-Tag"]).to include("noindex")
+      end
     end
 
     context "built-in callouts" do

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe "/resources", type: :request do
         expect(response.headers["Content-Security-Policy-Report-Only"]).to include("object-src 'self'")
       end
     end
+
+    context "search-engine indexing" do
+      it "does not send noindex for a normal resource" do
+        resource = Resource.create!(valid_attributes)
+
+        get resource_url(resource)
+
+        expect(response.headers["X-Robots-Tag"]).to be_nil
+      end
+
+      it "sends noindex for a resource hidden from search" do
+        resource = Resource.create!(valid_attributes.merge(hidden_from_search: true))
+
+        get resource_url(resource)
+
+        expect(response.headers["X-Robots-Tag"]).to include("noindex")
+      end
+    end
   end
 
   describe "GET /index (non-preview action)" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small header-only change across 8 public controllers + a shared concern

Keep personal ticket/registration/invoice pages and hidden-from-search resources out of Google — they were publicly reachable by slug/direct link and some were even in robots.txt's crawlable `Allow` list.

- New `SearchEngineHideable` concern sets `X-Robots-Tag: noindex, nofollow` on a response.
- Applied to the public ticket flow: registrations (ticket/invoice/receipt), public registration form, ticket callouts, bulk-payment submissions, event invoice, public forms, registration ticket callouts.
- Applied to `resources#show` only when the resource is `hidden_from_search`.
- Used an HTTP header rather than a `<meta>` tag so it also covers non-HTML responses (downloads, redirects); it's advisory — the slug/ticket token is still the real access gate.

### Note on robots.txt
The `/registration`, `/bulk_payment`, and `/f` slug paths already fall under robots.txt's `Disallow: /`. The genuinely-exposed pages were the `/events/:id/invoice` and `/events/:id/registration_ticket_callouts/:id` routes (under the allowed `/events`) and hidden resources (under allowed `/resources`) — all now noindexed.