### PR TITLE
Make communication channel chip match for comments and communications

### DIFF
--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -25,4 +25,13 @@ class CommentDecorator < ApplicationDecorator
   def timestamp
     created_at.strftime("%-m/%-d/%Y %-I:%M %p")
   end
+
+  # Chat icon + "Comment" type chip, mirroring NotificationDecorator#channel_chip
+  # so a comment row carries the same at-a-glance type affordance as a
+  # communication row's "Email" chip in the combined feed.
+  def type_chip(**options)
+    content = h.safe_join([ h.content_tag(:i, "", class: "fa-solid fa-comment", "aria-hidden": "true"), "Com't" ], " ")
+    chip_class = "inline-flex min-w-18 shrink-0 items-center justify-center gap-1 rounded #{DomainTheme.bg_class_for(:comments, intensity: 100)} px-1.5 py-0.5 text-xs font-medium #{DomainTheme.text_class_for(:comments, intensity: 800)}"
+    h.content_tag(:span, content, { class: chip_class, title: "Comment" }.merge(options))
+  end
 end

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -26,9 +26,6 @@ class CommentDecorator < ApplicationDecorator
     created_at.strftime("%-m/%-d/%Y %-I:%M %p")
   end
 
-  # Chat icon + "Comment" type chip, mirroring NotificationDecorator#channel_chip
-  # so a comment row carries the same at-a-glance type affordance as a
-  # communication row's "Email" chip in the combined feed.
   def type_chip(**options)
     content = h.safe_join([ h.content_tag(:i, "", class: "fa-solid fa-comment", "aria-hidden": "true"), "Com't" ], " ")
     chip_class = "inline-flex min-w-18 shrink-0 items-center justify-center gap-1 rounded #{DomainTheme.bg_class_for(:comments, intensity: 100)} px-1.5 py-0.5 text-xs font-medium #{DomainTheme.text_class_for(:comments, intensity: 800)}"

--- a/app/decorators/notification_decorator.rb
+++ b/app/decorators/notification_decorator.rb
@@ -218,7 +218,7 @@ class NotificationDecorator < ApplicationDecorator
     return "" if icon_class.blank?
 
     content = h.safe_join([ h.content_tag(:i, "", class: "fa-solid #{icon_class}", "aria-hidden": "true"), CHANNEL_LABELS[channel] || channel.to_s.titleize ], " ")
-    chip_class = "inline-flex items-center gap-1 rounded #{DomainTheme.bg_class_for(:notifications, intensity: 100)} px-1.5 py-0.5 text-xs font-medium #{DomainTheme.text_class_for(:notifications, intensity: 800)}"
+    chip_class = "inline-flex min-w-18 shrink-0 items-center justify-center gap-1 rounded #{DomainTheme.bg_class_for(:notifications, intensity: 100)} px-1.5 py-0.5 text-xs font-medium #{DomainTheme.text_class_for(:notifications, intensity: 800)}"
     h.content_tag(:span, content, { class: chip_class }.merge(options))
   end
 

--- a/app/views/comments/_comment_fields.html.erb
+++ b/app/views/comments/_comment_fields.html.erb
@@ -10,17 +10,17 @@
 <div class="nested-fields" data-paginated-fields-target="item">
   <%= f.hidden_field :id if f.object.persisted? %>
   <div class="flex items-start gap-x-1 rounded-md border <%= comment_card_class(warning: is_age_range_data) %> px-3 py-2">
-    <label class="mt-1 inline-flex w-4 shrink-0 cursor-pointer justify-center leading-none" title="Flag for follow-up">
+    <label class="mt-0.5 inline-flex w-4 shrink-0 cursor-pointer justify-center leading-none" title="Flag for follow-up">
       <%= f.check_box :flagged, class: "peer sr-only" %>
       <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]! hover:text-orange-400"></i>
     </label>
     <div class="grow">
     <% if f.object.persisted? %>
-      <div class="flex items-center gap-x-1" data-edit-toggle-target="view">
+      <div class="flex items-start gap-x-1" data-edit-toggle-target="view">
         <%= render "comments/comment_line", comment: f.object, body_target: true %>
       </div>
       <div class="flex hidden items-start gap-x-1" data-edit-toggle-target="edit">
