### PR TITLE
Add "how did you hear" breakdown to roster charts

### DIFF
--- a/app/models/form_field.rb
+++ b/app/models/form_field.rb
@@ -60,6 +60,9 @@ class FormField < ApplicationRecord
   # admin override is present.
   PAYMENT_METHOD_FIELD_IDENTIFIER = "payment_method"
 
+  # The "How did you hear about this AWBW training?" registration field.
+  REFERRAL_SOURCE_FIELD_IDENTIFIER = "referral_source"
+
   # Quote smart fields. When a submission carries these, its answers are captured
   # as a Quote (see Quotes::CaptureFromSubmission): "quote_body" or the simpler
   # "quote" is the quote text (either is accepted; "quote_body" wins when both are

--- a/app/services/attendees_breakdowns.rb
+++ b/app/services/attendees_breakdowns.rb
@@ -63,6 +63,18 @@ class AttendeesBreakdowns
     @all_age_group_counts ||= distinct_person_counts(age_rows) { |row| row[1] }
   end
 
+  # --- Referral source -------------------------------------------------------
+
+  # "How did you hear about this AWBW training?" answers across the scoped events'
+  # submissions, as [ label, count ] rows counting DISTINCT people per answer (so
+  # someone who gave the same answer at two trainings counts once; one who gave
+  # two different answers counts under each). A "specify" answer ("Other: Facebook")
+  # collapses to its option label, matching the single-event roster and results page.
+  def referral_source_counts
+    @referral_source_counts ||= distinct_person_counts(referral_rows) { |row| row[1] }
+      .sort_by { |label, count| [ -count, label ] }
+  end
+
   # --- Locations -------------------------------------------------------------
 
   def state_counts
@@ -259,6 +271,23 @@ class AttendeesBreakdowns
       .joins(category: :category_type)
       .where(categorizable_type: "Person", categorizable_id: person_ids, category_types: { name: "AgeRange" })
       .pluck(:categorizable_id, :category_id, :is_primary)
+  end
+
+  # [ [ person_id, label ], ... ] for referral-source answers on the scoped
+  # events' submissions by the scoped people. Each answer text is split (defensive
+  # for multi-value) and a "specify" answer folded to its option label.
+  def referral_rows
+    @referral_rows ||= FormAnswer
+      .joins(:form_field, :form_submission)
+      .where(form_fields: { field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER })
+      .where(form_submissions: { event_id: @events.select(:id), person_id: person_ids })
+      .pluck(Arel.sql("form_submissions.person_id"), :submitted_answer)
+      .flat_map do |person_id, submitted_answer|
+        submitted_answer.to_s.split(", ").map(&:strip).reject(&:blank?).map do |raw|
+          base = raw.split(": ", 2).first
+          [ person_id, FormField.specify_option?(base) ? base : raw ]
+        end
+      end
   end
 
   def category_counts(category_type_name)

--- a/app/services/attendees_breakdowns.rb
+++ b/app/services/attendees_breakdowns.rb
@@ -65,11 +65,8 @@ class AttendeesBreakdowns
 
   # --- Referral source -------------------------------------------------------
 
-  # "How did you hear about this AWBW training?" answers across the scoped events'
-  # submissions, as [ label, count ] rows counting DISTINCT people per answer (so
-  # someone who gave the same answer at two trainings counts once; one who gave
-  # two different answers counts under each). A "specify" answer ("Other: Facebook")
-  # collapses to its option label, matching the single-event roster and results page.
+  # Referral-source answers as [ label, count ] rows, counting distinct people per
+  # answer across the scoped events (like the age/sector cards).
   def referral_source_counts
     @referral_source_counts ||= distinct_person_counts(referral_rows) { |row| row[1] }
       .sort_by { |label, count| [ -count, label ] }
@@ -273,9 +270,8 @@ class AttendeesBreakdowns
       .pluck(:categorizable_id, :category_id, :is_primary)
   end
 
-  # [ [ person_id, label ], ... ] for referral-source answers on the scoped
-  # events' submissions by the scoped people. Each answer text is split (defensive
-  # for multi-value) and a "specify" answer folded to its option label.
+  # [ [ person_id, label ], ... ] for referral answers, folding a "specify" answer
+  # ("Other: Facebook") to its option label.
   def referral_rows
     @referral_rows ||= FormAnswer
       .joins(:form_field, :form_submission)

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -836,6 +836,37 @@ class EventDashboard
       .transform_values { |rows| rows.map(&:first).uniq }
   end
 
