### PR TITLE
Add a searchable New comment composer to the global comments index

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,8 +5,18 @@ class SearchController < ApplicationController
   # compound payer / funder pickers, listing organizations first.
   COMPOUND_MODEL = "person_or_organization".freeze
 
+  # Virtual "model" backing the global comments index's "New comment" picker —
+  # every type Comment#commentable can polymorphically point at (mirrors the
+  # case in CommentsHelper#commentable_label), searched together in one box.
+  COMMENTABLE_MODEL = "commentable".freeze
+  COMMENTABLE_MODELS = [
+    Person, User, EventRegistration, Scholarship, ContinuingEducationRegistration,
+    TopicSubscription, Story, StoryIdea, Affiliation, StaffTagging
+  ].freeze
+
   def index
     return render json: compound_results if params[:model] == COMPOUND_MODEL
+    return render json: commentable_results if params[:model] == COMMENTABLE_MODEL
 
     model_class = allowed_model(params[:model])
     unless model_class
@@ -50,6 +60,19 @@ class SearchController < ApplicationController
 
     records = authorized_scope(Organization.remote_search(query)).limit(25).to_a +
       authorized_scope(Person.remote_search(query)).limit(25).to_a
+
+    records.map(&:compound_search_label)
+  end
+
+  # Search across every commentable type at once, so the "Add a note to…" picker
+  # on the global comments index doesn't force a type pick first.
+  def commentable_results
+    COMMENTABLE_MODELS.each { |model_class| authorize! model_class, to: :search? }
+
+    query = params[:q].to_s.strip
+    return [] if query.blank?
+
+    records = COMMENTABLE_MODELS.flat_map { |model_class| authorized_scope(model_class.remote_search(query)).limit(10).to_a }
 
     records.map(&:compound_search_label)
   end

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,5 +1,6 @@
 class Affiliation < ApplicationRecord
   include Communicable
+  include RemoteSearchable
   # Standing title given to the "facilitator affiliation" we create on registration
   # and org linking. Matches the `facilitators` scope / `facilitator?` predicate
   # (both treat exactly "Facilitator" as canonical).
@@ -169,6 +170,19 @@ class Affiliation < ApplicationRecord
 
   def name
     "#{person.name}" if person
+  end
+
+  remote_searchable_by :person,
+    scope: ->(query) {
+      words = query.split.flat_map { |w| w.split(/[\s\-]+/) }.reject(&:blank?)
+      return none if words.blank?
+      pattern = "%#{words.join('%')}%"
+      joins(:person, :organization)
+        .where("people.first_name LIKE :p OR people.last_name LIKE :p OR organizations.name LIKE :p", p: pattern)
+    }
+
+  def remote_search_label
+    { id: id, label: "#{person&.full_name} @ #{organization&.name}" }
   end
 
   private

--- a/app/models/continuing_education_registration.rb
+++ b/app/models/continuing_education_registration.rb
@@ -2,6 +2,7 @@ class ContinuingEducationRegistration < ApplicationRecord
   include Registerable
   include Certifiable
   include Communicable
+  include RemoteSearchable
 
   # AWBW's continuing-education accreditation, referenced by the CE callout copy
   # and the completion certificate's CE clause. Kept here as the single source of
@@ -188,6 +189,19 @@ class ContinuingEducationRegistration < ApplicationRecord
     return "Paid" if paid_in_full?
     return "Partial" if partially_paid?
     "Due"
+  end
+
+  remote_searchable_by :event_registration,
+    scope: ->(query) {
+      words = query.split.flat_map { |w| w.split(/[\s\-]+/) }.reject(&:blank?)
+      return none if words.blank?
+      pattern = "%#{words.join('%')}%"
+      joins(event_registration: :registrant)
+        .where("people.first_name LIKE :p OR people.last_name LIKE :p OR people.email LIKE :p", p: pattern)
+    }
+
+  def remote_search_label
+    { id: id, label: "#{registrant.full_name} · CE ##{id}" }
   end
 
   private

