### PR TITLE
Theme the page accent rule by access level (admin / owner / auth / public)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -271,18 +271,21 @@ module ApplicationHelper
     base.change(hour: 9, min: 0)
   end
 
-  # True when the current page declared itself admin-only via its page_bg_class
-  # marker. The shared index/show shells use this to swap the public rainbow rule
-  # for the quieter brand-navy admin strip. Views set content_for(:page_bg_class)
-  # at their top, so it is captured before the shell renders.
-  def admin_only_page?
-    content_for(:page_bg_class).to_s.start_with?("admin-only")
-  end
-
-  # The accent strip partial for the current page: the brand-navy admin rule on
-  # admin-only pages, the public rainbow rule otherwise.
+  # The accent strip partial for the current page, chosen from its page_bg_class
+  # policy marker (set with content_for at the top of the view, so it is captured
+  # before the shell renders):
+  #   admin-only            → brand-navy admin sweep (internal tool)
+  #   any …public…          → public rainbow rule (genuinely public pages)
+  #   admin-or-owner…       → half navy / half rainbow (admin OR the record owner)
+  #   admin-or-auth…        → the teal rainbow rule (any authenticated user)
+  #   otherwise             → public rainbow rule
   def accent_strip_partial
-    admin_only_page? ? "shared/admin_accent_strip" : "shared/brand_accent_strip"
+    marker = content_for(:page_bg_class).to_s
+    return "shared/admin_accent_strip" if marker.start_with?("admin-only")
+    return "shared/brand_accent_strip" if marker.include?("public")
+    return "shared/owner_accent_strip" if marker.include?("owner")
+    return "shared/brand_accent_strip_alt" if marker.include?("auth")
+    "shared/brand_accent_strip"
   end
 
   # Rainbow gradient accent bar shown beside form section headers.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -271,6 +271,20 @@ module ApplicationHelper
     base.change(hour: 9, min: 0)
   end
 
+  # True when the current page declared itself admin-only via its page_bg_class
+  # marker. The shared index/show shells use this to swap the public rainbow rule
+  # for the quieter brand-navy admin strip. Views set content_for(:page_bg_class)
+  # at their top, so it is captured before the shell renders.
+  def admin_only_page?
+    content_for(:page_bg_class).to_s.start_with?("admin-only")
+  end
+
+  # The accent strip partial for the current page: the brand-navy admin rule on
+  # admin-only pages, the public rainbow rule otherwise.
+  def accent_strip_partial
+    admin_only_page? ? "shared/admin_accent_strip" : "shared/brand_accent_strip"
+  end
+
   # Rainbow gradient accent bar shown beside form section headers.
   def form_section_bar_class
     "h-5 w-1 rounded-full bg-[linear-gradient(to_bottom,#ec4899,#f97316,#22c55e,#3b82f6,#8b5cf6)]"

--- a/app/views/contact_us/index.html.erb
+++ b/app/views/contact_us/index.html.erb
@@ -3,7 +3,7 @@
 
 <% profile_return_path = (edit_person_path(current_user.person, anchor: "affiliations") if @return_to == "person_edit" && current_user&.person) %>
 <div class="border-primary/10 mx-auto w-full max-w-7xl overflow-hidden rounded-2xl border bg-white shadow-sm" id="contact-us-container">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <div class="p-6">
       <% if profile_return_path %>
         <div class="mb-3">

--- a/app/views/devise/_auth_card.html.erb
+++ b/app/views/devise/_auth_card.html.erb
@@ -5,7 +5,7 @@
     Devise controller, where `devise_mapping` is not defined. %>
 <div class="flex items-center justify-center px-4">
   <div class="border-primary/10 mt-8 w-full max-w-md overflow-hidden rounded-2xl border bg-white shadow-lg">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="p-8">
       <%= render "layouts/mailer/logo" %>
 

--- a/app/views/event_registrations/_ticket.html.erb
+++ b/app/views/event_registrations/_ticket.html.erb
@@ -4,7 +4,7 @@
   <%= render "event_registrations/transfer_notice", event_registration: event_registration %>
   <!-- Ticket Container -->
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <!-- Ticket Header -->
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">