-        <span class="mt-2 shrink-0 text-xs whitespace-nowrap text-gray-400">
+        <span class="mt-2 w-32 shrink-0 text-xs whitespace-nowrap text-gray-400">
           <%= f.object.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
         </span>
         <span class="mt-2 inline-flex w-20 shrink-0 items-center gap-x-1">
@@ -54,7 +54,7 @@
     <% else %>
       <% current_first_name = current_user&.person&.first_name || current_user&.name.to_s.split.first %>
       <div class="flex items-start gap-x-1">
-        <span class="mt-2 shrink-0 text-xs whitespace-nowrap text-gray-400">
+        <span class="mt-2 w-32 shrink-0 text-xs whitespace-nowrap text-gray-400">
           <%= Time.current.strftime("%-m/%-d/%Y %-I:%M %p") %>
         </span>
         <span class="mt-2 inline-flex w-20 shrink-0 items-center">

--- a/app/views/comments/_comment_line.html.erb
+++ b/app/views/comments/_comment_line.html.erb
@@ -20,7 +20,7 @@
 <% created_color = chip_color(created_user&.id) %>
 <% is_age_range_data = comment.body&.include?("[AGE_RANGE_DATA]") %>
 <% body_class = is_age_range_data ? "text-amber-700" : "text-gray-900" %>
-<span class="shrink-0 text-xs whitespace-nowrap text-gray-400">
+<span class="w-32 shrink-0 text-xs whitespace-nowrap text-gray-400">
   <%= comment.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
 </span>
 <span class="inline-flex w-20 shrink-0 items-center gap-x-1">
@@ -33,18 +33,19 @@
   <% end %>
 </span>
 <% if truncate_body %>
-  <span class="min-w-0 flex-1 truncate text-sm <%= body_class %>"
-        <% if body_target %>data-edit-toggle-target="body"<% end %>
-        title="<%= [ comment.topic, comment.body ].compact_blank.join(" — ") %>">
-    <% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i><% end %>
-    <% if comment.topic.present? %><span class="font-bold tracking-wide uppercase"><%= comment.topic %></span> <% end %><%= comment.body %>
-  </span>
+  <div class="flex min-w-0 flex-1 items-start gap-1 text-sm <%= body_class %>">
+    <% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation mt-0.5 shrink-0"></i><% end %>
+    <%= comment.decorate.type_chip %>
+    <span class="line-clamp-2 min-w-0 flex-1"
+          <% if body_target %>data-edit-toggle-target="body"<% end %>
+          title="<%= [ comment.topic, comment.body ].compact_blank.join(" — ") %>">
+      <% if comment.topic.present? %><span class="font-bold"><%= comment.topic %></span> <% end %><%= comment.body %>
+    </span>
+  </div>
 <% else %>
   <%# Topic and body share one column so the body starts flush with the topic. %>
   <div class="min-w-0 flex-1 text-sm <%= body_class %>">
-    <% if comment.topic.present? || is_age_range_data %>
-      <span><% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i> <% end %><span class="font-bold tracking-wide uppercase"><%= comment.topic %></span></span>
-    <% end %>
+    <span><% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i> <% end %><%= comment.decorate.type_chip %> <% if comment.topic.present? %><span class="font-bold"><%= comment.topic %></span><% end %></span>
     <div class="pt-1 whitespace-pre-line"><%= comment.body %></div>
   </div>
 <% end %>

--- a/app/views/notifications/_communication_line.html.erb
+++ b/app/views/notifications/_communication_line.html.erb
@@ -27,34 +27,42 @@
                   "text-gray-500"
                 end %>
 <% row = capture do %>
-  <div class="flex flex-wrap gap-x-1 gap-y-1 <%= truncate_body ? "items-center" : "items-start" %>">
+  <div class="flex flex-wrap items-start gap-x-1 gap-y-1">
     <%# Flag column left empty — communications have no follow-up flag. %>
     <span class="w-4 shrink-0"></span>
-    <span class="shrink-0 text-xs whitespace-nowrap text-gray-400">
+    <span class="w-32 shrink-0 text-xs whitespace-nowrap text-gray-400">
       <%= notification.created_at.strftime("%-m/%-d/%Y %-I:%M %p") %>
     </span>
     <span class="inline-flex w-20 shrink-0 items-center">
       <span class="<%= chip[0] %> <%= chip[1] %> max-w-full truncate rounded px-1.5 py-0.5 text-left text-xs" title="<%= decorated.from_title.presence || from_name %>"><%= truncate(from_first.to_s, length: 10, omission: "..") %></span>
     </span>
     <%# Subject and body share one column so the body starts flush with the subject. %>