--- a/app/models/scholarship.rb
+++ b/app/models/scholarship.rb
@@ -1,5 +1,6 @@
 class Scholarship < ApplicationRecord
   include Communicable
+  include RemoteSearchable
   belongs_to :recipient, class_name: "Person"
   belongs_to :grant, optional: true
   belongs_to :created_by, class_name: "User", optional: true
@@ -148,6 +149,19 @@ class Scholarship < ApplicationRecord
 
   def communications_email
     recipient&.preferred_email
+  end
+
+  remote_searchable_by :recipient,
+    scope: ->(query) {
+      words = query.split.flat_map { |w| w.split(/[\s\-]+/) }.reject(&:blank?)
+      return none if words.blank?
+      pattern = "%#{words.join('%')}%"
+      joins(:recipient)
+        .where("people.first_name LIKE :p OR people.last_name LIKE :p OR people.email LIKE :p", p: pattern)
+    }
+
+  def remote_search_label
+    { id: id, label: "#{recipient.full_name} · Scholarship ##{id}" }
   end
 
   private

--- a/app/models/staff_tagging.rb
+++ b/app/models/staff_tagging.rb
@@ -1,5 +1,6 @@
 class StaffTagging < ApplicationRecord
   include Communicable
+  include RemoteSearchable
 
   belongs_to :staff_tag
   belongs_to :staff_taggable, polymorphic: true, touch: true
@@ -65,6 +66,15 @@ class StaffTagging < ApplicationRecord
                                     .where("notifications.email_subject LIKE :q OR notifications.email_body_text LIKE :q OR notifications.custom_subject LIKE :q OR notifications.custom_message LIKE :q", q: like)
                                     .select(:noticeable_id)
     where(id: comment_ids).or(where(id: communication_ids)) }