--- a/app/views/events/bulk_payment_form_submissions/new.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/new.html.erb
@@ -29,7 +29,7 @@
 
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
 
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">

--- a/app/views/events/bulk_payment_form_submissions/show.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/show.html.erb
@@ -21,7 +21,7 @@
 
 <div class="mx-auto max-w-3xl px-4 pt-6 pb-12">
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">

--- a/app/views/events/bulk_payment_form_submissions/ticket.html.erb
+++ b/app/views/events/bulk_payment_form_submissions/ticket.html.erb
@@ -37,7 +37,7 @@
   <!-- Ticket Container -->
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
     <!-- Ticket Header -->
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0"><%= image_tag("logo.png", alt: "Organization logo", class: "h-9 w-auto") %></div>

--- a/app/views/events/callouts/_callout_page.html.erb
+++ b/app/views/events/callouts/_callout_page.html.erb
@@ -21,7 +21,7 @@
 
 <div class="<%= container_width %> mx-auto px-4 pt-6 pb-12">
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">

--- a/app/views/events/public_registrations/new.html.erb
+++ b/app/views/events/public_registrations/new.html.erb
@@ -71,7 +71,7 @@
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
 
     <%# Card Header %>
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="min-w-0">
         <h2 class="text-xl leading-tight font-semibold tracking-wide"><%= @registration_form.display_name %></h2>

--- a/app/views/events/public_registrations/show.html.erb
+++ b/app/views/events/public_registrations/show.html.erb
@@ -45,7 +45,7 @@
   <div class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden">
 
     <%# Card Header %>
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary text-white px-6 sm:px-8 py-5">
       <div class="flex items-center gap-5">
         <div class="shrink-0">
@@ -96,7 +96,7 @@
     <div id="scholarship-application" class="bg-white rounded-2xl shadow-xl ring-1 ring-black/5 overflow-hidden mt-8 scroll-mt-24">
 
       <%# Card Header %>
-      <%= render "shared/brand_accent_strip" %>
+      <%= render accent_strip_partial %>
       <div class="bg-primary text-white px-6 sm:px-8 py-5">
         <div class="flex items-center gap-3">
           <i class="fa-solid fa-hand-holding-heart text-accent text-xl"></i>

--- a/app/views/events/staff.html.erb
+++ b/app/views/events/staff.html.erb
@@ -5,7 +5,7 @@
 <% content_for(:full_width, true) %>
 <div class="mx-auto max-w-[96rem] px-2 sm:px-6 lg:px-8">
 <div class="<%= DomainTheme.bg_class_for(:events) %> <%= DomainTheme.border_class_for(:events, intensity: 200) %> overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <div class="p-4 sm:p-6">
   <%# Top bar: back link on the left; sub-nav (admins only) on the right %>
   <div class="flex flex-wrap items-center justify-between gap-2 sm:gap-4 mb-6 print:hidden">

--- a/app/views/events/templates/_centered.html.erb
+++ b/app/views/events/templates/_centered.html.erb
@@ -1,7 +1,7 @@
 <%# Centered — brand-polished centered layout: a cream card holds the header
     image, and a second cream card below holds the title, details and body. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "shared/brand_accent_strip_alt" %>
+<%= render accent_strip_partial %>
 
 <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>

--- a/app/views/events/templates/_editorial.html.erb
+++ b/app/views/events/templates/_editorial.html.erb
@@ -1,7 +1,7 @@
 <%# Editorial — warm cream page, centred masthead with a hairline meta line, the
     description on a white paper card. Best for text-heavy events. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "shared/brand_accent_strip_alt" %>
+<%= render accent_strip_partial %>
 
 <div class="bg-brand-cream w-full">
   <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">

--- a/app/views/events/templates/_hero.html.erb
+++ b/app/views/events/templates/_hero.html.erb
@@ -1,7 +1,7 @@
 <%# Navy hero — bold navy gradient band with the title, details and register beside
     the framed header image; the description sits below on a light page. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "shared/brand_accent_strip_alt" %>
