### PR TITLE
Source school-district chart from affiliation address

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -951,14 +951,14 @@ class EventsController < ApplicationController
     Address.active.where(addressable_type: "Person", country: country).select(:addressable_id)
   end
 
-  # People affiliated with an organization address in the given school district
-  # (Affiliation#organization_address → Address#district), active now — matching the
-  # cross-event breakdown's affiliation source and its as-of date, so an ended
-  # affiliation doesn't leak into the drilled list.
+  # People whose event-registration-linked affiliation points at an organization
+  # address in the given school district (Affiliation#organization_address →
+  # Address#district), scoped to the in-scope registrations — matching the
+  # breakdown's registration-linked affiliation source.
   def person_school_district_ids(district)
     address_ids = Address.active.where(district: district).select(:id)
     Affiliation
-      .active_by_date_on(Date.current)
+      .where(event_registration_id: attendee_registrations.select(:id))
       .where(organization_address_id: address_ids)
       .select(:person_id)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -951,8 +951,12 @@ class EventsController < ApplicationController
     Address.active.where(addressable_type: "Person", country: country).select(:addressable_id)
   end
 
+  # People affiliated with an organization address in the given school district
+  # (Affiliation#organization_address → Address#district), matching the breakdown's
+  # affiliation-based source.
   def person_school_district_ids(district)
-    Address.active.where(addressable_type: "Person", district: district).select(:addressable_id)
+    address_ids = Address.active.where(district: district).select(:id)
+    Affiliation.where(organization_address_id: address_ids).select(:person_id)
   end
 
   # Person ids with the given org linked on one of their in-scope registrations.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -952,11 +952,15 @@ class EventsController < ApplicationController
   end
 
   # People affiliated with an organization address in the given school district
-  # (Affiliation#organization_address → Address#district), matching the breakdown's
-  # affiliation-based source.
+  # (Affiliation#organization_address → Address#district), active now — matching the
+  # cross-event breakdown's affiliation source and its as-of date, so an ended
+  # affiliation doesn't leak into the drilled list.
   def person_school_district_ids(district)
     address_ids = Address.active.where(district: district).select(:id)
-    Affiliation.where(organization_address_id: address_ids).select(:person_id)
+    Affiliation
+      .active_by_date_on(Date.current)
+      .where(organization_address_id: address_ids)
+      .select(:person_id)
   end
 
   # Person ids with the given org linked on one of their in-scope registrations.

--- a/app/services/attendees_breakdowns.rb
+++ b/app/services/attendees_breakdowns.rb
@@ -193,15 +193,17 @@ class AttendeesBreakdowns
   end
 
   def state_registrant_ids_by_state
-    @state_registrant_ids_by_state ||= person_ids_by(address_rows.select { |_, state, _, _| Address::US_STATE_ABBREVIATIONS.include?(state.to_s.upcase) }) { |row| row[1] }
+    @state_registrant_ids_by_state ||= person_ids_by(address_rows.select { |_, state, _| Address::US_STATE_ABBREVIATIONS.include?(state.to_s.upcase) }) { |row| row[1] }
   end
 
   def country_registrant_ids_by_country
-    @country_registrant_ids_by_country ||= person_ids_by(address_rows.reject { |_, _, country, _| country.blank? }) { |row| row[2] }
+    @country_registrant_ids_by_country ||= person_ids_by(address_rows.reject { |_, _, country| country.blank? }) { |row| row[2] }
   end
 
   def school_district_registrant_ids_by_district
-    @school_district_registrant_ids_by_district ||= person_ids_by(address_rows.reject { |_, _, _, district| district.blank? }) { |row| row[3] }
+    @school_district_registrant_ids_by_district ||= affiliation_district_pairs
+      .group_by(&:first)
+      .transform_values { |pairs| pairs.map(&:last).uniq }
   end
 
   def organization_registrant_ids_by_org
@@ -300,10 +302,10 @@ class AttendeesBreakdowns
       .pluck(:categorizable_id, :category_id)
   end
 
-  # [ [ person_id, state, country, district ], ... ] — one load behind the state,
-  # country and district counts and their id maps.
+  # [ [ person_id, state, country ], ... ] — one load behind the state and country
+  # counts and their id maps.
   def address_rows
-    @address_rows ||= active_addresses.pluck(:addressable_id, :state, :country, :district)
+    @address_rows ||= active_addresses.pluck(:addressable_id, :state, :country)
   end
 
   # { key => distinct person ids }, grouping [ person_id, ... ] rows by the block.