+  def referral_source_field
+    registration_form_field(FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER)
+  end
+
+  # Referral-source answers as [ label, count ] rows. A "specify" answer
+  # ("Other: Facebook") collapses to its option label, matching how the form
+  # results page (FormResponseAggregator) charts the same question.
+  def referral_source_counts
+    @referral_source_counts ||= begin
+      field = referral_source_field
+      if field.nil?
+        []
+      else
+        specify_labels = field.specify_option_labels.to_set
+        tally = Hash.new(0)
+        FormAnswer
+          .where(form_field_id: field.id)
+          .joins(:form_submission)
+          .where(form_submissions: { person_id: registrant_ids })
+          .pluck(:submitted_answer)
+          .each do |submitted_answer|
+            submitted_answer.to_s.split(", ").map(&:strip).reject(&:blank?).each do |raw|
+              base = raw.split(": ", 2).first
+              tally[specify_labels.include?(base) ? base : raw] += 1
+            end
+          end
+        tally.sort_by { |label, count| [ -count, label ] }
+      end
+    end
+  end
+
   # US states only — international registrants' regions (e.g. provinces) are
   # excluded so the States breakdown reflects domestic residents.
   def states

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -840,9 +840,10 @@ class EventDashboard
     registration_form_field(FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER)
   end
 
-  # Referral-source answers as [ label, count ] rows. A "specify" answer
-  # ("Other: Facebook") collapses to its option label, matching how the form
-  # results page (FormResponseAggregator) charts the same question.
+  # Referral-source answers as [ label, count ] rows, scoped to submissions made
+  # for THIS event (a registration form can be shared across events). A "specify"
+  # answer ("Other: Facebook") collapses to its option label, matching how the
+  # form results page (FormResponseAggregator) charts the same question.
   def referral_source_counts
     @referral_source_counts ||= begin
       field = referral_source_field
@@ -854,7 +855,7 @@ class EventDashboard
         FormAnswer
           .where(form_field_id: field.id)
           .joins(:form_submission)
-          .where(form_submissions: { person_id: registrant_ids })
+          .where(form_submissions: { event_id: event.id, person_id: registrant_ids })
           .pluck(:submitted_answer)
           .each do |submitted_answer|
             submitted_answer.to_s.split(", ").map(&:strip).reject(&:blank?).each do |raw|

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -840,32 +840,16 @@ class EventDashboard
     registration_form_field(FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER)
   end
 
-  # Referral-source answers as [ label, count ] rows, scoped to submissions made
-  # for THIS event (a registration form can be shared across events). A "specify"
-  # answer ("Other: Facebook") collapses to its option label, matching how the
-  # form results page (FormResponseAggregator) charts the same question.
+  # Distinct registrant count per referral-source answer, as [ label, count ] rows
+  # scoped to submissions made for THIS event (a registration form can be shared
+  # across events). A "specify" answer ("Other: Facebook") collapses to its option
+  # label, matching how the form results page (FormResponseAggregator) charts the
+  # same question.
   def referral_source_counts
-    @referral_source_counts ||= begin
-      field = referral_source_field
-      if field.nil?
-        []
-      else
-        specify_labels = field.specify_option_labels.to_set
-        tally = Hash.new(0)
-        FormAnswer
-          .where(form_field_id: field.id)
-          .joins(:form_submission)
-          .where(form_submissions: { event_id: event.id, person_id: registrant_ids })
-          .pluck(:submitted_answer)
-          .each do |submitted_answer|
-            submitted_answer.to_s.split(", ").map(&:strip).reject(&:blank?).each do |raw|
-              base = raw.split(": ", 2).first
-              tally[specify_labels.include?(base) ? base : raw] += 1
-            end
-          end
-        tally.sort_by { |label, count| [ -count, label ] }
-      end
-    end
+    @referral_source_counts ||= referral_source_rows
+      .group_by(&:last)
+      .map { |label, rows| [ label, rows.map(&:first).uniq.size ] }
+      .sort_by { |label, count| [ -count, label ] }
   end
 
   # US states only — international registrants' regions (e.g. provinces) are