+<%= render accent_strip_partial %>
 
 <section class="from-brand-navy-950 via-brand-navy-900 to-brand-navy-800 w-full bg-gradient-to-br text-white">
   <div class="mx-auto grid max-w-6xl items-center gap-10 px-4 py-14 sm:px-6 lg:grid-cols-2 lg:px-8">

--- a/app/views/events/templates/_sidebar.html.erb
+++ b/app/views/events/templates/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <%# Details sidebar — description flows left; a sticky card on the right holds the
     details and register actions. Best for long, info-dense events. %>
 <% sample = local_assigns.fetch(:sample, false) %>
-<%= render "shared/brand_accent_strip_alt" %>
+<%= render accent_strip_partial %>
 
 <div class="mx-auto max-w-6xl px-4 pt-8 pb-16 sm:px-6 lg:px-8">
   <% if event.rhino_header.present? %>

--- a/app/views/form_submissions/show.html.erb
+++ b/app/views/form_submissions/show.html.erb
@@ -33,7 +33,7 @@
 
 <div class="mx-auto max-w-2xl px-4 pt-6 pb-12">
   <div class="overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="bg-primary px-6 py-5 text-white sm:px-8">
       <div class="flex items-center gap-5">
         <div class="shrink-0">

--- a/app/views/forms/_page_header.html.erb
+++ b/app/views/forms/_page_header.html.erb
@@ -3,7 +3,7 @@
     a domain tint, a circular icon badge, a domain-coloured eyebrow, and the
     title in the display serif. Optional `meta` holds the right-hand stat chips.
     locals: icon, eyebrow, title; optional meta. %>
-<%= render "shared/brand_accent_strip", rounded: true %>
+<%= render accent_strip_partial, rounded: true %>
 <div class="<%= DomainTheme.bg_class_for(:forms, intensity: 100) %> px-6 py-6 sm:px-8">
   <div class="flex flex-wrap items-center justify-between gap-4">
     <div class="flex items-center gap-4">

--- a/app/views/forms/_public_header.html.erb
+++ b/app/views/forms/_public_header.html.erb
@@ -2,7 +2,7 @@
     drift — a preview is only useful if it is a true likeness. Navy gradient
     band under the brand rule, carrying the form's name.
     locals: form; optional badge (e.g. the preview marker). %>
-<%= render "shared/brand_accent_strip" %>
+<%= render accent_strip_partial %>
 <div class="from-brand-navy-900 to-brand-navy-600 bg-gradient-to-r px-6 py-5 text-white sm:px-8">
   <div class="flex flex-wrap items-center justify-between gap-3">
     <h1 class="font-display text-2xl leading-tight font-semibold tracking-tight"><%= form.display_name %></h1>

--- a/app/views/home/_section.html.erb
+++ b/app/views/home/_section.html.erb
@@ -3,7 +3,7 @@
     locals: title, subtitle (optional), surface (defaults to white). %>
 <% surface = local_assigns[:surface].presence || "bg-white" %>
 <section class="<%= surface %>">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <div class="mx-auto max-w-6xl px-4 py-10">
     <div class="mb-8">
       <h2 class="text-primary font-display text-3xl"><%= title %></h2>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <div class="border-primary/10 <%= DomainTheme.bg_class_for(:organizations) %> mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <div class="p-6">
     <!-- Header -->
     <div class="mb-6 flex flex-col items-center justify-between gap-3 sm:flex-row sm:items-start">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <div class="bg-brand-cream border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <!-- Organization hero -->
   <div class="<%= DomainTheme.bg_class_for(:organizations, intensity: 100) %> px-4 pt-5 pb-8 sm:px-8">
     <!-- Eyebrow + header actions -->

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_bg_class, "admin-or-auth") %>
 <div class="border-primary/10 <%= DomainTheme.bg_class_for(:people) %> mx-auto max-w-7xl overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <div class="w-full p-6">
     <% back_label, back_path =
          case params[:return_to]

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -10,7 +10,7 @@
   </div>
 <% end %>
 <div class="admin-or-owner bg-brand-cream border-primary/10 overflow-hidden rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip" %>
