### PR TITLE
Attach the certificate signatures as a swappable linked resource

### DIFF
--- a/app/controllers/events/callouts_controller.rb
+++ b/app/controllers/events/callouts_controller.rb
@@ -41,7 +41,7 @@ module Events
       # conditions until then, so there's nothing to gate here.
       # Facilitator trainings render the branded certificate, whose signatures
       # come from an admin-managed record (never committed to this public repo).
-      @signature_file = Resource.training_certificate_signatures_file if @event.facilitator_training?
+      @signature_file = certificate_signature_file if @event.facilitator_training?
     end
 
     # Scholarship status: the award (amount, funder, criteria, tasks) once a
@@ -516,6 +516,15 @@ module Events
       callout = @builtin_callout
       callout = nil if action_name == "payment"
       @builtin_resource_cards = resource_cards_for(callout, icon: "fa-solid fa-file-lines", return_to: action_name)
+    end
+
+    # The certificate's signature strip: the certificate callout's first linked
+    # resource when an admin connected one (attached overrides the default), else
+    # the title-matched record. Mirrors the payment callout's W-9 resolution.
+    def certificate_signature_file
+      connected = @builtin_callout&.resources&.first
+      return connected.signature_file if connected
+      Resource.training_certificate_signatures_file
     end
 
     # This registrant's cards for a callout's linked resources (nil callout → none).

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -25,11 +25,13 @@ class Resource < ApplicationRecord
   # record/upload isn't present (e.g. dev/OSS), so the certificate simply omits
   # the signatures rather than erroring.
   def self.training_certificate_signatures_file
-    resource = find_by(title: TRAINING_CERTIFICATE_SIGNATURES_TITLE)
-    return unless resource
+    find_by(title: TRAINING_CERTIFICATE_SIGNATURES_TITLE)&.signature_file
+  end
 
-    [ resource.primary_asset, resource.downloadable_asset ].compact
-      .map(&:file).find(&:attached?)
+  # The first attached image on this resource (primary asset, then downloadable),
+  # for use as a certificate signature strip. Nil when nothing is attached.
+  def signature_file
+    [ primary_asset, downloadable_asset ].compact.map(&:file).find(&:attached?)
   end
 
   has_rich_text :rhino_body

--- a/app/services/builtin_callouts.rb
+++ b/app/services/builtin_callouts.rb
@@ -293,7 +293,12 @@ class BuiltinCallouts
         color_class: "green",
         # A published row shows before it unlocks as a pending card; once unlocked it
         # links to the certificate (BuiltinCalloutCards guards this).
-        hidden: ->(_event) { true }
+        hidden: ->(_event) { true },
+        # The facilitator-training certificate's signature strip is a removable linked
+        # resource, attached on create by title so admins can swap it per event. When
+        # nothing is linked (e.g. the record isn't seeded yet), the page falls back to
+        # the title-matched default. Mirrors the payment callout's W-9.
+        resources: -> { [ Resource.find_by(title: Resource::TRAINING_CERTIFICATE_SIGNATURES_TITLE) ].compact }
       },
       {
         builtin_key: "faq",

--- a/app/views/events/callouts/_training_certificate.html.erb
+++ b/app/views/events/callouts/_training_certificate.html.erb
@@ -1,7 +1,8 @@
 <%# The facilitator-training certificate — the branded painted-border design.
     The border/title are static brand assets (app/assets/images/certificates); the
-    signature strip is an admin-managed upload (Resource.training_certificate_signatures_file,
-    passed in as signature_file) so real signatures never live in this public repo.
+    signature strip is an admin-managed upload (the certificate callout's linked
+    resource, else the title-matched default), passed in as signature_file, so real
+    signatures never live in this public repo.
     The recipient name, dates, and CE clause are rendered live over the card.
     Sizes use container-query units (cqw) so the whole certificate scales as one. %>
 <article class="certificate @container relative mx-auto aspect-[2200/1556] w-full max-w-5xl overflow-hidden bg-white print:max-w-none">

--- a/spec/requests/events/callouts_spec.rb
+++ b/spec/requests/events/callouts_spec.rb
@@ -968,6 +968,20 @@ RSpec.describe "Events::Callouts", type: :request do
         expect(response.body).to include("/rails/active_storage/blobs/proxy")
       end
 
+      it "prefers a resource linked to the certificate callout over the title default" do
+        # The title-matched default carries no image, so a title-only lookup renders nothing.
+        create(:resource, title: Resource::TRAINING_CERTIFICATE_SIGNATURES_TITLE)
+        connected = create(:resource, title: "Event-specific signatures", hidden_from_search: true)
+        create(:primary_asset, :with_file, owner: connected)
+        create(:registration_ticket_callout, :action, event: event, builtin_key: "certificate",
+                                                       title: "Certificate of completion", resource: connected)
+
+        get registration_certificate_path(registration.slug)
+
+        expect(response.body).to include("Signed by Christy Turek Rials")
+        expect(response.body).to include("/rails/active_storage/blobs/proxy")
+      end
+
       it "still adds the shared CE accreditation clause when CE credit is earned" do
         event.update!(ce_hours_offered: 6)
         license = create(:professional_license, person: registration.registrant, number: "LIC-T")

--- a/spec/services/builtin_callouts_spec.rb
+++ b/spec/services/builtin_callouts_spec.rb
@@ -116,6 +116,25 @@ RSpec.describe BuiltinCallouts do
       expect(payment.resources).to eq([ w9 ])
     end
 
+    it "links the signatures record to the Certificate card as a removable resource" do
+      signatures = create(:resource, title: Resource::TRAINING_CERTIFICATE_SIGNATURES_TITLE)
+      event = create(:event)
+
+      described_class.seed(event)
+
+      certificate = event.registration_ticket_callouts.find_by(builtin_key: "certificate")
+      expect(certificate.resources).to eq([ signatures ])
+    end
+
+    it "leaves the Certificate card unlinked when the signatures record isn't seeded" do
+      event = create(:event)
+
+      described_class.seed(event)
+
+      certificate = event.registration_ticket_callouts.find_by(builtin_key: "certificate")
+      expect(certificate.resources).to be_empty
+    end
+
     it "seeds CE hours with its default title and no content" do
       event = create(:event)
 


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small resolution change mirroring an existing pattern, with specs

Facilitators' training certificate now takes its signature strip from a resource an admin can swap per event — the same way the payment card's W-9 already works — instead of only ever matching one global record by title.

- Attach the "Training certificate signatures" record to the **certificate** built-in callout on create, by title (mirrors the payment callout's W-9).
- The certificate page resolves its signatures from the callout's **linked resource first**, falling back to the title-matched default when none is linked.
- The HTML certificate and its Download PDF button are unchanged.

## Notes
- Falls back cleanly: a callout with no linked resource (e.g. the signatures record seeded after the event) still finds the title-matched default, so no backfill is needed.
- `Resource.training_certificate_signatures_file` stays as the title-search default; file extraction moved to a small `Resource#signature_file` instance method so both the linked and default records use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)