-    <div class="min-w-0 flex-1 text-sm <%= "truncate" if truncate_body %>">
-      <span>
+    <% if truncate_body %>
+      <div class="flex min-w-0 flex-1 items-start gap-1 text-sm">
         <%= decorated.channel_chip %>
-        <%= decorated.flag_badges %>
-        <% if truncate_body || !admin %>
+        <span class="line-clamp-2 min-w-0 flex-1">
+          <%= decorated.flag_badges %>
           <span class="font-semibold text-gray-900"><%= subject %></span>
-        <% else %>
-          <%= link_to subject, notification_path(notification), target: "_blank", rel: "noopener",
-                      class: "font-semibold text-gray-900 hover:underline" %>
+          <% if body.present? %><span class="<%= body_class %>" title="<%= body %>"><%= body %></span><% end %>
+        </span>
+      </div>
+    <% else %>
+      <div class="min-w-0 flex-1 text-sm">
+        <span>
+          <%= decorated.channel_chip %>
+          <%= decorated.flag_badges %>
+          <% if !admin %>
+            <span class="font-semibold text-gray-900"><%= subject %></span>
+          <% else %>
+            <%= link_to subject, notification_path(notification), target: "_blank", rel: "noopener",
+                        class: "font-semibold text-gray-900 hover:underline" %>
+          <% end %>
+        </span>
+        <% if body.present? %>
+          <div class="pt-1 whitespace-pre-line <%= body_class %>"><%= body %></div>
         <% end %>
-        <% if truncate_body && body.present? %>
-          <span class="<%= body_class %>" title="<%= body %>"><%= body %></span>
-        <% end %>
-      </span>
-      <% if !truncate_body && body.present? %>
-        <div class="pt-1 whitespace-pre-line <%= body_class %>"><%= body %></div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
     <%= trailing %>
   </div>
 <% end %>

--- a/app/views/people/comments_and_communications_results.html.erb
+++ b/app/views/people/comments_and_communications_results.html.erb
@@ -26,7 +26,7 @@
           <% record_chip = record_chip_for.call(entry.commentable) %>
           <div class="rounded-md border <%= comment_card_class(warning: entry.body&.include?("[AGE_RANGE_DATA]")) %> px-3 py-2">
             <div class="flex flex-wrap items-start gap-x-1 gap-y-1">
-              <span class="inline-flex w-4 shrink-0 justify-center leading-none" title="<%= entry.flagged? ? "Flagged for follow-up" : "Not flagged" %>">
+              <span class="mt-0.5 inline-flex w-4 shrink-0 justify-center leading-none" title="<%= entry.flagged? ? "Flagged for follow-up" : "Not flagged" %>">
                 <i class="fa-flag <%= entry.flagged? ? "fa-solid text-orange-500" : "fa-regular text-gray-400" %>"></i>
               </span>
               <%= render "comments/comment_line", comment: entry, truncate: false, trailing: record_chip %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "Tell comments from emails at a glance on the activity feed"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    On a record's comments and communications feed, each comment now shows a
+    "Com't" chip that matches the "Email" chip on sent messages, so you can tell
+    internal notes from communications at a glance. Rows line up in even columns
+    and show up to two lines of text.
+  pr_number: 2515
+
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting
   display_status: admin_facing

--- a/spec/decorators/comment_decorator_spec.rb
+++ b/spec/decorators/comment_decorator_spec.rb
@@ -65,4 +65,12 @@ RSpec.describe CommentDecorator do
       expect(comment.decorate.source_theme).to eq(:scholarships)
     end
   end
+
+  describe "#type_chip" do
+    it "renders a chat icon and a Com't label for parity with the Email chip" do
+      chip = create(:comment).decorate.type_chip
+      expect(chip).to include("fa-comment")
+      expect(chip).to include("Com&#39;t")
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 presentation-only rework of combined comments/communications rows plus one new decorator method

### What is this PR about?
Make the communication channel chip the same for comments and communications for more readability.


### Anything else to add?
Presentation only — no data or behavior changes; the standalone full-body feed keeps its existing single-body layout.




<img width="451" height="410" alt="Screenshot 2026-09-02 at 11 19 49 PM" src="https://github.com/user-attachments/assets/b35ed589-d68a-4fd4-9d54-aed5ac4bf0d1" />