+  <%= render accent_strip_partial %>
   <!-- Person hero -->
   <div class="<%= DomainTheme.bg_class_for(:people, intensity: 100) %> px-4 pt-5 pb-8 sm:px-8">
     <!-- Eyebrow + header actions -->

--- a/app/views/public_forms/thank_you.html.erb
+++ b/app/views/public_forms/thank_you.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="overflow-hidden rounded-2xl bg-white text-center shadow-xl ring-1 ring-black/5">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="px-6 py-12 sm:px-10">
     <span class="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 text-green-600">
       <i class="fa-solid fa-circle-check text-3xl" aria-hidden="true"></i>

--- a/app/views/shared/_admin_accent_strip.html.erb
+++ b/app/views/shared/_admin_accent_strip.html.erb
@@ -2,7 +2,6 @@
     marks a public, AWBW-branded page, this quieter brand-navy strip marks the
     internal admin tool — a tonal navy sweep (dark edges, a lit middle) rather
     than the bright multi-colour rule, so admin surfaces read as back-office, not
-    marketing. The shared index/show shells pick this automatically on admin-only
-    pages (see ApplicationHelper#admin_only_page?). Pass rounded: true when the
-    card is not clipping its own overflow. %>
+    marketing. Picked automatically on admin-only pages by accent_strip_partial.
+    Pass rounded: true when the card is not clipping its own overflow. %>
 <div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-navy-950),var(--color-brand-navy-800),var(--color-brand-navy-600),var(--color-brand-navy-800),var(--color-brand-navy-950))]"></div>

--- a/app/views/shared/_admin_accent_strip.html.erb
+++ b/app/views/shared/_admin_accent_strip.html.erb
@@ -1,0 +1,8 @@
+<%# The admin counterpart to shared/_brand_accent_strip. Where the rainbow rule
+    marks a public, AWBW-branded page, this quieter brand-navy strip marks the
+    internal admin tool — a tonal navy sweep (dark edges, a lit middle) rather
+    than the bright multi-colour rule, so admin surfaces read as back-office, not
+    marketing. The shared index/show shells pick this automatically on admin-only
+    pages (see ApplicationHelper#admin_only_page?). Pass rounded: true when the
+    card is not clipping its own overflow. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-navy-950),var(--color-brand-navy-800),var(--color-brand-navy-600),var(--color-brand-navy-800),var(--color-brand-navy-950))]"></div>

--- a/app/views/shared/_brand_accent_strip_alt.html.erb
+++ b/app/views/shared/_brand_accent_strip_alt.html.erb
@@ -1,6 +1,7 @@
-<%# The second AWBW rainbow rule — gold, navy and teal where
-    shared/_brand_accent_strip runs yellow, purple and navy. Used by the branded
-    event templates and the story-shares footer. Same locals as that partial:
-    pass rounded: true when the container is not clipping its own overflow, so
-    the rule still follows the container's rounded top corners. %>
-<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-green-700),var(--color-brand-orange-600),var(--color-brand-yellow-500),var(--color-brand-magenta-800),var(--color-brand-navy-800),var(--color-brand-teal-600))]"></div>
+<%# The second AWBW rainbow rule — warm-orange, navy and teal where
+    shared/_brand_accent_strip runs yellow, purple and navy. Lighter on gold than
+    the primary rule (no yellow stop). Used by the admin-or-auth page bar, the
+    branded event templates and the story-shares footer. Same locals as that
+    partial: pass rounded: true when the container is not clipping its own
+    overflow, so the rule still follows the container's rounded top corners. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-green-700),var(--color-brand-orange-600),var(--color-brand-magenta-800),var(--color-brand-navy-800),var(--color-brand-teal-600))]"></div>

--- a/app/views/shared/_form_page.html.erb
+++ b/app/views/shared/_form_page.html.erb
@@ -12,7 +12,7 @@
 <% width = local_assigns[:width].presence || "max-w-5xl" %>
 <% tint = DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= tint %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= width %> mx-auto w-full rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip", rounded: true %>