@@ -320,6 +322,32 @@ class AttendeesBreakdowns
       .joins(:event_registration)
       .where(event_registration_id: registration_ids)
       .pluck(:organization_id, Arel.sql("event_registrations.registrant_id"))
+  end
+
+  # [ [ district, person_id ], ... ] from each attendee's affiliations active as of
+  # #as_of (an event's start when a caller is scoped to one, else today), via the
+  # affiliation's chosen organization address (Affiliation#organization_address →
+  # Address#district). Attendees whose affiliation has no organization address, or
+  # whose org address has a blank district, are absent. Someone affiliated in more
+  # than one district appears once per district.
+  def affiliation_district_pairs
+    @affiliation_district_pairs ||= begin
+      pairs = Affiliation
+        .active_by_date_on(@as_of || Date.current)
+        .where(person_id: person_ids)
+        .where.not(organization_address_id: nil)
+        .pluck(:organization_address_id, :person_id)
+      district_by_address_id = Address
+        .active
+        .where(id: pairs.map(&:first).uniq)
+        .where.not(district: [ nil, "" ])
+        .pluck(:id, :district)
+        .to_h
+      pairs.filter_map do |address_id, person_id|
+        district = district_by_address_id[address_id]
+        [ district, person_id ] if district
+      end
+    end
   end
 
   # Judged on #as_of — the event's start date when the caller is scoped to one,

--- a/app/services/attendees_breakdowns.rb
+++ b/app/services/attendees_breakdowns.rb
@@ -324,17 +324,16 @@ class AttendeesBreakdowns
       .pluck(:organization_id, Arel.sql("event_registrations.registrant_id"))
   end
 
-  # [ [ district, person_id ], ... ] from each attendee's affiliations active as of
-  # #as_of (an event's start when a caller is scoped to one, else today), via the
+  # [ [ district, person_id ], ... ] from the affiliations linked to the attended-
+  # training registrations (the org each attendee registered under), via the
   # affiliation's chosen organization address (Affiliation#organization_address →
   # Address#district). Attendees whose affiliation has no organization address, or
-  # whose org address has a blank district, are absent. Someone affiliated in more
-  # than one district appears once per district.
+  # whose org address has a blank district, are absent. Someone who registered under
+  # more than one district appears once per district.
   def affiliation_district_pairs
     @affiliation_district_pairs ||= begin
       pairs = Affiliation
-        .active_by_date_on(@as_of || Date.current)
-        .where(person_id: person_ids)
+        .where(event_registration_id: registration_ids)
         .where.not(organization_address_id: nil)
         .pluck(:organization_address_id, :person_id)
       district_by_address_id = Address

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -900,20 +900,20 @@ class EventDashboard
       .pluck(:addressable_id)
   end
 
-  # School districts on file across active registrants' active addresses
-  # (Address#district), sorted by name.
+  # School districts across active registrants' affiliation organization addresses
+  # (Affiliation#organization_address → Address#district), sorted by name.
   def school_districts
-    @school_districts ||= district_addresses.distinct.pluck(:district).sort
+    @school_districts ||= school_district_registrant_ids_by_district.keys.sort
   end
 
   # Distinct registrant count per school district.
   def school_district_counts
-    @school_district_counts ||= district_addresses.group(:district).distinct.count(:addressable_id)
+    @school_district_counts ||= school_district_registrant_ids_by_district.transform_values(&:size)
   end
 
-  # Registrant ids that have at least one active address with a school district.
+  # Registrant ids affiliated with at least one school district.
   def school_district_registrant_ids
-    @school_district_registrant_ids ||= district_addresses.distinct.pluck(:addressable_id)
+    @school_district_registrant_ids ||= affiliation_district_pairs.map(&:last).uniq
   end
 
   # Registrant ids per country, keyed by country name — the people behind each
@@ -929,13 +929,14 @@ class EventDashboard
       .transform_values { |rows| rows.map(&:last).uniq }
   end
 
-  # Registrant ids per school district, for the breakdown's per-row drill-in.
+  # Registrant ids per school district, for the breakdown's per-row drill-in. A
+  # registrant affiliated in more than one district appears under each.
   def school_district_registrant_ids_by_district
