### PR TITLE
Keep People "Email addresses" in sync with the active filter

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -31,7 +31,7 @@ class PeopleController < ApplicationController
   end
 
   def email_addresses
-    authorize! Person, to: :index?
+    authorize! Person, to: :manage?
     people = authorized_scope(Person.includes(:user)).search_by_params(params.to_unsafe_h)
     @email_addresses = people.filter_map { |person| person.preferred_email.presence }.uniq.sort
   end

--- a/app/views/people/_email_addresses_link.html.erb
+++ b/app/views/people/_email_addresses_link.html.erb
@@ -1,0 +1,6 @@
+<span id="people_email_addresses_link">
+  <% if allowed_to?(:manage?, Person) %>
+    <%= link_to "Email addresses", email_addresses_people_path(request.query_parameters.except("page")),
+                class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
+  <% end %>
+</span>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -31,10 +31,7 @@
           <%= link_to "Subscriptions", topic_subscriptions_path,
                       class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
         <% end %>
-        <% if allowed_to?(:index?, Person) %>
-          <%= link_to "Email addresses", email_addresses_people_path(request.query_parameters),
-                      class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>
-        <% end %>
+        <%= render "email_addresses_link" %>
         <% if allowed_to?(:manage?, Person) %>
           <%= link_to "Dedupe", dedupe_index_people_path,
                       class: "admin-only bg-blue-100 text-sm #{eyebrow_link_class} px-2 py-1" %>

--- a/app/views/people/people_results.html.erb
+++ b/app/views/people/people_results.html.erb
@@ -1,5 +1,6 @@
 <%= turbo_frame_tag :people_results do %>
   <%= turbo_stream.replace("people_count", partial: "people_count") %>
+  <%= turbo_stream.replace("people_email_addresses_link", partial: "email_addresses_link") %>
 
   <div class="border-primary/10 animate-fade overflow-hidden rounded-2xl border bg-white blur-on-submit">
     <% if @people.any? %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -27,6 +27,16 @@
 
 # ── 2026-09 ─────────────────────────────────────────────────────────────────
 
+- name: "Email addresses respect the people filter"
+  area: people
+  display_status: admin_facing
+  released_on: 2026-09-10
+  summary: >-
+    The "Email addresses" list on the People directory now matches whatever
+    you have filtered to, even after you change the filters on the page — so
+    you copy just the people you're looking at, not everyone.
+  action_path: "/people"
+
 - name: "Activities feed defaults to admins in, interactions hidden"
   area: reporting
   display_status: admin_facing

--- a/spec/requests/people_email_addresses_spec.rb
+++ b/spec/requests/people_email_addresses_spec.rb
@@ -44,4 +44,13 @@ RSpec.describe "People email addresses", type: :request do
       expect(response).to redirect_to(root_path)
     end
   end
+
+  describe "Email addresses link on the filtered index frame" do
+    it "carries the active filter into the Email addresses link" do
+      get people_path(contact_info: "Alice"), headers: { "Turbo-Frame" => "people_results" }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(email_addresses_people_path(contact_info: "Alice"))
+    end
+  end
 end


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small view/controller change, re-renders one link in the existing Turbo frame

Admins who filter the People directory and then click "Email addresses" now get emails for just the filtered people, not everyone.

### What is the goal of this PR and why is this important?
- The "Email addresses" link sat in the static page header and was built once from the page's query params.
- Filters applied afterward drive the `people_results` Turbo frame without changing the top-level URL, so the link kept its stale (usually empty) params and returned every person's email.

### How did you approach the change?
- Moved the link into a partial re-rendered inside the frame response via `turbo_stream.replace` (same pattern as the people count), so it always carries the current filter.
- Gated it on `:manage?` instead of `:index?` to match the other admin-only buttons.
- Added a request spec covering the frame link and a Features & tips entry.

### Anything else to add?
`:index?` and `:manage?` both resolve to super-admin today, so who can use the feature is unchanged — the gate switch is for intent/future-proofing.