@@ -1551,6 +1535,29 @@ class EventDashboard
         submitted_answer.to_s.split(",").map(&:strip)
           .select { |token| token.match?(/\A\d+\z/) }
           .map { |token| [ person_id, token.to_i ] }
+      end
+      .uniq
+  end
+
+  # [ person_id, label ] pairs from registrants' referral-source answers on this
+  # event's submissions, with a "specify" answer folded to its option label.
+  # Deduped per [ registrant, label ], so a registrant who submitted the form
+  # twice counts once.
+  def referral_source_rows
+    field = referral_source_field
+    return [] unless field
+
+    specify_labels = field.specify_option_labels.to_set
+    FormAnswer
+      .where(form_field_id: field.id)
+      .joins(:form_submission)
+      .where(form_submissions: { event_id: event.id, person_id: registrant_ids })
+      .pluck(Arel.sql("form_submissions.person_id"), :submitted_answer)
+      .flat_map do |person_id, submitted_answer|
+        submitted_answer.to_s.split(", ").map(&:strip).reject(&:blank?).map do |raw|
+          base = raw.split(": ", 2).first
+          [ person_id, specify_labels.include?(base) ? base : raw ]
+        end
       end
       .uniq
   end

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -188,8 +188,8 @@ class SmartFormFields
     event_rating most_valuable improvement_suggestions
   ].freeze
 
-  # Answer-only identifiers whose stored value is surfaced somewhere worth pointing
-  # an admin to (a chart or report), keyed to that note. Rendered under the chip.
+  # Per-identifier note rendered under an answer-only chip, for values surfaced in
+  # a chart or report worth pointing an admin to.
   ANSWER_ONLY_NOTES = {
     "referral_source" => "Its value is charted as a \"How did you hear about us?\" breakdown in the " \
                          "event breakdowns and the reports breakdowns, and listed on the form answers " \

--- a/app/services/smart_form_fields.rb
+++ b/app/services/smart_form_fields.rb
@@ -188,6 +188,14 @@ class SmartFormFields
     event_rating most_valuable improvement_suggestions
   ].freeze
 