+  <%= render accent_strip_partial, rounded: true %>
   <div class="p-6 sm:p-8">
     <%= local_assigns[:notice] %>
     <div class="<%= "sticky top-0 z-10 #{tint} pb-3" if local_assigns[:sticky_header] %>">

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -1,8 +1,7 @@
 <%# Shared shell for an index page: the brand card (accent rule, rounded corners,
     soft domain border) over the domain's own tint, then the serif title with an
     optional eyebrow, subtitle and right-hand actions, and the page body as a block.
-    The accent rule is the public rainbow strip, or the quieter brand-navy admin
-    strip on admin-only pages (see accent_strip_partial).
+    The accent rule adapts to the page's access level (see accent_strip_partial).
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
     actions (captured markup), surface (defaults to the domain's 50 tint),
     topbar (captured back-eyebrow / sub-nav row, justify-between at the card top),

--- a/app/views/shared/_index_page.html.erb
+++ b/app/views/shared/_index_page.html.erb
@@ -1,13 +1,15 @@
-<%# Shared shell for an index page: the brand card (rainbow rule, rounded corners,
+<%# Shared shell for an index page: the brand card (accent rule, rounded corners,
     soft domain border) over the domain's own tint, then the serif title with an
     optional eyebrow, subtitle and right-hand actions, and the page body as a block.
+    The accent rule is the public rainbow strip, or the quieter brand-navy admin
+    strip on admin-only pages (see accent_strip_partial).
     locals: domain (a DomainTheme key), title; optional eyebrow, subtitle,
     actions (captured markup), surface (defaults to the domain's 50 tint),
     topbar (captured back-eyebrow / sub-nav row, justify-between at the card top),
     subtitle_width (subtitle max-width class, defaults to max-w-3xl). %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip", rounded: true %>
+  <%= render accent_strip_partial, rounded: true %>
   <div class="w-full p-6">
     <% if local_assigns[:topbar].present? %>
       <div class="mb-4 flex flex-wrap items-center justify-between gap-2"><%= topbar %></div>

--- a/app/views/shared/_owner_accent_strip.html.erb
+++ b/app/views/shared/_owner_accent_strip.html.erb
@@ -1,0 +1,6 @@
+<%# Half-and-half rule for admin-or-owner pages: the left half is the quiet
+    brand-navy admin sweep, the right half the public rainbow — because these
+    pages are reachable by an admin OR the record's own (non-admin) owner, so the
+    strip carries both signals. Picked automatically by accent_strip_partial.
+    Pass rounded: true when the card is not clipping its own overflow. %>
+<div class="h-1.5 w-full <%= "rounded-t-2xl" if local_assigns[:rounded] %> bg-[linear-gradient(to_right,var(--color-brand-navy-950)_0%,var(--color-brand-navy-600)_25%,var(--color-brand-navy-900)_50%,var(--color-brand-green-700)_50%,var(--color-brand-orange-600)_63%,var(--color-brand-yellow-400)_75%,var(--color-brand-magenta-800)_88%,var(--color-brand-purple-950)_100%)]"></div>

--- a/app/views/shared/_public_welcome_banner.html.erb
+++ b/app/views/shared/_public_welcome_banner.html.erb
@@ -3,7 +3,7 @@
       edge there. Everywhere else it sits above rounded cards, so it becomes one. %>
   <% full_bleed = content_for?(:full_width) %>
   <div class="bg-brand-cream overflow-hidden <%= "border-primary/10 mb-6 rounded-2xl border shadow-sm" unless full_bleed %>">
-    <%= render "shared/brand_accent_strip" %>
+    <%= render accent_strip_partial %>
     <div class="mx-auto flex max-w-6xl items-center justify-center gap-5 px-4 py-8">
       <div class="h-20 w-20 shrink-0 overflow-hidden rounded-full">
         <%= image_tag "logo-circle.png", class: "h-full w-full object-cover", alt: "AWBW logo" %>

--- a/app/views/shared/_show_page.html.erb
+++ b/app/views/shared/_show_page.html.erb
@@ -1,9 +1,11 @@
-<%# Shared shell for a public show page: the brand card (rainbow rule, rounded
-    corners, soft domain border) over the domain's own tint, with the page body
-    supplied as a block. Mirrors `shared/_index_page` for the listing pages.
+<%# Shared shell for a show page: the brand card (accent rule, rounded corners,
+    soft domain border) over the domain's own tint, with the page body supplied
+    as a block. The accent rule is the public rainbow strip, or the quieter
+    brand-navy admin strip on admin-only pages (see accent_strip_partial).
+    Mirrors `shared/_index_page` for the listing pages.
     locals: domain (a DomainTheme key); optional surface, extra_class. %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= local_assigns[:extra_class] %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">
