### PR TITLE
Default the Activities events feed to admins-in, interactions-hidden

### DIFF
--- a/app/controllers/admin/ahoy_activities_controller.rb
+++ b/app/controllers/admin/ahoy_activities_controller.rb
@@ -1,6 +1,12 @@
 module Admin
   class AhoyActivitiesController < ApplicationController
-    helper_method :scoped_visits, :scoped_events
+    helper_method :scoped_visits, :scoped_events, :hide_interactions?
+
+    # Most audience-filtered views (charts, visits) measure real-user engagement,
+    # so admins stay out by default. The events timeline is an audit log, where
+    # admins' own actions matter, so it defaults to including them.
+    DEFAULT_AUDIENCES = %w[visitors users].freeze
+    EVENTS_DEFAULT_AUDIENCES = %w[visitors users staff].freeze
 
     def index
       authorize! :ahoy_activity, to: :index?
@@ -10,6 +16,8 @@ module Admin
       # The full page renders only the header, filters, and an empty results frame;
       # the frame's src request (turbo_frame_request?) loads the filtered rows.
       return render :index unless turbo_frame_request?
+
+      @audience_default = EVENTS_DEFAULT_AUDIENCES
 
       @users = params[:user_id].present? ? User.where(id: params[:user_id].to_s.split("--")) : nil
 
@@ -734,14 +742,23 @@ module Admin
     end
 
     def selected_audiences
-      @selected_audiences ||= Array(params[:audience]).reject(&:blank?).presence || %w[visitors users]
+      @selected_audiences ||= Array(params[:audience]).reject(&:blank?).presence || (@audience_default || DEFAULT_AUDIENCES)
     end
 
     def hidden_name_patterns
       patterns = []
       patterns.concat(Ahoy::Event::ACCOUNT_NAME_PATTERNS) if param_true?(params[:hide_account])
-      patterns.concat(Ahoy::Event::INTERACTION_NAME_PATTERNS) if param_true?(params[:hide_interactions])
+      patterns.concat(Ahoy::Event::INTERACTION_NAME_PATTERNS) if hide_interactions?
       patterns
+    end
+
+    # Read/browse noise dominates the timeline, so hide it unless the toggle is
+    # explicitly off. An absent param means the default (hidden); the toggle's
+    # hidden field submits "0" so unchecking is distinguishable from first load.
+    def hide_interactions?
+      return true unless params.key?(:hide_interactions)
+
+      param_true?(params[:hide_interactions])
     end
 
     def hide_communications?

--- a/app/views/admin/ahoy_activities/_filter_toggles.html.erb
+++ b/app/views/admin/ahoy_activities/_filter_toggles.html.erb
@@ -4,16 +4,19 @@
     means hide, so the collection controller auto-submits the exclusion. %>
 <%
   cast = ActiveModel::Type::Boolean.new
+  # default_on toggles pair the checkbox with a hidden "0" so unchecking submits
+  # an explicit off — otherwise an absent param falls back to the "on" default.
   toggles = [
-    ["hide_account", "Hide account", cast.cast(params[:hide_account])],
-    ["hide_interactions", "Hide interactions", cast.cast(params[:hide_interactions])],
-    ["hide_communications", "Hide communications", cast.cast(params[:hide_communications])]
+    ["hide_account", "Hide account", cast.cast(params[:hide_account]), false],
+    ["hide_interactions", "Hide interactions", hide_interactions?, true],
+    ["hide_communications", "Hide communications", cast.cast(params[:hide_communications]), false]
   ]
 %>
 <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
   <span class="text-sm font-medium text-gray-600">Hide:</span>
-  <% toggles.each do |name, label, checked| %>
+  <% toggles.each do |name, label, checked, default_on| %>
     <label class="flex items-center gap-2 cursor-pointer select-none">
+      <% if default_on %><%= hidden_field_tag name, "0" %><% end %>
       <%= check_box_tag name, "1", checked, class: "peer sr-only" %>
       <span class="relative inline-block w-9 h-5 rounded-full bg-gray-300 transition-colors peer-checked:bg-indigo-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:shadow after:transition-transform peer-checked:after:translate-x-4"></span>
       <span class="text-sm text-gray-700"><%= label %></span>

--- a/app/views/admin/ahoy_activities/index.html.erb
+++ b/app/views/admin/ahoy_activities/index.html.erb
@@ -26,7 +26,9 @@
       </div>
 
       <div class="mb-6 text-sm min-h-10">
-        <%= render "admin/shared/active_filters_subheader" %>
+        <%= render "admin/shared/active_filters_subheader",
+              default_audiences: Admin::AhoyActivitiesController::EVENTS_DEFAULT_AUDIENCES,
+              hide_interactions: hide_interactions? %>
       </div>
 
       <div class="bg-white border border-primary/10 rounded-2xl shadow-sm p-6 mb-6">
@@ -81,7 +83,8 @@
             </div>
 
             <div class="min-w-0 flex-1">
-              <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true %>
+              <%= render "admin/shared/audience_dropdown", auto_submit: false, stacked: true,
+                    default_audiences: Admin::AhoyActivitiesController::EVENTS_DEFAULT_AUDIENCES %>
             </div>
 
             <div class="min-w-0 flex-1">

--- a/app/views/admin/shared/_active_filters_subheader.html.erb
+++ b/app/views/admin/shared/_active_filters_subheader.html.erb
@@ -13,7 +13,7 @@
     "staff"    => "Admins"
   }
 
