### PR TITLE
Left-align a single neutral source chip on the comments feed

### DIFF
--- a/app/views/comments/_comment_line.html.erb
+++ b/app/views/comments/_comment_line.html.erb
@@ -7,10 +7,13 @@
     one line, so the body rides along in the headline; the standalone page passes
     false, which leaves the topic alone on the headline row and drops the full
     body onto its own line underneath), body_target (default false — the section
-    marks the headline so edit-toggle can sync unsaved edits into it), trailing
-    (HTML to close the headline row with, e.g. the attached-record chip). %>
+    marks the headline so edit-toggle can sync unsaved edits into it), leading (a
+    chip to open the headline with in place of the type chip — the aggregated feed
+    passes the neutral source chip, whose icon already conveys the type), trailing
+    (HTML to close the headline row with). %>
 <% truncate_body = local_assigns.fetch(:truncate, true) %>
 <% body_target = local_assigns.fetch(:body_target, false) %>
+<% leading = local_assigns[:leading] %>
 <% trailing = local_assigns[:trailing] %>
 <% created_user = comment.created_by %>
 <% updated_user = comment.updated_by %>
@@ -45,7 +48,7 @@
 <% else %>
   <%# Topic and body share one column so the body starts flush with the topic. %>
   <div class="min-w-0 flex-1 text-sm <%= body_class %>">
-    <span><% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i> <% end %><%= comment.decorate.type_chip %> <% if comment.topic.present? %><span class="font-bold"><%= comment.topic %></span><% end %></span>
+    <span><% if is_age_range_data %><i class="fa-solid fa-triangle-exclamation"></i> <% end %><%= leading || comment.decorate.type_chip %> <% if comment.topic.present? %><span class="font-bold"><%= comment.topic %></span><% end %></span>
     <div class="pt-1 whitespace-pre-line"><%= comment.body %></div>
   </div>
 <% end %>

--- a/app/views/notifications/_communication_line.html.erb
+++ b/app/views/notifications/_communication_line.html.erb
@@ -4,11 +4,13 @@
     All comments & communications page passes truncate: false, which leaves
     channel/badges/subject on the headline row, drops the full body onto its own
     line underneath, and — since a card-wide link can hold no other links — makes