-    @school_district_registrant_ids_by_district ||= district_addresses
-      .distinct
-      .pluck(:district, :addressable_id)
-      .group_by(&:first)
-      .transform_values { |rows| rows.map(&:last).uniq }
+    @school_district_registrant_ids_by_district ||= affiliation_district_pairs
+      .each_with_object(Hash.new { |hash, key| hash[key] = Set.new }) do |(district, person_id), map|
+        map[district] << person_id
+      end
+      .transform_values(&:to_a)
   end
 
   # Distinct [ state, county ] pairs across active registrants' active addresses,
@@ -1022,11 +1023,30 @@ class EventDashboard
       .where("UPPER(addresses.state) IN (?)", Address::US_STATE_ABBREVIATIONS)
   end
 
-  def district_addresses
-    Address
-      .active
-      .where(addressable_type: "Person", addressable_id: registrant_ids)
-      .where.not(district: [ nil, "" ])
+  # [ [ district, registrant_id ], ... ] from each registrant's affiliations active
+  # as of the event (#reference_date), via the affiliation's chosen organization
+  # address (Affiliation#organization_address → Address#district). Registrants whose
+  # affiliation has no organization address, or whose org address has a blank
+  # district, are absent. A registrant affiliated in more than one district appears
+  # once per district.
+  def affiliation_district_pairs
+    @affiliation_district_pairs ||= begin
+      pairs = Affiliation
+        .active_by_date_on(reference_date)
+        .where(person_id: registrant_ids)
+        .where.not(organization_address_id: nil)
+        .pluck(:organization_address_id, :person_id)
+      district_by_address_id = Address
+        .active
+        .where(id: pairs.map(&:first).uniq)
+        .where.not(district: [ nil, "" ])
+        .pluck(:id, :district)
+        .to_h
+      pairs.filter_map do |address_id, person_id|
+        district = district_by_address_id[address_id]
+        [ district, person_id ] if district
+      end
+    end
   end
 
   def active_registrations

--- a/app/services/event_dashboard.rb
+++ b/app/services/event_dashboard.rb
@@ -1023,17 +1023,16 @@ class EventDashboard
       .where("UPPER(addresses.state) IN (?)", Address::US_STATE_ABBREVIATIONS)
   end
 
-  # [ [ district, registrant_id ], ... ] from each registrant's affiliations active
-  # as of the event (#reference_date), via the affiliation's chosen organization
-  # address (Affiliation#organization_address → Address#district). Registrants whose
-  # affiliation has no organization address, or whose org address has a blank
-  # district, are absent. A registrant affiliated in more than one district appears
-  # once per district.
+  # [ [ district, registrant_id ], ... ] from the affiliations linked to this event's
+  # active registrations (the org each registrant registered under), via the
+  # affiliation's chosen organization address (Affiliation#organization_address →
+  # Address#district). Registrations whose affiliation has no organization address, or
+  # whose org address has a blank district, are absent. A registrant who registered
+  # under more than one district appears once per district.
   def affiliation_district_pairs
     @affiliation_district_pairs ||= begin
       pairs = Affiliation
-        .active_by_date_on(reference_date)
-        .where(person_id: registrant_ids)
+        .where(event_registration_id: active_registration_ids)
         .where.not(organization_address_id: nil)
         .pluck(:organization_address_id, :person_id)
       district_by_address_id = Address

--- a/app/views/addresses/_address_fields.html.erb
+++ b/app/views/addresses/_address_fields.html.erb
@@ -114,7 +114,7 @@
 
   <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :district,
-                label: "District",
+                label: "School district",
                 input_html: {
                   class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
                 } %>

--- a/app/views/events/_registrant_breakdowns.html.erb
+++ b/app/views/events/_registrant_breakdowns.html.erb
@@ -164,7 +164,7 @@
                                        data: referral_source_data, chart: :bar, palette: palette %>
         <% end %>
         <% if school_district_data.any? %>
-          <%= render "breakdown_card", title: "School districts (via Address data)", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>
+          <%= render "breakdown_card", title: "School districts (via affiliation)", data: school_district_data, chart: :bar, palette: palette, row_paths: school_district_paths %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/organizations/_address_fields.html.erb
+++ b/app/views/organizations/_address_fields.html.erb
@@ -113,7 +113,7 @@
 
   <div class="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
     <%= f.input :district,
-                label: "District",
+                label: "School district",
                 input_html: {
                   class: "rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200"
                 } %>