-  <%= render "shared/brand_accent_strip", rounded: true %>
+  <%= render accent_strip_partial, rounded: true %>
   <div class="p-6"><%= yield %></div>
 </div>

--- a/app/views/shared/_show_page.html.erb
+++ b/app/views/shared/_show_page.html.erb
@@ -1,8 +1,7 @@
 <%# Shared shell for a show page: the brand card (accent rule, rounded corners,
     soft domain border) over the domain's own tint, with the page body supplied
-    as a block. The accent rule is the public rainbow strip, or the quieter
-    brand-navy admin strip on admin-only pages (see accent_strip_partial).
-    Mirrors `shared/_index_page` for the listing pages.
+    as a block. The accent rule adapts to the page's access level (see
+    accent_strip_partial). Mirrors `shared/_index_page` for the listing pages.
     locals: domain (a DomainTheme key); optional surface, extra_class. %>
 <% surface = local_assigns[:surface].presence || DomainTheme.bg_class_for(domain, intensity: 50) %>
 <div class="<%= surface %> <%= DomainTheme.border_class_for(domain, intensity: 200) %> <%= local_assigns[:extra_class] %> mx-auto w-full max-w-7xl rounded-2xl border shadow-sm">

--- a/app/views/story_shares/_portal_footer.html.erb
+++ b/app/views/story_shares/_portal_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="bg-brand-navy-950 text-white print:hidden">
-  <%= render "shared/brand_accent_strip_alt" %>
+  <%= render accent_strip_partial %>
 
   <div class="mx-auto max-w-6xl px-4 py-14 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-10 md:grid-cols-2 lg:grid-cols-4">

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,14 +38,15 @@
     and show up to two lines of text.
   pr_number: 2515
 
-- name: "Admin-only pages now carry a navy accent, not the public rainbow rule"
+- name: "The page accent rule now reflects who can see the page"
   area: reporting
   display_status: admin_facing
   released_on: 2026-09-02
   summary: >-
-    Admin-only pages are topped with a quiet brand-navy strip instead of the
-    public rainbow rule, so at a glance you can tell an internal admin page from
-    a public, brand-facing one.
+    The colored rule atop each page card now signals its access level: a quiet
+    navy strip on admin-only pages, a half navy/rainbow strip on admin-or-owner
+    pages, and a teal rainbow for any signed-in user — so you can tell an
+    internal page from a public, brand-facing one at a glance.
   action_path: /forms
   pr_number: 2516
 

--- a/config/features.yml
+++ b/config/features.yml
@@ -38,6 +38,17 @@
     and show up to two lines of text.
   pr_number: 2515
 