-  default_audiences = %w[visitors users]
+  default_audiences = local_assigns.fetch(:default_audiences, %w[visitors users])
   audience_values = Array(params[:audience]).reject(&:blank?).presence || default_audiences
   audience_labels = audience_values.filter_map { |v| audience_labels_map[v] }
 
@@ -24,7 +24,7 @@
   cast = ActiveModel::Type::Boolean.new
   hidden_labels = {
     "Account hidden" => cast.cast(params[:hide_account]),
-    "Interactions hidden" => cast.cast(params[:hide_interactions]),
+    "Interactions hidden" => local_assigns.fetch(:hide_interactions, cast.cast(params[:hide_interactions])),
     "Communications hidden" => cast.cast(params[:hide_communications])
   }.select { |_label, on| on }.keys
 

--- a/app/views/admin/shared/_audience_dropdown.html.erb
+++ b/app/views/admin/shared/_audience_dropdown.html.erb
@@ -1,5 +1,5 @@
 <%
-  default_audiences = %w[visitors users]
+  default_audiences = local_assigns.fetch(:default_audiences, %w[visitors users])
   selected = Array(params[:audience]).reject(&:blank?).presence || default_audiences
   auto_submit = local_assigns.fetch(:auto_submit, true)
   stacked = local_assigns.fetch(:stacked, false)

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,17 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "Activities feed defaults to admins in, interactions hidden"
+  area: reporting
+  display_status: admin_facing
+  released_on: 2026-09-03
+  summary: >-
+    The admin Activities feed now opens showing admins' own actions and with
+    read/browse noise (views, searches, filters, downloads) hidden — so the
+    default view is the changelog you usually want. Both are still toggles you
+    can flip.
+  action_path: "/admin/activities/events"
+
 - name: "See a person's full record on their profile"
   area: people
   display_status: admin_facing
@@ -37,6 +48,7 @@
     profile", and data that used to live only on the edit form now sits in an
     "Admin details" panel.
   pr_number: 2502
+
 - name: "Tell comments from emails at a glance on the activity feed"
   area: communications
   display_status: admin_facing

--- a/spec/requests/admin/ahoy_activities_spec.rb
+++ b/spec/requests/admin/ahoy_activities_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         create(:ahoy_event, name: "view.events.reports", user: user, visit: visit_for_user,
                             time: 2.hours.ago)
 
-        get index_path, params: { time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+        get index_path, params: { time_period: "all_time", audience: %w[visitors users staff], hide_interactions: "0" }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("activity_results")
@@ -202,6 +202,19 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.body).not_to include("interaction_noise_marker")
         expect(response.body).to include("create.bookmark")
+      end
+
+      it "defaults to including admin actors and hiding interactions" do
+        create(:ahoy_event, name: "create.workshop", user: admin, visit: visit_for_admin,
+                            time: 1.hour.ago, properties: { "resource_title" => "admin_actor_marker" })
+        create(:ahoy_event, name: "view.workshop", user: user, visit: visit_for_user,
+                            time: 1.hour.ago, properties: { "resource_title" => "interaction_default_marker" })
+
+        get index_path, headers: frame_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("admin_actor_marker")
+        expect(response.body).not_to include("interaction_default_marker")
       end
 
       it "keeps person_id as a hidden field so the filter form stays person-scoped" do
@@ -307,7 +320,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
                             visit: create(:ahoy_visit, user: nil, started_at: 1.day.ago),
                             time: 1.day.ago, properties: { "resource_title" => "Anger Masks" })
 
-        get index_path, params: { event_name: "feelings", time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+        get index_path, params: { event_name: "feelings", time_period: "all_time", audience: %w[visitors users staff], hide_interactions: "0" }, headers: frame_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("view.workshop_match")
@@ -344,7 +357,7 @@ RSpec.describe "Admin::AhoyActivities", type: :request do
                time: 1.day.ago, properties: { "resource_title" => "other_activity_marker" })
 
         %w[Hernandez Rudolfo rudy.alt@example.com rudy-login@example.com].each do |term|
-          get index_path, params: { user_search: term, time_period: "all_time", audience: %w[visitors users staff] }, headers: frame_headers
+          get index_path, params: { user_search: term, time_period: "all_time", audience: %w[visitors users staff], hide_interactions: "0" }, headers: frame_headers
 
           expect(response.body).to include("rudy_activity_marker"), "expected #{term.inspect} to match Rudy"
           expect(response.body).not_to include("other_activity_marker")


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small default-filter logic change on one admin page, with a checkbox-default gotcha (hidden field)

The admin Activities timeline now opens the way you usually want it: showing admins' own actions and with read/browse noise (views, searches, filters, downloads) hidden — the changelog, not the raw firehose. Both remain toggles.

## What changed
- **Audience default includes Admins** on the events view only. Charts, Visits, and Analytics still default to visitors + users (they measure real-user engagement, where admins would skew the numbers).
- **Hide interactions defaults on** for the events view.

## The one gotcha worth a look
- `hide_interactions` defaults to *on* when the param is absent (first load). To let a user actually turn it off, the toggle now carries a hidden `"0"` field, so an unchecked box submits an explicit off — distinguishable from "never set." That distinction lives in `hide_interactions?` on the controller.

## Scoping
- Defaults are threaded into the shared `_audience_dropdown` / `_active_filters_subheader` partials via a `default_audiences` local (they keep visitors+users when not passed), so nothing changes on the other pages that render them.