+
+  remote_searchable_by :staff_tag,
+    scope: ->(query) {
+      where(staff_taggable_type: "Person", staff_taggable_id: matching_person_ids(query))
+    }
+
+  def remote_search_label
+    { id: id, label: "#{staff_taggable.try(:full_name) || "Person ##{staff_taggable_id}"} · #{staff_tag.name}" }
+  end
 
   def self.search_by_params(params)
     results = all

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -2,6 +2,7 @@ class Story < ApplicationRecord
   include AuthorCreditable
   include Featureable, Publishable, TagFilterable, Trendable, WindowsTypeFilterable, RichTextSearchable
   include Communicable
+  include RemoteSearchable
 
   has_rich_text :rhino_body
 
@@ -133,6 +134,8 @@ class Story < ApplicationRecord
   def communications_email
     author_person&.preferred_email
   end
+
+  remote_searchable_by :title
 
   def organization_name
     organization&.name

--- a/app/models/story_idea.rb
+++ b/app/models/story_idea.rb
@@ -1,6 +1,7 @@
 class StoryIdea < ApplicationRecord
   include AuthorCreditable
   include Communicable
+  include RemoteSearchable
   # The submitter is the author when none is named.
   credits_creator
 
@@ -85,5 +86,11 @@ class StoryIdea < ApplicationRecord
 
   def organization_description
     organization&.organization_description
+  end
+
+  remote_searchable_by :title
+
+  def remote_search_label
+    { id: id, label: title.presence || "Story idea ##{id}" }
   end
 end

--- a/app/models/topic_subscription.rb
+++ b/app/models/topic_subscription.rb
@@ -1,5 +1,6 @@
 class TopicSubscription < ApplicationRecord
   include Communicable
+  include RemoteSearchable
   belongs_to :person
   belongs_to :topic_subscription_type
   # Optional narrowing to a specific event (e.g. one training). Null = the topic
@@ -95,6 +96,19 @@ class TopicSubscription < ApplicationRecord
 
   def topic_label
     topic_subscription_type&.name
+  end
+
+  remote_searchable_by :person,
+    scope: ->(query) {
+      words = query.split.flat_map { |w| w.split(/[\s\-]+/) }.reject(&:blank?)
+      return none if words.blank?
+      pattern = "%#{words.join('%')}%"
+      joins(:person)
+        .where("people.first_name LIKE :p OR people.last_name LIKE :p OR people.email LIKE :p", p: pattern)
+    }
+
+  def remote_search_label
+    { id: id, label: "#{person.full_name} · #{topic_label}" }
   end
 
   def unsubscribe!

--- a/app/policies/continuing_education_registration_policy.rb
+++ b/app/policies/continuing_education_registration_policy.rb
@@ -3,4 +3,9 @@ class ContinuingEducationRegistrationPolicy < ApplicationPolicy
   alias_rule :index?, :show?, :new?, :create?, :edit?, :update?, :destroy?, :toggle_certificate?, to: :manage?
 
   def manage? = admin?
+
+  relation_scope do |relation|
+    next relation if admin?
+    relation.none
+  end
 end

--- a/app/policies/topic_subscription_policy.rb
+++ b/app/policies/topic_subscription_policy.rb
@@ -2,4 +2,9 @@ class TopicSubscriptionPolicy < ApplicationPolicy
   def index?
     admin?
   end
+
+  relation_scope do |relation|
+    next relation if admin?
+    relation.none
+  end
 end

--- a/app/views/comments/_global_composer.html.erb
+++ b/app/views/comments/_global_composer.html.erb
@@ -1,0 +1,43 @@
+<%# "New comment" composer for the global comments index. Unlike comments/_composer
+    (used on a person's page, whose "Add a note to…" picker is a static list of
+    that person's own records), this page has no single-person context, so the
+    picker is a live cross-type search instead (remote-select against the
+    "commentable" virtual model in SearchController). Submits as a plain,
+    non-Turbo request so the redirect lands back on a freshly loaded index —
+    the same stream: false pattern comments/_composer uses on the combined
+    comments & communications page. %>
+<div id="global_comment_composer"
+     class="hidden rounded-lg border <%= DomainTheme.border_class_for(:comments) %> <%= DomainTheme.bg_class_for(:comments, intensity: 50) %> p-4 shadow-sm">
+  <%= simple_form_for Comment.new, url: comments_path, data: { turbo: false } do |f| %>
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
+      <div class="sm:w-1/3 shrink-0">
+        <label class="block text-xs font-semibold text-gray-600 mb-1" for="commentable_sgid">Add a note to</label>
+        <%= select_tag :commentable_sgid, nil,
+                       include_blank: true, prompt: "Search for a person, registration, scholarship…",
+                       class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none",
+                       data: { controller: "remote-select", remote_select_model_value: "commentable" } %>
+        <%= f.input_field :topic,
+                          placeholder: "Topic (optional)",
+                          class: "mt-2 w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      </div>
+      <div class="grow">
+        <label class="block text-xs font-semibold text-gray-600 mb-1" for="comment_body">Comment</label>
+        <%= f.input_field :body,
+                          as: :text,
+                          rows: 3,
+                          required: true,
+                          placeholder: "Type your comment",
+                          class: "w-full bg-white rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:outline-none" %>
+      </div>
+    </div>
+
+    <div class="mt-3 flex items-center gap-x-3">
+      <%= f.submit "Add comment", class: button_classes(:secondary_outline) %>
+      <label class="inline-flex items-center cursor-pointer select-none" title="Flag this note for follow-up">
+        <%= f.check_box :flagged, class: "peer sr-only" %>
+        <i class="fa-regular fa-flag text-gray-500 peer-checked:text-orange-500 peer-checked:[--fa-style:900]!"></i>
+        <span class="ml-1.5 text-sm text-gray-500 peer-checked:text-orange-600">Flag</span>
+      </label>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -16,8 +16,19 @@
   <div class="space-y-6 p-4 sm:p-8">
     <div class="flex flex-wrap items-baseline justify-between gap-2">
       <h1 class="text-primary font-display text-2xl font-semibold">All comments</h1>
-      <p class="text-sm text-gray-500"><%= pluralize(@total_count, "comment") %></p>
+      <div class="flex items-center gap-3">
+        <p class="text-sm text-gray-500"><%= pluralize(@total_count, "comment") %></p>
+        <button type="button"
+                data-controller="dropdown"
+                data-action="dropdown#toggle"
+                data-dropdown-payload-param='[{"global_comment_composer":"hidden"}]'
+                class="<%= button_classes(:secondary_outline) %>">
+          <i class="fa-solid fa-plus"></i> New comment
+        </button>
+      </div>
     </div>
+
+    <%= render "comments/global_composer" %>
 
     <%= render "comments/search_boxes",
                url: comments_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,9 +59,10 @@ Rails.application.routes.draw do
 
   resources :fm_archives, only: [ :index, :show ]
 
-  # Top-level update lets the aggregated feed flag/edit any comment by id, even
-  # when its commentable has no nested comments route (affiliations, staff tags…).
-  resources :comments, only: [ :index, :update ]
+  # Top-level create/update let the global index's "New comment" composer and
+  # the aggregated feed's flag/edit reach any commentable by id, even one with
+  # no nested comments route (affiliations, staff tags…).
+  resources :comments, only: [ :index, :create, :update ]
 
   resources :banners
   resources :bookmarks do

--- a/spec/requests/commentable_search_spec.rb
+++ b/spec/requests/commentable_search_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Commentable search (global comments index composer)", type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before { sign_in admin }
+
+  describe "GET /search/commentable" do
+    it "finds a matching person and resolves back to the record via its sgid" do
+      person = create(:person, first_name: "Searchable", last_name: "Commentable")
+
+      get "/search/commentable", params: { q: "Searchable Commentable" }
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      resolved = json.map { |row| GlobalID::Locator.locate_signed(row["id"]) }
+      expect(resolved).to include(person)
+    end
+
+    it "finds a matching affiliation, which has no nested comments route" do
+      affiliation = create(:affiliation, person: create(:person, last_name: "Affiliatery"))
+
+      get "/search/commentable", params: { q: "Affiliatery" }
+
+      resolved = response.parsed_body.map { |row| GlobalID::Locator.locate_signed(row["id"]) }
+      expect(resolved).to include(affiliation)
+    end
+
+    it "finds a matching story by title" do
+      story = create(:story, title: "A Very Searchable Story Title")
+
+      get "/search/commentable", params: { q: "Very Searchable Story" }
+
+      resolved = response.parsed_body.map { |row| GlobalID::Locator.locate_signed(row["id"]) }
+      expect(resolved).to include(story)
+    end
+
+    it "returns an empty array for a blank query" do
+      get "/search/commentable", params: { q: "" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it "forbids non-admins" do
+      sign_in create(:user)
+      get "/search/commentable", params: { q: "anything" }
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/comments_index_spec.rb
+++ b/spec/requests/comments_index_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe "Comments index", type: :request do
       expect(response.body).to include("person_id", "event_id")
     end
 
+    it "includes a New comment composer with a searchable commentable picker" do
+      sign_in admin
+      get comments_path
+
+      expect(response.body).to include("New comment", "global_comment_composer", "commentable_sgid")
+    end
+
     it "lists every comment in the results frame" do
       sign_in admin
       create(:comment, commentable: create(:person), body: "One")

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe "Comments", type: :request do
     end
   end
 
+  describe "POST /comments (commentable_sgid)" do
+    it "creates a comment against a record with no nested comments route, like an affiliation" do
+      affiliation = create(:affiliation)
+
+      expect {
+        post comments_path, params: { commentable_sgid: affiliation.to_sgid.to_s, comment: { body: "Ended after training." } }
+      }.to change(affiliation.comments, :count).by(1)
+
+      expect(affiliation.comments.last.body).to eq("Ended after training.")
+    end
+  end
+
   describe "PATCH /people/:person_id/comments/:id" do
     it "toggles the flagged state" do
       comment = create(:comment, commentable: person, body: "Called the family.")
@@ -34,6 +46,18 @@ RSpec.describe "Comments", type: :request do
 
       patch person_comment_path(person, comment), params: { comment: { flagged: "false" } }, as: :turbo_stream
       expect(comment.reload).not_to be_flagged
+    end
+  end
+
+  describe "PATCH /comments/:id" do
+    it "toggles the flagged state on a comment whose commentable has no nested comments route" do
+      affiliation = create(:affiliation)
+      comment = create(:comment, commentable: affiliation, body: "A note.")
+
+      patch comment_path(comment), params: { comment: { flagged: "true" } }, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(comment.reload).to be_flagged
     end
   end
 end

--- a/spec/system/comments_new_comment_composer_spec.rb
+++ b/spec/system/comments_new_comment_composer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "New comment composer on the global comments index", type: :system do
+  let(:admin) { create(:user, :admin) }
+
+  # Sets the TomSelect value directly instead of typing into it, so the spec
+  # doesn't depend on a live /search/commentable fetch completing in time —
+  # same pattern person_saves_workshop_log_spec.rb uses for its workshop picker.
+  def select_tom_select_option(hidden_select_id, value, label)
+    page.execute_script(<<~JS)
+      var el = document.getElementById('#{hidden_select_id}');
+      var ts = el.tomselect;
+      ts.addOption({id: '#{value}', label: '#{label}'});
+      ts.setValue('#{value}');
+    JS
+  end
+
+  it "creates a comment against an affiliation, which has no nested comments route" do
+    affiliation = create(:affiliation, person: create(:person, first_name: "Fiona", last_name: "Facilitator"))
+
+    sign_in admin
+    visit comments_path
+
+    click_button "New comment"
+    select_tom_select_option("commentable_sgid", affiliation.to_sgid.to_s,
+      "#{affiliation.person.full_name} @ #{affiliation.organization.name}")
+    fill_in "comment_body", with: "Great facilitator, ended affiliation on good terms."
+    click_button "Add comment"
+
+    expect(page).to have_content("Great facilitator, ended affiliation on good terms.")
+  end
+end


### PR DESCRIPTION
🤖 suggested review level: 5 Inspect 🔬 new cross-type search endpoint, remote-search wiring across 7 models, two relation_scope additions, and a new admin-only create route

Admins had no way to log a comment from the global **Comments** index (`/comments`) — you had to know which record's edit page to open first. Adds a **New comment** button (top right) that reveals a composer with a live search across every commentable type, so an admin can find "Jane Doe" or "Jane Doe @ Some Org" and attach a note directly.

## Why a new search endpoint
The existing composer (used on a person's page) only ever offers *that person's own* records — there's no single-person context on the global index to scope a picker to. Added `SearchController#commentable_results`, a compound search across all 10 commentable types (same pattern as the existing person+organization payer/funder picker), returning signed GlobalIDs the existing `commentable_sgid` create flow already resolves.

## Other changes needed to make that possible
- 7 of the 10 commentable types had no remote search at all yet (`Scholarship`, `ContinuingEducationRegistration`, `TopicSubscription`, `Story`, `StoryIdea`, `Affiliation`, `StaffTagging`) — added `remote_searchable_by` + a descriptive `remote_search_label` to each.
- 2 of those policies (`ContinuingEducationRegistrationPolicy`, `TopicSubscriptionPolicy`) had no `relation_scope`, which `authorized_scope` requires for an `ActiveRecord::Relation` — added the same admin-only `relation_scope` pattern already used by their sibling policies.
- Added a top-level `POST /comments` route — `set_commentable` already resolved `commentable_sgid` generically, so this just exposes the same `create` action outside a nested-resource URL (needed since some commentable types, like `Affiliation`, have no nested comments route at all — this is also why #2521 fixed the Oopsie on this same page).

## Testing
Request specs for the new search endpoint and comment creation, plus a system spec driving the actual button → search → submit flow (TomSelect value set via JS injection rather than a live fetch, matching the existing workshop-log picker spec's pattern, to avoid flakiness).