### PR TITLE
Fix comments index Oopsie for records without nested comment routes

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
   include AhoyTracking
 
-  before_action :set_commentable, except: :index
+  before_action :set_commentable, only: :create
 
   # Global, admin-only index of every comment, with the same search boxes as a
   # person's aggregated feed plus remote person/event filters. The nested
@@ -39,7 +39,7 @@ class CommentsController < ApplicationController
   end
 
   def update
-    @comment = @commentable.comments.find(params[:id])
+    @comment = Comment.find(params[:id])
     authorize! @comment
     @comment.update(comment_params)
     setup_aggregated_context if aggregated?

--- a/app/views/comments/_aggregated_comment.html.erb
+++ b/app/views/comments/_aggregated_comment.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       </div>
       <div class="flex shrink-0 items-center gap-3">
-        <%= render "comments/flag_toggle", commentable: comment.commentable, comment: comment.object %>
+        <%= render "comments/flag_toggle", comment: comment.object %>
         <button type="button" data-action="edit-toggle#toggle"
                 class="text-xs <%= eyebrow_link_class %>">
           <i class="fa-solid fa-pen text-2xs"></i> Edit
@@ -31,7 +31,7 @@
 
   <div data-edit-toggle-target="edit" class="hidden">
     <%= simple_form_for comment.object,
-                        url: polymorphic_path([ comment.commentable, comment.object ]), method: :patch do |f| %>
+                        url: comment_path(comment.object), method: :patch do |f| %>
       <%= hidden_field_tag :aggregated, 1 %>
       <% if person %><%= hidden_field_tag :for_person_id, person.id %><% end %>
       <div class="flex items-start gap-x-2">

--- a/app/views/comments/_flag_toggle.html.erb
+++ b/app/views/comments/_flag_toggle.html.erb
@@ -1,4 +1,4 @@
-<%= button_to polymorphic_path([ commentable, comment ]),
+<%= button_to comment_path(comment),
               method: :patch,
               params: { comment: { flagged: !comment.flagged } },
               form: { id: dom_id(comment, :flag) },

--- a/app/views/comments/update.turbo_stream.erb
+++ b/app/views/comments/update.turbo_stream.erb
@@ -4,6 +4,6 @@
   <% end %>
 <% else %>
   <%= turbo_stream.replace dom_id(@comment, :flag) do %>
-    <%= render "comments/flag_toggle", commentable: @commentable, comment: @comment %>
+    <%= render "comments/flag_toggle", comment: @comment %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,9 @@ Rails.application.routes.draw do
 
   resources :fm_archives, only: [ :index, :show ]
 
-  resources :comments, only: [ :index ]
+  # Top-level update lets the aggregated feed flag/edit any comment by id, even
+  # when its commentable has no nested comments route (affiliations, staff tags…).
+  resources :comments, only: [ :index, :update ]
 
   resources :banners
   resources :bookmarks do

--- a/spec/requests/comments_index_spec.rb
+++ b/spec/requests/comments_index_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe "Comments index", type: :request do
       expect_frame_breakout(response.body, "/people/#{commentable.id}/edit")
     end
 
+    it "renders comments on records without a nested comments route without Oopsie-ing" do
+      sign_in admin
+      affiliation = create(:affiliation)
+      create(:comment, commentable: affiliation, body: "Affiliation note")
+
+      get comments_path, headers: frame_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("comments_results", "Affiliation note")
+    end
+
     it "filters to comments connected to a person" do
       sign_in admin
       target = create(:person)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small routing/controller change plus two view edits, covered by a new request spec

Fixes the admin **Comments** index, which showed "Oopsie! Something went wrong" instead of the comment list whenever the results included a comment on an affiliation, staff tagging, story, or story idea — i.e. most real data.

## Why it broke
- The aggregated feed built its inline flag-toggle and edit-form URLs with `polymorphic_path([commentable, comment])`.
- That needs a **nested** `comments` route, which only 8 commentable types have.
- Affiliations et al. have none, so the frame raised → the `turbo:frame-missing` "Oopsie!" box.

## Fix
- Added a top-level, admin-only `comments#update` (find-by-id) and route flag/edit through `comment_path(comment)`, so every commentable type works uniformly.
- Dropped the now-unused `commentable:` local from `_flag_toggle`.
- Added a request spec with an affiliation comment (fails before, passes after).