### PR TITLE
Render audit-footer actor credits as text links, not chips

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -134,6 +134,17 @@ module PersonHelper
     end
   end
 
+  # Text-link sibling of user_button for the audit footer. Non-admin viewers, who
+  # can't follow the admin-only user show page, get the plain name instead.
+  def user_link(user, data: {})
+    name = user.try(:full_name).presence || user.try(:name).presence || user.email
+    return content_tag(:span, name, class: "font-medium text-gray-700") unless allowed_to?(:show?, user)
+
+    link_to name, user_path(user),
+            data: { turbo_prefetch: false }.merge(data),
+            class: "font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+  end
+
   private
 
   # Shared color palette for the person profile/edit buttons, keyed off the same

--- a/app/views/shared/_audit_info.html.erb
+++ b/app/views/shared/_audit_info.html.erb
@@ -15,7 +15,7 @@
         <span class="font-medium">Created:</span>
         <%= resource.created_at.strftime("%b %d, %Y at %-l:%M %p") %>
         <% if created_by_user %>
-          by <%= user_button(created_by_user) %>
+          by <%= user_link(created_by_user) %>
         <% end %>
         <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
           <%= link_to admin_activities_events_path(resource_type: model.class.name, resource_id: resource.id),
@@ -32,7 +32,7 @@
         <span class="font-medium">Last updated:</span>
         <%= resource.updated_at.strftime("%b %d, %Y at %-l:%M %p") %>
         <% if updated_by_user %>
-          by <%= user_button(updated_by_user) %>
+          by <%= user_link(updated_by_user) %>
         <% end %>
         <% if allowed_to?(:index?, with: Admin::AhoyActivityPolicy) %>
           <%= link_to admin_activities_events_path(resource_type: model.class.name, resource_id: resource.id),

--- a/spec/helpers/person_helper_spec.rb
+++ b/spec/helpers/person_helper_spec.rb
@@ -115,4 +115,25 @@ RSpec.describe PersonHelper, type: :helper do
       expect(link["data-turbo-frame"]).to eq("_top")
     end
   end
+
+  describe "#user_link" do
+    let(:user) { create(:user, person: create(:person, first_name: "Cara", last_name: "Lang")) }
+
+    it "renders a plain text link to the user's show page for a viewer who may see it" do
+      allow(helper).to receive(:allowed_to?).with(:show?, user).and_return(true)
+      link = Nokogiri::HTML(helper.user_link(user)).at_css("a")
+
+      expect(link["href"]).to eq(user_path(user))
+      expect(link.text).to eq("Cara Lang")
+      expect(link["class"]).to include("hover:underline")
+    end
+
+    it "renders a plain name, not a link, when the viewer may not see the user" do
+      allow(helper).to receive(:allowed_to?).with(:show?, user).and_return(false)
+      html = helper.user_link(user)
+
+      expect(html).not_to include("href=")
+      expect(html).to include("Cara Lang")
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only: swaps a chip presenter for a text link in the shared audit footer

Audit-footer "Created by / Last updated by" credits are now plain hover-underline text links instead of blue chip pills, so the actor credit reads as passive metadata rather than a call-to-action.

### What is the goal of this PR and why is this important?
The chip pill drew more attention than an audit credit warrants. A muted indigo text link (color + underline on hover), matching the neighboring Ahoy chart-icon link, is the right weight for this footer.

### How did you approach the change?
Added a `user_link` text-link sibling to `user_button` (same admin-only policy gate — non-admins get a plain name) and switched `shared/_audit_info` to it. Left `user_button` untouched for its story-idea and bookmark callers. Added helper specs.

### Anything else to add?
Helper specs pass, lint clean.