+  # Answer-only identifiers whose stored value is surfaced somewhere worth pointing
+  # an admin to (a chart or report), keyed to that note. Rendered under the chip.
+  ANSWER_ONLY_NOTES = {
+    "referral_source" => "Its value is charted as a \"How did you hear about us?\" breakdown in the " \
+                         "event breakdowns and the reports breakdowns, and listed on the form answers " \
+                         "and form results pages."
+  }.freeze
+
   def self.groups
     GROUPS.map do |group|
       Group.new(
@@ -206,5 +214,9 @@ class SmartFormFields
 
   def self.role_note(key)
     ROLE_NOTES[key]
+  end
+
+  def self.answer_only_note(identifier)
+    ANSWER_ONLY_NOTES[identifier]
   end
 end

--- a/app/views/events/_registrant_breakdowns.html.erb
+++ b/app/views/events/_registrant_breakdowns.html.erb
@@ -37,6 +37,9 @@
 <% other_response_data = data.other_sector_response_rows.map { |text, count, _ids| [ text, count ] } %>
 <% age_group_data = data.age_groups.map { |c| [ c.name, data.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% all_age_group_data = data.all_age_groups.map { |c| [ c.name, data.all_age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
+<%# Referral source is a per-training registration answer, so only EventDashboard supplies it. %>
+<% referral_source_data = data.respond_to?(:referral_source_counts) ? data.referral_source_counts : [] %>
+<% referral_source_field = data.respond_to?(:referral_source_field) ? data.referral_source_field : nil %>
 <% state_data = data.state_counts.sort_by { |_, count| -count } %>
 <% country_data = data.country_counts.sort_by { |_, count| -count } %>
 <% school_district_data = data.school_district_counts.sort_by { |_, count| -count } %>
@@ -151,10 +154,14 @@
     <% end %>
     <%= render "breakdown_card", title: "Primary age group", data: age_group_data, chart: :pie, palette: palette,
                                  empty_message: "No age group responses yet.", row_paths: age_group_paths %>
-    <% if all_age_group_data.any? || school_district_data.any? %>
+    <% if all_age_group_data.any? || referral_source_data.any? || school_district_data.any? %>
       <div class="flex flex-col gap-6">
         <% if all_age_group_data.any? %>
           <%= render "breakdown_card", title: "All age groups", data: all_age_group_data, chart: :pie, palette: palette, row_paths: all_age_group_paths %>
+        <% end %>
+        <% if referral_source_data.any? %>
+          <%= render "breakdown_card", title: referral_source_field&.name.presence || "How did you hear about this AWBW training?",
+                                       data: referral_source_data, chart: :bar, palette: palette %>
         <% end %>
         <% if school_district_data.any? %>
           <%= render "breakdown_card", title: "School districts (via Address data)", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>

--- a/app/views/events/_registrant_breakdowns.html.erb
+++ b/app/views/events/_registrant_breakdowns.html.erb
@@ -37,7 +37,7 @@
 <% other_response_data = data.other_sector_response_rows.map { |text, count, _ids| [ text, count ] } %>
 <% age_group_data = data.age_groups.map { |c| [ c.name, data.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% all_age_group_data = data.all_age_groups.map { |c| [ c.name, data.all_age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
-<%# Referral source is a per-training registration answer, so only EventDashboard supplies it. %>
+<%# EventDashboard tallies this from the event's form answers; the cross-event sources don't, so guard on it. %>
 <% referral_source_data = data.respond_to?(:referral_source_counts) ? data.referral_source_counts : [] %>
 <% referral_source_field = data.respond_to?(:referral_source_field) ? data.referral_source_field : nil %>
 <% state_data = data.state_counts.sort_by { |_, count| -count } %>

--- a/app/views/events/_registrant_breakdowns.html.erb
+++ b/app/views/events/_registrant_breakdowns.html.erb
@@ -37,8 +37,8 @@
 <% other_response_data = data.other_sector_response_rows.map { |text, count, _ids| [ text, count ] } %>
 <% age_group_data = data.age_groups.map { |c| [ c.name, data.age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
 <% all_age_group_data = data.all_age_groups.map { |c| [ c.name, data.all_age_group_counts.fetch(c.id, 0) ] }.sort_by { |_, count| -count } %>
-<%# EventDashboard tallies this from the event's form answers; the cross-event sources don't, so guard on it. %>
-<% referral_source_data = data.respond_to?(:referral_source_counts) ? data.referral_source_counts : [] %>
+<%# Both sources tally referral answers; only EventDashboard has one form to name the card after. %>
+<% referral_source_data = data.referral_source_counts %>
 <% referral_source_field = data.respond_to?(:referral_source_field) ? data.referral_source_field : nil %>
 <% state_data = data.state_counts.sort_by { |_, count| -count } %>
 <% country_data = data.country_counts.sort_by { |_, count| -count } %>

--- a/app/views/forms/smart_form_settings.html.erb
+++ b/app/views/forms/smart_form_settings.html.erb
@@ -81,8 +81,21 @@
             These come with the question library and are stored on the submission like any ordinary question.
             They carry a smart field only so reports and exports can find them by name — no record is updated.
           </p>
+          <% noted, plain = @answer_only_identifiers.partition { |identifier| SmartFormFields.answer_only_note(identifier) } %>
+          <% if noted.any? %>
+            <dl class="divide-y divide-gray-100 mb-4">
+              <% noted.each do |identifier| %>
+                <div class="py-3 sm:flex sm:gap-6">
+                  <dt class="sm:w-72 sm:shrink-0">
+                    <code class="inline-block rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-800 break-all"><%= identifier %></code>
+                  </dt>
+                  <dd class="mt-1 sm:mt-0 text-sm text-gray-700"><%= SmartFormFields.answer_only_note(identifier) %></dd>
+                </div>
+              <% end %>
+            </dl>
+          <% end %>
           <div class="flex flex-wrap gap-2">
-            <% @answer_only_identifiers.each do |identifier| %>
+            <% plain.each do |identifier| %>
               <code class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700"><%= identifier %></code>
             <% end %>
           </div>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3195,8 +3195,8 @@
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    An event's roster charts now include a "How did you hear about this AWBW
-    training?" breakdown, right below All age groups — the same referral-source
-    tally shown on a form's results page, but scoped to that training's
-    registrants.
+    The event roster charts and the reports (attendees) breakdowns now include a
+    "How did you hear about this AWBW training?" tally, right below All age groups
+    — the same referral-source breakdown shown on a form's results page, scoped to
+    the training(s) in view.
   pr_number: 2513

--- a/config/features.yml
+++ b/config/features.yml
@@ -3199,3 +3199,4 @@
     training?" breakdown, right below All age groups — the same referral-source
     tally shown on a form's results page, but scoped to that training's
     registrants.
+  pr_number: 2513

--- a/config/features.yml
+++ b/config/features.yml
@@ -3189,3 +3189,13 @@
     trail of who changed the portal's nav and when.
   action_path: "/story_share/admin"
   pr_number: 2492
+
+- name: "How-did-you-hear breakdown on the roster charts"
+  area: events
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    An event's roster charts now include a "How did you hear about this AWBW
+    training?" breakdown, right below All age groups — the same referral-source
+    tally shown on a form's results page, but scoped to that training's
+    registrants.

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1221,6 +1221,20 @@ record_professional_answers = ->(submission, i) do
                                     question_name_when_answered: additional_field.name)
   end
 
+  # "How did you hear about this AWBW training?" — a single-select radio storing the
+  # chosen option label verbatim (a "specify" option folds in free text as
+  # "<label>: <text>"). Rotate through the field's own options so the roster's
+  # referral-source chart shows a spread.
+  referral_field = form.form_fields.find_by(field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER)
+  referral_options = referral_field ? referral_field.answer_options.order(:position).pluck(:name) : []
+  if referral_field && referral_options.any? && submission.form_answers.where(form_field: referral_field).none?
+    referral = referral_options[i % referral_options.size]
+    referral = "#{referral}: A friend told me" if FormField.other_option?(referral)
+    submission.form_answers.create!(form_field: referral_field,
+                                    submitted_answer: referral,
+                                    question_name_when_answered: referral_field.name)
+  end
+
   # Tag the person with the same primary/additional split assign_tags applies, so
   # the All-sectors chart has data and the recipients page + profile crown a single
   # primary that matches the form. Idempotent (a person enriched once per event).

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -326,6 +326,21 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).to include("All sectors")
         end
 
+        it "renders the referral-source breakdown from attendees' \"how did you hear\" answers" do
+          registration_form = create(:form, name: "Registration")
+          create(:event_form, event: recent_training, form: registration_form, role: "registration")
+          field = create(:form_field, form: registration_form,
+                                      field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER,
+                                      name: "How did you hear about this AWBW training?",
+                                      answer_type: :single_select_radio)
+          submission = create(:form_submission, person: attendee, form: registration_form, event: recent_training)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Online Search")
+
+          get attendees_events_url, headers: charts_frame_headers
+          expect(response.body).to include("How did you hear about this AWBW training?")
+          expect(response.body).to include("Online Search")
+        end
+
         it "filters by a breakdown drill-in (country)" do
           create(:address, addressable: attendee, country: "Canada", inactive: false)
           other = create(:person, first_name: "Zed", last_name: "Zulu")

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3274,7 +3274,7 @@ RSpec.describe "Events", type: :request do
                                       field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER,
                                       name: "How did you hear about this AWBW training?",
                                       answer_type: :single_select_radio)
-          submission = create(:form_submission, person: person, form: registration_form)
+          submission = create(:form_submission, person: person, form: registration_form, event: owned_event)
           create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Online Search")
 
           get roster_event_path(owned_event), headers: charts_headers

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3267,6 +3267,22 @@ RSpec.describe "Events", type: :request do
           expect(response.body).to include("Teens")
         end
 
+        it "shows a referral-source breakdown from the \"how did you hear\" registration answers" do
+          registration_form = create(:form, name: "Registration")
+          create(:event_form, event: owned_event, form: registration_form, role: "registration")
+          field = create(:form_field, form: registration_form,
+                                      field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER,
+                                      name: "How did you hear about this AWBW training?",
+                                      answer_type: :single_select_radio)
+          submission = create(:form_submission, person: person, form: registration_form)
+          create(:form_answer, form_submission: submission, form_field: field, submitted_answer: "Online Search")
+
+          get roster_event_path(owned_event), headers: charts_headers
+
+          expect(response.body).to include("How did you hear about this AWBW training?")
+          expect(response.body).to include("Online Search")
+        end
+
         it "shows a life experiences breakdown from registrants' StoryPopulation tags" do
           story_population = create(:category_type, name: "StoryPopulation")
           experience = create(:category, name: "Veterans", category_type: story_population)

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -142,6 +142,14 @@ RSpec.describe "Forms", type: :request do
         expect(response.body).to include("Smart fields that do nothing extra")
       end
 
+      it "notes where the referral-source answer is surfaced" do
+        get smart_form_settings_forms_path
+
+        expect(response.body).to include("event breakdowns")
+        expect(response.body).to include("reports breakdowns")
+        expect(response.body).to include("form results")
+      end
+
       # Reached from a form editor, so it has to offer a way back to that editor
       # rather than dropping the admin on the generic forms list.
       it "links back to the form it was opened from" do

--- a/spec/services/attendees_breakdowns_spec.rb
+++ b/spec/services/attendees_breakdowns_spec.rb
@@ -86,6 +86,44 @@ RSpec.describe AttendeesBreakdowns do
   # The breakdown rows drill in by person id on the roster and recipients pages,
   # so each dimension exposes the people behind it. These regroup rows already
   # loaded for the counts — asking for both must not cost a second query.
+  describe "referral source (how did you hear about this AWBW training?)" do
+    let(:registration_form) { create(:form, name: "Registration") }
+    let!(:referral_field) do
+      field = create(:form_field, form: registration_form, field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER,
+                                  name: "How did you hear about this AWBW training?", answer_type: :single_select_radio)
+      create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: "Online Search"))
+      create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: "Other"))
+      field
+    end
+    let!(:other_training) { create(:event, facilitator_training: true, start_date: Date.new(2025, 6, 1)) }
+
+    def answer(who, event, value)
+      submission = create(:form_submission, person: who, form: registration_form, event: event)
+      create(:form_answer, form_field: referral_field, submitted_answer: value, form_submission: submission)
+    end
+
+    it "counts distinct people per answer across the scoped events, collapsing specify answers" do
+      p2 = create(:person)
+      create(:event_registration, event: training, registrant: p2, status: "attended")
+
+      answer(person, training, "Online Search")
+      answer(person, other_training, "Online Search") # same person + answer, other event → counted once
+      answer(p2, training, "Online Search")
+      answer(p2, other_training, "Other: Facebook")   # collapses to "Other"
+
+      bd = described_class.new(Person.where(id: [ person.id, p2.id ]))
+      expect(bd.referral_source_counts).to eq([ [ "Online Search", 2 ], [ "Other", 1 ] ])
+    end
+
+    it "ignores answers on events outside the scoped set" do
+      answer(person, training, "Online Search")
+      answer(person, other_training, "Social Media")
+
+      bd = described_class.new(Person.where(id: person.id), events: Event.where(id: training.id))
+      expect(bd.referral_source_counts).to eq([ [ "Online Search", 1 ] ])
+    end
+  end
+
   describe "person ids per row" do
     it "returns the people behind each dimension" do
       sector = create(:sector, name: "Healthcare")

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -421,6 +421,39 @@ RSpec.describe EventDashboard do
       end
     end
 
+    describe "referral source (how did you hear about this AWBW training?)" do
+      let(:referral_field) do
+        field = create(:form_field, form: registration_form, field_identifier: FormField::REFERRAL_SOURCE_FIELD_IDENTIFIER,
+                                    name: "How did you hear about this AWBW training?", answer_type: :single_select_radio)
+        create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: "Online Search"))
+        create(:form_field_answer_option, form_field: field, answer_option: create(:answer_option, name: "Other"))
+        field
+      end
+
+      before do
+        # person1 → Online Search; person2 → Other (with specify text, which
+        # collapses to "Other"); cancelled → Word of Mouth (ignored).
+        create(:form_answer, form_field: referral_field, submitted_answer: "Online Search",
+                             form_submission: create(:form_submission, person: person1, form: registration_form))
+        create(:form_answer, form_field: referral_field, submitted_answer: "Other: Facebook",
+                             form_submission: create(:form_submission, person: person2, form: registration_form))
+        create(:form_answer, form_field: referral_field, submitted_answer: "Word of Mouth",
+                             form_submission: create(:form_submission, person: cancelled_person, form: registration_form))
+      end
+
+      it "exposes the registration form's referral-source field" do
+        expect(dashboard.referral_source_field).to eq(referral_field)
+      end
+
+      it "tallies active registrants' answers, collapsing a specify answer to its option label" do
+        expect(dashboard.referral_source_counts).to eq([ [ "Online Search", 1 ], [ "Other", 1 ] ])
+      end
+
+      it "ignores cancelled registrants' answers" do
+        expect(dashboard.referral_source_counts.map(&:first)).not_to include("Word of Mouth")
+      end
+    end
+
     describe "states" do
       it "returns unique states from active registrants' active addresses" do
         expect(dashboard.states).to eq(%w[CA NY])

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -432,13 +432,14 @@ RSpec.describe EventDashboard do
 
       before do
         # person1 → Online Search; person2 → Other (with specify text, which
-        # collapses to "Other"); cancelled → Word of Mouth (ignored).
+        # collapses to "Other"); cancelled → Word of Mouth (ignored). All on
+        # submissions made for THIS event.
         create(:form_answer, form_field: referral_field, submitted_answer: "Online Search",
-                             form_submission: create(:form_submission, person: person1, form: registration_form))
+                             form_submission: create(:form_submission, person: person1, form: registration_form, event: event))
         create(:form_answer, form_field: referral_field, submitted_answer: "Other: Facebook",
-                             form_submission: create(:form_submission, person: person2, form: registration_form))
+                             form_submission: create(:form_submission, person: person2, form: registration_form, event: event))
         create(:form_answer, form_field: referral_field, submitted_answer: "Word of Mouth",
-                             form_submission: create(:form_submission, person: cancelled_person, form: registration_form))
+                             form_submission: create(:form_submission, person: cancelled_person, form: registration_form, event: event))
       end
 
       it "exposes the registration form's referral-source field" do