--- a/app/views/people/_admin_details.html.erb
+++ b/app/views/people/_admin_details.html.erb
@@ -75,7 +75,7 @@
                 <% if address.locality.present? %><span><%= address.locality %></span><% end %>
                 <% if address.county.present? %><span><%= address.county %> County</span><% end %>
                 <% if address.country.present? %><span><%= address.country %></span><% end %>
-                <% if address.district.present? %><span>District <%= address.district %></span><% end %>
+                <% if address.district.present? %><span>School district <%= address.district %></span><% end %>
                 <% if address.la_city_council_district.present? %><span>LA council district <%= address.la_city_council_district %></span><% end %>
                 <% if address.la_supervisorial_district.present? %><span>LA supervisorial district <%= address.la_supervisorial_district %></span><% end %>
                 <% if address.la_service_planning_area.present? %><span>LA SPA <%= address.la_service_planning_area %></span><% end %>

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1445,25 +1445,26 @@ shoutout_texts = [
   end
 end
 
-puts "Recording school districts on affiliation organization addresses…"
-# The Background page breaks registrants out by school district, sourced from each
-# registrant's affiliation organization address (Affiliation#organization_address →
-# Address#district). Assign a deterministic spread to a subset of the data-rich
-# trainings' registrants that have an affiliation. Idempotent: skips an affiliation
-# already pointing at a districted org address.
+puts "Recording school districts on registration-linked affiliation org addresses…"
+# The Background page breaks registrants out by school district, sourced from the
+# affiliation linked to each event registration (the org they registered under), via
+# Affiliation#organization_address → Address#district. Assign a deterministic spread
+# to a subset of the data-rich trainings' registrations. Idempotent: skips an
+# affiliation already pointing at a districted org address.
 school_district_names = [ "Los Angeles Unified", "Garden Grove Unified", "Compton Unified",
                           "Riverside Unified", "Long Beach Unified" ]
 [ facilitator_training, trauma_training ].compact.each do |evt|
-  evt.event_registrations.active.includes(registrant: { affiliations: :organization }).order(:registrant_id).each_with_index do |registration, i|
-    next unless i.even? # roughly half the registrants are tied to a district
-    affiliation = registration.registrant&.affiliations&.detect(&:organization)
+  evt.event_registrations.active.includes(:affiliations, registrant: { affiliations: :organization }).order(:registrant_id).each_with_index do |registration, i|
+    next unless i.even? # roughly half the registrations are tied to a district
+    affiliation = registration.affiliations.detect(&:organization) ||
+                  registration.registrant&.affiliations&.detect(&:organization)
     next unless affiliation
     next if affiliation.organization_address&.district.present?
 
     address = affiliation.organization.addresses.reject(&:inactive?).first ||
               affiliation.organization.addresses.build
     address.update!(district: school_district_names[(i / 2) % school_district_names.size])
-    affiliation.update!(organization_address: address)
+    affiliation.update!(organization_address: address, event_registration: registration)
   end
 end
 

--- a/db/seeds/dev/events_management.rb
+++ b/db/seeds/dev/events_management.rb
@@ -1445,23 +1445,25 @@ shoutout_texts = [
   end
 end
 
-puts "Recording school districts on registrant addresses…"
-# The Background page breaks registrants out by school district (Address#district).
-# The address pass above leaves district blank, so assign a deterministic spread
-# to a subset of the data-rich trainings' US registrants. Idempotent: skips an
-# address that already has a district, and only US addresses get one (K-12
-# districts are domestic).
+puts "Recording school districts on affiliation organization addresses…"
+# The Background page breaks registrants out by school district, sourced from each
+# registrant's affiliation organization address (Affiliation#organization_address →
+# Address#district). Assign a deterministic spread to a subset of the data-rich
+# trainings' registrants that have an affiliation. Idempotent: skips an affiliation
+# already pointing at a districted org address.
 school_district_names = [ "Los Angeles Unified", "Garden Grove Unified", "Compton Unified",
                           "Riverside Unified", "Long Beach Unified" ]
 [ facilitator_training, trauma_training ].compact.each do |evt|
-  evt.event_registrations.active.includes(registrant: :addresses).order(:registrant_id).each_with_index do |registration, i|
+  evt.event_registrations.active.includes(registrant: { affiliations: :organization }).order(:registrant_id).each_with_index do |registration, i|
     next unless i.even? # roughly half the registrants are tied to a district
-    person = registration.registrant
-    address = person&.addresses&.reject(&:inactive?)&.first
-    next unless address && address.district.blank?
-    next unless address.country.blank? || address.country == "United States"
+    affiliation = registration.registrant&.affiliations&.detect(&:organization)
+    next unless affiliation
+    next if affiliation.organization_address&.district.present?
 
+    address = affiliation.organization.addresses.reject(&:inactive?).first ||
+              affiliation.organization.addresses.build
     address.update!(district: school_district_names[(i / 2) % school_district_names.size])
+    affiliation.update!(organization_address: address)
   end
 end
 

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -351,23 +351,23 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).not_to include("Zed Zulu")
         end
 
-        it "filters by a school-district drill-in (via the affiliation's org address)" do
+        it "filters by a school-district drill-in (via the org they registered under)" do
           org = create(:organization, name: "Compton Schools")
           org_address = create(:address, addressable: org, district: "Compton Unified", inactive: false)
-          create(:affiliation, person: attendee, organization: org, organization_address: org_address)
+          create(:affiliation, person: attendee, organization: org, organization_address: org_address, event_registration: attendee_registration)
           other = create(:person, first_name: "Zed", last_name: "Zulu")
           create(:event_registration, event: recent_training, registrant: other, status: "attended")
 
-          # An ended affiliation to the same district is excluded, matching the chart's as-of.
-          lapsed = create(:person, first_name: "Old", last_name: "Timer")
-          create(:event_registration, event: recent_training, registrant: lapsed, status: "attended")
-          create(:affiliation, person: lapsed, organization: org, organization_address: org_address,
-                               start_date: 2.years.ago.to_date, end_date: 1.year.ago.to_date)
+          # An affiliation to the same district that isn't linked to a training
+          # registration is excluded — only the org each attendee registered under counts.
+          unlinked = create(:person, first_name: "Off", last_name: "Roster")
+          create(:event_registration, event: recent_training, registrant: unlinked, status: "attended")
+          create(:affiliation, person: unlinked, organization: org, organization_address: org_address)
 
           get attendees_events_url(school_district: "Compton Unified"), headers: frame_headers
           expect(response.body).to include("Ada Lovelace")
           expect(response.body).not_to include("Zed Zulu")
-          expect(response.body).not_to include("Old Timer")
+          expect(response.body).not_to include("Off Roster")
         end
 
         it "renders the cities breakdown and filters by an org-city drill-in" do

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -358,9 +358,16 @@ RSpec.describe "Events attendees", type: :request do
           other = create(:person, first_name: "Zed", last_name: "Zulu")
           create(:event_registration, event: recent_training, registrant: other, status: "attended")
 
+          # An ended affiliation to the same district is excluded, matching the chart's as-of.
+          lapsed = create(:person, first_name: "Old", last_name: "Timer")
+          create(:event_registration, event: recent_training, registrant: lapsed, status: "attended")
+          create(:affiliation, person: lapsed, organization: org, organization_address: org_address,
+                               start_date: 2.years.ago.to_date, end_date: 1.year.ago.to_date)
+
           get attendees_events_url(school_district: "Compton Unified"), headers: frame_headers
           expect(response.body).to include("Ada Lovelace")
           expect(response.body).not_to include("Zed Zulu")
+          expect(response.body).not_to include("Old Timer")
         end
 
         it "renders the cities breakdown and filters by an org-city drill-in" do

--- a/spec/requests/events/attendees_spec.rb
+++ b/spec/requests/events/attendees_spec.rb
@@ -351,6 +351,18 @@ RSpec.describe "Events attendees", type: :request do
           expect(response.body).not_to include("Zed Zulu")
         end
 
+        it "filters by a school-district drill-in (via the affiliation's org address)" do
+          org = create(:organization, name: "Compton Schools")
+          org_address = create(:address, addressable: org, district: "Compton Unified", inactive: false)
+          create(:affiliation, person: attendee, organization: org, organization_address: org_address)
+          other = create(:person, first_name: "Zed", last_name: "Zulu")
+          create(:event_registration, event: recent_training, registrant: other, status: "attended")
+
+          get attendees_events_url(school_district: "Compton Unified"), headers: frame_headers
+          expect(response.body).to include("Ada Lovelace")
+          expect(response.body).not_to include("Zed Zulu")
+        end
+
         it "renders the cities breakdown and filters by an org-city drill-in" do
           org = create(:organization, name: "Wellness Org")
           create(:address, addressable: org, city: "Austin", state: "TX", inactive: false)

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3164,8 +3164,9 @@ RSpec.describe "Events", type: :request do
           expect(response.body).to include("Countries")
         end
 
-        it "shows a school districts breakdown from registrant addresses" do
-          create(:address, addressable: person, state: "CA", district: "Compton Unified", inactive: false)
+        it "shows a school districts breakdown from a registrant's affiliation address" do
+          org_address = create(:address, addressable: organization, district: "Compton Unified", inactive: false)
+          person.affiliations.find_by(organization: organization).update!(organization_address: org_address)
 
           get roster_event_path(owned_event), headers: charts_headers
 

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3164,9 +3164,9 @@ RSpec.describe "Events", type: :request do
           expect(response.body).to include("Countries")
         end
 
-        it "shows a school districts breakdown from a registrant's affiliation address" do
+        it "shows a school districts breakdown from the org a registrant registered under" do
           org_address = create(:address, addressable: organization, district: "Compton Unified", inactive: false)
-          person.affiliations.find_by(organization: organization).update!(organization_address: org_address)
+          person.affiliations.find_by(organization: organization).update!(organization_address: org_address, event_registration: registration)
 
           get roster_event_path(owned_event), headers: charts_headers
 

--- a/spec/services/attendees_breakdowns_spec.rb
+++ b/spec/services/attendees_breakdowns_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe AttendeesBreakdowns do
     expect(rows.first.registrant_count).to eq(1)
   end
 
+  it "groups attendees by the school district of their affiliation's organization address" do
+    organization = create(:organization, name: "Wellness Org")
+    org_address = create(:address, addressable: organization, district: "Austin ISD", inactive: false)
+    create(:affiliation, person: person, organization: organization, organization_address: org_address)
+
+    expect(breakdowns.school_district_counts).to eq("Austin ISD" => 1)
+    expect(breakdowns.school_district_registrant_ids_by_district["Austin ISD"]).to eq([ person.id ])
+  end
+
   it "counts scholarship recipients and CE registrants across training registrations" do
     scholarship = create(:scholarship, recipient: person, amount_cents: 1_000)
     create(:allocation, source: scholarship, allocatable: registration, amount: 1_000)

--- a/spec/services/attendees_breakdowns_spec.rb
+++ b/spec/services/attendees_breakdowns_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe AttendeesBreakdowns do
     expect(rows.first.registrant_count).to eq(1)
   end
 
-  it "groups attendees by the school district of their affiliation's organization address" do
+  it "groups attendees by the school district of the org they registered under" do
     organization = create(:organization, name: "Wellness Org")
     org_address = create(:address, addressable: organization, district: "Austin ISD", inactive: false)
-    create(:affiliation, person: person, organization: organization, organization_address: org_address)
+    create(:affiliation, person: person, organization: organization, organization_address: org_address, event_registration: registration)
 
     expect(breakdowns.school_district_counts).to eq("Austin ISD" => 1)
     expect(breakdowns.school_district_registrant_ids_by_district["Austin ISD"]).to eq([ person.id ])

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -506,12 +506,15 @@ RSpec.describe EventDashboard do
 
     describe "school districts" do
       before do
-        person1.addresses.first.update!(district: "Los Angeles Unified")
-        person2.addresses.where(inactive: false).first.update!(district: "Garden Grove Unified")
-        cancelled_person.addresses.first.update!(district: "Excluded Unified")
+        org_a_address = create(:address, addressable: org_a, district: "Los Angeles Unified")
+        org_c_address = create(:address, addressable: org_c, district: "Garden Grove Unified")
+        org_excluded_address = create(:address, addressable: org_excluded, district: "Excluded Unified")
+        person1.affiliations.find_by(organization: org_a).update!(organization_address: org_a_address)
+        person2.affiliations.find_by(organization: org_c).update!(organization_address: org_c_address)
+        cancelled_person.affiliations.find_by(organization: org_excluded).update!(organization_address: org_excluded_address)
       end
 
-      it "lists distinct school districts from active registrants' addresses" do
+      it "lists distinct school districts from active registrants' affiliation addresses" do
         expect(dashboard.school_districts).to eq([ "Garden Grove Unified", "Los Angeles Unified" ])
       end
 
@@ -520,6 +523,17 @@ RSpec.describe EventDashboard do
       end
 
       it "returns the registrant ids behind each district, excluding cancelled" do
+        expect(dashboard.school_district_registrant_ids).to contain_exactly(person1.id, person2.id)
+      end
+
+      it "counts a registrant in each district they're affiliated with" do
+        org_b_address = create(:address, addressable: org_b, district: "Pasadena Unified")
+        person1.affiliations.find_by(organization: org_b).update!(organization_address: org_b_address)
+
+        expect(dashboard.school_district_counts).to eq(
+          "Los Angeles Unified" => 1, "Garden Grove Unified" => 1, "Pasadena Unified" => 1
+        )
+        expect(dashboard.school_district_registrant_ids_by_district["Pasadena Unified"]).to contain_exactly(person1.id)
         expect(dashboard.school_district_registrant_ids).to contain_exactly(person1.id, person2.id)
       end
     end

--- a/spec/services/event_dashboard_spec.rb
+++ b/spec/services/event_dashboard_spec.rb
@@ -509,12 +509,13 @@ RSpec.describe EventDashboard do
         org_a_address = create(:address, addressable: org_a, district: "Los Angeles Unified")
         org_c_address = create(:address, addressable: org_c, district: "Garden Grove Unified")
         org_excluded_address = create(:address, addressable: org_excluded, district: "Excluded Unified")
-        person1.affiliations.find_by(organization: org_a).update!(organization_address: org_a_address)
-        person2.affiliations.find_by(organization: org_c).update!(organization_address: org_c_address)
-        cancelled_person.affiliations.find_by(organization: org_excluded).update!(organization_address: org_excluded_address)
+        cancelled_reg = event.event_registrations.find_by(registrant: cancelled_person)
+        person1.affiliations.find_by(organization: org_a).update!(organization_address: org_a_address, event_registration: reg1)
+        person2.affiliations.find_by(organization: org_c).update!(organization_address: org_c_address, event_registration: reg2)
+        cancelled_person.affiliations.find_by(organization: org_excluded).update!(organization_address: org_excluded_address, event_registration: cancelled_reg)
       end
 
-      it "lists distinct school districts from active registrants' affiliation addresses" do
+      it "lists distinct school districts from the registration-linked affiliation addresses" do
         expect(dashboard.school_districts).to eq([ "Garden Grove Unified", "Los Angeles Unified" ])
       end
 
@@ -526,9 +527,9 @@ RSpec.describe EventDashboard do
         expect(dashboard.school_district_registrant_ids).to contain_exactly(person1.id, person2.id)
       end
 
-      it "counts a registrant in each district they're affiliated with" do
+      it "counts a registrant in each district they registered under" do
         org_b_address = create(:address, addressable: org_b, district: "Pasadena Unified")
-        person1.affiliations.find_by(organization: org_b).update!(organization_address: org_b_address)
+        person1.affiliations.find_by(organization: org_b).update!(organization_address: org_b_address, event_registration: reg1)
 
         expect(dashboard.school_district_counts).to eq(
           "Los Angeles Unified" => 1, "Garden Grove Unified" => 1, "Pasadena Unified" => 1


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 contained re-source of one breakdown + label change, covered by service/request specs

Re-sources the registrant "School districts" breakdown from the affiliation linked to each event registration (the org the person registered under) instead of their personal home address — a school district describes the institution someone facilitates at, not where they live.

## What changes
- **Chart source** — `school_district_*` now reads the affiliations linked to the event's registrations (`Affiliation#event_registration_id`) → `organization_address` → `Address#district`, in both the single-event dashboard and the cross-event attendees breakdowns. Only the org each registrant *registered under* counts — not every affiliation the person holds.
- **One row per district** — a registrant who registered under more than one district counts in each (matches how the org breakdown already double-counts across orgs).
- **Filter + drill-in in sync** — the attendees `school_district` drill-in and chip resolve people the same way (affiliation scoped to the in-scope registrations), so the list matches the chart. No as-of date needed: registration-scoping is inherently event-bounded.
- **Relabel** — the address "District" field reads "School district" on the person and organization address forms and the person admin details. The column stays `district` (a rename is a data migration touching ~15 files for no user-facing gain; the app's param/chip/title vocab is already `school_district`).
- Card title is now "School districts (via affiliation)".

## Notes for the reviewer
- The person's own-address "School district" field still exists (relabeled) but no longer feeds the chart — kept per request to relabel all address surfaces.
- Dev seed now writes districts onto the registration-linked affiliation's org address so the seeded chart still shows data.