### PR TITLE
Allow image-only community news bodies + friendlier blank error

### DIFF
--- a/app/models/community_news.rb
+++ b/app/models/community_news.rb
@@ -29,7 +29,7 @@ class CommunityNews < ApplicationRecord
   # author is required in the form; left optional at the model so legacy rows
   # (created before author became a person) remain valid.
   validates :title, presence: true, length: { maximum: 150 }
-  validates :rhino_body, presence: true
+  validate :rhino_body_present
   validates :reference_url, length: { maximum: 255 }
   validates :youtube_url, length: { maximum: 255 }
 
@@ -83,5 +83,16 @@ class CommunityNews < ApplicationRecord
     community_news = community_news.where(organization_id: params[:organization_id]) if params[:organization_id].present?
     community_news = community_news.authored_by(params[:author_id])
     community_news
+  end
+
+  private
+
+  # ActionText's blank? is text-only, so a body that's just an embedded image
+  # (an image-based newsletter) reads as blank. Count any media as content too.
+  def rhino_body_present
+    return if rhino_body.to_plain_text.present?
+    content = rhino_body.body
+    return if content && (content.attachments.any? || content.fragment.source.css("img").any?)
+    errors.add(:rhino_body, :blank)
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -37,6 +37,16 @@
     you copy just the people you're looking at, not everyone.
   action_path: "/people"
 
+- name: "Post image-only community news"
+  area: communications
+  display_status: admin_facing
+  released_on: 2026-09-10
+  summary: >-
+    Community news can now be saved when the body is just an embedded image (an
+    image-based newsletter) with no typed text — it's no longer rejected as
+    blank. A truly empty body is still required to have content.
+  action_path: "/community_news/new"
+
 - name: "Activities feed defaults to admins in, interactions hidden"
   area: reporting
   display_status: admin_facing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
     all_section_none: "No comments or communications match these filters."
   activerecord:
     attributes:
+      community_news:
+        rhino_body: "Body / Description"
       grant:
         funder_sgid: "Funder"
       workshop_variation:

--- a/spec/models/community_news_spec.rb
+++ b/spec/models/community_news_spec.rb
@@ -3,6 +3,34 @@ require 'rails_helper'
 RSpec.describe CommunityNews, type: :model do
   it_behaves_like "author_creditable", factory: :community_news, org_credited: true
 
+  describe "rhino_body presence" do
+    it "is valid with text content" do
+      expect(build(:community_news, rhino_body: "<p>Hello</p>")).to be_valid
+    end
+
+    it "is valid when the body is only an uploaded image attachment" do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("img"), filename: "newsletter.png", content_type: "image/png"
+      )
+      attachment_only = %(<action-text-attachment sgid="#{blob.attachable_sgid}"></action-text-attachment>)
+      expect(build(:community_news, rhino_body: attachment_only)).to be_valid
+    end
+
+    it "is valid when the body is only an image with no text" do
+      news = build(:community_news, rhino_body: %(<img src="http://example.com/newsletter.png">))
+      expect(news.rhino_body.to_plain_text).to be_blank
+      expect(news).to be_valid
+    end
+
+    it "is invalid when the body is visually empty" do
+      [ "", "   ", "<p><br></p>", "<div></div>" ].each do |body|
+        news = build(:community_news, rhino_body: body)
+        expect(news).to be_invalid
+        expect(news.errors[:rhino_body]).to include("can't be blank")
+      end
+    end
+  end
+
   describe "#author_person" do
     let(:creator) { create(:user, :with_person) }
     let(:person) { create(:person) }

--- a/spec/requests/community_news_spec.rb
+++ b/spec/requests/community_news_spec.rb
@@ -175,6 +175,41 @@ RSpec.describe "/community_news", type: :request do
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
+
+    context "with an image-only body (no typed text)" do
+      let(:image_only_attributes) {
+        valid_attributes.merge(rhino_body: %(<img src="http://example.com/newsletter.png">))
+      }
+
+      it "creates the CommunityNews instead of rejecting it as blank" do
+        expect {
+          post community_news_index_url, params: { community_news: image_only_attributes }
+        }.to change(CommunityNews, :count).by(1)
+      end
+
+      it "advances to the created record instead of re-rendering the form" do
+        post community_news_index_url, params: { community_news: image_only_attributes }
+        expect(response).to redirect_to(community_news_url(CommunityNews.last))
+      end
+    end
+
+    context "with a genuinely empty body" do
+      let(:empty_body_attributes) {
+        valid_attributes.merge(rhino_body: "<p><br></p>")
+      }
+
+      it "does not create a CommunityNews" do
+        expect {
+          post community_news_index_url, params: { community_news: empty_body_attributes }
+        }.to change(CommunityNews, :count).by(0)
+      end
+
+      it "shows the friendly field label in the error, not the internal attribute name" do
+        post community_news_index_url, params: { community_news: empty_body_attributes }
+        expect(response.body).to include("Body / Description can&#39;t be blank")
+        expect(response.body).not_to include("Rhino body can&#39;t be blank")
+      end
+    end
   end
 
   describe "PATCH /update" do


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 small validation + i18n change on one model, covered by model and request specs

Community news that's just an embedded image (an image-based newsletter, no typed text) can now be saved — it was being rejected as "blank" even though it clearly had content.

- **Why:** ActionText's `blank?` is text-only, so an image/attachment-only body reads as empty. Facilitators posting an image newsletter hit "can't be blank" with no way through.
- Accept any body that has **text or embedded media** (an ActionText attachment or an `<img>`); a genuinely empty body is still rejected.
- **Label fix:** the error now reads **"Body / Description can't be blank"** instead of the internal **"Rhino body …"** (added the missing i18n attribute override that sibling models already have).
- Added model specs (text / uploaded-image / image-only valid; empty invalid) and request specs proving the create path now saves an image-only body and 422s an empty one with the friendly label.

Note: this is **not** the fix for the duplicate-records/"doesn't advance" report — that's a missing Turbo `:see_other` redirect, coming in a follow-up PR.