+- name: "Admin-only pages now carry a navy accent, not the public rainbow rule"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-02
+  summary: >-
+    Admin-only pages are topped with a quiet brand-navy strip instead of the
+    public rainbow rule, so at a glance you can tell an internal admin page from
+    a public, brand-facing one.
+  action_path: /forms
+  pr_number: 2516
+
 - name: "Jump from the activity timeline to the page each row logged"
   area: reporting
   display_status: admin_facing

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,37 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  describe "#accent_strip_partial" do
+    def strip_for(marker)
+      helper.content_for(:page_bg_class, marker) if marker
+      helper.accent_strip_partial
+    end
+
+    it "uses the brand-navy admin strip on admin-only pages" do
+      expect(strip_for("admin-only bg-blue-100")).to eq("shared/admin_accent_strip")
+    end
+
+    it "uses the half navy/rainbow strip on admin-or-owner pages" do
+      expect(strip_for("admin-or-owner")).to eq("shared/owner_accent_strip")
+    end
+
+    it "uses the teal rainbow strip on admin-or-auth pages" do
+      expect(strip_for("admin-or-auth")).to eq("shared/brand_accent_strip_alt")
+    end
+
+    it "keeps the public rainbow strip on public pages" do
+      expect(strip_for("public")).to eq("shared/brand_accent_strip")
+    end
+
+    it "treats an owner page that is also public as public, not half-and-half" do
+      expect(strip_for("admin-or-owner-or-public-or-authpublished")).to eq("shared/brand_accent_strip")
+    end
+
+    it "defaults to the public rainbow strip when no marker is set" do
+      expect(strip_for(nil)).to eq("shared/brand_accent_strip")
+    end
+  end
+
   describe "#credited_author_link" do
     let(:person) { create(:person, first_name: "Ada", last_name: "Lovelace") }
 

--- a/spec/requests/community_news_spec.rb
+++ b/spec/requests/community_news_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe "/community_news", type: :request do
       expect(response).to be_successful
     end
 
+    it "keeps the public rainbow rule on this public index, not the admin strip" do
+      get community_news_index_url
+      expect(response.body).to include("var(--color-brand-green-700),var(--color-brand-orange-600)")
+      expect(response.body).not_to include("var(--color-brand-navy-950),var(--color-brand-navy-800),var(--color-brand-navy-600)")
+    end
+
     it "sorts by the credited author, not by whoever entered the record" do
       aaron = create(:person, first_name: "Aaron", last_name: "Adams")
       zeke = create(:person, first_name: "Zeke", last_name: "Zimmer")

--- a/spec/requests/forms_spec.rb
+++ b/spec/requests/forms_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "Forms", type: :request do
         expect(response).to have_http_status(:success)
       end
 
+      it "tops the admin-only card with the brand-navy admin strip, not the rainbow rule" do
+        get forms_path
+        expect(response.body).to include("var(--color-brand-navy-950),var(--color-brand-navy-800),var(--color-brand-navy-600)")
+        expect(response.body).not_to include("var(--color-brand-green-700),var(--color-brand-orange-600)")
+      end
+
       it "lists standalone forms in the results frame" do
         create(:form, :standalone, name: "My Form")
         get forms_path, headers: frame_headers


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one helper picks the strip partial from each page's page_bg_class marker; every card strip now flows through it, branch logic covered by a helper spec

The colored rule atop each page card now reflects who can reach the page, driven entirely by the page's `page_bg_class` policy marker — so admins can tell an internal page from a public, brand-facing one at a glance, and the rule stays correct automatically if a page's policy changes.

## The bars
- **Admin-only** → quiet brand-navy strip (internal tool).
- **Admin-or-owner** → half navy / half rainbow (admin OR the record's own non-admin owner).
- **Admin-or-auth** → teal rainbow (now lighter on gold — no yellow stop).
- **Public / no marker** → primary rainbow.

## How
- `accent_strip_partial` (application_helper) maps the `page_bg_class` marker → a strip partial, captured before the shell renders.
- **Every** card strip now flows through it — the shared index/show shells, the people/organizations pages, and all former direct callers (public form pages, tickets, devise cards, event templates, story-shares footer). No view hardcodes a strip anymore.
- New `_admin_accent_strip` (navy) and `_owner_accent_strip` (half-and-half); the two rainbows already existed.

## Notable effects
- Branded **event templates** + **story-shares footer** now follow their `public` marker → primary rainbow (they were explicitly teal before). The teal `_alt` rule is now reserved for `admin-or-auth` pages.
- **Form builder** pages (`forms/new`, `forms/edit`) are `admin-only` → navy.
- `form_submissions/show` has no marker → primary rainbow (unchanged); it shares partials with the public confirmation view.
- Precedence: a marker that is both owner *and* public (e.g. events `show`) resolves to public.

## Tests
Helper spec covers all five branches; request specs confirm forms→navy, community_news→rainbow, and no render errors across people/orgs/events/public-form pages. Features & tips entry added.