@@ -451,6 +452,14 @@ RSpec.describe EventDashboard do
 
       it "ignores cancelled registrants' answers" do
         expect(dashboard.referral_source_counts.map(&:first)).not_to include("Word of Mouth")
+      end
+
+      it "ignores the same registrant's answer on the shared form for a different event" do
+        other_event = create(:event)
+        create(:form_answer, form_field: referral_field, submitted_answer: "Presentation",
+                             form_submission: create(:form_submission, person: person1, form: registration_form, event: other_event))
+
+        expect(dashboard.referral_source_counts.map(&:first)).not_to include("Presentation")
       end
     end
 

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -454,6 +454,13 @@ RSpec.describe EventDashboard do
         expect(dashboard.referral_source_counts.map(&:first)).not_to include("Word of Mouth")
       end
 
+      it "counts a registrant who submitted the form twice for this event once" do
+        create(:form_answer, form_field: referral_field, submitted_answer: "Online Search",
+                             form_submission: create(:form_submission, person: person1, form: registration_form, event: event))
+
+        expect(dashboard.referral_source_counts).to eq([ [ "Online Search", 1 ], [ "Other", 1 ] ])
+      end
+
       it "ignores the same registrant's answer on the shared form for a different event" do
         other_event = create(:event)
         create(:form_answer, form_field: referral_field, submitted_answer: "Presentation",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 referral tally on two breakdown pages + a smart-fields doc note; form-answer aggregation

Adds a "How did you hear about this AWBW training?" breakdown so staff can read a training's referral mix without opening the form's results page.

### What is the goal of this PR and why is this important?
Facilitators and admins wanted the referral-source tally the form results page shows, surfaced alongside the other demographics on the breakdown pages, scoped to the training(s) in view.

### How did you approach the change?
- **Event breakdowns (roster):** `EventDashboard` tallies the registration form's `referral_source` answers for this event's active registrants, scoped by `event_id` (a registration form can be shared across events). Collapses specify answers (`Other: Facebook`) to their option label, matching the form results page.
- **Reports breakdowns (attendees + recipients):** `AttendeesBreakdowns` computes the same tally across the events in view.
- **Both count distinct people** per answer, like the age/sector cards — a registrant who submitted the form twice for one event counts once, so the roster and recipients charts agree.
- **Shared card** renders below All age groups on both pages.
- **Smart field settings:** documents where a `referral_source` answer surfaces (event breakdowns, reports breakdowns, form answers, form results).
- Dev seeds populate referral answers so the charts have data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)