-    the subject the link to the communication so `trailing` can be a link too (the
-    attached-record chip, pointing at that record's edit page). %>
+    the subject the link to the communication so `leading` can be a link too (the
+    neutral source chip, pointing at that record's edit page, with the channel icon
+    inside it). %>
 <% admin = local_assigns.fetch(:admin, true) %>
 <% mark_admin_only = local_assigns.fetch(:mark_admin_only, false) %>
 <% truncate_body = local_assigns.fetch(:truncate, true) %>
+<% leading = local_assigns[:leading] %>
 <% trailing = local_assigns[:trailing] %>
 <% decorated = notification.decorate %>
 <% body_admin_only = notification.channel != "autoemail" %>
@@ -49,7 +51,7 @@
     <% else %>
       <div class="min-w-0 flex-1 text-sm">
         <span>
-          <%= decorated.channel_chip %>
+          <%= leading || decorated.channel_chip %>
           <%= decorated.flag_badges %>
           <% if !admin %>
             <span class="font-semibold text-gray-900"><%= subject %></span>

--- a/app/views/people/comments_and_communications_results.html.erb
+++ b/app/views/people/comments_and_communications_results.html.erb
@@ -6,35 +6,35 @@
     </h2>
   </div>
 
-  <%# Each card leads with a headline row — flag, date, from, subject/topic, and a
-      chip for the record it hangs off — then drops the body onto its own line.
-      The chip links to that record's edit page for both kinds. %>
-  <% chip_class = "inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium" %>
-  <% record_chip_for = ->(record) do
+  <%# Each card leads with a headline row — flag, date, from, then a single neutral
+      chip naming the record it hangs off (with the entry's type icon inside it) and
+      the subject/topic. The chip is left-aligned and links to that record's edit
+      page for both kinds. %>
+  <% chip_class = "inline-flex shrink-0 items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-900" %>
+  <% source_chip_for = ->(record, icon_html) do
        next if record.blank?
 
-       theme = record_theme(record)
-       classes = "ml-auto #{chip_class} #{DomainTheme.border_class_for(theme)} #{DomainTheme.bg_class_for(theme, intensity: 100)} #{DomainTheme.text_class_for(theme, intensity: 800)}"
-       label = commentable_label(record)
+       inner = safe_join([ icon_html, commentable_label(record) ], " ")
        path = record_edit_path(record)
-       path ? link_to(label, path, target: "_blank", rel: "noopener", class: "#{classes} hover:underline") : content_tag(:span, label, class: classes)
+       path ? link_to(inner, path, target: "_blank", rel: "noopener", class: "#{chip_class} hover:underline") : content_tag(:span, inner, class: chip_class)
      end %>
+  <% comment_icon = content_tag(:i, "", class: "fa-solid fa-comment text-gray-500", "aria-hidden": "true", title: "Comment") %>
   <div class="space-y-2">
     <% if @entries.any? %>
       <% @entries.each do |entry| %>
         <% if entry.is_a?(Comment) %>
-          <% record_chip = record_chip_for.call(entry.commentable) %>
+          <% source_chip = source_chip_for.call(entry.commentable, comment_icon) %>
           <div class="rounded-md border <%= comment_card_class(warning: entry.body&.include?("[AGE_RANGE_DATA]")) %> px-3 py-2">
             <div class="flex flex-wrap items-start gap-x-1 gap-y-1">
               <span class="mt-0.5 inline-flex w-4 shrink-0 justify-center leading-none" title="<%= entry.flagged? ? "Flagged for follow-up" : "Not flagged" %>">
                 <i class="fa-flag <%= entry.flagged? ? "fa-solid text-orange-500" : "fa-regular text-gray-400" %>"></i>
               </span>
-              <%= render "comments/comment_line", comment: entry, truncate: false, trailing: record_chip %>
+              <%= render "comments/comment_line", comment: entry, truncate: false, leading: source_chip %>
             </div>
           </div>
         <% else %>
-          <% record_chip = record_chip_for.call(entry.noticeable) %>
-          <%= render "notifications/communication_line", notification: entry, admin: true, truncate: false, trailing: record_chip %>
+          <% source_chip = source_chip_for.call(entry.noticeable, entry.decorate.channel_icon) %>
+          <%= render "notifications/communication_line", notification: entry, admin: true, truncate: false, leading: source_chip %>
         <% end %>
       <% end %>
     <% else %>

--- a/spec/requests/people_comments_and_communications_spec.rb
+++ b/spec/requests/people_comments_and_communications_spec.rb
@@ -48,11 +48,12 @@ RSpec.describe "Person comments and communications", type: :request do
 
       get comments_and_communications_person_path(person), headers: { "Turbo-Frame" => "comments_and_communications_results" }
 
-      chip = Nokogiri::HTML(response.body).at_css("a[href='#{edit_event_registration_path(registration)}']")
-      body = Nokogiri::HTML(response.body).css("div").find { |div| div.text.strip == "On the registration" }
+      doc = Nokogiri::HTML(response.body)
+      chip = doc.at_css("a[href='#{edit_event_registration_path(registration)}']")
+      body = doc.css("div").find { |div| div.text.strip == "On the registration" }
       expect(chip).to be_present
-      # The chip closes the headline row; the body follows it as a full-width line.
-      expect(chip.path < body.path).to be(true)
+      # The chip leads the headline row; the body follows it as a full-width line.
+      expect(chip <=> body).to eq(-1)
     end
 
     it "links a communication's chip to its noticeable and names the record" do


### PR DESCRIPTION
🤖 suggested review level: 1 Skim 👀 view-only chip restyle on one admin feed page

The All comments & communications feed now shows one neutral, left-aligned chip per row instead of a colored chip floated to the right plus a separate type chip.

- Merges the attached-record chip and the type chip into a single chip: it names the record (Affiliation · …, Registration · …, Profile) with the entry's type icon (comment / email channel) inside it.
- Drops the `ml-auto` right-lean and the per-domain color — the chip is now `border-gray-300 bg-gray-100 text-gray-900`, left-aligned at the head of the row.
- Only the standalone feed (`truncate: false`) changes; the per-record combined section on edit pages still renders its inline type chip unchanged.