### PR TITLE
Redirect create actions with 303 See Other so Turbo advances

### DIFF
--- a/app/controllers/community_news_controller.rb
+++ b/app/controllers/community_news_controller.rb
@@ -80,7 +80,7 @@ class CommunityNewsController < ApplicationController
 
     if success
       redirect_to @community_news,
-                  notice: "Community news was successfully created."
+                  notice: "Community news was successfully created.", status: :see_other
     else
       @community_news = @community_news.decorate
       set_form_variables

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -563,7 +563,7 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if success
-        format.html { redirect_to @event, notice: "Event was successfully created." }
+        format.html { redirect_to @event, notice: "Event was successfully created.", status: :see_other }
         format.json { render :show, status: :created, location: @event }
       else
         set_form_variables

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -92,7 +92,7 @@ class ResourcesController < ApplicationController
     end
 
     if success
-      redirect_to @resource
+      redirect_to @resource, status: :see_other
     else
       @resource = @resource.decorate
       set_form_variables

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -84,7 +84,7 @@ class StoriesController < ApplicationController
     end
 
     if success
-      redirect_to @story, notice: "Story was successfully created."
+      redirect_to @story, notice: "Story was successfully created.", status: :see_other
     else
       @story = @story.decorate
       set_form_variables

--- a/app/controllers/video_recordings_controller.rb
+++ b/app/controllers/video_recordings_controller.rb
@@ -59,7 +59,7 @@ class VideoRecordingsController < ApplicationController
     end
 
     if success
-      redirect_to @video_recording, notice: "#{VideoRecording.model_name.human} was successfully created."
+      redirect_to @video_recording, notice: "#{VideoRecording.model_name.human} was successfully created.", status: :see_other
     else
       @video_recording = @video_recording.decorate
       set_form_variables

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -61,7 +61,7 @@ class WorkshopsController < ApplicationController
 
     if success
       flash[:notice] = "Workshop created successfully."
-      redirect_to @workshop
+      redirect_to @workshop, status: :see_other
     else
       set_form_variables
       flash.now[:alert] = "Unable to save the workshop."

--- a/spec/requests/community_news_spec.rb
+++ b/spec/requests/community_news_spec.rb
@@ -149,6 +149,11 @@ RSpec.describe "/community_news", type: :request do
         expect(response).to redirect_to(community_news_url(CommunityNews.last))
       end
 
+      it "redirects with 303 See Other so Turbo advances past the form" do
+        post community_news_index_url, params: { community_news: valid_attributes }
+        expect(response).to have_http_status(:see_other)
+      end
+
       it "records the current user as created_by regardless of submitted value" do
         someone_else = create(:user)
         post community_news_index_url, params: { community_news: valid_attributes.merge(created_by_id: someone_else.id) }

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1151,6 +1151,11 @@ RSpec.describe "Events", type: :request do
         expect(response).to redirect_to(event_url(Event.last))
       end
 
+      it "redirects with 303 See Other so Turbo advances past the form" do
+        post events_path, params: valid_params
+        expect(response).to have_http_status(:see_other)
+      end
+
       it "persists edited built-in callouts from the new form without duplicating them" do
         params = valid_params.deep_dup
         params[:event][:registration_ticket_callouts_attributes] = {

--- a/spec/requests/resources_spec.rb
+++ b/spec/requests/resources_spec.rb
@@ -149,6 +149,11 @@ RSpec.describe "/resources", type: :request do
         expect(response).to redirect_to(resource_url(Resource.last))
       end
 
+      it "redirects with 303 See Other so Turbo advances past the form" do
+        post resources_url, params: { resource: valid_attributes }
+        expect(response).to have_http_status(:see_other)
+      end
+
       it "credits the chosen person as author and records the creator" do
         facilitator = create(:person)
 

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -251,6 +251,11 @@ RSpec.describe "/stories", type: :request do
         expect(response).to redirect_to(story_url(Story.last))
       end
 
+      it "redirects with 303 See Other so Turbo advances past the form" do
+        post stories_url, params: { story: base_attributes }
+        expect(response).to have_http_status(:see_other)
+      end
+
       it "records the current user as created_by regardless of submitted value" do
         someone_else = create(:user)
         post stories_url, params: { story: base_attributes.merge(created_by_id: someone_else.id) }

--- a/spec/requests/video_recordings_spec.rb
+++ b/spec/requests/video_recordings_spec.rb
@@ -99,6 +99,11 @@ RSpec.describe "/video_recordings", type: :request do
         post video_recordings_url, params: { video_recording: valid_attributes }
         expect(response).to redirect_to(video_recording_url(VideoRecording.last))
       end
+
+      it "redirects with 303 See Other so Turbo advances past the form" do
+        post video_recordings_url, params: { video_recording: valid_attributes }
+        expect(response).to have_http_status(:see_other)
+      end
     end
 
     context "with invalid parameters" do

--- a/spec/requests/workshops_spec.rb
+++ b/spec/requests/workshops_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe "/workshops", type: :request do
       expect(Workshop.last.sectors).to include(sector)
     end
 
+    it "redirects with 303 See Other so Turbo advances past the form" do
+      post workshops_url, params: {
+        workshop: {
+          title: "See Other Workshop",
+          windows_type_id: windows_type.id,
+          category_ids: [ "" ]
+        }
+      }
+
+      expect(response).to have_http_status(:see_other)
+    end
+
     it "updates sectors via sector_ids on update" do
       workshop = create(:workshop)
       second_sector = create(:sector, :published)


### PR DESCRIPTION
🤖 suggested review level: 3 Read 📖 one-line status change on 6 create redirects + a request spec each

Fixes a Turbo bug where a successful create didn't advance the page: the record saved but the user stayed on the form, so re-clicking Save produced **duplicate records**.

- **Why:** Turbo Drive needs a **303 See Other** (not 302) to navigate after a form POST. These `create` actions redirected with a plain 302, so Turbo didn't move on. The `update` actions already used `:see_other` — this just aligns `create` to match.
- Added `status: :see_other` to the create-success redirect in **community_news, stories, events, workshops, resources, video_recordings**, each with a request spec asserting 303.

### Scope
- The same 302-after-POST gap exists on other create/destroy actions across the app (e.g. organizations, grants, people, features, sectors…). This PR fixes the content-form controllers where the duplicate-record symptom was reported. Happy to do a broader sweep in a follow-up if wanted — a blanket change is avoided here because some of those redirects are guard/error paths where 303 isn't the right call.