### PR TITLE
Preserve workshop-settings checkboxes on person-edit validation error

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -478,6 +478,15 @@ class PeopleController < ApplicationController
     # saving the form can't drop a person's other category connections.
     @managed_category_type_ids = @person_categories_grouped.map { |type, _| type.id }
 
+    # category_ids is applied via assign_associations only on a successful save, so
+    # on a validation-error re-render reflect the just-submitted selections rather
+    # than the stale persisted set — otherwise the checkboxes silently revert.
+    @selected_category_ids = if params.dig(:person, :category_ids)
+      Array(params[:person][:category_ids]).reject(&:blank?).map(&:to_i)
+    else
+      @person.category_ids
+    end
+
     @staff_tags_collection = StaffTag.published.ordered.pluck(:name, :id)
     @current_staff_tag_ids = @person.staff_tag_ids
   end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -235,7 +235,7 @@
           <div class="flex flex-wrap gap-3">
             <% cats.each do |category| %>
               <%= render "shared/category_checkbox", param_key: "person", category: category,
-                         checked: @person.category_ids.include?(category.id),
+                         checked: (@selected_category_ids || @person.category_ids).include?(category.id),
                          is_age: false,
                          primary_checked: false %>
             <% end %>

--- a/spec/requests/people_workshop_settings_preserved_on_error_spec.rb
+++ b/spec/requests/people_workshop_settings_preserved_on_error_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# Workshop-settings category checkboxes are applied through
+# TagAssignable#assign_associations, which only runs on a successful save. When a
+# validation error (e.g. a malformed email) re-renders the edit form, the just-
+# submitted selections must still reflect what the admin checked — not silently
+# revert to the last-saved database state like they used to.
+RSpec.describe "People edit — workshop settings preserved on validation error", type: :request do
+  let(:category_type) { create(:category_type, :published, profile_specific: true) }
+  let(:category) { create(:category, :published, category_type: category_type) }
+  let(:person) { create(:person) }
+
+  before { sign_in create(:user, :admin) }
+
+  def checkbox_for(category)
+    Nokogiri::HTML(response.body).at_css("#person_category_ids_#{category.id}")
+  end
+
+  it "keeps a newly-checked workshop setting checked after an email validation error" do
+    patch person_path(person), params: {
+      person: {
+        email: "not-an-email",
+        category_ids: [ category.id ],
+        managed_category_type_ids: [ category_type.id ]
+      }
+    }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(checkbox_for(category)&.[]("checked")).to eq("checked")
+  end
+
+  it "keeps an unchecked workshop setting unchecked after an email validation error" do
+    create(:categorizable_item, categorizable: person, category: category)
+
+    patch person_path(person), params: {
+      person: {
+        email: "not-an-email",
+        category_ids: [],
+        managed_category_type_ids: [ category_type.id ]
+      }
+    }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(checkbox_for(category)&.[]("checked")).to be_nil
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small controller + view fix with a regression spec, contained blast radius

When a person-edit save fails validation (e.g. a malformed email), the "workshop settings" checkboxes silently reverted to their last-saved state, losing what the admin just checked — every other field on the form kept its value.

## Why it happened
- Those checkboxes are the only group applied via `TagAssignable#assign_associations`, which runs **only on a successful save**.
- On a failed save the form re-renders reading `@person.category_ids` (persisted state), so the submitted selection was dropped.
- Everything else flows through `assign_attributes`, so it survives the re-render.

## Fix
- Compute `@selected_category_ids` in `set_form_variables` — the submitted `category_ids` on a re-render, falling back to `@person.category_ids` on a fresh GET.
- Checkbox `checked:` reads that instead of the persisted set.
- Covers `update`, `create`, and the duplicate-check re-render (all call `set_form_variables`).

## Audit
Checked the whole person form: `category_ids` was the only success-only association write it submits. Sectors, age ranges (incl. primary flags), addresses, contact methods, staff tags, affiliations, licenses, and all scalars go through nested attributes / `assign_attributes` and already survive. Nothing else reverts.

## Tests
- New request spec asserts a newly-checked setting stays checked, and an unchecked one stays unchecked, after an email validation error (both directions failed before the fix).