### PR TITLE
Fix affiliation-history dev seed aborting on re-run

### DIFF
--- a/db/seeds/dev/affiliation_history.rb
+++ b/db/seeds/dev/affiliation_history.rb
@@ -5,11 +5,18 @@
 # Ahoy lifecycle events are written directly rather than letting AhoyTrackable fire
 # them, because the whole point is timestamps spread over past years.
 
+# The uniquely-titled training this seed mints — also its idempotency sentinel:
+# its presence means the seed already ran, so a re-run skips cleanly. (The old
+# guard checked Ahoy events on the pre-existing first affiliation, but the seed
+# only writes those onto the records it creates, so it never tripped and re-runs
+# collided on the duplicate facilitator affiliation.)
+first_training_title = "Facilitator Training: Foundations"
+
 affiliation = Affiliation.order(:id).first
 
 if affiliation.nil?
   puts "Skipping affiliation history seed: no affiliations. Run db:seed:dev first."
-elsif Ahoy::Event.where(resource_type: "Affiliation", resource_id: affiliation.id).where("time < ?", 1.year.ago).exists?
+elsif Event.exists?(title: first_training_title)
   puts "Skipping affiliation history seed (already seeded)"
 else
   person = affiliation.person
@@ -94,7 +101,7 @@ else
     year = ->(n) { Date.current - n.years }
 
     # ── 7 years ago: first training, becomes a facilitator ───────────────────
-    first_registration = training.("Facilitator Training: Foundations", year.(7), "attended", second_org)
+    first_registration = training.(first_training_title, year.(7), "attended", second_org)
     note.(first_registration, "Travelled in from out of state; covered by a partial scholarship.",
           year.(7) + 1.day, topic: "Registration")
     email.("Welcome to the AWBW facilitator community",


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line dev-seed idempotency fix, no app code

Re-running `db:seed:dev` crashed in `affiliation_history.rb` with an empty-message `RecordInvalid` — so a second seed never completed.

- The idempotency guard checked for old Ahoy events on the *pre-existing* first affiliation, but the seed only writes those events onto the records it *creates*, so the guard never tripped.
- Each re-run re-ran the whole block and collided on the duplicate facilitator affiliation, which `Affiliation#skip_if_duplicate` aborts (a halted callback surfaces as `RecordInvalid` with no errors — hence the blank message).
- Now the guard keys off the uniquely-titled training the seed mints, so a second run skips cleanly. Dev-seed only; no app behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)